### PR TITLE
Experiment trying to get Ethernet working during WiFi installs

### DIFF
--- a/iiab-network
+++ b/iiab-network
@@ -30,7 +30,7 @@ End=`date`
 
 
 # Record critical diagnostics to [/opt/iiab/iiab/]iiab-network.log
-echo "" >> iiab-network.log
+echo >> iiab-network.log
 
 # redhat path
 # Paul Armstrong's Shell Style Guide (https://google.github.io/styleguide/shell.xml)

--- a/roles/0-init/tasks/tz.yml
+++ b/roles/0-init/tasks/tz.yml
@@ -5,28 +5,28 @@
 
 - name: Set local and iiab TZ to UTC if /etc/localtime is not set
   set_fact:
-      local_tz: 'UTC'
-      iiab_TZ: 'UTC'
+    local_tz: 'UTC'
+    iiab_TZ: 'UTC'
   when: TZ_set.stdout == ""
 
 - name: Override ansible on timezone if TZ set
   set_fact:
-      local_tz: '{{ TZ_set.stdout }}'
+    local_tz: '{{ TZ_set.stdout }}'
   when: TZ_set.stdout != ""
 
 - name: Using iiab TZ for local TZ
   set_fact:
-      local_tz: '{{ iiab_TZ }}'
+    local_tz: '{{ iiab_TZ }}'
   when: iiab_TZ is defined and iiab_TZ != "" and iiab_TZ != "TZ_set.stdout"
 
-- name: Set default Timezone from iiab TZ -  Debian
+- name: Set default Timezone from iiab TZ (debuntu)
   shell: timedatectl set-timezone {{ iiab_TZ }}
   when: is_debuntu and iiab_TZ is defined and iiab_TZ != "" and iiab_TZ != "TZ_set.stdout"
 
-- name: Set default Timezone from iiab TZ -  Redhat
+- name: Set default Timezone from iiab TZ (redhat)
   file:
-      path: /etc/localtime
-      src: /usr/share/zoneinfo/{{ iiab_TZ }}
-      force: yes
-      state: link
+    path: /etc/localtime
+    src: "/usr/share/zoneinfo/{{ iiab_TZ }}"
+    force: yes
+    state: link
   when: is_redhat and iiab_TZ is defined and iiab_TZ != "" and iiab_TZ != "TZ_set.stdout"

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -4,5 +4,9 @@
 if [ ! -f /etc/iiab/uuid ]; then
    uuidgen > /etc/iiab/uuid
 fi
-exit 0
 
