### PR TITLE
treat ubuntu dhcpd similarly to debian

### DIFF
--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -250,7 +250,7 @@
 - name: for debian, always use bridging
   set_fact:
      iiab_lan_iface: br0
-  when: 'discovered_lan_iface != "none" and num_lan_interfaces >= "1" and is_debian'
+  when: 'discovered_lan_iface != "none" and num_lan_interfaces >= "1" and is_debuntu'
 
 - name: 2 or more devices on the LAN - use bridging
   set_fact:


### PR DESCRIPTION
Even when there is only one LAN interface, put it under the bridge, and the dhcpd always attaches to the bridge.