### PR TITLE
iiab-install: checks Ansible version & explains what it's doing

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -2,15 +2,14 @@
 # running from a git repo
 # Add cmdline options for passing to ansible
 # todo add proper shift to gobble up --debug --reinstall
-ARGS=""
-OLD_RPI_KERN="4.9.41-v7+"
 PLAYBOOK="iiab-stages.yml"
 INVENTORY="ansible_hosts"
+ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-
-function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+MIN_RPI_KERN=4.9.59-v7+
+MIN_ANSIBLE_VER=2.4.1.0
 
 export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
 
@@ -20,17 +19,35 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-if [ $OS == "raspbian" ]; then
-    echo "Found Raspbian"
-    CURRENT_KERN=`uname -r`
-    if version_gt $CURRENT_KERN $OLD_RPI_KERN ; then
-    	echo "Kernel looks ok - continuing"
-    else
-	echo "Kernel "$CURRENT_KERN" is too old. Before running './iiab-install' you first need"
-	echo "to update your system with 'apt update' then 'apt dist-upgrade' then reboot."
-	echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
-	exit 1
-    fi
+# Subroutine compares software version numbers. Generates rare false positives
+# like "1.0 > 1" and "2.4.0 > 2.4". Avoid risks by structuring conditionals w/
+# a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
+function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+
+# Verify that Raspbian is running a recent enough kernel.  As Raspbian
+# updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.
+CURR_KERN=`uname -r`
+echo "Found Kernel "$CURR_KERN""
+if [ $OS == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN; then
+    echo "Kernel "$MIN_RPI_KERN" or higher requires on Raspbian."
+    echo "Please run 'apt update' then 'apt install raspberrypi-kernel' then reboot."
+    echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
+    exit 1
+fi
+
+# Verify that a recent enough version of Ansible is installed. See #449. The
+# "include:" command was inconsistently implemented prior to Ansible 2.4.x.x
+CURRENT_ANSIBLE_VER=0
+if [[ `type -P ansible` ]]; then
+    CURRENT_ANSIBLE_VER=`ansible --version | head -1 | sed -e 's/.* //'`
+    echo "Found Ansible "$CURRENT_ANSIBLE_VER""
+fi
+if version_gt $MIN_ANSIBLE_VER $CURRENT_ANSIBLE_VER; then
+    echo "IIAB requires Ansible "$MIN_ANSIBLE_VER" or higher.  Prior versions can often"
+    echo "be removed with 'apt purge ansible' or 'pip uninstall ansible'.  We recommend"
+    echo "you run './scripts/ansible' to install the latest Ansible from PPA or RPM."
+    echo "'apt -a list ansible' can also sometimes be useful to show options!"
+    exit 1
 fi
 
 if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
@@ -38,37 +55,34 @@ if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
 fi
 cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
-STAGE=""
-
+# Stage 0 will always be run.  From there on up to Stage 9 we keep a counter
+# (in /etc/iiab/iiab.env) of the highest completed Stage.  Avoid repetition!
+STAGE=0
 if [ ! -f /etc/iiab/iiab.env ]; then
     mkdir -p /etc/iiab
-    # ./scripts/ansible   # needs discussion
 else
-    OLD=`grep XSCE /etc/iiab/iiab.env | wc -l`
-    if [ "$OLD" != 0 ] || [ "$1" == "--reinstall" ]; then
-        echo "All IIAB install Stages 0-9 will now be run."
+    if [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
         rm /etc/iiab/iiab.env
-        # check ansible version here and force ansible upgrade if needed
+        echo "Deleted /etc/iiab/iiab.env"
     else
-        source /etc/iiab/iiab.env
         if [ "$1" == "--debug" ]; then
-            echo "Entering debug mode"
-            sed -i -e 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
-        elif [ ! $STAGE == 9 ]; then
-            echo "Restarting *after* STAGE $STAGE..as soon as Stage 0 completes. Stage 9 comes last."
-        elif [ $STAGE == 9 ]; then
-            # place keeper add read response
-            # "offer 'Y' or stage number dialog box option to override"
-            echo "'iiab-install' has already been completed."
-            echo "Use --debug to override."
-            #echo "In demo mode not preventing second run"
-            echo "Exiting."
+            sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
+            echo "Wrote STAGE=2 to /etc/iiab/iiab.env"
+        fi
+        source /etc/iiab/iiab.env
+        echo "Extracted STAGE counter from /etc/iiab/iiab.env"
+        if [ $STAGE == 9 ]; then
+            echo "Exiting: 'iiab-install' already completed, according to /etc/iiab/iiab.env"
+            echo "Use 'iiab-install --reinstall' to run all Stages 0-9."
+            echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
+            echo "Use './runtags' to run a single Stage or Tag or Role."
             exit 1
         fi
     fi
 fi
 
-# if vars/local_vars.yml is missing, put a default one in place - First Run
+# If vars/local_vars.yml is missing, put a default one in place.
+# See MIN/MEDIUM/BIG options @ http://wiki.iiab.io/local_vars.yml
 if [ ! -f ./vars/local_vars.yml ]; then
     case $OS in
         OLPC | fedora)
@@ -78,12 +92,14 @@ if [ ! -f ./vars/local_vars.yml ]; then
             cp ./vars/medium.localvars ./vars/local_vars.yml
             ;;
         *)
