### PR TITLE
Add PR template and Bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+### Expected behavior and actual behavior.
+
+### Steps to reproduce the problem.
+
+### Specifications like the version of the IIAB, operating system version, or hardware details.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+# Fixes Bug
+
+# Description of changes proposed in this pull request.
+
+# Smoke-tested in operating system.
+
+# Mention a team member for further information or comment using @ name

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-# Fixes Bug
+### Fixes Bug
 
-# Description of changes proposed in this pull request.
+### Description of changes proposed in this pull request.
 
-# Smoke-tested in operating system.
+### Smoke-tested in operating system.
 
-# Mention a team member for further information or comment using @ name
+### Mention a team member for further information or comment using @ name


### PR DESCRIPTION
Adding PR template and Bug template under .github directory. These files will be picked up by the github.com interface.  Fixes #390 #391