### PR TITLE
Fixing broken symlink

### DIFF
--- a/roles/httpd/templates/iiab-console.conf.j2
+++ b/roles/httpd/templates/iiab-console.conf.j2
@@ -1,1 +1,0 @@
-/opt/schoolserver/xsce/roles/xsce-admin/templates/console/xs-console.conf.j2


### PR DESCRIPTION
Perhaps xsce-admin is renamed to iiab-admin-console. Fixing bug #348 with new symlink. 


 "ln -sf /opt/iiab/iiab-admin-console/roles/console/templates/admin-console.conf.j2 iiab-console.conf.j2 "