### PR TITLE
force br0 to always be available on rpi

### DIFF
--- a/roles/network/templates/network/rpi.j2
+++ b/roles/network/templates/network/rpi.j2
@@ -7,6 +7,8 @@ auto br0
 iface br0 inet manual
 {% if iiab_wired_lan_iface is defined %}
     bridge_ports {{ iiab_wired_lan_iface }}
+{% else %}
+    bridge_ports none
 {% endif %}
     bridge_maxwait 0
     dns-nameservers 127.0.0.1


### PR DESCRIPTION
### Fixes Bug

### Description of changes proposed in this pull request.

### Smoke-tested in operating system.

### Mention a team member for further information or comment using @ name
