### PR TITLE
Toughened phpMyAdmin playbook

### DIFF
--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -60,10 +60,10 @@
   with_items: "{{ files_to_delete.files }}"
 
 - name: add mongodb to service list
-  ini_file: dest='{{ service_filelist }}'
+  ini_file: dest="{{ service_filelist }}"
             section=mongodb
-            option='{{ item.option }}'
-            value='"{{ item.value }}"'
+            option="{{ item.option }}"
+            value="{{ item.value }}"
   with_items:
        - option: name
          value: MongoDB

--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -1,3 +1,4 @@
 phpmyadmin_install: False
 phpmyadmin_enabled: False
-phpMyAdmin: "phpMyAdmin-4.7.5-all-languages.zip"
+phpmyadmin_name: "phpMyAdmin-4.7.5-all-languages"
+phpmyadmin_name_zip: "{{ phpmyadmin_name }}.zip"

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -74,7 +74,7 @@
     - option: name
       value: phpMyAdmin
     - option: description
-      value: "phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."
+      value: '"phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."'
     - option: path
       value: /opt/phpmyadmin
     - option: enabled

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Create symbolic link /opt/phpmyadmin to phpMyAdmin folder above
   file:
     src: "{{ phpmyadmin_name }}"
-    path: /opt/phpmyadmin
+    dest: /opt/phpmyadmin
     owner: "{{ apache_user }}"
     state: link
 
@@ -53,8 +53,8 @@
 
 - name: Enable phpMyAdmin
   file:
-    path: /etc/apache2/sites-enabled/phpmyadmin.conf
     src: /etc/apache2/sites-available/phpmyadmin.conf
+    dest: /etc/apache2/sites-enabled/phpmyadmin.conf
     state: link
   when: phpmyadmin_enabled and is_debuntu
 

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -2,7 +2,7 @@
   get_url:
     url: "{{ iiab_download_url }}/{{ phpmyadmin_name_zip }}"
     dest: "{{ downloads_dir }}"
-  register: phpmyadmin_dl_output
+  #register: phpmyadmin_dl_output
   when: internet_available
 
 - name: Check if /opt/iiab/downloads/{{ phpmyadmin_name_zip }} exists

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -1,45 +1,81 @@
-    - name: Get the phpMyAdmin software
-      get_url: url="{{ iiab_download_url }}/{{ phpMyAdmin }}"  dest="{{ downloads_dir }}/phpMyAdmin.zip"
-      when: internet_available
+- name: Get the phpMyAdmin software
+  get_url:
+    url: "{{ iiab_download_url }}/{{ phpmyadmin_name_zip }}"
+    dest: "{{ downloads_dir }}"
+  register: phpmyadmin_dl_output
+  when: internet_available
 
-    - name: Copy it to permanent location /opt
-      unarchive: src={{ downloads_dir }}/phpMyAdmin.zip  dest=/opt/
+- name: Check if /opt/iiab/downloads/{{ phpmyadmin_name_zip }} exists
+  stat:
+    path: "{{ downloads_dir }}/{{ phpmyadmin_name_zip }}"
+  register: phpmyadmin_dl
 
-    - name: Create a symbolic link to the folder of the current version phpMyAdmin
-      file: path=/opt/phpmyadmin src=phpMyAdmin-4.7.5-all-languages state=link
+- name: FAIL (force Ansible to exit) IF /opt/iiab/downloads/{{ phpmyadmin_name_zip }} doesn't exist
+  fail:
+    msg: "{{ downloads_dir }}/{{ phpmyadmin_name_zip }} is REQUIRED in order to install phpMyAdmin."
+  when: not phpmyadmin_dl.stat.exists
 
-    - name: Copy the phpMyAdmin config file into place
-      template: src=config.inc.php dest=/opt/phpmyadmin/config.inc.php
+- name: Unzip to permanent location /opt/{{ phpmyadmin_name }}
+  unarchive:
+    src: "{{ downloads_dir }}/{{ phpmyadmin_name_zip }}"
+    dest: /opt
+    owner: "{{ apache_user }}"
 
-    - name: Change the owner of the PHP tree to Apache
-      shell: "chown -R {{ apache_user }} /opt/phpmyadmin"
+- name: Create symbolic link /opt/phpmyadmin to phpMyAdmin folder above
+  file:
+    src: "{{ phpmyadmin_name }}"
+    path: /opt/phpmyadmin
+    owner: "{{ apache_user }}"
+    state: link
 
