### PR TITLE
multiple ./runtags comment: X,Y,Z instead of XXX

### DIFF
--- a/runtags
+++ b/runtags
@@ -46,7 +46,7 @@ fi
 if [ $# -ne 1 ]; then
 	echo "usage: $0 <tagname>"
 	echo
-	echo " If you would like a list of possible values, enter $0 XXX"
+	echo " If you would like a list of possible values, enter $0 X,Y,Z"
 	exit 1
 fi
 export ANSIBLE_LOG_PATH="$XSCE_DIR/iiab-debug.log"


### PR DESCRIPTION
Per @jvonau "It used to be spaces, and XXX would return a list of tags but now use ./runtags cups,elgg,dokuwiki and XXX is broken."