### PR TITLE
kalite static only

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -10,11 +10,10 @@
   get_url: url={{ kalite_requirements }} dest={{ pip_packages_dir }}/kalite.txt
   when: internet_available
 
-#- name: Install KA Lite devel with pip - (debuntu)
+#- name: Install KA Lite non-static + reqs file with pip - (debuntu)
 #  pip: requirements={{ pip_packages_dir }}/kalite.txt
 #       virtualenv={{ kalite_venv }}
 #       virtualenv_site_packages=no
-#       extra_args="--no-cache-dir"
 #       extra_args="--no-cache-dir"
 #       extra_args="--disable-pip-version-check"
 #  when: internet_available and is_debuntu
@@ -25,11 +24,10 @@
        virtualenv={{ kalite_venv }}
        virtualenv_site_packages=no
        extra_args="--no-cache-dir"
-#       extra_args="--no-cache-dir"
 #       extra_args="--disable-pip-version-check"
   when: internet_available and is_debuntu
 
-#- name: Install KA Lite devel with pip - (OS's other than debuntu)
+#- name: Install KA Lite non-static + reqs file with pip - (OS's other than debuntu)
 #  pip: requirements={{ pip_packages_dir }}/kalite.txt
 #       virtualenv={{ kalite_venv }}
 #       virtualenv_site_packages=no

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -10,16 +10,16 @@
   get_url: url={{ kalite_requirements }} dest={{ pip_packages_dir }}/kalite.txt
   when: internet_available
 
-- name: Install KA Lite dependencies with pip (debuntu)
-  pip: requirements={{ pip_packages_dir }}/kalite.txt
-       virtualenv={{ kalite_venv }}
-       virtualenv_site_packages=no
-       extra_args="--no-cache-dir"
+#- name: Install KA Lite devel with pip - (debuntu)
+#  pip: requirements={{ pip_packages_dir }}/kalite.txt
+#       virtualenv={{ kalite_venv }}
+#       virtualenv_site_packages=no
+#       extra_args="--no-cache-dir"
 #       extra_args="--no-cache-dir"
 #       extra_args="--disable-pip-version-check"
-  when: internet_available and is_debuntu
+#  when: internet_available and is_debuntu
 
-- name: Install KA Lite with pip (debuntu) 
+- name: Install KA Lite static with pip - (debuntu)
   pip: name=ka-lite-static
        version={{ kalite_version }}
        virtualenv={{ kalite_venv }}
@@ -29,15 +29,15 @@
 #       extra_args="--disable-pip-version-check"
   when: internet_available and is_debuntu
 
-- name: Install KA Lite dependencies with pip (debuntu)
-  pip: requirements={{ pip_packages_dir }}/kalite.txt
-       virtualenv={{ kalite_venv }}
-       virtualenv_site_packages=no
+#- name: Install KA Lite devel with pip - (OS's other than debuntu)
+#  pip: requirements={{ pip_packages_dir }}/kalite.txt
+#       virtualenv={{ kalite_venv }}
+#       virtualenv_site_packages=no
 #       extra_args="--no-cache-dir"
 #       extra_args="--disable-pip-version-check"
-  when: internet_available and not is_debuntu
+#  when: internet_available and not is_debuntu
 
-- name: Install KA Lite with pip (OS's other than debuntu)
+- name: Install KA Lite static with pip - (OS's other than debuntu)
   pip: name=ka-lite-static
        version={{ kalite_version }}
        virtualenv={{ kalite_venv }}


### PR DESCRIPTION
### Fixes Bug
Needing removal of /etc/pip.conf, needs further confirmation on clean test with /etc/pip.conf intact.
### Description of changes proposed in this pull request.
just run static libs
### Smoke-tested in operating system.
jenkins /job/IIAB-debian-jvonau/126/console
![jenkins-kalite-static-test](https://user-images.githubusercontent.com/5579710/32532919-2452ff46-c413-11e7-816e-3fda91ab8986.png)

jenkins job/iiab-CentOS-jv/75/console installed clean but install exited for other reasons
### Mention a team member for further information or comment using @ name
