### PR TITLE
kiwix-serve -> kiwix in /etc/iiab/iiab.ini for iiab-make-kiwix-lib.py used by ./cp-menus

### DIFF
--- a/roles/kiwix/templates/iiab-make-kiwix-lib.py
+++ b/roles/kiwix/templates/iiab-make-kiwix-lib.py
@@ -108,8 +108,8 @@ def init():
     config = ConfigParser.SafeConfigParser()
     config.read(iiab_config_file)
     iiab_base_path = config.get('location','iiab_base')
-    iiab_zim_path = config.get('kiwix-serve','iiab_zim_path')
-    kiwix_library_xml = config.get('kiwix-serve','kiwix_library_xml')
+    iiab_zim_path = config.get('kiwix','iiab_zim_path')
+    kiwix_library_xml = config.get('kiwix','kiwix_library_xml')
     kiwix_manage = iiab_base_path + "/kiwix/bin/kiwix-manage"
 
 # Now start the application


### PR DESCRIPTION
1) The name "kiwix" seems more broadly appropriate than "kiwix-serve" and is now part of the kiwix playbook, as placed in /etc/iiab/iiab.ini automatically during install.  Similar to the "./runtags kiwix" name etc.

2) Does anyone know if this kiwix section (formerly kiwix-serve section) within /etc/iiab/iiab.ini is referenced in any other places, beyond just iiab-make-kiwix-lib.py ?  (as used by https://github.com/iiab/iiab-menu/blob/master/cp-menus)