### PR TITLE
Kiwix

### DIFF
--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Set kiwix source file name armv7l
   set_fact:
-     kiwix_src_file: "kiwix-tools_armhf_2017-06-02.tar-gz"
+     kiwix_src_file: "kiwix-tools_armhf_2017-06-02.tar.gz"
      kiwix_src_bin_only: True
   when: ansible_machine == "armv7l"
 

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -1,19 +1,19 @@
 
-- name: Set kiwix source file name i686
-  set_fact:
-     kiwix_src_file: "kiwix-linux-i686.tar.bz2"
-     kiwix_src_bin_only: False
-  when: ansible_machine == "i686"
+#- name: Set kiwix source file name i686
+#  set_fact:
+#     kiwix_src_file: "kiwix-linux-i686.tar.bz2"
+#     kiwix_src_bin_only: False
+#  when: ansible_machine == "i686"
 
 - name: Set kiwix source file name x86_64
   set_fact:
-     kiwix_src_file: "kiwix-0.9-linux-x86_64.tar.bz2"
-     kiwix_src_bin_only: False
+     kiwix_src_file: "kiwix-tools_linux64_2017-06-02.tar.gz"
+     kiwix_src_bin_only: True
   when: ansible_machine == "x86_64"
 
 - name: Set kiwix source file name armv7l
   set_fact:
-     kiwix_src_file: "kiwix-server-0.9-linux-armv5tejl.tar.bz2"
+     kiwix_src_file: "kiwix-tools_armhf_2017-06-02.tar-gz"
      kiwix_src_bin_only: True
   when: ansible_machine == "armv7l"
 


### PR DESCRIPTION
smoke tested in CentOS, and raspbian.
upgrade from centos xsce-6.2 required deletion of /etc/xsce/xsce.env and /library/zims/library.xml
on pi I deleted /library/zims/library.xml and it worked
It does not look like there is a i386 version available -- don't think win32 version cuts it.