### PR TITLE
remove anything that breaks if resolvconf service is referenced

### DIFF
--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -16,12 +16,6 @@
   when: named_enabled
   register: dns_started
 
-# decide if resolvconf will ever be used FIXME
-- name: Configure resolvconf -- put localhost in resolv.conf
-  lineinfile: line="nameserver 127.0.0.1"
-              dest=/etc/resolvconf/resolv.conf.d/head
-  when: named_enabled and is_debuntu and dns_started.changed
-
 - name: Stop dansguardian
   service: name=dansguardian
            state=stopped

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -16,12 +16,7 @@
 
 - name: Get the stock resolv.conf manager
   package: name=resolvconf
-           state=present
-
-- name: recent raspbian uses dhcpcd rather than resolvconf
-  service: name=resolvconf
-           enabled=False
-           state=stopped
+           state=absent
 
 - name: on upgrade from earlier xsce versions, remove /etc/network/interfaces.d/br0
   file: path=/etc/network/interfaces.d/br0


### PR DESCRIPTION
This is an oversight. dhcpcd replaces resolvconf in the current iiab playbook