### PR TITLE
IIAB Travis CI Testing Implementation (Fixes #386)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible, ansible-lint and ansible-review
+  - pip install ansible
+  - pip install ansible-review
+
+  # Check ansible,  version
+  - ansible --version
+  - ansible-lint --version
+  - ansible-review --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Continuous integration: syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check -vvv
+
+  # Continous integration: ansible-list
+  - ansible-lint -p *yml
+
+  #  Continous integration: ansible code review
+  - git ls-files *yml roles/ vars/ tests/  | xargs ansible-review
+
+  # Continouse integration: ansible code review of changes between master and current branch
+  - git diff master | ansible-review
+
+
+#notifications:
+#  webhooks:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Internet-in-a-Box (IIAB)
+# Internet-in-a-Box (IIAB) [![Build Status](https://travis-ci.org/iiab/iiab/iiab.svg?branch=master)](https://travis-ci.org/iiab/iiab)
 
 Welcome to the Git repository of the Internet-in-a-Box (IIAB) project. This is a community-based project developed and supported by volunteers from around the world. The Internet-in-a-Box (IIAB) is small, inexpensive device which provides essential Internet resources (like Wikipedia, OpenStreetMap, Khan Academy and others) without any Internet connection. It provides a local content server of the world’s Free Knowledge.
 

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -77,7 +77,7 @@
   file: path=/etc/apache2/sites-enabled/022-moodle.conf
         src=/etc/apache2/sites-available/022-moodle.conf
         state=link
-  when: moodle_enabled and is_debuntu	
+  when: moodle_enabled and is_debuntu
 
 - name: Disable moodle
   file: path=/etc/apache2/sites-enabled/022-moodle.conf

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,61 @@
+---
+- hosts: localhost
+  remote_user: root
+  # TODO: Making a anisble-iiab roles for ansible-galaxy
+  #  roles:
+  #      - iiab
+  # For now hardcoding all the roles manually with  ls -l roles/ | cut -d " " -f 10
+  roles:
+    - ../roles/1-prep
+    - ../roles/2-common
+    - ../roles/3-base-server
+    - ../roles/4-server-options
+    - ../roles/5-xo-services
+    - ../roles/6-generic-apps
+    - ../roles/7-edu-apps
+    - ../roles/8-mgmt-tools
+    - ../roles/9-local-addons
+    - ../roles/activity-server
+    - ../roles/ajenti
+    - ../roles/authserver
+    - ../roles/awstats
+    - ../roles/calibre
+    - ../roles/cups
+    - ../roles/debian_schooltool
+    - ../roles/docker
+    - ../roles/dokuwiki
+    - ../roles/ejabberd
+    - ../roles/ejabberd_xs
+    - ../roles/elgg
+    # Disabling gateway doesn't contain any tasks?
+    #- ../roles/gateway
+    - ../roles/httpd
+    - ../roles/idmgr
+    - ../roles/iiab-admin
+    - ../roles/kalite
+    - ../roles/kiwix
+    - ../roles/mongodb
+    - ../roles/monit
+    - ../roles/moodle
+    - ../roles/moodle-1.9
+    - ../roles/munin
+    - ../roles/mysql
+    - ../roles/network
+    - ../roles/nextcloud
+    - ../roles/openvpn
+    - ../roles/osm
+    - ../roles/owncloud
+    - ../roles/pathagar
+    - ../roles/phpmyadmin
+    - ../roles/postgresql
+    - ../roles/rachel
+    - ../roles/samba
+    - ../roles/schooltool
+    - ../roles/sshd
+    - ../roles/sugarizer
+    - ../roles/sugar-stats
+    - ../roles/teamviewer
+    - ../roles/usb-lib
+    - ../roles/vnstat
+    - ../roles/wordpress
+    - ../roles/xovis


### PR DESCRIPTION
This pull request is complete implementation of IIAB Travis CI Testing for syntax errors, code linting and code review. 

Adds: Top level .travis.yml file. Add 'tests' directory with a 'inventory' and 'tests.yml' files. 

Modifies:  roles/moodle/tasks/main.yml to fix ansible-lint parsing problem. 

Modifies: README.md to add Build status button 
This is Git squash of many commits. Please look at individual commit message for the content changes. 

Creating an initial travis testing based on Jeff Geerling's testing ansible methodology

https://www.jeffgeerling.com/blog/testing-ansible-roles-travis-ci-github
Adding Ansible-lint, Ansible-review tests to travis


Added ansible-review for full repo and diff master


Removing ansible-lint install step, it automatically installed by ansible-review

Ansible-review only .yml files in root and  roles, vars, tests folders

Updated comments

Corrected ansible-lint parameters

Removed extraneous tab that breaks ansible-lint

Removed a tab character that causes problems with ansible-lint 

See https://github.com/willthames/ansible-lint/issues/166
Fixing Travis Ansible Syntax tests roles path

The ansible roles path had problems due: 
1. Absence of top level global role 'iiab' 
2. Hardcoded paths '/etc/iiab' in ansible.cfg 

Fixing them in a hacky way. :(
Adding Travis Build status to Readme file