### PR TITLE
vnstat - guard against iiab_lan_iface not defined in Appliance Mode

### DIFF
--- a/roles/vnstat/tasks/main.yml
+++ b/roles/vnstat/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Create database for LAN to collect vnStat data if not appliance config
   shell: /usr/bin/vnstat -i {{ iiab_lan_iface }}
-  when: not iiab_lan_iface == ""
+  when: iiab_lan_iface is defined
 
 - name: Start vnStat daemon via systemd
   service: name=vnstat enabled=yes state=started


### PR DESCRIPTION
### Fixes Bug
#488 
### Description of changes proposed in this pull request.
see diff
### Smoke-tested in operating system.
seen in vm testing

discuss in meeting 
