### PR TITLE
lockout xo service on debian family

### DIFF
--- a/iiab.yml
+++ b/iiab.yml
@@ -13,7 +13,7 @@
       - { role: 2-common, tags: ['common','base'] }
       - { role: 3-base-server, tags: ['base'] }
       - { role: 4-server-options, tags: ['options'] }
-      - { role: 5-xo-services, tags: ['xo-services'] }
+      - { role: 5-xo-services, when: not is_debuntu, tags: ['xo-services'] }
       - { role: 6-generic-apps, tags: ['generic-apps'] }
       - { role: 7-edu-apps, tags: ['edu-apps'] }
       - { role: 8-mgmt-tools, tags: ['tools'] }

--- a/roles/6-generic-apps/meta/main.yml
+++ b/roles/6-generic-apps/meta/main.yml
@@ -6,3 +6,4 @@ dependencies:
    - { role: dokuwiki, tags: ['generic','dokuwiki'], when: dokuwiki_install }
    - { role: wordpress, tags: ['generic','wordpress'], when: wordpress_install }
    - { role: calibre, tags: ['generic','calibre'], when: calibre_install }
+   - { role: ejabberd, tags: ['generic','ejabberd'], when: ejabberd_install }


### PR DESCRIPTION
Until the xo-services doesn't crash or otherwise upset the user experience lets hide them from being discovered by the end-user. 