-            echo "IIAB supports raspbian, debian, ubuntu, centos, and OLPC - exiting now..."
+            echo "IIAB requires raspbian, debian, ubuntu, centos or OLPC/fedora - exiting now..."
             exit 1
             ;;
     esac
 fi
 
-echo "Running local playbooks!"
+echo -e "\nTRY TO RERUN './iiab-install' IF IT FAILS DUE TO CONNECTIVITY ISSUES ETC!"
+echo -e "\nRunning local playbooks....Stage 0 will now run....followed by Stages $(($STAGE + 1))-9"
+
 ansible -m setup -i $INVENTORY localhost --connection=local >> /dev/null
 ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local

--- a/iiab-install
+++ b/iiab-install
@@ -47,7 +47,7 @@ if [ ! -f /etc/iiab/iiab.env ]; then
 else
     OLD=`grep XSCE /etc/iiab/iiab.env | wc -l`
     if [ "$OLD" != 0 ] || [ "$1" == "--reinstall" ]; then
-        echo "Found old XSCE install - re-installing from scratch"
+        echo "All IIAB install Stages 0-9 will now be run."
         rm /etc/iiab/iiab.env
         # check ansible version here and force ansible upgrade if needed
     else

--- a/iiab-install
+++ b/iiab-install
@@ -29,7 +29,7 @@ function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ];
 CURR_KERN=`uname -r`
 echo "Found Kernel "$CURR_KERN""
 if [ $OS == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN; then
-    echo "Kernel "$MIN_RPI_KERN" or higher required on Raspbian."
+    echo "Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
     echo "Please run 'apt update' then 'apt install raspberrypi-kernel' then reboot."
     echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1

--- a/iiab-install
+++ b/iiab-install
@@ -37,12 +37,12 @@ fi
 
 # Verify that a recent enough version of Ansible is installed.  See #449.  The
 # "include:" command was inconsistently implemented prior to Ansible 2.4.x.x
-CURRENT_ANSIBLE_VER=0
+CURR_ANSIBLE_VER=0
 if [[ `type -P ansible` ]]; then
-    CURRENT_ANSIBLE_VER=`ansible --version | head -1 | sed -e 's/.* //'`
-    echo "Found Ansible "$CURRENT_ANSIBLE_VER""
+    CURR_ANSIBLE_VER=`ansible --version | head -1 | sed -e 's/.* //'`
+    echo "Found Ansible "$CURR_ANSIBLE_VER""
 fi
-if version_gt $MIN_ANSIBLE_VER $CURRENT_ANSIBLE_VER; then
+if version_gt $MIN_ANSIBLE_VER $CURR_ANSIBLE_VER; then
     echo "IIAB requires Ansible "$MIN_ANSIBLE_VER" or higher.  Prior versions can often"
     echo "be removed with 'apt purge ansible' or 'pip uninstall ansible'.  We recommend"
     echo "you run './scripts/ansible' to install the latest Ansible from PPA or RPM."

--- a/iiab-install
+++ b/iiab-install
@@ -15,9 +15,8 @@ function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ];
 export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
 
 if [ ! -f $PLAYBOOK ]; then
-    echo "IIAB Playbook not found."
-    echo "Please run this command from the top level of the git repo."
-    echo "Exiting."
+    echo "Exiting: IIAB Playbook not found."
+    echo "Please run 'iiab-install' from /opt/iiab/iiab (top level of git repo)."
     exit 1
 fi
 

--- a/iiab-install
+++ b/iiab-install
@@ -19,8 +19,8 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-# Subroutine compares software version numbers. Generates rare false positives
-# like "1.0 > 1" and "2.4.0 > 2.4". Avoid risks by structuring conditionals w/
+# Subroutine compares software version numbers.  Generates rare false positives
+# like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
 # a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
 function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
 
