### PR TITLE
WordPress 4.8 instead of 4.7.3

### DIFF
--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -1,4 +1,4 @@
-wordpress_src: wordpress-4.7.3.tar.gz
+wordpress_src: wordpress-4.8.tar.gz
 wp_db_name: iiab_wp
 wp_db_user: iiab_wp
 wp_db_user_password: changeme


### PR DESCRIPTION
WordPress 4.8 was released 4 days ago and I tested this on Raspbian, based on:

   http://download.iiab.io/packages/wordpress-4.8.tar.gz

If folks care about testing this on Debian, CentOS, Ubuntu, etc please do that promptly in coming days so this can be pushed/merged into master, Thanks!