### PR TITLE
Fix octal permissions warnings in Travis CI

### DIFF
--- a/roles/kalite/tasks/install-f18.yml
+++ b/roles/kalite/tasks/install-f18.yml
@@ -52,7 +52,7 @@
             dest="{{ kalite_root }}/kalite/local_settings.py"
             owner={{ kalite_user }}
             group={{ kalite_user }}
-            mode=644
+            mode=0644
 
 - name: Create kalite service(s) and support scripts
   template: backup=no

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -31,7 +31,7 @@
             dest=/etc/avahi/services/schoolserver.service
             owner=avahi
             group=avahi
-            mode=640
+            mode=0640
   when: 'gui_wan == True'
 
 - name: Find a clean copy of ssh.service

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -6,7 +6,7 @@
   user: name="{{ smbuser }}" shell=/sbin/nologin password="{{ smbpassword }}"
 
 - name: create the public folder
-  file: dest="{{ shared_dir }}" owner="{{ smbuser }}" group="{{ smbuser }}" mode=777 state=directory
+  file: dest="{{ shared_dir }}" owner="{{ smbuser }}" group="{{ smbuser }}" mode=0777 state=directory
 
 # Install and configure samba server (requires ports 137, 138, 139, 445 open).
 - name: Ensure Samba-related packages are installed.


### PR DESCRIPTION
Simple fix to remove octal warnings  "[EANSIBLE0009] Octal file permissions must contain leading zero" in Travis CI tests. 

Files modified: 
 roles/kalite/tasks/install-f18.yml  
 roles/network/tasks/avahi.yml     
 roles/samba/tasks/main.yml         
