### PR TITLE
roles/calibre/templates/calibre.conf legacy change from 8010 to 8080 ?

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Get Calibre setup file
+- name: Get Calibre setup file (CentOS)
 # the installer works for intel fedora, and Centos, and deals with dependencies
   get_url:
     url="{{ calibre_src_url }}"
@@ -32,7 +32,7 @@
     - { src: 'calibre.conf', dest: '/etc/{{ apache_config_dir }}', mode: '0644'}
   when: calibre_install
 
-- name: Create the link for sites-enabled
+- name: Create the link for sites-enabled (debuntu)
   file: src=/etc/apache2/sites-available/calibre.conf
         dest=/etc/apache2/sites-enabled/calibre.conf
         state=link

--- a/roles/calibre/templates/calibre.conf
+++ b/roles/calibre/templates/calibre.conf
@@ -1,2 +1,2 @@
-ProxyPass /calibre  http://localhost:8010
-ProxyPassReverse /calibre http://localhost:8010
+ProxyPass /calibre  http://localhost:8080
+ProxyPassReverse /calibre http://localhost:8080

--- a/roles/sugarizer/templates/sugarizer.conf
+++ b/roles/sugarizer/templates/sugarizer.conf
@@ -1,4 +1,3 @@
 RewriteRule       ^/sugarizer(.*)$  http://localhost:8089/sugarizer$1 [P,L]
 ProxyPassReverse  /sugarizer        http://localhost:8010/sugarizer
 ProxyRequests     Off
-


### PR DESCRIPTION
(1) Note that calibre_port itself was updated from 8010 to 8080 a several months ago, in [default_vars.yml](https://github.com/iiab/iiab/blob/master/vars/default_vars.yml) and [local_vars.yml](http://wiki.laptop.org/go/IIAB/local_vars.yml) and this change (if a good one) merely catches up with that months-old change from 8010 to 8080.

(2) FWIW I noticed on Ubuntu 17.10 that /opt/iiab/iiab/roles/calibre/templates/calibre.conf is copied into these 2 places during IIAB installation:

/etc/apache2/sites-available/calibre.conf
/etc/apache2/sites-enabled/calibre.conf

_(3) Why does /var/iiab/iiab/roles/sugarizer/templates/sugarizer.conf **also** contain 8010 here?_
```
ProxyPassReverse  /sugarizer        http://localhost:8010/sugarizer
```