### PR TITLE
update kiwix-tools_linux64 2017-09-27 to 2017-09-28

### DIFF
--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Set kiwix source file name x86_64
   set_fact:
-     kiwix_src_file: "kiwix-tools_linux64_2017-09-27.tar.gz"
+     kiwix_src_file: "kiwix-tools_linux64_2017-09-28.tar.gz"
      kiwix_src_bin_only: True
   when: ansible_machine == "x86_64"
 


### PR DESCRIPTION
Trying to keep "big iron school server" PC's (linux64) in sync with RPi (armhf), so that kiwix-tools functionality is hopefully the same across both &mdash; i.e. all IIAB 6.4 installations will likely run kiwix-tools from 2017-09-28 if this version proves solid.