### PR TITLE
Small bugs in scripts/ansible & possible tuneup?

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,12 +1,14 @@
 #!/bin/bash -e
-# Installs or upgrades to the best possible Ansible release, so iiab-install can proceed.
-# Ensure you are online before running this script!
 
-GOOD_VER="2.4.2"       # Ansible version for OLPC.  On other OS's we install/upgrade to the latest Ansible.
-                       # Pinning to 2.4.x could be considered in future, if truly nec?
-VER="undefined"
-# FOUND="false"        # NOT USED AS OF 2017-12-11
-# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
+# Installs or upgrades to the best possible Ansible release, so iiab-install
+# can proceed.  Ensure you're online before running this script!
+
+GOOD_VER="2.4.2"      # Ansible version for OLPC, for pip.
+                      # On other OS's we install/upgrade to the latest Ansible.
+                      # Pin all to 2.4.x in future, if really/truly nec?
+CURR_VER="undefined"
+# FOUND="false"       # NOT USED AS OF 2017-12-12
+# FAMILY="undefined"  # NOT USED AS OF 2017-12-12
 # below are unused for future use
 # URL="NA"
 
@@ -20,10 +22,10 @@ if ! [ `which ansible-playbook` ]; then
         yum -y install python-pip python-setuptools python-wheel patch
         yum -y install http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.2.0-1.el7.ans.noarch.rpm
         # FOUND="true"
-        # FAMILY="redhat"   # NOT USED AS OF 2017-12-11
+        # FAMILY="redhat"
 #    elif [ -f /etc/fedora-release ]; then
-#        VER=`grep VERSION_ID /etc/*elease | cut -d= -f2`
-#        URL=https://github.com/jvonau/iiab/blob/ansible/vars/fedora-$VER.yml
+#        CURR_VER=`grep VERSION_ID /etc/*elease | cut -d= -f2`
+#        URL=https://github.com/jvonau/iiab/blob/ansible/vars/fedora-$CURR_VER.yml
 #        dnf -y install ansible git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
 #        dnf -y install python-pip python-setuptools python-wheel patch
 #        FOUND="true"
@@ -35,21 +37,22 @@ if ! [ `which ansible-playbook` ]; then
         pip install --upgrade pip setuptools wheel #EOL just do it
         pip install ansible==$GOOD_VER --disable-pip-version-check
         # FOUND="true"
