### PR TITLE
set iiab_lan_iface to none if no discovered interfaces found

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -17,8 +17,6 @@ iiab_lan_iface: "none"
 #discovered_lan_iface: "none"
 discovered_wired_iface: "none"
 discovered_wireless_iface: "none"
-#iiab_wired_lan_iface: "none"
-#iiab_wireless_lan_iface: "none"
 
 #Redhat
 has_WAN: False

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -166,6 +166,11 @@
       iiab_lan_iface: "{{ iiab_wireless_lan_iface }}"
   when: iiab_wireless_lan_iface is defined and nobridge is defined
 
+- name: Disabling LAN as only single interface found
+  set_fact:
+      iiab_lan_iface: none
+  when: not iiab_wireless_lan_iface is defined and not iiab_wired_lan_iface is defined
+
 - name: in VM disable LAN - needs local_vars entry to activate
   set_fact:
       iiab_lan_iface: none


### PR DESCRIPTION
### Fixes Bug
#504 single interface detected as gateway mode
### Description of changes proposed in this pull request.

### Smoke-tested in operating system.
If the is_VM workaround is successful this should be the fix.
### Mention a team member for further information or comment using @ name
