### PR TITLE
atstart: auto-create /etc/iiab/uuid on cloned images

### DIFF
--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -10,6 +10,7 @@
 - name: Copy startup script
   template: src=iiab-startup.sh
             dest=/usr/libexec/
+            mode=0755
   when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
 
 - name: Ask systemd to recognize the changes

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -44,6 +44,8 @@
 
 - include_tasks: udev.yml
 
+- include_tasks: iiab-startup.yml
+
 - name: Recording STAGE 2 HAS COMPLETED ==========================
   lineinfile: dest=/etc/iiab/iiab.env
               regexp='^STAGE=*'

--- a/roles/2-common/tasks/startup.yml
+++ b/roles/2-common/tasks/startup.yml
@@ -1,0 +1,25 @@
+- name: Does systemd startup service exist
+  stat: path="{{ systemd_location }}/iiab-startup.service"
+  register: startup_unit
+
+- name: Copy startup service to /etc/systemd/system
+  template: src=iiab-startup.service
+            dest=/etc/systemd/system/
+  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+
+- name: Copy startup script
+  template: src=iiab-startup.sh
+            dest=/usr/libexec/
+  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+
+- name: Ask systemd to recognize the changes
+  shell: systemctl daemon-reload
+  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+
+- name: Restart so systemd recognizes the changes
+  shell: systemctl restart iiab-startup.service
+  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+
+- name: Enable the reload service
+  shell: systemctl enable iiab-startup.service
+  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists

--- a/roles/2-common/templates/iiab-startup.service
+++ b/roles/2-common/templates/iiab-startup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Execute startup script  
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libecec/iiab-startup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/2-common/templates/iiab-startup.service
+++ b/roles/2-common/templates/iiab-startup.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/libecec/iiab-startup.sh
+ExecStart=/usr/libexec/iiab-startup.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -4,4 +4,5 @@
 if [ ! -f /etc/iiab/uuid ]; then
    uuidgen > /etc/iiab/uuid
 fi
+exit 0
 

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# put initialization that needs to happen at every startup for IIAB here
+
+if [ ! -f /etc/iiab/uuid ]; then
+   uuidgen > /etc/iiab/uuid
+fi
+


### PR DESCRIPTION
### Fixes Bug
This is an alternative to #271. I do not like generating a uuid only if openvpn is installed.
### Description of changes proposed in this pull request. I 
This creates a bash script that is run at every boot, which in turn looks for uuid, and generates it if it does not exist`
I think a uuid is strategic for determining how many people are contributing to "field back".
### Smoke-tested in operating system.
rpi stretch (but not a fresh install)

### Mention a team member for further information or comment using @ name
