### PR TITLE
Proposed fix for OSM issue #448

### DIFF
--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -73,7 +73,7 @@
 
 - name: All - Point wsgi to virtual environment
   lineinfile: dest={{ osm_venv }}/bin/iiab.wsgi
-              regexp="path_to_virtualenv*"
+              regexp="path_to_virtualenv = None"
               line="path_to_virtualenv = '/usr/local/osm'"
               state=present
 

--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -71,6 +71,12 @@
      osm_path: "{{ osm_venv }}/lib/python2.7/site-packages/iiab"
   when: osm_enabled and is_debuntu
 
+- name: All - Point wsgi to virtual environment
+  lineinfile: dest={{ osm_venv }}/bin/iiab.wsgi
+              regexp='path_to_virtualenv*'
+              line='path_to_virtualenv = /usr/local/osm'
+              state=present
+
 - name: All - Copy IIAB config file
   template: backup=no
             src=osm.conf.j2

--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -73,8 +73,8 @@
 
 - name: All - Point wsgi to virtual environment
   lineinfile: dest={{ osm_venv }}/bin/iiab.wsgi
-              regexp='path_to_virtualenv*'
-              line='path_to_virtualenv = /usr/local/osm'
+              regexp="path_to_virtualenv*"
+              line="path_to_virtualenv = '/usr/local/osm'"
               state=present
 
 - name: All - Copy IIAB config file


### PR DESCRIPTION
Might need full path ie {{ osm_path }} in place of {{ osm_venv }}
With the push by the distros to python3 we took the step to use virtual
environments to better contain python 2.7 based programs.