### PR TITLE
STAGE variable in /etc/iiab/iiab.env can now be 0-9 (had been restricted to 1-9)

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -77,7 +77,7 @@ if [ -f /etc/iiab/iiab.env ]; then
         if ! [ "$STAGE" -eq "$STAGE" ] 2> /dev/null; then
             echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is non-integer in /etc/iiab/iiab.env"
             exit 1
-        elif [ "$STAGE" -lt 1 ] || [ "$STAGE" -gt 9 ]; then
+        elif [ "$STAGE" -lt 0 ] || [ "$STAGE" -gt 9 ]; then
             echo -e "\nEXITING: STAGE (counter) value == "$STAGE" is out-of-range in /etc/iiab/iiab.env"
             exit 1
         fi


### PR DESCRIPTION
In the past, the only valid values for the STAGE variable in /etc/iiab/iiab.env were 1-thru-9.

Line 93 (now Line 92) [changed this](https://github.com/iiab/iiab/commit/3c593c2ca30861a15be8700482c969c8f51d8bb8#diff-50899b61edfedc741e84b4fbbb63ebb3) on Nov 20, expanding the valid values to 0-thu-9.