### PR TITLE
teamviewer is non-arm and CentOS only BUGFIX

### DIFF
--- a/roles/teamviewer/tasks/main.yml
+++ b/roles/teamviewer/tasks/main.yml
@@ -1,12 +1,12 @@
-- name: Teamviewer exclude ARM
+- name: Teamviewer exclude ARM and debian family
   set_fact:
     teamviewer_install: False
     teamviewer_enabled: "unavailable"
-  when: ansible_architecture == "armv7l"
+  when: ansible_architecture == "armv7l" or not is_redhat
 
 - name: Install Teamviewer if intel
   include: install.yml
-  when: ansible_architecture == "i386" or ansible_architecture == "x86_64"
+  when: teamviewer_install
 
 - name: Add teamviewer to service list
   ini_file: dest='{{ service_filelist }}'


### PR DESCRIPTION
smoke tested with runtags
TASK [teamviewer : Teamviewer exclude ARM] *************************************
ok: [127.0.0.1]

TASK [teamviewer : Install xfce group of packages] *****************************
skipping: [127.0.0.1]

TASK [teamviewer : Install X11 group of packages] ******************************
skipping: [127.0.0.1]

TASK [teamviewer : Install xfce group of packages] *****************************
skipping: [127.0.0.1]

TASK [teamviewer : Install X Windows on CentOS] ********************************
skipping: [127.0.0.1]

TASK [teamviewer : Get the teamviewer software] ********************************
skipping: [127.0.0.1]

TASK [teamviewer : Do the install of teamviewer, pulling in any required dependencies] ***
skipping: [127.0.0.1]

TASK [teamviewer : making local copy available] ********************************
skipping: [127.0.0.1]

TASK [teamviewer : using local copy] *******************************************
skipping: [127.0.0.1] => (item=[]) 

TASK [teamviewer : Add teamviewer to service list] *****************************
skipping: [127.0.0.1] => (item={u'option': u'name', u'value': u'teamviewer'}) 
skipping: [127.0.0.1] => (item={u'option': u'description', u'value': u'"TeamViewer - the All-In-One Software for Remote Support and Online Meetings"'}) 
skipping: [127.0.0.1] => (item={u'option': u'installed', u'value': False}) 
skipping: [127.0.0.1] => (item={u'option': u'enabled', u'value': u'unavailable'}) 

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=59   changed=13   unreachable=0    failed=0   

