### PR TITLE
guard against losing dns lookups when the machine has alreay been con…

### DIFF
--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -90,3 +90,6 @@
   file: path=/etc/{{ apache_config_dir }}/dns-jail.conf
         state=absent
   when: not is_debuntu and not dns_jail_enabled
+
+- name: Start named after copying files
+  service: name={{ dns_service }} state=started


### PR DESCRIPTION
…figured in which /etc/resolv.conf would contain 127.0.0.1 as the nameserver address with resolvconf in action and /etc/iiab/iiab.env absent

### Fixes Bug

### Description of changes proposed in this pull request.

### Smoke-tested in operating system.

### Mention a team member for further information or comment using @ name