@@ -29,13 +29,13 @@ function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ];
 CURR_KERN=`uname -r`
 echo "Found Kernel "$CURR_KERN""
 if [ $OS == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN; then
-    echo "Kernel "$MIN_RPI_KERN" or higher requires on Raspbian."
+    echo "Kernel "$MIN_RPI_KERN" or higher required on Raspbian."
     echo "Please run 'apt update' then 'apt install raspberrypi-kernel' then reboot."
     echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 fi
 
-# Verify that a recent enough version of Ansible is installed. See #449. The
+# Verify that a recent enough version of Ansible is installed.  See #449.  The
 # "include:" command was inconsistently implemented prior to Ansible 2.4.x.x
 CURRENT_ANSIBLE_VER=0
 if [[ `type -P ansible` ]]; then

--- a/iiab-install
+++ b/iiab-install
@@ -2,6 +2,15 @@
 # running from a git repo
 # Add cmdline options for passing to ansible
 # todo add proper shift to gobble up --debug --reinstall
+
+if [ "$1" != "--debug" ] && [ "$1" != "--reinstall" ] && [ "$1" != "" ]; then
+    echo "Use 'iiab-install' for regular installs, or to continue an install."
+    echo "Use 'iiab-install --reinstall' to force running all Stages 0-9."
+    echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
+    echo "Use './runtags' to run a single Stage or Tag or Role."
+    exit 1
+fi
+
 PLAYBOOK="iiab-stages.yml"
 INVENTORY="ansible_hosts"
 ARGS=""
@@ -14,7 +23,7 @@ MIN_ANSIBLE_VER=2.4.1.0
 export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
 
 if [ ! -f $PLAYBOOK ]; then
-    echo "Exiting: IIAB Playbook not found."
+    echo "EXITING: IIAB Playbook not found."
     echo "Please run 'iiab-install' from /opt/iiab/iiab (top level of git repo)."
     exit 1
 fi
@@ -28,10 +37,10 @@ function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ];
 # updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.
 CURR_KERN=`uname -r`
 echo "Found Kernel "$CURR_KERN""
