### PR TITLE
Net wip

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi_2.yml
+++ b/roles/1-prep/tasks/raspberry_pi_2.yml
@@ -32,9 +32,6 @@
   with_items:
     - ntp
 
-- name: disable the renaming of eth0
-  shell: sed -i -e 's/deadline fsck/deadline  net.ifnames=0 fsck/' /boot/cmdline.txt
-
 - name: increase the swap file size (kalite pip download fails)
   lineinfile: regexp="^CONF_SWAPSIZE"
               line=CONF_SWAPSIZE=500

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -16,9 +16,9 @@
            enabled=False
   ignore_errors: True
 
-- name: Get the dhcp client daemon used in recent raspbian
-  package: name=dhcpcd5
-           state=present
+#- name: Get the dhcp client daemon used in recent raspbian
+#  package: name=dhcpcd5
+#           state=present
 
 - name: for upgrades from earlier 6.2, remove br0 file
   file: path=/etc/network/interfaces.d/br0
@@ -34,10 +34,10 @@
             src=network/interfaces.j2
   register: interface
 
-- name: start up the dhcpcd service
-  service: name=dhcpcd
-           enabled=True
-           state=started
+#- name: start up the dhcpcd service
+#  service: name=dhcpcd
+#           enabled=True
+#           state=started
 
 - name: If this was a change, things need to shift
   service: name=hostapd state=stopped

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -27,11 +27,6 @@
       gui_desired_network_role: "LanController"
   when: not gui_desired_network_role is defined
 
-- name: set the interface variables based upon gui_desired_role
-  set_fact: 
-       discovered_wireless_iface: wlan0
-       discovered_wan_iface: eth0
-       
 - name: Copy the network config script -- previously in /etc/network/interfaces.d/br0 
   template: dest=/etc/network/interfaces
             src=network/interfaces.j2
@@ -40,6 +35,11 @@
 - name: If this was a change, things need to shift
   service: name=hostapd state=stopped
   when: interface.changed
+
+- name: reset the bridge slaves interface
+  command: ifdown {{ detected_lan }}
+  ignore_errors: True
+  when: interface.changed and detected_lan != "none"
 
 - name: dhcpd may be affected
   service: name=bind9 state=stopped
@@ -52,11 +52,6 @@
 
 - name: and remove the device 
   command: brctl delbr br0
-  ignore_errors: True
-  when: interface.changed
-
-- name: reset the eth0 interface 
-  command: ifdown eth0
   ignore_errors: True
   when: interface.changed
 

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -56,7 +56,7 @@
   when: interface.changed
 
 - name: reset the eth0 interface 
-  command: ifdown etho
+  command: ifdown eth0
   ignore_errors: True
   when: interface.changed
 

