### PR TITLE
remove "OS not supported" broken conditional

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -3,10 +3,6 @@
     is_F18: True
   when: ansible_distribution_release == "based on Fedora 18" or ansible_distribution_version == "18"
 
-- name: abort if the OS is not supported
-  debug: msg="{{ ansible_local.local_facts.os }} Operating System is not supported"
-  failed_when: ansible_local.local_facts.os_ver == "OS_not_supported"
-
 - name: get the uuidgen program
   package: name=uuid-runtime
            state=present


### PR DESCRIPTION
This (flawed) error msg is universally deceptive/distracting to new installers.

Exact language is "Operating System is not supported" -- @georgejhunt believes the entire 3 lines are erroneous and can be removed.