### PR TITLE
suppress doc generation when requested

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -147,5 +147,4 @@
 
 - name: generate the offline documents
   command: /usr/bin/iiab-refresh-wiki-docs
-
-
+  when: not nodocs

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -306,7 +306,7 @@ xovis_chart_heading: "My School: Usage Data Visualization"
 # 9-LOCAL-ADDONS
 
 # Platforms - turn all off and let <OS>.yml turn on as appropriate
-
+nodocs: False
 is_rpi: False
 is_debian: False
 is_debuntu: False


### PR DESCRIPTION
Intended as short term workaround for #75 by adding 'nodocs: True' to vars/local_vars.yml to allow further testing. If you don't intend to fix doc generation on XOs I suggest that nodocs: True be added to vars/OLPC.yml