### PR TITLE
use ansible_date_time.tz for local_tz

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -36,7 +36,7 @@ default_language: en
 language_priority: en es
 
 # Time Zone (php needs timezone to be set)
-local_tz: "{{lookup ('env','TZ') }}"
+local_tz: "{{ ansible_date_time.tz }}"
 
 # Network Parameters
 


### PR DESCRIPTION
Think this might be a better starting point, should always be present. Would indicate that /etc/localtime has been set if not blank.