### PR TITLE
Kiwix playbook reinforced for offline & for readability #2

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -6,9 +6,10 @@ kiwix_src_file_i686: "kiwix-0.10-linux-i686.tar.bz2"   # Published Oct 2016 ("ex
 # KIWIX FOR i686 SHOULD BE REPLACED BEFORE FEB 2018: https://github.com/kiwix/kiwix-build/issues/94
 
 kiwix_port: 3000
-# The following 2 lines are unused: (Nov 2017)
-# kiwix_url: /kiwix
-# kiwix_path: "{{ iiab_base }}/kiwix"
+# Expected to be used soon for Kiwix proxy:
+kiwix_url: /kiwix
+# Unused in Nov 2017, but should be:
+kiwix_path: "{{ iiab_base }}/kiwix"
 
 # /library/zims contains 3 important things:
 # - library.xml

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -17,7 +17,7 @@ kiwix_port: 3000
 iiab_zim_path: "{{ content_base }}/zims"
 kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # Unused: (Nov 2017)
-kiwix_content_path: "{{ iiab_zim_path }}/content"
+# kiwix_content_path: "{{ iiab_zim_path }}/content"
 
 # Installation Variables
 kiwix_install: True

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -172,4 +172,4 @@
 #   - option: kiwix_content_path
 #     value: "{{ kiwix_content_path }}"
   - option: enabled
-value: "{{ kiwix_enabled }}"
+    value: "{{ kiwix_enabled }}"

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -31,7 +31,7 @@
 
 - name: Check for /opt/iiab/kiwix/bin/kiwix-serve binary
   stat:
-    path: "{{ iiab_base }}/kiwix/bin/kiwix-serve"
+    path: "{{ kiwix_path }}/bin/kiwix-serve"
   register: kiwix_bin
 
 - name: Set kiwix_force_install if kiwix-serve not found
@@ -51,7 +51,7 @@
 
 - name: Create /opt/iiab/kiwix/bin directory
   file:
-    path: "{{ iiab_base }}/kiwix/bin"
+    path: "{{ kiwix_path }}/bin"
     owner: root
     group: root
     mode: 0755
@@ -63,7 +63,7 @@
 - name: Unarchive Kiwix binaries to permanent location (NOT i686)
   unarchive:
     src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
-    dest: "{{ iiab_base }}/kiwix/bin"
+    dest: "{{ kiwix_path }}/bin"
     owner: root
     group: root
   when: kiwix_src_bin_only and kiwix_force_install
