### PR TITLE
Postgresql_db attributed corrected: 'db', 'sudo' and 'sudo_user'

### DIFF
--- a/roles/sugar-stats/tasks/statistics-consolidation.yml
+++ b/roles/sugar-stats/tasks/statistics-consolidation.yml
@@ -34,9 +34,9 @@
   become_user: postgres
 
 - name: Create postgres database
-  postgresql_db: db=statsconso owner=statsconso
-  sudo: yes
-  sudo_user: postgres
+  postgresql_db: name=statsconso owner=statsconso
+  become: yes
+  become_user: postgres
 
 - name: Install conf file
   template: backup=yes


### PR DESCRIPTION
This corrects the following warnings: 

 [WARNING]: Ignoring invalid attribute: sudo_user
 [WARNING]: Ignoring invalid attribute: sudo

Modifies:  roles/sugar-stats/tasks/statistics-consolidation.yml

Refer: 
http://docs.ansible.com/ansible/latest/postgresql_db_module.html

Smoked tested on Travis CI and Debian 9.2 