-    - name: Put the alias into Apache config when enabled
-      template: src=phpmyadmin.j2 dest=/etc/{{ apache_config_dir }}/phpmyadmin.conf
-      when: phpmyadmin_enabled
+- name: Copy phpMyAdmin's config file into place
+  template:
+    src: config.inc.php
+    dest: /opt/phpmyadmin/config.inc.php
+    owner: "{{ apache_user }}"
 
-    - name: Enable phpMyAdmin
-      file: path=/etc/apache2/sites-enabled/phpmyadmin.conf
-            src=/etc/apache2/sites-available/phpmyadmin.conf
-            state=link
-      when: phpmyadmin_enabled and is_debuntu
+# Above 3 stanzas set link/tree/contents ownership to {{ apache_user }}:root
+# OOPS: CHOWN BELOW CHANGED LINK ALONE (TREE/CONTENTS REMAINED root:root)
 
-    - name: Remove the alias into Apache config when not enabled
-      file: path=/etc/apache2/sites-enabled/phpmyadmin.conf
-            state=absent
-      when: not phpmyadmin_enabled and is_debuntu
+# - name: Change the owner of the PHP tree to Apache
+#   shell: "chown -R {{ apache_user }} /opt/phpmyadmin"
+#   #file:
+#   #  path: "/opt/{{ phpmyadmin_name_zip }}"
+#   #  owner: "{{ apache_user }}"
+#   #  recurse: yes
+#   #  state: directory
 
-    - name: Add phpmyadmin to service list
-      ini_file: dest='{{ service_filelist }}'
-                    section=phpmyadmin
-                    option='{{ item.option }}'
-                    value='"{{ item.value }}"'
-      with_items:
-            - option: name
-              value: phpMyAdmin
-            - option: description
-              value: '"phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."'
-            - option: path
-              value: /opt/phpmyadmin
-            - option: enabled
-              value: "{{ phpmyadmin_enabled }}"
+- name: Put the alias into Apache config when enabled
+  template:
+    src: phpmyadmin.j2
+    dest: "/etc/{{ apache_config_dir }}/phpmyadmin.conf"
+  when: phpmyadmin_enabled
+
+- name: Enable phpMyAdmin
+  file:
+    path: /etc/apache2/sites-enabled/phpmyadmin.conf
+    src: /etc/apache2/sites-available/phpmyadmin.conf
+    state: link
+  when: phpmyadmin_enabled and is_debuntu
+
+- name: Remove the alias into Apache config when not enabled
+  file:
+    path: /etc/apache2/sites-enabled/phpmyadmin.conf
+    state: absent
+  when: not phpmyadmin_enabled and is_debuntu
+
+- name: Add phpmyadmin to service list
+  ini_file:
+    dest: "{{ service_filelist }}"
+    section: phpmyadmin
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+    - option: name
+      value: phpMyAdmin
+    - option: description
+      value: "phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."
+    - option: path
+      value: /opt/phpmyadmin
+    - option: enabled
+      value: "{{ phpmyadmin_enabled }}"

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Get the phpMyAdmin software
+- name: Download the phpMyAdmin software
   get_url:
     url: "{{ iiab_download_url }}/{{ phpmyadmin_name_zip }}"
     dest: "{{ downloads_dir }}"

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -87,10 +87,10 @@
   when: not sugarizer_enabled
 
 - name: Add 'sugarizer' to service list
-  ini_file: dest='{{ service_filelist }}'
+  ini_file: dest="{{ service_filelist }}"
             section=sugarizer
-            option='{{ item.option }}'
-            value='"{{ item.value }}"'
+            option="{{ item.option }}"
+            value="{{ item.value }}"
   with_items:
        - option: name
          value: Sugarizer


### PR DESCRIPTION
Essentially phpMyAdmin playbook has been refactored to make it more resilient:

- Works when offline!  Either way:
  1. Rebuilds /opt/phpmyadmin or...
  2. Fails with clear messaging when prereq zip file is missing
- Better preserves state in /opt/iiab/downloads (better visibility of phpMyAdmin version number)
- Version Number now only needs to be set once in [roles/phpmyadmin/defaults/main.yml](https://github.com/iiab/iiab/blob/master/roles/phpmyadmin/defaults/main.yml) e.g.
  phpmyadmin_name: "phpMyAdmin-4.7.5-all-languages"
- Safer as link (/opt/phpmyadmin) & tree/content (e.g. /opt/phpMyAdmin-4.7.5-all-languages) are now all set to {{ apache_user }}:root (owner:group) (earlier the link was the only one whose owner was set, e.g. to www-data:root)
- Ansible output much improved
- Ansible syntax modernized, to its new multi-line format

Tested on Ubuntu 16.04 LTS.

Testing on other OS's would be great.