### PR TITLE
Record -> Recording STAGE 3 HAS COMPLETED

### DIFF
--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -30,7 +30,7 @@
            state=restarted
   when: not installing
 
-- name: Record STAGE 3 HAS COMPLETED ========================
+- name: Recording STAGE 3 HAS COMPLETED =====================
   lineinfile: dest=/etc/iiab/iiab.env
               regexp='^STAGE=*'
               line='STAGE=3'


### PR DESCRIPTION
Align with 8 other main stages[*] each of which records to STAGE (counter) in /etc/iiab/iiab.env on completion.

[*] STAGE 0 is a bit different.  It does not record its completion as above.  The reason is that it is mandatory at the beginning of all runs of ./runtags and ./iiab-install etc.