### PR TITLE
Actively suggest ./iiab-install instead of ./runansible

### DIFF
--- a/runansible
+++ b/runansible
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+
+echo "Please consider ./iiab-install instead of the lesser-supported ./runansible"
+
 PLAYBOOK="iiab.yml"
 INVENTORY="ansible_hosts"
 # Pass cmdline options for ansible


### PR DESCRIPTION
This warning/announcement can be enhanced once we better understand #560 that @georgejhunt ran into.