### PR TITLE
"reboot_to_AP: False" (today for RPi only) was being ignored

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -14,7 +14,7 @@
       iiab_wan_iface: "{{ discovered_wired_iface }}"
       iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
       iiab_wired_lan_iface: ""
-  when: is_rpi and discovered_wireless_iface is defined and discovered_wireless_iface == iiab_wan_iface and reboot_to_AP is defined
+  when: is_rpi and discovered_wireless_iface is defined and discovered_wireless_iface == iiab_wan_iface and reboot_to_AP
 
 - include_tasks: computed_network.yml
   when: not installing


### PR DESCRIPTION
Conditional fixed, by changing "reboot_to_AP is defined" to "reboot_to_AP", thanks to @jvonau figuring this out, as explained in https://github.com/iiab/iiab/issues/197#issuecomment-349140385
