### PR TITLE
change the default servername from schoolserver to box

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -43,7 +43,7 @@ local_tz: "{{lookup ('env','TZ') }}"
 
 # Network Parameters
 
-xsce_hostname: schoolserver
+xsce_hostname: box
 xsce_domain: lan
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0


### PR DESCRIPTION
I manually changed the /etc/hosts file 172.18.96.1   schoolserver.lan   schoolserver to 172.18.96.1 box.lan box and confirmed Adam's observation that on the local console, this is sufficient to fix the problem.

Associated to the wifi, box resolves even without this change.