-if [ $OS == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN; then
-    echo "Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
-    echo "Please run 'apt update' then 'apt install raspberrypi-kernel' then reboot."
-    echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
+if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN; then
+    echo -e "\nEXITING: Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
+    echo "PLEASE RUN 'apt update' then 'apt install raspberrypi-kernel' then reboot."
+    echo "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 fi
 
@@ -43,11 +52,11 @@ if [[ `type -P ansible` ]]; then
     echo "Found Ansible "$CURR_ANSIBLE_VER""
 fi
 if version_gt $MIN_ANSIBLE_VER $CURR_ANSIBLE_VER; then
-    echo "IIAB requires Ansible "$MIN_ANSIBLE_VER" or higher.  Prior versions can often"
-    echo "be removed with 'apt purge ansible' or 'pip uninstall ansible'.  We recommend"
-    echo "you run './scripts/ansible' to install the latest Ansible from PPA or RPM."
-    echo "'apt -a list ansible' can also sometimes be useful to show options!"
-    echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
+    echo -e "\nEXITING: Ansible "$MIN_ANSIBLE_VER" or higher required."
+    echo "PLEASE RUN './scripts/ansible' to install the latest Ansible from PPA or RPM."
+    echo "'ansible --version' and 'apt -a list ansible' can also be useful here.  Try"
+    echo "to remove prior versions with 'apt purge ansible' or 'pip uninstall ansible'."
+    echo "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 fi
 
@@ -55,6 +64,7 @@ if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
     mkdir -p /etc/ansible/facts.d
 fi
 cp ./scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
+echo "Placed /etc/ansible/facts.d/local_facts.fact into position."
 
 # Stage 0 will always be run.  From there on up to Stage 9 we keep a counter
 # (in /etc/iiab/iiab.env) of the highest completed Stage.  Avoid repetition!
@@ -62,38 +72,48 @@ STAGE=0
 if [ ! -f /etc/iiab/iiab.env ]; then
     mkdir -p /etc/iiab
 else
-    if [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
+    source /etc/iiab/iiab.env
+    echo "Extracted STAGE="$STAGE" (counter) from /etc/iiab/iiab.env"
+    if ! [ "$STAGE" -eq "$STAGE" ] 2> /dev/null; then
+        echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is non-integer in /etc/iiab/iiab.env"
+        exit 1
+    elif [ "$STAGE" -lt 1 ] || [ "$STAGE" -gt 9 ]; then
+        echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is out-of-range in /etc/iiab/iiab.env"
+        exit 1
+    elif [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
+        STAGE=0
         rm /etc/iiab/iiab.env
-        echo "Removed /etc/iiab/iiab.env"
-    else
-        if [ "$1" == "--debug" ]; then
-            sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
-            echo "Wrote STAGE=2 to /etc/iiab/iiab.env"
-        fi
-        source /etc/iiab/iiab.env
-        echo "Extracted STAGE counter from /etc/iiab/iiab.env"
-        if [ $STAGE == 9 ]; then
-            echo "Exiting: 'iiab-install' already completed, according to /etc/iiab/iiab.env"
-            echo "Use 'iiab-install --reinstall' to run all Stages 0-9."
-            echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
-            echo "Use './runtags' to run a single Stage or Tag or Role."
-            exit 1
-        fi
+        echo "Removed /etc/iiab/iiab.env effectively resetting STAGE (counter)."
+    elif [ "$STAGE" -ge 2 ] && [ "$1" == "--debug" ]; then
+        STAGE=2
+        sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
+        echo "Wrote STAGE=2 (counter) to /etc/iiab/iiab.env"
+    elif [ "$STAGE" -eq 9 ]; then
+        echo -e "\nEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done."
+        echo "Use 'iiab-install --reinstall' to force running all Stages 0-9."
+        echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
+        echo "Use './runtags' to run a single Stage or Tag or Role."
+        exit 1
     fi
 fi
+if [ "$STAGE" -lt 2 ] && [ "$1" == "--debug" ]; then
+    echo -e "\n'--debug' *ignored* as STAGE (counter) < 2."
+fi
 
-# If vars/local_vars.yml is missing, put a default one in place.
-# See MIN/MEDIUM/BIG options @ http://wiki.iiab.io/local_vars.yml
+# If vars/local_vars.yml is missing, put a default file in place.
 if [ ! -f ./vars/local_vars.yml ]; then
     case $OS in
         OLPC | fedora)
             cp ./vars/olpc.localvars ./vars/local_vars.yml
+            echo -e "\nvars/local_vars.yml created from olpc.localvars defaults."
             ;;
         centos | debian | ubuntu | raspbian)
             cp ./vars/medium.localvars ./vars/local_vars.yml
+            echo -e "\nvars/local_vars.yml created from medium.localvars defaults."
+            echo "See MIN/MEDIUM/BIG options @ http://wiki.iiab.io/local_vars.yml"
             ;;
         *)
-            echo "Exiting: IIAB requires Raspbian, Debian, Ubuntu, CentOS or OLPC/Fedora."
+            echo -e "\nEXITING: IIAB requires Raspbian, Debian, Ubuntu, CentOS or OLPC/Fedora."
             exit 1
             ;;
     esac

--- a/iiab-install
+++ b/iiab-install
@@ -1,13 +1,14 @@
 #!/bin/bash -e
-# running from a git repo
+# Running from a git repo
 # Add cmdline options for passing to ansible
-# todo add proper shift to gobble up --debug --reinstall
+# Todo add proper shift to gobble up --debug --reinstall
 
 if [ "$1" != "--debug" ] && [ "$1" != "--reinstall" ] && [ "$1" != "" ]; then
-    echo "Use 'iiab-install' for regular installs, or to continue an install."
-    echo "Use 'iiab-install --reinstall' to force running all Stages 0-9."
-    echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
+    echo "Use './iiab-install' for regular installs, or to continue an install."
+    echo "Use './iiab-install --reinstall' to force running all Stages 0-9."
+    echo "Use './iiab-install --debug' to run Stage 0, followed by Stages 3-9."
     echo "Use './runtags' to run a single Stage or Tag or Role."
+    echo "Use './iiab-network' to run Network sections."
     exit 1
 fi
 
@@ -72,15 +73,18 @@ STAGE=0
 if [ ! -f /etc/iiab/iiab.env ]; then
     mkdir -p /etc/iiab
 else
