### PR TITLE
Update ansible.cfg to match upstream

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,7 +13,8 @@
 
 hostfile       = /etc/ansible/hosts
 library        = /usr/share/ansible
-remote_tmp     = $HOME/.ansible/tmp
+remote_tmp     = ~/.ansible/tmp
+local_tmp      = ~/.ansible/tmp
 pattern        = *
 forks          = 5
 poll_interval  = 15


### PR DESCRIPTION
This fixes ansible versions 2.2.1+ & 2.3.0  See: https://github.com/ansible/ansible/pull/1855