### PR TITLE
use python_path as a global variable,

### DIFF
--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -79,6 +79,16 @@
     docker_enabled: True
   when: schooltool_enabled or schooltool_install
 
+- name: Set python_path for is_redhat
+  set_fact:
+    python_path: /usr/lib/python2.7/site-packages/
+  when: is_redhat
+
+- name: Set python_path for is_debuntu
+  set_fact:
+    python_path: /usr/local/lib/python2.7/dist-packages/
+  when: is_debuntu
+
 # for various reasons the mysql service can not be enabled on fedora 20,
 # but 'mariadb', which is its real name can
 # on fedora 18 we need to use 'mysqld'
@@ -97,7 +107,7 @@
 - name: Set mysql service name to mysql for debian
   set_fact:
     mysql_service: mysql
-  when: is_debuntu 
+  when: is_debuntu
 
 # PLATFORM variables
 - name: Fedora 20

--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -67,6 +67,10 @@
        state=present
   when: internet_available 
 
+- name: Set osm_path
+  set_fact:
+     osm_path: "{{ python_path }}iiab"
+
 - name: Copy IIAB config file
   template: backup=yes
             src=osm.conf.j2
@@ -113,24 +117,16 @@
         group={{ apache_user }}
 
 # the following was brought into OSM playbook from iiab-factory osm-fix script
-- name: Get the path for python-redhat
-  set_fact: python_path=/usr/lib/python2.7/site-packages/iiab
-  when: is_redhat
-
-- name: Get the path for python-debuntu
-  set_fact: python_path=/usr/local/lib/python2.7/dist-packages/iiab
-  when: is_debuntu
-
-- name: Copy the files 
+- name: Copy the files
   template: src={{ item.src }} dest={{ item.dest }}
   with_items:
-     - { src: 'defaults.ini', dest: "{{ python_path }}/" }
+     - { src: 'defaults.ini', dest: "{{ osm_path }}/" }
      - { src: 'etc.iiab.conf', dest: '/etc/iiab.conf' }
-     - { src: 'map_search.py', dest: "{{ python_path }}/map_search.py" }
-     - { src: 'map.html', dest: "{{ python_path }}/static/map.html" }
-     - { src: 'l.control.geosearch.js', dest: "{{ python_path }}/static/lib/leaflet/geosearch/l.control.geosearch.js" }
+     - { src: 'map_search.py', dest: "{{ osm_path }}/map_search.py" }
+     - { src: 'map.html', dest: "{{ osm_path }}/static/map.html" }
+     - { src: 'l.control.geosearch.js', dest: "{{ osm_path }}/static/lib/leaflet/geosearch/l.control.geosearch.js" }
 #  end of imported osm-fix
-     - { src: '{{ python_path }}/static/map.html', dest: "{{ python_path }}/static/index.html" }
+     - { src: '{{ osm_path }}/static/map.html', dest: "{{ osm_path }}/static/index.html" }
 
 - name: add osm to service list
   ini_file: dest='{{ service_filelist }}'

--- a/roles/osm/templates/osm.conf.j2
+++ b/roles/osm/templates/osm.conf.j2
@@ -5,18 +5,10 @@ XSendFilePath /
 
 WSGIScriptAlias /iiab {{ doc_root }}/osm.wsgi
 
-{% if is_debuntu %}
-Alias /iiabstatic /usr/local/lib/python2.7/dist-packages/iiab/static
-Alias /osm /usr/local/lib/python2.7/dist-packages/iiab/static
-Alias /maps /usr/local/lib/python2.7/dist-packages/iiab/static
+Alias /iiabstatic {{ osm_path }}/static
+Alias /osm {{ osm_path }}/static
+Alias /maps {{ osm_path }}/static
 
-<Directory /usr/local/lib/python2.7/dist-packages/iiab/static>
-{% else %}
-Alias /iiabstatic /usr/lib/python2.7/site-packages/iiab/static
-Alias /osm /usr/lib/python2.7/site-packages/iiab/static
-Alias /maps /usr/lib/python2.7/site-packages/iiab/static
-
-<Directory /usr/lib/python2.7/site-packages/iiab/static>
-{% endif %}
+<Directory {{ osm_path }}/static>
 	require all granted
 </Directory>


### PR DESCRIPTION
allows use of python_path as a global variable, useful for porting redhat specific routines.