### PR TITLE
restart kiwix-serve 4AM nightly (not 15min after every hour) & restrict chown to /opt/iiab/kiwix

### DIFF
--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -75,15 +75,15 @@
   command: "chown -R root:root {{ iiab_base }}"
 
 # workaround because kiwix-serve does not stay running
-- name: Make an entry in crontab to restart every hour
+- name: Make an entry in crontab to restart at 4AM
 # *  *  *  *  * user-name  command to be executed
-  lineinfile: line="15 *  *  *  * root /bin/systemctl restart kiwix-serve.service"
+  lineinfile: line="0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
               dest=/etc/crontab
   when: is_debuntu
 
-- name: Make an entry in crontab to restart every hour
+- name: Make an entry in crontab to restart at 4AM
 # *  *  *  *  * user-name  command to be executed
-  lineinfile: line="15 *  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
+  lineinfile: line="0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
               dest=/etc/crontab
   when: is_redhat
 

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -71,8 +71,8 @@
   when: kiwix_src_bin_only and kiwix_first_pass
 
 # workaround because unarchive does not set ownership properly
-- name: "Set Kiwix ownership - WARNING 'chown -R root:root' runs across all of /opt/iiab"
-  command: "chown -R root:root {{ iiab_base }}"
+- name: "Set ownership: 'chown -R root:root /opt/iiab/kiwix'"
+  command: "chown -R root:root {{ iiab_base }}/kiwix"
 
 # workaround because kiwix-serve does not stay running
 - name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -1,4 +1,4 @@
-- name: Create various directories for ZIM files
+- name: Create various directories for Kiwix's ZIM files
   file: path={{ item }}
         owner=root
         group=root
@@ -9,11 +9,11 @@
     - "{{ kiwix_content_path }}"
     - "{{ iiab_zim_path }}/index"
 
-- name: Check for kiwix-serve binary
+- name: Check for 'kiwix-serve' binary
   stat: path={{ iiab_base }}/kiwix/bin/kiwix-serve
   register: kiwix_bin
 
-- name: Set kiwix first pass
+- name: Set kiwix_first_pass
   set_fact:
     kiwix_first_pass: True
   when: kiwix_bin.stat.exists is defined and not kiwix_bin.stat.exists
@@ -47,7 +47,7 @@
              group=root
   when: not kiwix_src_bin_only and kiwix_first_pass
 
-- name: Create directory for kiwix bin
+- name: Create kiwix/bin directory
   file: path="{{ iiab_base }}/kiwix/bin"
         owner=root
         group=root
@@ -63,7 +63,7 @@
     - rewrite
   when: is_debuntu
 
-- name: Unarchive it to permanent location - bin only
+- name: Unarchive Kiwix to permanent location - bin only
   unarchive: src="{{ downloads_dir }}/{{ kiwix_src_file }}"
              dest="{{ iiab_base }}/kiwix/bin"
              owner=root
@@ -71,17 +71,17 @@
   when: kiwix_src_bin_only and kiwix_first_pass
 
 # workaround because unarchive does not set ownership properly
-- name: Set kiwix ownership to root [WARNING chown -R across all of /opt/iiab]
+- name: "Set Kiwix ownership - WARNING 'chown -R root:root' runs across all of /opt/iiab"
   command: "chown -R root:root {{ iiab_base }}"
 
 # workaround because kiwix-serve does not stay running
-- name: Make an entry in crontab to restart at 4AM
+- name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
 # *  *  *  *  * user-name  command to be executed
   lineinfile: line="0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
               dest=/etc/crontab
   when: is_debuntu
 
-- name: Make an entry in crontab to restart at 4AM
+- name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
 # *  *  *  *  * user-name  command to be executed
   lineinfile: line="0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
               dest=/etc/crontab
@@ -89,7 +89,7 @@
 
 # Create kiwix service
 
-- name: Create kiwix-serve service
+- name: Create 'kiwix-serve' service
   template: backup=no
             src={{ item.src }}
             dest={{ item.dest }}
@@ -105,7 +105,7 @@
     - { src: 'iiab-make-apache-config.py', dest: '/usr/bin/iiab-make-apache-config.py', mode: '0755'}
 
 
-- name: Add kiwix-serve to list of services
+- name: Add 'kiwix-serve' to list of services
   ini_file: dest='{{ service_filelist }}'
             section=kiwix-serve
             option='{{ item.option }}'
@@ -130,13 +130,13 @@
     - option: enabled
       value: "{{ kiwix_enabled }}"
 
-- name: Enable kiwix-serve service
+- name: Enable 'kiwix-serve' service
   service: name=kiwix-serve
            enabled=yes
            state=restarted
   when: kiwix_enabled
 
-- name: Disable kiwix-serve service
+- name: Disable 'kiwix-serve' service
   service: name=kiwix-serve
            enabled=no
            state=stopped


### PR DESCRIPTION
This is a proposed solution to #484 — full-text searching across all ZIMs breaks (& cached results are wiped) "15min into every lesson".

Not yet smoke-tested.