@@ -78,7 +78,7 @@
   when: not kiwix_src_bin_only and kiwix_force_install
 
 - name: Move /tmp/kiwix*i686/bin/* to permanent location /opt/iiab/kiwix/bin (i686)
-  shell: "mv /tmp/kiwix*i686/bin/* /opt/iiab/kiwix/bin/"
+  shell: "mv /tmp/kiwix*i686/bin/* {{ kiwix_path }}/bin/"
   when: not kiwix_src_bin_only and kiwix_force_install
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -1,4 +1,6 @@
-- name: Create various directories for Kiwix's ZIM files
+# 1. CREATE/VERIFY CRITICAL DIRECTORIES & FILES ARE IN PLACE
+
+- name: Create various directories for Kiwix ZIM files
   file:
     path: "{{ item }}"
     owner: root
@@ -7,7 +9,7 @@
     state: directory
   with_items:
   - "{{ iiab_zim_path }}"
-  - "{{ kiwix_content_path }}"
+  - "{{ iiab_zim_path }}/content"
   - "{{ iiab_zim_path }}/index"
 
 - name: Check for /library/zims/library.xml
@@ -35,25 +37,38 @@
 - name: Set kiwix_force_install if kiwix-serve not found
   set_fact:
     kiwix_force_install: True
-  when: kiwix_bin.stat.exists is defined and not kiwix_bin.stat.exists
+  when: not kiwix_bin.stat.exists
 
-- name: Copy test.zim file
+- name: Copy test.zim file if kiwix_force_install
   copy:
     src: test.zim
-    dest: "{{ kiwix_content_path }}/test.zim"
+    dest: "{{ iiab_zim_path }}/content/test.zim"
     mode: 0644
     owner: root
     group: root
     force: no
   when: kiwix_force_install
 
-# We get a whole web server for i686 but only the kiwix execs for linux64 & armhf
+- name: Create /opt/iiab/kiwix/bin directory
+  file:
+    path: "{{ iiab_base }}/kiwix/bin"
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
 
-# EXPERIMENTAL i686 CODE PATH: as of Nov 2017 bunzip2 then untar unpacks
-# to /tmp/kiwix-0.10-i686/bin WHOSE CONTENTS NEEDS TO BE MOVED TO
-# /opt/iiab/kiwix/bin (STANZA FURTHER BELOW).  All i686 code needs testing.
-# ALSO: code below may need to be revived to chown -R root:root & chmod
-- name: Unarchive kiwix-*-linux-i686.tar.bz2 to /tmp (not bin_only, i.e. i686)
+# 2. INSTALL KIWIX-TOOLS EXECUTABLES IF kiwix_force_install
+# (We get a whole web server for i686 but only kiwix execs for linux64 & armhf)
+
+- name: Unarchive Kiwix binaries to permanent location (NOT i686)
+  unarchive:
+    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
+    dest: "{{ iiab_base }}/kiwix/bin"
+    owner: root
+    group: root
+  when: kiwix_src_bin_only and kiwix_force_install
+
+- name: Unarchive kiwix*i686.tar.bz2 to /tmp (i686)
   unarchive:
     src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
     dest: /tmp
@@ -62,36 +77,11 @@
     group: root
   when: not kiwix_src_bin_only and kiwix_force_install
 
-- name: Create kiwix/bin directory
-  file:
-    path: "{{ iiab_base }}/kiwix/bin"
-    owner: root
-    group: root
-    mode: 0755
-    state: directory
-
-# EXPERIMENTAL i686 CODE PATH
-- name: move /tmp/kiwix*i686/bin/* to permanent location /opt/iiab/kiwix/bin (not bin_only, i.e. i686)
+- name: Move /tmp/kiwix*i686/bin/* to permanent location /opt/iiab/kiwix/bin (i686)
   shell: "mv /tmp/kiwix*i686/bin/* /opt/iiab/kiwix/bin/"
   when: not kiwix_src_bin_only and kiwix_force_install
 
-- name: Unarchive Kiwix to permanent location (bin_only, i.e. not i686)
-  unarchive:
-    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
-    dest: "{{ iiab_base }}/kiwix/bin"
-    owner: root
-    group: root
-  when: kiwix_src_bin_only and kiwix_force_install
-
-# MIGHT BE RESTORED LATER FOR i686?  Unused as of Nov 2017:
-# # workaround because unarchive does not set ownership properly
-# - name: "Set ownership as if: 'chown -R root:root /opt/iiab/kiwix'"
-#   file:
-#     path: "{{ iiab_base }}/kiwix"
-#     owner: root
-#     group: root
-#     recurse: yes
-#     mode: ????
+# 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU
 
 - name: Enable the mods which permit Apache to proxy (debuntu)
   apache2_module:
@@ -103,22 +93,7 @@
   - rewrite
   when: is_debuntu
 
-# workaround because kiwix-serve does not stay running
-- name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
-# *  *  *  *  * user-name  command to be executed
-  lineinfile:
-    line: "0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
-    dest: /etc/crontab
-  when: is_debuntu
-
-- name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
-# *  *  *  *  * user-name  command to be executed
-  lineinfile:
-    line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
-    dest: /etc/crontab
-  when: is_redhat
-
-# Create Kiwix service
+# 4. CREATE/ENABLE/DISABLE KIWIX SERVICE & ITS CRON JOB
 
 - name: Create 'kiwix-serve' service
   template:
@@ -148,8 +123,30 @@
     enabled: no
     state: stopped
   when: not kiwix_enabled
+# IN THEORY: BOTH CRON ENTRIES BELOW *SHOULD* BE DELETED "when: not kiwix_enabled"
 
-- name: Add 'kiwix-serve' to list of services at /opt/iiab/iiab.ini
+# In the past kiwix-serve did not stay running, so we'd been doing this hourly.
+# @mgautierfr & others suggest kiwix-serve might be auto-restarted w/o cron in
+# future, whenever service fails, if this really catches all cases??
+# https://github.com/iiab/iiab/issues/484#issuecomment-342151726
+- name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
+  lineinfile:
+         # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
+    line: "0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
+    dest: /etc/crontab
+  when: kiwix_enabled and is_debuntu
+
+- name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
+# *  *  *  *  * user-name  command to be executed
+  lineinfile:
+         # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
+    line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
+    dest: /etc/crontab
+  when: kiwix_enabled and is_redhat
+
+# 5. FINALIZE
+
+- name: Add 'kiwix-serve' to list of services at /etc/iiab/iiab.ini
   ini_file:
     dest: "{{ service_filelist }}"
     section: kiwix-serve
@@ -160,7 +157,7 @@
     value: kiwix-serve
   - option: description
     value: '"Part of https://github.com/kiwix/kiwix-tools/ - kiwix-serve is the most used web server for ZIM files."'
-# The following 4 lines are unused as of Nov 2017:
+# The following 4 lines are unused: (Nov 2017)
 #   - option: kiwix_url
 #     value: "{{ kiwix_url }}"
 #   - option: kiwix_path
@@ -171,7 +168,8 @@
     value: "{{ iiab_zim_path }}"
   - option: kiwix_library_xml
     value: "{{ kiwix_library_xml }}"
-  - option: kiwix_content_path
-    value: "{{ kiwix_content_path }}"
+# The following 2 lines are unused: (Nov 2017)
+#   - option: kiwix_content_path
+#     value: "{{ kiwix_content_path }}"
   - option: enabled
-    value: "{{ kiwix_enabled }}"
+value: "{{ kiwix_enabled }}"

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -157,11 +157,10 @@
     value: kiwix-serve
   - option: description
     value: '"Part of https://github.com/kiwix/kiwix-tools/ - kiwix-serve is the most used web server for ZIM files."'
-# The following 4 lines are unused: (Nov 2017)
-#   - option: kiwix_url
-#     value: "{{ kiwix_url }}"
-#   - option: kiwix_path
-#     value: "{{ kiwix_path }}"
+  - option: kiwix_url
+    value: "{{ kiwix_url }}"
+  - option: kiwix_path
+    value: "{{ kiwix_path }}"
   - option: kiwix_port
     value: "{{ kiwix_port }}"
   - option: iiab_zim_path


### PR DESCRIPTION
This is PR #568 rebased to be easier to read [*] so that it's more clear that it's really just:

1) Fixing support for i686 & documents how to test on x86_64.
2) Checks for library.xml & test.zim so playbook can run offline, reconstituting these if accidentally deleted.
3) 5-step structure documented in tasks/kiwix_install.yml so it's much more clear what is happening between the 5 headings (stanzas re-ordered for readability).

[*] after pulling out #570 "Clarifying what gets put into /etc/iiab/iiab.ini"

Extensively tested on Raspbian Lite and Ubuntu 16.04 LTS both.