### PR TITLE
toggle to "set +e" ignoring errors when working with /etc/iiab files (then back to "set -e")

### DIFF
--- a/runansible
+++ b/runansible
@@ -26,6 +26,7 @@ if [ ! -f ./vars/local_vars.yml ]; then
     esac
 fi
 
+set +e
 # copy var files to /etc/iiab for subsequent use
 # If iiab.env exists, on second or upgrade run, check for stale variables
 # iiab.env gets created at the end of stage-4 on First Run
@@ -43,6 +44,7 @@ else
   mkdir -p /etc/iiab
   echo "{}" > /etc/iiab/config_vars.yml
 fi
+set -e
 
 CWD=`pwd`
 


### PR DESCRIPTION
### Fixes Bug
related to #560

### Description of changes proposed in this pull request.

### Smoke-tested in operating system.
yes on the failing rpi
### Mention a team member for further information or comment using @ name
