### PR TITLE
document reboot_to_AP in default_vars.yml (essentially does iiab-hotspot-off on 1st boot)

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -3,12 +3,12 @@
 # RUNS IF /usr/bin/calibre-uninstall DOES NOT ALEADY EXIST
 - name: Install Calibre via calibre-installer.py (OS's other than Raspbian)
   include_tasks: py-installer.yml
-  when: (not is_rpi) and (not calibre_debs_on_debian)
-  #when: is_redhat or is_ubuntu
+  when: is_redhat or is_ubuntu or (is_debian and not calibre_debs_on_debian)
+  #when: not is_rpi
 
 - name: Install Calibre via .debs (Raspbian)
   include_tasks: debs.yml
-  when: is_rpi or calibre_debs_on_debian
+  when: is_rpi or (is_debian and calibre_debs_on_debian)
   #when: is_rpi or is_debian     # (is_debian also covers & includes is_rpi)
 
 # 2. STOP CALIBRE SERVICE IF IT EXISTS (REQUIRED FOR DB ACTIVITY...AND IF not calibre_enabled)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -69,7 +69,7 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-# Option to reboot to internal WiFi Access Point after installing IIAB over WiFi (equiv to running iiab-hotspot-on)
+# Option to reboot to internal WiFi Access Point after installing IIAB over WiFi (equiv to running iiab-hotspot-on). This only works with RPi's for now:
 reboot_to_AP: False
 
 # Gateway mode

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -69,6 +69,8 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
+# Option to reboot to Access Point after installing over WiFi (equiv to running iiab-hotspot-on)
+reboot_to_AP: False
 
 # Gateway mode
 iiab_lan_enabled: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -69,7 +69,9 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-# Option to reboot to internal WiFi Access Point after installing IIAB over WiFi (equiv to running iiab-hotspot-on). This only works with RPi's for now:
+# For those installing IIAB over WiFi: "reboot_to_AP: True" makes the internal
+# WiFi Access active after the next reboot.  This is equivalent to manually
+# running "iiab-hotspot-on".  Note this variable only works with RPi's for now.
 reboot_to_AP: False
 
 # Gateway mode

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -69,7 +69,7 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-# Option to reboot to Access Point after installing over WiFi (equiv to running iiab-hotspot-on)
+# Option to reboot to internal WiFi Access Point after installing IIAB over WiFi (equiv to running iiab-hotspot-on)
 reboot_to_AP: False
 
 # Gateway mode


### PR DESCRIPTION
For #559 "flip default reboot_to_AP to be optional"