### PR TITLE
centos pip does not have option disable-pip-version-check

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -14,7 +14,7 @@
   pip: requirements={{ pip_packages_dir }}/kalite.txt
        virtualenv={{ kalite_venv }}
        virtualenv_site_packages=no
-       extra_args="--disable-pip-version-check"
+#       extra_args="--disable-pip-version-check"
   when: internet_available 
 
 - name: Install ka-lite with pip
@@ -22,7 +22,7 @@
        version={{ kalite_version }}
        virtualenv={{ kalite_venv }}
        virtualenv_site_packages=no
-       extra_args="--disable-pip-version-check"
+#       extra_args="--disable-pip-version-check"
   when: internet_available 
 
 - name: Default is to have cronserve started with kalite


### PR DESCRIPTION
required to get a successful ansible run on centos
smoke tested