### PR TITLE
Disable pip caching for osm (Fixes #385)

### DIFF
--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -27,14 +27,14 @@
        virtualenv={{ osm_venv }}
        virtualenv_site_packages=no
        version=2.6
-       extra_args="--disable-pip-version-check"
+       extra_args="--disable-pip-version-check --no-cache-dir"
   when: internet_available
 
 - name: Install IIAB with dependencies
   pip: name={{ item }}
        virtualenv={{ osm_venv }}
        virtualenv_site_packages=no
-       extra_args="--disable-pip-version-check"
+       extra_args="--disable-pip-version-check --no-cache-dir"
   with_items:
     - MarkupSafe
     - pytz


### PR DESCRIPTION
Disabling caching with '--no-cache-dir" for OSM pip installs.

@holta @jvonau  Please kindly review this PR. 