### PR TITLE
WordPress 4.8.1 instead of 4.8

### DIFF
--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -1,4 +1,4 @@
-wordpress_src: wordpress-4.8.tar.gz
+wordpress_src: wordpress-4.8.1.tar.gz
 wp_db_name: iiab_wp
 wp_db_user: iiab_wp
 wp_db_user_password: changeme


### PR DESCRIPTION
In preparation for IIAB 6.4 release.