+# Experimental/Temporary workaround for WiFi "10SEC disease"
+# https://github.com/iiab/iiab/issues/638#issuecomment-355455454
+if grep -qi raspbian /etc/*release; then ip link set dev wlan0 promisc on; fi
+
+exit 0

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -48,9 +48,13 @@ host_country_code: US
 hostapd_secure: True
 hostapd_password: "iiab2017"
 driver_name: nl80211
-manually_toggle_AP: false
-# Above defers AP if installing via WiFi (then after ./iiab-install completes
-# and content is downloaded, run "iiab-hotspot-on" to enable internal AP).
+hostapd_enabled: True
+# Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
+# being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
+# and content is downloaded, to enable the internal WiFi Access Point / AP!)
+reboot_to_AP: False
+# For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
+# behavior, forcing "hostapd_enabled: True" even if installing over WiFi.
 
 network_config_dir: /etc/network/interfaces.d
 #iiab_network_mode: "Gateway"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -48,6 +48,8 @@ host_country_code: US
 hostapd_secure: True
 hostapd_password: "iiab2017"
 driver_name: nl80211
+# Defer AP if WiFi install detected ("iiab-hotspot-on" should be run manually)
+manually_toggle_AP: false
 
 network_config_dir: /etc/network/interfaces.d
 #iiab_network_mode: "Gateway"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -48,8 +48,9 @@ host_country_code: US
 hostapd_secure: True
 hostapd_password: "iiab2017"
 driver_name: nl80211
-# Defer AP if WiFi install detected ("iiab-hotspot-on" should be run manually)
 manually_toggle_AP: false
+# Above defers AP if installing via WiFi (then after ./iiab-install completes
+# and content is downloaded, run "iiab-hotspot-on" to enable internal AP).
 
 network_config_dir: /etc/network/interfaces.d
 #iiab_network_mode: "Gateway"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -54,7 +54,7 @@ hostapd_enabled: True
 # and content is downloaded, to enable the internal WiFi Access Point / AP!)
 reboot_to_AP: False
 # For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
-# behavior, forcing "hostapd_enabled: True" even if installing over WiFi.
+# detection of WiFi-as-gateway, forcing "hostapd_enabled: True" regardless.
 
 network_config_dir: /etc/network/interfaces.d
 #iiab_network_mode: "Gateway"

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -121,19 +121,19 @@
 
 # Select an adapter that is not WAN and not wireless
 # if there is more than one the last one wins
-- name: Set discovered_wired_iface fact if present
+- name: Set discovered_wired_iface if present
   set_fact:
       discovered_wired_iface: "{{ item|trim }}"
   when: lan_list_result.stdout_lines is defined and item|trim != discovered_wireless_iface
   with_items:
       - "{{ lan_list_result.stdout_lines }}"
 
-- name: Set discovered_wireless_lan_iface fact if present
+- name: Set iiab_wireless_lan_iface if present
   set_fact:
        iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
   when: discovered_wireless_iface is defined and discovered_wireless_iface != "none" and discovered_wireless_iface != iiab_wan_iface
 
-- name: Set variable discovered_wired_lan_iface if present
+- name: Set iiab_wired_lan_iface if present
   set_fact:
        iiab_wired_lan_iface: "{{ discovered_wired_iface }}"
   when: discovered_wired_iface is defined and discovered_wired_iface != "none" and discovered_wired_iface != iiab_wan_iface

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -47,7 +47,7 @@
     group: root
     mode: 0755
 
-- name: Enable the Access Point 'hostapd' service
+- name: Enable/Restart the Access Point 'hostapd' service
   service:
     # enabled: yes
     state: restarted

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -1,4 +1,4 @@
-- name: Create a config file for hostapd
+- name: Create /etc/hostapd/hostapd.conf from template
   template: src=hostapd/hostapd.conf.j2
             dest=/etc/hostapd/hostapd.conf
             owner=root
@@ -6,7 +6,7 @@
             mode=0644
   when: iiab_wireless_lan_iface is defined
 
-- name: Create a config template for hostapd
+- name: Create /etc/hostapd/hostapd.conf.iiab from template
   template: src=hostapd/iiab-hostapd.conf.j2
             dest=/etc/hostapd/hostapd.conf.iiab
             owner=root
@@ -27,14 +27,14 @@
             mode=0644
   when: hostapd_enabled
 
-- name: Use custom iiab-hotspot-on
+- name: Create /usr/bin/iiab-hotspot-on from template
   template: src=network/iiab-hotspot-on
             dest=/usr/bin/iiab-hotspot-on
             owner=root
             group=root
             mode=0755
 
-- name: Use custom iiab-hotspot-off
+- name: Create /usr/bin/iiab-hotspot-off from template
   template: src=network/iiab-hotspot-off
             dest=/usr/bin/iiab-hotspot-off
             owner=root

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -1,47 +1,55 @@
 - name: Create /etc/hostapd/hostapd.conf from template
-  template: src=hostapd/hostapd.conf.j2
-            dest=/etc/hostapd/hostapd.conf
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: hostapd/hostapd.conf.j2
+    dest: /etc/hostapd/hostapd.conf
+    owner: root
+    group: root
+    mode: 0644
   when: iiab_wireless_lan_iface is defined
 
 - name: Create /etc/hostapd/hostapd.conf.iiab from template
-  template: src=hostapd/iiab-hostapd.conf.j2
-            dest=/etc/hostapd/hostapd.conf.iiab
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: hostapd/iiab-hostapd.conf.j2
+    dest: /etc/hostapd/hostapd.conf.iiab
+    owner: root
+    group: root
+    mode: 0644
   when: discovered_wireless_iface is defined
 
 - name: Disable the Access Point 'hostapd' service
-  service: enabled=no
-           name=hostapd.service
+  service:
+    enabled: no
+    name: hostapd.service
   when: not hostapd_enabled
 
 - name: Use custom systemd unit file to start 'hostapd' service
-  template: src=hostapd/hostapd.service.j2
-            dest=/etc/systemd/system/hostapd.service
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: hostapd/hostapd.service.j2
+    dest: /etc/systemd/system/hostapd.service
+    owner: root
+    group: root
+    mode: 0644
   when: hostapd_enabled
 
 - name: Create /usr/bin/iiab-hotspot-on from template
-  template: src=network/iiab-hotspot-on
-            dest=/usr/bin/iiab-hotspot-on
-            owner=root
-            group=root
-            mode=0755
+  template:
+    src: network/iiab-hotspot-on
+    dest: /usr/bin/iiab-hotspot-on
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Create /usr/bin/iiab-hotspot-off from template
-  template: src=network/iiab-hotspot-off
-            dest=/usr/bin/iiab-hotspot-off
-            owner=root
-            group=root
-            mode=0755
+  template:
+    src: network/iiab-hotspot-off
+    dest: /usr/bin/iiab-hotspot-off
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Enable the Access Point 'hostapd' service
-  service: enabled=yes
-           name=hostapd.service
-  when: iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance" and hostapd_enabled
+  service:
+    # enabled: yes
+    state: restarted
+    name: hostapd.service
+  when: hostapd_enabled and not manually_toggle_AP and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -52,4 +52,4 @@
     # enabled: yes
     state: restarted
     name: hostapd.service
-  when: hostapd_enabled and not manually_toggle_AP and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -127,7 +127,7 @@
     - network
 
 # this is moving
-- name: Record iiab_wan_device
+- name: Record IIAB_WAN_DEVICE to /etc/iiab/iiab.env
   lineinfile:
     dest: /etc/iiab/iiab.env
     regexp: '^IIAB_WAN_DEVICE=*'
@@ -137,7 +137,7 @@
   tags:
     - network
 
-- name: Record iiab_lan_device
+- name: Record IIAB_LAN_DEVICE to /etc/iiab/iiab.env
   lineinfile:
     dest: /etc/iiab/iiab.env
     regexp: '^IIAB_LAN_DEVICE=*'

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -3,7 +3,7 @@
   tags:
     - network            #REMOVE SUCH LINES (BELOW TOO) AS WE'RE IN "network" ?
     - network-discover
-  
+
 - name: IF WIFI IS PRIMARY GATEWAY, PLEASE RUN 'iiab-hotspot-on' MANUALLY
   set_fact:
     hostapd_enabled: False    # used in (1) hostapd.yml, (2) rpi_debian.yml +
@@ -11,6 +11,9 @@
     no_net_restart: True      # used below in (1) sysd-netd-debian.yml,
                               # (2) debian.yml, (3) rpi_debian.yml
   when: discovered_wireless_iface == iiab_wan_iface and not reboot_to_AP
+# Idea, Not Without Risks: should WiFi-as-gateway detection logic
+# be encapsulated into roles/network/tasks/hostapd.yml in future?
+# Today "./runtags hostapd" doesn't exist & "./runtags AP" is at yr own risk.
 
 #- name: RPi - reboot to AP post install - installed via wifi so the services are ready
 #  set_fact:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -6,11 +6,13 @@
   tags:
     - network            #REMOVE SUCH LINES (BELOW TOO) AS WE'RE IN "network" ?
     - network-discover
-
-# manually_toggle_AP is used in hostapd.yml and in rpi_debian.yml's dhcpcd.conf.j2 (both below)
+  
 - name: Enable manually_toggle_AP if WiFi is primary gateway
   set_fact:
-    manually_toggle_AP: true
+    manually_toggle_AP: true  # used in (1) hostapd.yml, (2) rpi_debian.yml +
+                              # (3) its dhcpcd.conf.j2, (4) restart.yml
+    no_net_restart: True      # used below in (1) sysd-netd-debian.yml,
+                              # (2) debian.yml, (3) rpi_debian.yml
   when: discovered_wireless_iface == iiab_wan_iface and not reboot_to_AP
 
 #- name: RPi - reboot to AP post install - installed via wifi so the services are ready

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,15 +1,12 @@
-#- include_vars: roles/network/defaults/main.yml
-#- include_vars: vars/local_vars.yml
-
 - include_tasks: detected_network.yml
   when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
   tags:
     - network            #REMOVE SUCH LINES (BELOW TOO) AS WE'RE IN "network" ?
     - network-discover
   
-- name: Enable manually_toggle_AP if WiFi is primary gateway
+- name: IF WIFI IS PRIMARY GATEWAY, PLEASE RUN 'iiab-hotspot-on' MANUALLY
   set_fact:
-    manually_toggle_AP: true  # used in (1) hostapd.yml, (2) rpi_debian.yml +
+    hostapd_enabled: False    # used in (1) hostapd.yml, (2) rpi_debian.yml +
                               # (3) its dhcpcd.conf.j2, (4) restart.yml
     no_net_restart: True      # used below in (1) sysd-netd-debian.yml,
                               # (2) debian.yml, (3) rpi_debian.yml

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -93,7 +93,8 @@
 #### Start network layout
 - name: Redhat networking
   include_tasks: ifcfg_mods.yml
-  when: is_redhat and not installing
+  when: is_redhat
+#and not installing
   tags:
     - network
 
@@ -132,7 +133,7 @@
     regexp: '^IIAB_WAN_DEVICE=*'
     line: 'IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
     state: present
-  when: not installing
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
   tags:
     - network
 
@@ -142,7 +143,7 @@
     regexp: '^IIAB_LAN_DEVICE=*'
     line: 'IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
     state: present
-  when: not installing
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
   tags:
     - network
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,23 +1,27 @@
-
 #- include_vars: roles/network/defaults/main.yml
 #- include_vars: vars/local_vars.yml
 
 - include_tasks: detected_network.yml
-  when: not installing
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
   tags:
-    - network
+    - network            #REMOVE SUCH LINES (BELOW TOO) AS WE'RE IN "network" ?
     - network-discover
+
+- name: Enable manually_toggle_AP if WiFi is primary gateway
+  set_fact:
+    manually_toggle_AP: true
+  when: discovered_wireless_iface == iiab_wan_iface
 
 - name: RPi - reboot to AP post install - installed via wifi so the services are ready
   set_fact:
-      iiab_lan_iface: br0
-      iiab_wan_iface: "{{ discovered_wired_iface }}"
-      iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
-      iiab_wired_lan_iface: ""
+    iiab_lan_iface: br0
+    iiab_wan_iface: "{{ discovered_wired_iface }}"
+    iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
+    iiab_wired_lan_iface: ""
   when: is_rpi and discovered_wireless_iface is defined and discovered_wireless_iface == iiab_wan_iface and reboot_to_AP
 
 - include_tasks: computed_network.yml
-  when: not installing
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
   tags:
     - network
     - network-discover
@@ -29,8 +33,8 @@
 
 - name: RPi - don't reboot to AP post install - installed via wifi - don't blow away current network
   set_fact:
-      no_net_restart: True
-      hostapd_enabled: False
+    no_net_restart: True
+    hostapd_enabled: False
   when: is_rpi and discovered_wireless_iface is defined and discovered_wired_iface != iiab_wan_iface
 
 ##### Start static ip address info for first run #####
@@ -47,7 +51,9 @@
 - name: Configuring wondershaper
   include_tasks: wondershaper.yml
   when: wondershaper_install
-  tags: wondershaper, network
+  tags:
+    - network
+    - wondershaper
 
 - name: (Re)Installing named
   include_tasks: named.yml
@@ -86,64 +92,66 @@
 #### Start network layout
 - name: Redhat networking
   include_tasks: ifcfg_mods.yml
-  tags:
-  - network
   when: is_redhat and not installing
+  tags:
+    - network
 
 - name: NetworkManager in use
   include_tasks: NM-debian.yml
-  tags:
-  - network
   when: is_debuntu and network_manager_active
 #and not installing
+  tags:
+    - network
 
 - name: systemd-networkd in use
   include_tasks: sysd-netd-debian.yml
-  tags:
-  - network
   when: is_debuntu and systemd_networkd_active
 #and not installing
+  tags:
+    - network
 
 - name: RPi's have dhcpcd in use
   include_tasks: rpi_debian.yml
-  tags:
-  - network
   when: is_debuntu and is_rpi
 #and not installing
+  tags:
+    - network
 
 - name: Not RPi, Not NetworkManager, Not systemd-networkd in use
   include_tasks: debian.yml
-  tags:
-  - network
   when: not is_rpi and not network_manager_active and not systemd_networkd_active and is_debuntu
 #and not installing
+  tags:
+    - network
 
 # this is moving
 - name: Record iiab_wan_device
-  lineinfile: dest=/etc/iiab/iiab.env
-              regexp='^IIAB_WAN_DEVICE=*'
-              line='IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
-              state=present
+  lineinfile:
+    dest: /etc/iiab/iiab.env
+    regexp: '^IIAB_WAN_DEVICE=*'
+    line: 'IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
+    state: present
   when: not installing
   tags:
-  - network
+    - network
 
 - name: Record iiab_lan_device
-  lineinfile: dest=/etc/iiab/iiab.env
-              regexp='^IIAB_LAN_DEVICE=*'
-              line='IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
-              state=present
+  lineinfile:
+    dest: /etc/iiab/iiab.env
+    regexp: '^IIAB_LAN_DEVICE=*'
+    line: 'IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
+    state: present
   when: not installing
   tags:
-  - network
+    - network
 
 #### end network layout
 - include_tasks: restart.yml
   when: not installing
   tags:
-  - network
-  - named
-  - dhcpd
-  - dnsmasq
-  - squid
-  - AP
+    - network
+    - named
+    - dhcpd
+    - dnsmasq
+    - squid
+    - AP

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -27,7 +27,7 @@
     - network
     - AP
 
-- name: RPi reboot to AP post install - installed via wifi - don't blow away current network
+- name: RPi - don't reboot to AP post install - installed via wifi - don't blow away current network
   set_fact:
       no_net_restart: True
       hostapd_enabled: False

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -7,18 +7,19 @@
     - network            #REMOVE SUCH LINES (BELOW TOO) AS WE'RE IN "network" ?
     - network-discover
 
+# manually_toggle_AP is used in hostapd.yml and in rpi_debian.yml's dhcpcd.conf.j2 (both below)
 - name: Enable manually_toggle_AP if WiFi is primary gateway
   set_fact:
     manually_toggle_AP: true
-  when: discovered_wireless_iface == iiab_wan_iface
+  when: discovered_wireless_iface == iiab_wan_iface and not reboot_to_AP
 
-- name: RPi - reboot to AP post install - installed via wifi so the services are ready
-  set_fact:
-    iiab_lan_iface: br0
-    iiab_wan_iface: "{{ discovered_wired_iface }}"
-    iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
-    iiab_wired_lan_iface: ""
-  when: is_rpi and discovered_wireless_iface is defined and discovered_wireless_iface == iiab_wan_iface and reboot_to_AP
+#- name: RPi - reboot to AP post install - installed via wifi so the services are ready
+#  set_fact:
+#    iiab_lan_iface: br0
+#    iiab_wan_iface: "{{ discovered_wired_iface }}"
+#    iiab_wireless_lan_iface: "{{ discovered_wireless_iface }}"
+#    iiab_wired_lan_iface: ""
+#  when: is_rpi and discovered_wireless_iface is defined and discovered_wireless_iface == iiab_wan_iface and reboot_to_AP
 
 - include_tasks: computed_network.yml
   when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
@@ -31,11 +32,11 @@
     - network
     - AP
 
-- name: RPi - don't reboot to AP post install - installed via wifi - don't blow away current network
-  set_fact:
-    no_net_restart: True
-    hostapd_enabled: False
-  when: is_rpi and discovered_wireless_iface is defined and discovered_wired_iface != iiab_wan_iface
+#- name: RPi - don't reboot to AP post install - installed via wifi - don't blow away current network
+#  set_fact:
+#    no_net_restart: True
+#    hostapd_enabled: False
+#  when: is_rpi and discovered_wireless_iface is defined and discovered_wired_iface != iiab_wan_iface
 
 ##### Start static ip address info for first run #####
 #- include_tasks: static.yml

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -59,14 +59,14 @@
 
 - name: Checking if WiFi slave is active
   shell: brctl show br0 | grep {{ iiab_wireless_lan_iface }} | wc -l
-  when: iiab_wireless_lan_iface is defined and iiab_lan_iface == "br0" and hostapd_enabled
+  when: hostapd_enabled and iiab_wireless_lan_iface is defined and iiab_lan_iface == "br0"
   register: wifi_slave
 
 - name: Restart hostapd if WiFi slave is inactive
   service:
     name: hostapd.service
     state: restarted
-  when: hostapd_enabled and not manually_toggle_AP and wifi_slave.stdout is defined and wifi_slave.stdout == 0
+  when: hostapd_enabled and wifi_slave.stdout is defined and wifi_slave.stdout == 0
 
 - name: dhcp_server may be affected - starting - user choice
   service:

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -3,44 +3,52 @@
 #  when: iiab_wireless_lan_iface is defined and hostapd_enabled
 
 - name: Start named service
-  service: name={{ dns_service }}
-           state=restarted
+  service:
+    name: "{{ dns_service }}"
+    state: restarted
   when: named_enabled and named_install
 
 - name: Stop Squid service
-  service: name={{ proxy }}
-           state=stopped
+  service:
+    name: "{{ proxy }}"
+    state: stopped
   async: 120
   when: squid_install
 
 - name: Stop DansGuardian
-  service: name=dansguardian
-           state=stopped
+  service:
+    name: dansguardian
+    state: stopped
   when: dansguardian_install
 
 - name: Restart DansGuardian - except Ubuntu which needs reboot to activate
-  service: name=dansguardian
-           state=restarted
+  service:
+    name: dansguardian
+    state: restarted
   when: dansguardian_enabled and dansguardian_install and ( not is_ubuntu and iiab_stage|int < 4 )
 
 # Squid get re-loaded with dispatcher.d
 - name: Restart Squid service
-  service: name={{ proxy }}
-           state=restarted
+  service:
+    name: "{{ proxy }}"
+    state: restarted
   when: squid_enabled and squid_install
 
 - name: Restart Wondershaper service
-  service: name=wondershaper
-           state=restarted
+  service:
+    name: wondershaper
+    state: restarted
   when: wondershaper_enabled
 
 - name: Restart avahi service
-  service: name=avahi-daemon
-           state=restarted
+  service:
+    name: avahi-daemon
+    state: restarted
 
 - name: Create gateway flag
   shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway
-         creates=/etc/sysconfig/olpc-scripts/setup.d/installed/gateway
+  args:
+    creates: /etc/sysconfig/olpc-scripts/setup.d/installed/gateway
   when: iiab_network_mode == "Gateway"
 
 - name: Waiting {{ hostapd_wait }} seconds for network to stabilize
@@ -55,11 +63,13 @@
   register: wifi_slave
 
 - name: Restart hostapd if WiFi slave is inactive
-  service: name=hostapd.service
-           state=restarted
-  when: wifi_slave.stdout is defined and hostapd_enabled and wifi_slave.stdout == 0
+  service:
+    name: hostapd.service
+    state: restarted
+  when: hostapd_enabled and not manually_toggle_AP and wifi_slave.stdout is defined and wifi_slave.stdout == 0
 
 - name: dhcp_server may be affected - starting - user choice
-  service: name={{ dhcp_service2 }}
-           state=restarted
+  service:
+    name: "{{ dhcp_service2 }}"
+    state: restarted
   when: iiab_network_mode != "Appliance"

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -38,19 +38,19 @@
     name: dhcpcd
     state: restarted
 
-- name: Restart the networking service
+- name: Restart the networking service if appropriate
   service:
     name: networking
     enabled: yes
     state: restarted
   when: not nobridge is defined and not no_net_restart
 
-- name: Restart hostapd when WiFi is present
+- name: Restart hostapd if appropriate
   service:
     name: hostapd
     enabled: yes
     state: restarted
-  when: iiab_wireless_lan_iface is defined and hostapd_enabled and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and not manually_toggle_AP and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"
 
 #- name: dhcp_server may be affected - starting - user choice
 #  service: name={{ dhcp_service2 }} state=started

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -50,7 +50,7 @@
     name: hostapd
     enabled: yes
     state: restarted
-  when: hostapd_enabled and not manually_toggle_AP and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"
 
 #- name: dhcp_server may be affected - starting - user choice
 #  service: name={{ dhcp_service2 }} state=started

--- a/roles/network/templates/hostapd/hostapd.conf.j2
+++ b/roles/network/templates/hostapd/hostapd.conf.j2
@@ -5,7 +5,7 @@ interface={% if iiab_wireless_lan_iface is defined %}{{ iiab_wireless_lan_iface 
 
 ssid={{ host_ssid }}
 channel={{ host_channel }}
-{%if iiab_lan_iface  == "br0" %}
+{%if iiab_lan_iface == "br0" %}
 bridge=br0
 {% endif %}
 

--- a/roles/network/templates/hostapd/hostapd.conf.j2
+++ b/roles/network/templates/hostapd/hostapd.conf.j2
@@ -2,6 +2,7 @@
 
 interface={% if iiab_wireless_lan_iface is defined %}{{ iiab_wireless_lan_iface }}{% endif %}
 
+
 ssid={{ host_ssid }}
 channel={{ host_channel }}
 {%if iiab_lan_iface  == "br0" %}

--- a/roles/network/templates/hostapd/iiab-hostapd.conf.j2
+++ b/roles/network/templates/hostapd/iiab-hostapd.conf.j2
@@ -4,7 +4,7 @@ interface={{ discovered_wireless_iface }}
 
 ssid={{ host_ssid }}
 channel={{ host_channel }}
-{%if iiab_lan_iface  == "br0" %}
+{%if iiab_lan_iface == "br0" %}
 bridge=br0
 {% endif %}
 

--- a/roles/network/templates/network/dhcpcd.conf.j2
+++ b/roles/network/templates/network/dhcpcd.conf.j2
@@ -37,11 +37,13 @@ require dhcp_server_identifier
 # Generate Stable Private IPv6 Addresses instead of hardware based ones
 slaac private
 
-# IIAB - always support Ethernet-to-Internet on RPi
-{% if is_rpi and manually_toggle_AP %}
-#denyinterfaces {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %}
-{% elif is_rpi %}
+# IIAB
+
+# always support Ethernet-to-Internet on RPi (avoid "denyinterfaces eth0")
+{% if is_rpi and hostapd_enabled %}
 denyinterfaces {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %}
+{% elif is_rpi %}
+#denyinterfaces {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %}
 {% else %}
 denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
 {% endif %}

--- a/roles/network/templates/network/dhcpcd.conf.j2
+++ b/roles/network/templates/network/dhcpcd.conf.j2
@@ -38,10 +38,13 @@ require dhcp_server_identifier
 slaac private
 
 # IIAB
-denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %}
-#denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
+{% if is_rpi %}
+#denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %}
+{% else %}
+denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
+{% endif %}
 
-#{% if iiab_lan_iface != "br0" %} {{ iiab_lan_iface }} {% endif %}
+{# {% if iiab_lan_iface != "br0" %} {{ iiab_lan_iface }} {% endif %} #}
 
 {% if dhcpcd_result == "enabled" and iiab_lan_iface != "none" %}
 interface {{ iiab_lan_iface }}

--- a/roles/network/templates/network/dhcpcd.conf.j2
+++ b/roles/network/templates/network/dhcpcd.conf.j2
@@ -37,9 +37,11 @@ require dhcp_server_identifier
 # Generate Stable Private IPv6 Addresses instead of hardware based ones
 slaac private
 
-# IIAB
-{% if is_rpi %}
-#denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %}
+# IIAB - always support Ethernet-to-Internet on RPi
+{% if is_rpi and manually_toggle_AP %}
+#denyinterfaces {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %}
+{% elif is_rpi %}
+denyinterfaces {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %}
 {% else %}
 denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
 {% endif %}

--- a/roles/network/templates/network/dhcpcd.conf.j2
+++ b/roles/network/templates/network/dhcpcd.conf.j2
@@ -38,7 +38,8 @@ require dhcp_server_identifier
 slaac private
 
 # IIAB
-denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
+denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %}
+#denyinterfaces {% if iiab_wireless_lan_iface is defined %} {{ iiab_wireless_lan_iface }} {% endif %} {% if iiab_wired_lan_iface is defined %} {{ iiab_wired_lan_iface }} {% endif %}
 
 #{% if iiab_lan_iface != "br0" %} {{ iiab_lan_iface }} {% endif %}
 

--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -7,3 +7,7 @@ systemctl stop dhcpd
 systemctl daemon-reload
 systemctl restart dhcpcd
 systemctl restart networking
+
+# Experimental/Temporary workaround for WiFi "10SEC disease"
+# https://github.com/iiab/iiab/issues/638#issuecomment-355455454
+if grep -qi raspbian /etc/*release; then ip link set dev wlan0 promisc on; fi

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -65,16 +65,22 @@ lan_netmask: 255.255.224.0
 # Internal Wi-Fi Access Point
 # Values are used if there is an internal Wi-Fi adapter and hostapd is enabled
 # The platform variable adapts install to specific hardware (raspberry pi=rpi2)
-hostapd_enabled: True
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-# For those installing IIAB over WiFi: "reboot_to_AP: True" makes the internal
-# WiFi Access active after the next reboot.  This is equivalent to manually
-# running "iiab-hotspot-on".  Note this variable only works with RPi's for now.
+hostapd_enabled: True
+# Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
+# being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
+# and content is downloaded, to enable the internal WiFi Access Point / AP!)
 reboot_to_AP: False
+# For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
+# behavior, forcing "hostapd_enabled: True" even if installing over WiFi.
+## Note this variable only works with RPi's for now.
+## makes the internal
+## WiFi Access active after the next reboot.  This is equivalent to manually
+## running "iiab-hotspot-on".  Note this variable only works with RPi's for now.
 
 # Gateway mode
 iiab_lan_enabled: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -77,10 +77,6 @@ hostapd_enabled: True
 reboot_to_AP: False
 # For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
 # behavior, forcing "hostapd_enabled: True" even if installing over WiFi.
-## Note this variable only works with RPi's for now.
-## makes the internal
-## WiFi Access active after the next reboot.  This is equivalent to manually
-## running "iiab-hotspot-on".  Note this variable only works with RPi's for now.
 
 # Gateway mode
 iiab_lan_enabled: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -76,7 +76,7 @@ hostapd_enabled: True
 # and content is downloaded, to enable the internal WiFi Access Point / AP!)
 reboot_to_AP: False
 # For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
-# behavior, forcing "hostapd_enabled: True" even if installing over WiFi.
+# detection of WiFi-as-gateway, forcing "hostapd_enabled: True" regardless.
 
 # Gateway mode
 iiab_lan_enabled: True


### PR DESCRIPTION
Highly-experimental attempt at fixing #616 "WiFi-installed IIAB does not connect using an Ethernet cable"

_Hopefully @jvonau and others can help refine this!_

Context: too many WiFi installs are failing, and implementers get profoundly stuck, needing Ethernet-to-Internet in order to recover. 

Once they finally get through `./iiab-install` (using Ethernet-to-Internet or WiFi-to-Internet) they of course need to run `iiab-hotspot-on` if they began the process over WiFi &mdash; as documented @ https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch (Item 3.)

Also Related: https://github.com/iiab/iiab/issues/558#issuecomment-350842090, PR #617 _(still nec or not?),_ PR #634 _merged._