### PR TITLE
Fix calibre_debs_on_debian conditionals

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -3,12 +3,12 @@
 # RUNS IF /usr/bin/calibre-uninstall DOES NOT ALEADY EXIST
 - name: Install Calibre via calibre-installer.py (OS's other than Raspbian)
   include_tasks: py-installer.yml
-  when: (not is_rpi) and (not calibre_debs_on_debian)
-  #when: is_redhat or is_ubuntu
+  when: is_redhat or is_ubuntu or (is_debian and not calibre_debs_on_debian)
+  #when: not is_rpi
 
 - name: Install Calibre via .debs (Raspbian)
   include_tasks: debs.yml
-  when: is_rpi or calibre_debs_on_debian
+  when: is_rpi or (is_debian and calibre_debs_on_debian)
   #when: is_rpi or is_debian     # (is_debian also covers & includes is_rpi)
 
 # 2. STOP CALIBRE SERVICE IF IT EXISTS (REQUIRED FOR DB ACTIVITY...AND IF not calibre_enabled)


### PR DESCRIPTION
### Fixes Bug

Calibre playbook was not running on Ubuntu & CentOS due to error in calibre_debs_on_debian conditionals.

### Description of changes proposed in this pull request.

Conditionals fixed on Lines 6 & 11 of roles/calibre/tasks/main.yml

### Smoke-tested in operating system.

Ubuntu 16.04 LTS

### Mention a team member for further information or comment using @ name

@jvonau notified and Ubuntu 16.04 LTS errors posted to:
https://paste.fedoraproject.org/paste/e7FD9TsxpdL8x45PHTUSYA
https://paste.fedoraproject.org/paste/KKp8BtpFCOqoKlNGGPRhtQ