-    source /etc/iiab/iiab.env
-    echo "Extracted STAGE="$STAGE" (counter) from /etc/iiab/iiab.env"
-    if ! [ "$STAGE" -eq "$STAGE" ] 2> /dev/null; then
-        echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is non-integer in /etc/iiab/iiab.env"
-        exit 1
-    elif [ "$STAGE" -lt 1 ] || [ "$STAGE" -gt 9 ]; then
-        echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is out-of-range in /etc/iiab/iiab.env"
-        exit 1
-    elif [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
+    if [[ `grep STAGE= /etc/iiab/iiab.env` ]]; then
+        source /etc/iiab/iiab.env
+        echo "Extracted STAGE="$STAGE" (counter) from /etc/iiab/iiab.env"
+        if ! [ "$STAGE" -eq "$STAGE" ] 2> /dev/null; then
+            echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is non-integer in /etc/iiab/iiab.env"
+            exit 1
+        elif [ "$STAGE" -lt 1 ] || [ "$STAGE" -gt 9 ]; then
+            echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is out-of-range in /etc/iiab/iiab.env"
+            exit 1
+        fi
+    fi
+    if [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
         STAGE=0
         rm /etc/iiab/iiab.env
         echo "Removed /etc/iiab/iiab.env effectively resetting STAGE (counter)."
@@ -90,9 +94,10 @@ else
         echo "Wrote STAGE=2 (counter) to /etc/iiab/iiab.env"
     elif [ "$STAGE" -eq 9 ]; then
         echo -e "\nEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done."
-        echo "Use 'iiab-install --reinstall' to force running all Stages 0-9."
-        echo "Use 'iiab-install --debug' to run Stage 0, followed by Stages 3-9."
+        echo "Use './iiab-install --reinstall' to force running all Stages 0-9."
+        echo "Use './iiab-install --debug' to run Stage 0, followed by Stages 3-9."
         echo "Use './runtags' to run a single Stage or Tag or Role."
+        echo "Use './iiab-network' to run Network sections."
         exit 1
     fi
 fi

--- a/iiab-install
+++ b/iiab-install
@@ -47,6 +47,7 @@ if version_gt $MIN_ANSIBLE_VER $CURRENT_ANSIBLE_VER; then
     echo "be removed with 'apt purge ansible' or 'pip uninstall ansible'.  We recommend"
     echo "you run './scripts/ansible' to install the latest Ansible from PPA or RPM."
     echo "'apt -a list ansible' can also sometimes be useful to show options!"
+    echo "INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 fi
 
@@ -63,7 +64,7 @@ if [ ! -f /etc/iiab/iiab.env ]; then
 else
     if [[ `grep XSCE /etc/iiab/iiab.env` ]] || [ "$1" == "--reinstall" ]; then
         rm /etc/iiab/iiab.env
-        echo "Deleted /etc/iiab/iiab.env"
+        echo "Removed /etc/iiab/iiab.env"
     else
         if [ "$1" == "--debug" ]; then
             sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
@@ -92,7 +93,7 @@ if [ ! -f ./vars/local_vars.yml ]; then
             cp ./vars/medium.localvars ./vars/local_vars.yml
             ;;
         *)
-            echo "IIAB requires raspbian, debian, ubuntu, centos or OLPC/fedora - exiting now..."
+            echo "Exiting: IIAB requires Raspbian, Debian, Ubuntu, CentOS or OLPC/Fedora."
             exit 1
             ;;
     esac

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -17,7 +17,7 @@
 
 #- name: Loading computed_vars
 #  include_tasks: roles/0-init/tasks/computed_vars.yml
-- name: re-read local_facts.facts from /etc/ansible/facts.d
+- name: Re-read local_facts.facts from /etc/ansible/facts.d
   setup: filter=ansible_local
 
 # set top level variables from local facts for convenience
@@ -27,7 +27,7 @@
       iiab_stage: '{{ ansible_local.local_facts.stage }}'
 
 # Networking uses a different file for the rpi
-- name: Discover if this is a rpi -- assume if so it is running raspbian
+- name: Discover if this is a RPi -- if so assume it is running Raspbian
   set_fact:
       rpi_model: "rpi"
       is_rpi: True
@@ -116,12 +116,12 @@
     docker_enabled: True
   when: schooltool_enabled or schooltool_install
 
-- name: Set python_path for is_redhat
+- name: Set python_path (redhat)
   set_fact:
     python_path: /usr/lib/python2.7/site-packages/
   when: is_redhat
 
-- name: Set python_path for is_debuntu
+- name: Set python_path (debuntu)
   set_fact:
     python_path: /usr/local/lib/python2.7/dist-packages/
   when: is_debuntu
@@ -134,14 +134,14 @@
   set_fact:
     mysql_service: mariadb
 
-- name: Set mysqld_service to mysqld for Fedora 18
+- name: Set mysqld_service to mysqld (etc) for Fedora 18
   set_fact:
     mysql_service: mysqld
     no_NM_reload: True
     is_F18: True
   when: ansible_distribution_release == "based on Fedora 18" or ansible_distribution_version == "18"
 
-- name: Set mysql_service to mysql for Debian
+- name: Set mysql_service to mysql (debuntu)
   set_fact:
     mysql_service: mysql
   when: is_debuntu
@@ -156,7 +156,7 @@
       FQDN_changed: True
   when: iiab_fqdn != ansible_fqdn
 
-- name: add version section
+- name: Add version section
   ini_file: dest='{{ iiab_config_file }}'
             section=runtime
             option='{{ item.option }}'

--- a/roles/elgg/tasks/main.yml
+++ b/roles/elgg/tasks/main.yml
@@ -1,7 +1,7 @@
 # Assume we only get here if elgg_install: True
 # Assume mysql is running
 
-- name: Download current version from our copy
+- name: Download current version from our site
   shell: wget {{ iiab_download_url }}/elgg-{{ elgg_version }}.zip -c -P {{ downloads_dir }}
          creates={{ downloads_dir }}/elgg-{{ elgg_version }}.zip
   when: internet_available
@@ -54,7 +54,7 @@
 - name: Change permissions on engine directory so Apache can write
   file: path=/opt/elgg/engine/ owner={{ apache_user }} mode=0755 state=directory
 
-- name: Create an upload directory that Apache can write in or elgg
+- name: Create an upload directory that Apache can write in or Elgg
   file: path={{ elgg_upload_path }} state=directory owner={{ apache_user }}
 
 - name: Change ownership
@@ -83,7 +83,7 @@
 # tar up a mysqldump of freshly installed database and use it in the install to avoid the startup
 # form, which worries me a lot. (/var/lib/mysql/elggdb)
 
-- name: Load elgg database dump
+- name: Load Elgg database dump
   mysql_db: name={{ dbname }}
             state=import
             target=/tmp/elggdb.sql
@@ -92,26 +92,26 @@
 - name: Remove database dump after load
   file: name=/tmp/elggdb.sql state=absent
 
-- name: Install config file for elgg in Apache
+- name: Install config file for Elgg in Apache
   template: src=elgg.conf dest=/etc/{{ apache_config_dir }}/elgg.conf
 
-- name: Enable Elgg for debuntu (will already be enabled above for Redhat)
+- name: Enable Elgg for debuntu (will already be enabled above for redhat)
   file: path=/etc/apache2/sites-enabled/elgg.conf
         src=/etc/apache2/sites-available/elgg.conf
         state=link
   when: elgg_enabled and is_debuntu
 
-- name: Disable Elgg for debuntu
+- name: Disable Elgg - remove config file for Elgg in Apache (debuntu)
   file: path=/etc/apache2/sites-enabled/elgg.conf
         state=absent
   when: not elgg_enabled and is_debuntu
 
-- name: Disable Elgg for Redhat - remove config file for Elgg in Apache
+- name: Disable Elgg - remove config file for Elgg in Apache (redhat)
   file: dest=/etc/{{ apache_config_dir }}/elgg.conf
         state=absent
   when: not elgg_enabled and is_redhat
 
-- name: Add Elgg to service list
+- name: Add 'elgg' to service list
   ini_file: dest='{{ service_filelist }}'
             section=elgg
             option='{{ item.option }}'
@@ -126,5 +126,5 @@
     - option: enabled
       value: "{{ elgg_enabled }}"
 
-- name: Restart apache, so it picks up the new aliases
+- name: Restart Apache, so it picks up the new aliases
   service: name={{ apache_service }} state=restarted


### PR DESCRIPTION
### Fixes Bug
Usability improvement, especially for folks running a stale version of Ansible or stale Kernel &mdash; folks who frequently get stuck b/c they fail to RTFM @ https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch but will now have concierge service PSA's (Public Service Announcements :-) to extricate efficiently.

### Description of changes proposed in this pull request.
See Code: restructured to communicate better while it's running.

### Smoke-tested in operating system.
Thoroughly on Raspbian Lite 2017-09-07 and lightly on Ubuntu 16.04 LTS with:
- different kernels
- different versions of Ansible
- different levels of progress across Stages 0-9 (as recorded in /etc/iiab/iiab.env)
- intentionally erroneous input parameters
- intentionally erroneous input from /etc/iiab/iiab.env e.g. STAGE (counter) variable is now enforced to live within its spec of 1-9 integer values only

### Mention a team member for further information or comment using @ name
@jvonau