### PR TITLE
Nodejs 6.X - npm is not available standalone

### DIFF
--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -12,20 +12,24 @@
         src={{ sugarizer_location }}/{{ sugarizer_version }}
         state=link
 
+- name: Set up apt sources on is_debuntu
+  shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
+  when: internet_available and is_debuntu
+
 - name: Install sugarizer required packages - is_debuntu
   package: name={{ item }}
            state=present
-  with_items:
-    - node-gyp
   when: internet_available and is_debuntu
+  with_items:
+    - nodejs
 
 - name: Install npm non is_debuntu
   package: name={{ item }}
            state=present
+  when: internet_available and not is_debuntu
   with_items:
     - nodejs
     - npm
-  when: internet_available and not is_debuntu
 
 # attempting to reinstall npn is broken on raspbian 9
 - name: check for sugarizer already installed
@@ -36,18 +40,6 @@
   set_fact:
      npm_exists: True
   when: npm.stat.exists is defined and npm.stat.exists
-
-- name: Set up apt sources on is_debuntu
-  shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
-  when: internet_available and is_debuntu
-
-- name: Actually get it installed on is_debuntu
-  package: name={{ item }}
-           state=present
-  with_items:
-    - nodejs
-    - npm
-  when: internet_available and is_debuntu
 
 - name: Create systemd files and copy our ini file 
   template: src={{ item.src }}


### PR DESCRIPTION
Think would be better to install /etc/apt/sources.list.d/nodesource.list and the needed key in 2-common or move the curl script to 2 common so any other NEW nodejs apps will used a common 6.X starting point.