### PR TITLE
add mbstring for debian

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -21,6 +21,7 @@
   with_items:
     - libapache2-mod-php{{ php_version }}
     - php{{ php_version }}-mbstring
+    - php{{ php_version }}-zip
   when: is_debian
 
 - name: ubuntu and debian treat names differently

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -20,6 +20,7 @@
   package: name={{ item }} state=present
   with_items:
     - libapache2-mod-php{{ php_version }}
+    - php{{ php_version }}-mbstring
   when: is_debian
 
 - name: ubuntu and debian treat names differently


### PR DESCRIPTION
smoke tested on debian 9 vm, will test on other platforms, and rpi hardware, with other branches