### PR TITLE
workaround enables WordPress playbook offline

### DIFF
--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -5,6 +5,7 @@
 
 - name: Copy it to permanent location /library
   unarchive: src={{ wp_download_output.dest }}  dest=/library
+  when: internet_available
 
 - name: Rename /library/wordpress* to /library/wordpress
   shell: if [ ! -d {{ wp_abs_path }} ]; then mv {{ wp_abs_path }}* {{ wp_abs_path }}; fi


### PR DESCRIPTION
For #293 (it's time to stop hosting WordPress at download.iiab.io)

Smoke-tested on RPi3.