### PR TITLE
Ifnames

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi_2.yml
+++ b/roles/1-prep/tasks/raspberry_pi_2.yml
@@ -41,7 +41,7 @@
               dest=/etc/dphys-swapfile
   when: is_debuntu
 
-- name: restart the swqp service
+- name: restart the swap service
   command: /etc/init.d/dphys-swapfile restart
   when: is_debuntu
 
@@ -58,3 +58,12 @@
 - name: Enable rootfs resizing service
   service: name=iiab-rpi-root-resize
            enabled=yes
+
+- name: substitute jessie wifi driver on raspbian-9 workaround
+  get_url: url={{ iiab_download_url }}/{{ item }}
+           dest=/lib/firmware/brcm/
+           force=yes
+  with_items:
+           - brcmfmac43430-sdio.bin
+           - brcmfmac43430-sdio.txt
+  when:  ansible_local.local_facts.os_ver  == "raspbian-9"

--- a/runansible
+++ b/runansible
@@ -64,7 +64,8 @@ raspbian_ver=`./scripts/local_facts.fact|grep os_ver|gawk -F '"' '{print $4}'`
 if [ "$raspbian_ver" == "raspbian-9" ]; then
    grep net.ifnames=0 /boot/cmdline.txt
    if [ $? -ne 0 ]; then
-       sed -i -e 's/deadline +fsck/deadline net.ifnames=0 fsck/' /boot/cmdline.txt
+       sed -i -r 's/deadline +fsck/deadline net.ifnames=0 fsck/' /boot/cmdline.txt
+       echo
        echo "Kernel cmdline changed. Will now reboot so that network interface names will"
        echo "  be same for all raspberry pi\'s. Hit enter, and then restart this script"
        read var

--- a/runansible
+++ b/runansible
@@ -60,7 +60,7 @@ cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
 # raspbian-9 changes network interface names to include mac address
 # which defeats copying an image from one SD card to another
-raspbian_ver=`./scripts/local_facts.fact|grep os_ver|gawk -F '"' '{print $4}'`
+raspbian_ver=`./scripts/local_facts.fact|grep os_ver|awk -F '"' '{print $4}'`
 if [ "$raspbian_ver" == "raspbian-9" ]; then
    grep net.ifnames=0 /boot/cmdline.txt
    if [ $? -ne 0 ]; then

--- a/runansible
+++ b/runansible
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 
 # copy var files to /etc/iiab for subsequent use
 mkdir -p /etc/iiab
@@ -57,6 +57,20 @@ if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
    mkdir -p /etc/ansible/facts.d
 fi
 cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
+
+# raspbian-9 changes network interface names to include mac address
+# which defeats copying an image from one SD card to another
+raspbian_ver=`./scripts/local_facts.fact|grep os_ver|gawk -F '"' '{print $4}'`
+if [ "$raspbian_ver" == "raspbian-9" ]; then
+   grep net.ifnames=0 /boot/cmdline.txt
+   if [ $? -ne 0 ]; then
+       sed -i -e 's/deadline +fsck/deadline net.ifnames=0 fsck/' /boot/cmdline.txt
+       echo "Kernel cmdline changed. Will now reboot so that network interface names will"
+       echo "  be same for all raspberry pi\'s. Hit enter, and then restart this script"
+       read var
+       reboot
+   fi
+fi
 
 PLAYBOOK="iiab.yml"
 INVENTORY="ansible_hosts"


### PR DESCRIPTION
Don't waste users time (raspbian-9), when the networking breaks due to interface name change, and will work after a reboot- but user might just give up