-        # FAMILY="olpc"   # NOT USED AS OF 2017-12-11
-    elif [ -f /etc/debian_version ] || [[ `grep -i raspbian /etc/*elease` ]]; then
-        if [[ ! `grep -i ansible /etc/apt/sources.list` ]] && [ ! -f /etc/apt/sources.list.d/ansible ]; then
+        # FAMILY="olpc"
+    elif [ -f /etc/debian_version ] || (grep -qi raspbian /etc/*elease) ; then
+        if ( ! grep -qi ansible /etc/apt/sources.list) && [ ! -f /etc/apt/sources.list.d/ansible ]; then
             apt -y install dirmngr python-pip python-setuptools python-wheel patch
             echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
                  >> /etc/apt/sources.list.d/ansible.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
         fi
         # FOUND="true"
-        # FAMILY="debian"   # NOT USED AS OF 2017-12-11
-    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -i ubuntu /etc/os-release` ]]; then
+        # FAMILY="debian"
+        # Parens are optional, but greatly clarify :)
+    elif (grep -qi ubuntu /etc/lsb-release) || (grep -qi ubuntu /etc/os-release); then
         apt -y install python-pip python-setuptools python-wheel patch
         apt-add-repository -y ppa:ansible/ansible
         # FOUND="true"
-        # FAMILY="debian"   # NOT USED AS OF 2017-12-11
+        # FAMILY="debian"
     # fi
     # if [ ! $FOUND = "true" ]; then
     else
@@ -57,8 +60,8 @@ if ! [ `which ansible-playbook` ]; then
         exit 1
     fi
 else
-    VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
-    echo "Current ansible version installed is $VER"
+    CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
+    echo "Current ansible version installed is $CURR_VER"
     if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
         echo "Please use your system's package manager to update ansible"
         exit 0
@@ -67,7 +70,7 @@ else
         exit 0
     #fi
     #if [[ `grep -qi ansible /etc/apt/sources.list` ]] || [ -f /etc/apt/sources.list.d/ansible*.list ]; then
-    elif [[ `grep -i ansible /etc/apt/sources.list` ]] || ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1 ; then
+    elif (grep -qi ansible /etc/apt/sources.list) || (ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1) ; then
         echo "Ansible repo(s) found within /etc/apt/sources.list*"
     else
         echo "Upstream ansible source repo not found, please uninstall ansible and re-run this script"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -61,7 +61,7 @@ if ! which ansible-playbook ; then
     fi
 else
     #CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
-    CURR_VER=`ansible --version | head -1 | awk '{print $2}'`
+    CURR_VER=`ansible --version | head -1 | awk '{print $2}'`  # to match iiab-install
     echo "Current ansible version installed is $CURR_VER"
     if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
         echo "Please use your system's package manager to update ansible"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,6 +1,9 @@
 #!/bin/bash -e
-# required to start loading IIAB with ansible
-GOOD_VER="2.4.2"
+# Installs or upgrades to the best possible Ansible release, so iiab-install can proceed.
+# Ensure you are online before running this script!
+
+GOOD_VER="2.4.2".      # Ansible version for OLPC.  On other OS's we install/upgrade to the latest Ansible.
+                       # Pinning to 2.4.x could be considered in future, if truly nec?
 VER="undefined"
 # FOUND="false".       # NOT USED AS OF 2017-12-11
 # FAMILY="undefined"   # NOT USED AS OF 2017-12-11

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 # required to start loading IIAB with ansible
 GOOD_VER="2.4.2"
-FOUND="false"
-# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
 VER="undefined"
+# FOUND="false".       # NOT USED AS OF 2017-12-11
+# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
 # below are unused for future use
 # URL="NA"
 
@@ -16,7 +16,7 @@ if ! [ `which ansible-playbook` ]; then
         yum -y install git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
         yum -y install python-pip python-setuptools python-wheel patch
         yum -y install http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.2.0-1.el7.ans.noarch.rpm
-        FOUND="true"
+        # FOUND="true"
         # FAMILY="redhat"   # NOT USED AS OF 2017-12-11
 #    elif [ -f /etc/fedora-release ]; then
 #        VER=`grep VERSION_ID /etc/*elease | cut -d= -f2`
@@ -31,7 +31,7 @@ if ! [ `which ansible-playbook` ]; then
         yum -y install python-pip python-setuptools python-wheel patch
         pip install --upgrade pip setuptools wheel #EOL just do it
         pip install ansible==$GOOD_VER --disable-pip-version-check
-        FOUND="true"
+        # FOUND="true"
         # FAMILY="olpc"   # NOT USED AS OF 2017-12-11
     elif [ -f /etc/debian_version ] || [[ `grep -i raspbian /etc/*elease` ]]; then
         if [[ ! `grep -i ansible /etc/apt/sources.list` ]] && [ ! -f /etc/apt/sources.list.d/ansible ]; then
@@ -40,15 +40,16 @@ if ! [ `which ansible-playbook` ]; then
                  >> /etc/apt/sources.list.d/ansible.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
         fi
-        FOUND="true"
+        # FOUND="true"
         # FAMILY="debian"   # NOT USED AS OF 2017-12-11
     elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -i ubuntu /etc/os-release` ]]; then
         apt -y install python-pip python-setuptools python-wheel patch
         apt-add-repository -y ppa:ansible/ansible
-        FOUND="true"
+        # FOUND="true"
         # FAMILY="debian"   # NOT USED AS OF 2017-12-11
-    fi
-    if [ ! $FOUND = "true" ]; then
+    # fi
+    # if [ ! $FOUND = "true" ]; then
+    else
         echo "WARN: Could not detect distro or distro unsupported"
         exit 1
     fi
@@ -58,13 +59,12 @@ else
     if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
         echo "Please use your system's package manager to update ansible"
         exit 0
-    fi
-    if [ -f /etc/olpc-release ]; then
+    elif [ -f /etc/olpc-release ]; then
         echo "Please use pip package manager to update ansible"
         exit 0
-    fi
+    #fi
     #if [[ `grep -qi ansible /etc/apt/sources.list` ]] || [ -f /etc/apt/sources.list.d/ansible*.list ]; then
-    if [[ `grep -i ansible /etc/apt/sources.list` ]] || ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1 ; then
+    elif [[ `grep -i ansible /etc/apt/sources.list` ]] || ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1 ; then
         echo "Ansible repo(s) found within /etc/apt/sources.list*"
     else
         echo "Upstream ansible source repo not found, please uninstall ansible and re-run this script"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -42,7 +42,7 @@ if ! [ `which ansible-playbook` ]; then
         fi
         FOUND="true"
         # FAMILY="debian"   # NOT USED AS OF 2017-12-11
-    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -qi ubuntu /etc/os-release` ]]; then
+    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -q ubuntu /etc/os-release` ]]; then
         apt -y install python-pip python-setuptools python-wheel patch
         apt-add-repository -y ppa:ansible/ansible
         FOUND="true"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -2,8 +2,8 @@
 # required to start loading IIAB with ansible
 GOOD_VER="2.4.2"
 FOUND="false"
-# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
 VER="undefined"
+# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
 # below are unused for future use
 # URL="NA"
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -2,8 +2,8 @@
 # required to start loading IIAB with ansible
 GOOD_VER="2.4.2"
 FOUND="false"
-VER="undefined"
 # FAMILY="undefined"   # NOT USED AS OF 2017-12-11
+VER="undefined"
 # below are unused for future use
 # URL="NA"
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,27 +1,29 @@
 #!/bin/bash -e
 # required to start loading IIAB with ansible
 GOOD_VER="2.4.2"
-FOUND=""
-FAMILY=""
-VER=""
+FOUND="false"
+# FAMILY="undefined"   # NOT USED AS OF 2017-12-11
+VER="undefined"
 # below are unused for future use
-URL="NA"
+# URL="NA"
+
 export DEBIAN_FRONTEND=noninteractive
-if ! [ $(which ansible-playbook) ]; then
+
+if ! [ `which ansible-playbook` ]; then
     echo "Installing --- Please Wait"
     if [ -f /etc/centos-release ]; then
         yum -y install ca-certificates nss epel-release
         yum -y install git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
         yum -y install python-pip python-setuptools python-wheel patch
         yum -y install http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.2.0-1.el7.ans.noarch.rpm
-        FOUND="yes"
-        FAMILY="redhat"
+        FOUND="true"
+        # FAMILY="redhat"   # NOT USED AS OF 2017-12-11
 #    elif [ -f /etc/fedora-release ]; then
 #        VER=`grep VERSION_ID /etc/*elease | cut -d= -f2`
 #        URL=https://github.com/jvonau/iiab/blob/ansible/vars/fedora-$VER.yml
 #        dnf -y install ansible git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
 #        dnf -y install python-pip python-setuptools python-wheel patch
-#        FOUND="yes"
+#        FOUND="true"
 #        FAMILY="redhat"
     elif [ -f /etc/olpc-release ]; then
         yum -y install ca-certificates nss
@@ -29,29 +31,29 @@ if ! [ $(which ansible-playbook) ]; then
         yum -y install python-pip python-setuptools python-wheel patch
         pip install --upgrade pip setuptools wheel #EOL just do it
         pip install ansible==$GOOD_VER --disable-pip-version-check
-        FOUND="yes"
-        FAMILY="olpc"
-    elif [ -f /etc/debian_version ] || [ `grep -qi raspbian /etc/*elease` ]; then
-        if [ ! `grep -qi ansible /etc/apt/sources.list` ] && [ ! -f /etc/apt/sources.list.d/ansible ]; then
-            apt-get -y install dirmngr python-pip python-setuptools python-wheel patch
+        FOUND="true"
+        # FAMILY="olpc"   # NOT USED AS OF 2017-12-11
+    elif [ -f /etc/debian_version ] || [[ `grep -i raspbian /etc/*elease` ]]; then
+        if [[ ! `grep -i ansible /etc/apt/sources.list` ]] && [ ! -f /etc/apt/sources.list.d/ansible ]; then
+            apt -y install dirmngr python-pip python-setuptools python-wheel patch
             echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
-            >> /etc/apt/sources.list.d/ansible.list
+                 >> /etc/apt/sources.list.d/ansible.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
         fi
-        FOUND="yes"
-        FAMILY="debian"
-    elif [ `grep -qi ubuntu /etc/lsb-release` ] ||  [ `grep -qi ubuntu /etc/os-release` ]; then
-        apt-get -y install python-pip python-setuptools python-wheel patch
+        FOUND="true"
+        # FAMILY="debian"   # NOT USED AS OF 2017-12-11
+    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -qi ubuntu /etc/os-release` ]]; then
+        apt -y install python-pip python-setuptools python-wheel patch
         apt-add-repository -y ppa:ansible/ansible
-        FOUND="yes"
-        FAMILY="debian"
+        FOUND="true"
+        # FAMILY="debian"   # NOT USED AS OF 2017-12-11
     fi
-    if [ ! $FOUND = "yes" ]; then
-        echo 'WARN: Could not detect distro or distro unsupported'
+    if [ ! $FOUND = "true" ]; then
+        echo "WARN: Could not detect distro or distro unsupported"
         exit 1
     fi
 else
-    VER=`ansible --version|head -n 1|cut -f 2 -d " "`
+    VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
     echo "Current ansible version installed is $VER"
     if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
         echo "Please use your system's package manager to update ansible"
@@ -61,19 +63,19 @@ else
         echo "Please use pip package manager to update ansible"
         exit 0
     fi
-    if [[ `grep -qi ansible /etc/apt/sources.list` ]] || [ -f /etc/apt/sources.list.d/ansible*.list ]; then
-        echo "repos found"
+    #if [[ `grep -qi ansible /etc/apt/sources.list` ]] || [ -f /etc/apt/sources.list.d/ansible*.list ]; then
+    if [[ `grep -i ansible /etc/apt/sources.list` ]] || ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1 ; then
+        echo "Ansible repo(s) found"
     else
         echo "Upstream ansible source repo not found, please uninstall ansible and re-run this script"
         exit 1
     fi
 fi
 
-if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && \
-   [ ! -f /etc/olpc-release ]; then
-    echo "Using OS package manager to check for ansible updates"
-    apt-get -y update
-    apt-get -y install ansible
+if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/olpc-release ]; then
+    echo "Using apt to check for & install ansible updates"
+    apt update
+    apt -y install ansible
 fi
 
 # needed?

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -65,7 +65,7 @@ else
     fi
     #if [[ `grep -qi ansible /etc/apt/sources.list` ]] || [ -f /etc/apt/sources.list.d/ansible*.list ]; then
     if [[ `grep -i ansible /etc/apt/sources.list` ]] || ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1 ; then
-        echo "Ansible repo(s) found"
+        echo "Ansible repo(s) found within /etc/apt/sources.list*"
     else
         echo "Upstream ansible source repo not found, please uninstall ansible and re-run this script"
         exit 1
@@ -73,7 +73,7 @@ else
 fi
 
 if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/olpc-release ]; then
-    echo "Using apt to check for & install ansible updates"
+    echo "Using apt to check for updates, then install/upgrade ansible"
     apt update
     apt -y install ansible
 fi

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -14,7 +14,7 @@ CURR_VER="undefined"
 
 export DEBIAN_FRONTEND=noninteractive
 
-if ! [ `which ansible-playbook` ]; then
+if ! which ansible-playbook ; then
     echo "Installing --- Please Wait"
     if [ -f /etc/centos-release ]; then
         yum -y install ca-certificates nss epel-release

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -2,10 +2,10 @@
 # Installs or upgrades to the best possible Ansible release, so iiab-install can proceed.
 # Ensure you are online before running this script!
 
-GOOD_VER="2.4.2".      # Ansible version for OLPC.  On other OS's we install/upgrade to the latest Ansible.
+GOOD_VER="2.4.2"       # Ansible version for OLPC.  On other OS's we install/upgrade to the latest Ansible.
                        # Pinning to 2.4.x could be considered in future, if truly nec?
 VER="undefined"
-# FOUND="false".       # NOT USED AS OF 2017-12-11
+# FOUND="false"        # NOT USED AS OF 2017-12-11
 # FAMILY="undefined"   # NOT USED AS OF 2017-12-11
 # below are unused for future use
 # URL="NA"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -42,7 +42,7 @@ if ! [ `which ansible-playbook` ]; then
         fi
         FOUND="true"
         # FAMILY="debian"   # NOT USED AS OF 2017-12-11
-    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -q ubuntu /etc/os-release` ]]; then
+    elif [[ `grep -i ubuntu /etc/lsb-release` ]] || [[ `grep -i ubuntu /etc/os-release` ]]; then
         apt -y install python-pip python-setuptools python-wheel patch
         apt-add-repository -y ppa:ansible/ansible
         FOUND="true"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -60,7 +60,8 @@ if ! which ansible-playbook ; then
         exit 1
     fi
 else
-    CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
+    #CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
+    CURR_VER=`ansible --version | head -1 | awk '{print $2}'`
     echo "Current ansible version installed is $CURR_VER"
     if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
         echo "Please use your system's package manager to update ansible"


### PR DESCRIPTION
### Fixes Bug

These bash conditionals were failing in my tests:
```
[ -f /etc/apt/sources.list.d/ansible*.list ]
[ `grep -qi <pattern> <file>` ]
```

### Description of changes proposed in this pull request.

Square brackets & backticks caused errors.  So the above conditionals were replaced with:
```
# tests for existence of at least 1 such file
ls /etc/apt/sources.list.d/ansible*.list >/dev/null 2>&1

# tests for existence of at least 1 such pattern
grep -qi <pattern> <file>
# or for readability...
(grep -qi <pattern> <file>)
# IN THE INTERIM IT HAD BEEN:
[[ `grep -i <pattern> <file>` ]]
```

### Smoke-tested in operating system.

Ubuntu 16.04 LTS

### Mention a team member for further information or comment using @ name

"rpm -q" and "-f <path>/ansible*.list" are real bugs, but the rest are merely work-in-progress suggestions, for when @jvonau has time to review with me.

Hopefully we can add in a couple short sentences then, explaining the overall flow & purpose &mdash; _so all understand better when /opt/iiab/iiab/scripts/ansible should be run and when it should not :-)_