### PR TITLE
use Ansible to pin nodejs to 6.x (curl was not suffic on Raspbian Desktop)

### DIFF
--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -16,12 +16,10 @@
   shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
   when: internet_available and is_debuntu
 
-- name: Install sugarizer required packages - is_debuntu
-  package: name={{ item }}
+- name: Install nodejs=6.* which also installs npm - is_debuntu
+  package: name=nodejs=6.*
            state=present
   when: internet_available and is_debuntu
-  with_items:
-    - nodejs
 
 - name: Install npm non is_debuntu
   package: name={{ item }}

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -31,7 +31,7 @@
     - nodejs
     - npm
 
-# attempting to reinstall npn is broken on raspbian 9
+# attempting to reinstall npm is broken on raspbian 9
 - name: check for sugarizer already installed
   stat: path={{ sugarizer_location }}/sugarizer/server/node_modules
   register: npm

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -16,7 +16,7 @@
   shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
   when: internet_available and is_debuntu
 
-- name: Install nodejs=6.* which also installs npm - is_debuntu
+- name: Install nodejs=6.* which includes /usr/bin/npm - is_debuntu
   package: name=nodejs=6.*
            state=present
   when: internet_available and is_debuntu


### PR DESCRIPTION
@jvonau please help me review this, in case it can be tightened up further per https://github.com/iiab/iiab/issues/432#issuecomment-338193790 (towards hopefully finalizing Sugarizer's installation routine At Long Last!)