--- a/roles/network/templates/network/interfaces.j2
+++ b/roles/network/templates/network/interfaces.j2
@@ -7,7 +7,9 @@ source /etc/network/interfaces.d/*
 auto lo
 iface lo inet loopback
 
-# iiab_network_mode is {{ gui_desired_network_role }}
+# iiab_network_mode is {{ iiab_network_role }}
+# gui_desired_network_role is {{ gui_desired_network_role }}
+
 {% if iiab_wireless_lan_iface != 'none' %}
 # we always want the wireless to be configured (and under bridge) if it exists
 auto {{ iiab_wireless_lan_iface }}

--- a/roles/network/templates/network/interfaces.j2
+++ b/roles/network/templates/network/interfaces.j2
@@ -57,7 +57,7 @@ iface {{ iiab_wan_iface }} inet static
 #################   LANCONTROLLER   ###################
 auto br0
 iface br0 inet static
-    bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if detected_lan != "none" %} {{ detected_lan }} {% endif %}
+    bridge_ports {% if iiab_wireless_lan_iface != "none" %} {{ iiab_wireless_lan_iface }} {% endif %} {% if detected_lan != "none" %} {{ detected_lan }} {% endif %}
 
     bridge_maxwait 0
     address {{ lan_ip }}

--- a/roles/network/templates/network/interfaces.j2
+++ b/roles/network/templates/network/interfaces.j2
@@ -8,21 +8,22 @@ auto lo
 iface lo inet loopback
 
 # iiab_network_mode is {{ gui_desired_network_role }}
-{% if discovered_wireless_iface != 'none' %}
+{% if iiab_wireless_lan_iface != 'none' %}
 # we always want the wireless to be configured (and under bridge) if it exists
-auto {{ discovered_wireless_iface }}
-iface {{discovered_wireless_iface }} inet manual
+auto {{ iiab_wireless_lan_iface }}
+iface {{ iiab_wireless_lan_iface }} inet manual
    pre-up   ifconfig $IFACE up
    pre-down ifconfig $IFACE down
 {% endif %}
 
 {% if iiab_network_mode == "Appliance"  %}
 #################   APPLIANCE #########################
-auto {{ discovered_wan_iface }}
+auto {{ iiab_wan_iface }}
 {% if gui_static_wan == false %}
-iface {{ discovered_wan_iface }} inet manual
+auto {{ iiab_wan_iface }}
+iface {{ iiab_wan_iface }} inet dhcp
 {% else %} # gui_static_wan_ip is set 
-iface {{ discovered_wan_iface }} inet static
+iface {{ iiab_wan_iface }} inet static
     address {{ gui_static_wan_ip }}
     netmask {{ gui_static_wan_netmask }}
     gateway {{ gui_static_wan_gateway }}
@@ -33,17 +34,17 @@ iface {{ discovered_wan_iface }} inet static
 #################   GATEWAY   #########################
 auto br0
 iface br0 inet static
-    bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if discovered_lan_iface != "none" %} {{ discovered_lan_iface }} {% endif %}
+    bridge_ports {% if iiab_wireless_lan_iface != "none" %} {{ iiab_wireless_lan_iface }} {% endif %} {% if detected_lan != "none" %} {{ detected_lan }} {% endif %}
 
     bridge_maxwait 0
     address {{ lan_ip }}
     netmask {{ lan_netmask }}
     dns-nameservers {{ lan_ip }}
 {% if gui_static_wan == false %}
-auto {{ discovered_wan_iface }}
-iface {{ discovered_wan_iface }} inet dhcp
+auto {{ iiab_wan_iface }}
+iface {{ iiab_wan_iface }} inet dhcp
 {% else %} # gui_static_wan_ip is set 
-iface {{ discovered_wan_iface }} inet static
+iface {{ iiab_wan_iface }} inet static
     address {{ gui_static_wan_ip }}
     netmask {{ gui_static_wan_netmask }}
     gateway {{ gui_static_wan_gateway }}
@@ -56,7 +57,7 @@ iface {{ discovered_wan_iface }} inet static
 #################   LANCONTROLLER   ###################
 auto br0
 iface br0 inet static
-    bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if discovered_wan_iface != "none" %} {{ discovered_wan_iface }} {% endif %}
+    bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if detected_lan != "none" %} {{ detected_lan }} {% endif %}
 
     bridge_maxwait 0
     address {{ lan_ip }}
@@ -66,4 +67,3 @@ iface br0 inet static
     dns-search {{ iiab_domain }}
     post-up systemctl restart dhcpd && systemctl restart hostapd
 {% endif %}
-

--- a/roles/network/templates/network/interfaces.j2
+++ b/roles/network/templates/network/interfaces.j2
@@ -22,7 +22,6 @@ iface {{ iiab_wireless_lan_iface }} inet manual
 #################   APPLIANCE #########################
 auto {{ iiab_wan_iface }}
 {% if gui_static_wan == false %}
-auto {{ iiab_wan_iface }}
 iface {{ iiab_wan_iface }} inet dhcp
 {% else %} # gui_static_wan_ip is set 
 iface {{ iiab_wan_iface }} inet static


### PR DESCRIPTION
The switch away from discovered_*_iface is to allow the overrides like iiab_lan_enabled in computed_network,yml to be effective, as those set the interface to be none and taken into the calculation of iiab_network_mode.