### PR TITLE
9/7/17 version of raspbian -- reverse fixes for flawed August stretch raspbian

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi_2.yml
+++ b/roles/1-prep/tasks/raspberry_pi_2.yml
@@ -59,11 +59,11 @@
   service: name=iiab-rpi-root-resize
            enabled=yes
 
-- name: substitute jessie wifi driver on raspbian-9 workaround
-  get_url: url={{ iiab_download_url }}/{{ item }}
-           dest=/lib/firmware/brcm/
-           force=yes
-  with_items:
-           - brcmfmac43430-sdio.bin
-           - brcmfmac43430-sdio.txt
-  when:  ansible_local.local_facts.os_ver  == "raspbian-9"
+#- name: substitute jessie wifi driver on raspbian-9 workaround
+#  get_url: #url={{ iiab_download_url }}/{{ item }}
+#           dest=/lib/firmware/brcm/
+#           force=yes
+#  with_items:
+#           - brcmfmac43430-sdio.bin
+#           - brcmfmac43430-sdio.txt
+#  when:  ansible_local.local_facts.os_ver  == "raspbian-9"

--- a/roles/1-prep/tasks/raspberry_pi_2.yml
+++ b/roles/1-prep/tasks/raspberry_pi_2.yml
@@ -32,9 +32,6 @@
   with_items:
     - ntp
 
-- name: disable the renaming of eth0
-  shell: sed -i -e 's/deadline fsck/deadline  net.ifnames=0 fsck/' /boot/cmdline.txt
-
 - name: increase the swap file size (kalite pip download fails)
   lineinfile: regexp="^CONF_SWAPSIZE"
               line=CONF_SWAPSIZE=500
@@ -59,11 +56,3 @@
   service: name=iiab-rpi-root-resize
            enabled=yes
 
-#- name: substitute jessie wifi driver on raspbian-9 workaround
-#  get_url: #url={{ iiab_download_url }}/{{ item }}
-#           dest=/lib/firmware/brcm/
-#           force=yes
-#  with_items:
-#           - brcmfmac43430-sdio.bin
-#           - brcmfmac43430-sdio.txt
-#  when:  ansible_local.local_facts.os_ver  == "raspbian-9"

--- a/runansible
+++ b/runansible
@@ -56,8 +56,10 @@ fi
 if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
    mkdir -p /etc/ansible/facts.d
 fi
-cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
+
+function dummy{
+cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 # raspbian-9 changes network interface names to include mac address
 # which defeats copying an image from one SD card to another
 raspbian_ver=`./scripts/local_facts.fact|grep os_ver|awk -F '"' '{print $4}'`
@@ -72,6 +74,7 @@ if [ "$raspbian_ver" == "raspbian-9" ]; then
        reboot
    fi
 fi
+}
 
 PLAYBOOK="iiab.yml"
 INVENTORY="ansible_hosts"

--- a/runansible
+++ b/runansible
@@ -57,9 +57,9 @@ if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
    mkdir -p /etc/ansible/facts.d
 fi
 
-
-function dummy{
 cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
+
+function dummy(){
 # raspbian-9 changes network interface names to include mac address
 # which defeats copying an image from one SD card to another
 raspbian_ver=`./scripts/local_facts.fact|grep os_ver|awk -F '"' '{print $4}'`

--- a/runansible
+++ b/runansible
@@ -59,23 +59,6 @@ fi
 
 cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
-function dummy(){
-# raspbian-9 changes network interface names to include mac address
-# which defeats copying an image from one SD card to another
-raspbian_ver=`./scripts/local_facts.fact|grep os_ver|awk -F '"' '{print $4}'`
-if [ "$raspbian_ver" == "raspbian-9" ]; then
-   grep net.ifnames=0 /boot/cmdline.txt
-   if [ $? -ne 0 ]; then
-       sed -i -r 's/deadline +fsck/deadline net.ifnames=0 fsck/' /boot/cmdline.txt
-       echo
-       echo "Kernel cmdline changed. Will now reboot so that network interface names will"
-       echo "  be same for all raspberry pi\'s. Hit enter, and then restart this script"
-       read var
-       reboot
-   fi
-fi
-}
-
 PLAYBOOK="iiab.yml"
 INVENTORY="ansible_hosts"
 CWD=`pwd`


### PR DESCRIPTION
I can confirm that the wifi functions in AP  mode, and that removal of workarounds for August still works.
This has been tested on rpi3, using Adam's medium local_vars. Interface names returned to previous -- eth0 and wlan0.