### PR TITLE
runtags enabled & documentation improvements

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -72,6 +72,7 @@ echo "Placed /etc/ansible/facts.d/local_facts.fact into position."
 STAGE=0
 if [ ! -f /etc/iiab/iiab.env ]; then
     mkdir -p /etc/iiab
+    echo "{}" > /etc/iiab/config_vars.yml
 else
     if [[ `grep STAGE= /etc/iiab/iiab.env` ]]; then
         source /etc/iiab/iiab.env

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -27,7 +27,7 @@
       iiab_stage: '{{ ansible_local.local_facts.stage }}'
 
 # Networking uses a different file for the rpi
-- name: Discover if this is a RPi -- if so assume it is running Raspbian
+- name: Discover if this is running Raspbian -- if so assume it is an RPi
   set_fact:
       rpi_model: "rpi"
       is_rpi: True
@@ -134,7 +134,7 @@
   set_fact:
     mysql_service: mariadb
 
-- name: Set mysqld_service to mysqld (etc) for Fedora 18
+- name: Set mysqld_service to mysqld etc (Fedora 18)
   set_fact:
     mysql_service: mysqld
     no_NM_reload: True

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -8,7 +8,7 @@
   tags:
     - download
 
-- name: Install AWStats package
+- name: Install AWStats package (debuntu)
   package: name={{ item }}
            state=present
   with_items:
@@ -18,7 +18,7 @@
   tags:
     - download
 
-- name: enable cgi execution
+- name: enable cgi execution (debuntu)
   command: a2enmod cgi
   when: is_debuntu
 
@@ -33,7 +33,7 @@
     - "{{ awstats_data_dir }}"
     - "{{ apache_log_dir }}"
 
-- name: Install the Apache config for AWStats
+- name: Install the Apache config for AWStats (debuntu)
   template: src=apache.conf
             dest=/etc/{{ apache_config_dir }}/awstats.conf
             owner=root
@@ -41,7 +41,7 @@
             mode=0644
   when: awstats_enabled and is_debuntu
 
-- name: Install the Apache config for AWStats
+- name: Install the Apache config for AWStats (OS's other than debuntu)
   template: src=apache-awstats.conf
             dest=/etc/{{ apache_config_dir }}/awstats.conf
             owner=root
@@ -49,7 +49,7 @@
             mode=0644
   when: awstats_enabled and not is_debuntu
 
-- name: make sure logrotate does not make logs unreadable
+- name: make sure logrotate does not make logs unreadable (debuntu)
   template: src=logrotate.d.apache2
             dest=/etc/logrotate.d/apache2
   when: is_debuntu
@@ -63,13 +63,13 @@
   command: mv /etc/awstats/awstats.conf /etc/awstats/awstats.conf.dist
   when: awstats.stat.islnk is defined and not awstats.stat.islnk
 
-- name: Enable AWStats
+- name: Enable AWStats (debuntu)
   file: src=/etc/apache2/sites-available/awstats.conf
         path=/etc/apache2/sites-enabled/awstats.conf
         state=link
   when: awstats_enabled and is_debuntu
 
-- name: Disable AWStats
+- name: Disable AWStats (debuntu)
   file: path=/etc/apache2/sites-enabled/awstats.conf
         state=absent
   when: not awstats_enabled and is_debuntu
@@ -88,10 +88,10 @@
         state=link
   when: awstats_enabled
 
-- name: On first enabling of AWStats, summarize httpd logs up to now
+- name: On first enabling of AWStats, summarize httpd logs up to now (OS's other than debuntu)
   shell: /bin/perl /usr/share/awstats/wwwroot/cgi-bin/awstats.pl -config=schoolserver -update
   when: awstats_enabled and not is_debuntu
 
-- name: On first enabling of AWStats, summarize httpd logs up to now
+- name: On first enabling of AWStats, summarize httpd logs up to now (debuntu)
   shell: /usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=schoolserver -update
   when: awstats_enabled and is_debuntu

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -12,16 +12,16 @@
         src={{ sugarizer_location }}/{{ sugarizer_version }}
         state=link
 
-- name: Set up apt sources on is_debuntu
+- name: Set up apt sources (debuntu)
   shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
   when: internet_available and is_debuntu
 
-- name: Install nodejs=6.* which includes /usr/bin/npm - is_debuntu
+- name: Install nodejs=6.* which includes /usr/bin/npm (debuntu)
   package: name=nodejs=6.*
            state=present
   when: internet_available and is_debuntu
 
-- name: Install npm non is_debuntu
+- name: Install npm (OS's other than debuntu)
   package: name={{ item }}
            state=present
   when: internet_available and not is_debuntu
@@ -55,20 +55,20 @@
 #        dest=/etc/apache2/sites-enabled/sugarizer.conf
 #        state=link
 
-- name: Create the express framework for node.js - ALL less F18
+- name: Create the express framework for node.js (OS's other than Fedora 18)
   shell:  npm install
   args:
      chdir: "{{ sugarizer_location }}/sugarizer/server"
      creates: "{{ sugarizer_location }}/sugarizer/server/node_modules"
   when: not is_F18 and not npm_exists
 
-- name: Create the express framework for node.js - F18
+- name: Create the express framework for node.js (Fedora 18)
   shell:  npm install
   args:
      chdir: "{{ sugarizer_location }}/sugarizer/server"
   when: is_F18 and not npm_exists
 
-- name: Enable services - All
+- name: Enable services (all OS's)
   service: name={{ item.name }}
            enabled=yes
            state=restarted
@@ -76,7 +76,7 @@
       - { name: sugarizer }
   when: sugarizer_enabled
 
-- name: Disable services - All
+- name: Disable services (all OS's)
   service: name={{ item.name }}
            enabled=no
            state=stopped
@@ -84,7 +84,7 @@
       - { name: sugarizer }
   when: not sugarizer_enabled
 
-- name: Add Sugarizer to service list
+- name: Add 'sugarizer' to service list
   ini_file: dest='{{ service_filelist }}'
             section=sugarizer
             option='{{ item.option }}'


### PR DESCRIPTION
`echo "{}" > /etc/iiab/config_vars.yml` when /etc/iiab created in ./iiab-install (for now, so runtags works).

A better solution may be possible after discussing with @jvonau, @tim-moody and @georgejhunt etc during our Monday community/team call (http://minutes.iiab.io).