### PR TITLE
establish "auto_admin: True" (instead of no_admin: undefined) in default_vars & local_vars

### DIFF
--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: admin-user.yml
   tags:
     - base
-  when: not no_admin
+  when: auto_admin
 
 - include_tasks: access.yml
   tags:

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: admin-user.yml
   tags:
     - base
-  when: not no_admin is defined
+  when: not no_admin
 
 - include_tasks: access.yml
   tags:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -29,20 +29,17 @@ disregard_network: False  # use cache or error out if cache does not exist
 
 # Users and Passwords
 
-# Uncomment the following if you don't want iiab_admin_user (by default
-# iiab-admin) to be auto-created in roles/iiab-admin/tasks/main.yml
-# Also disables sudo-based verification of published passwords.
-
-# no_admin: ""
-
-# If no_admin variable is established above (its actual value is IGNORED) also
-# set iiab_admin_user (below) to an existing Linux user that has sudo access.
-# That is the username you'll use to login to Admin Console @ http://box/admin
-
 iiab_admin_user: iiab-admin
-
 # Obtain a password hash with: python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 iiab_admin_passw_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
+auto_admin: True
+
+# Set auto_admin: False if you don't want iiab_admin_user & wheel group to be
+# auto-created in roles/iiab-admin/tasks/main.yml, thereby disabling sudo-based
+# warnings on use of published passwords like pi/raspberry & iiab-admin/g0adm1n
+
+# If auto_admin: False, set iiab_admin_user (below) to an existing Linux user
+# that has sudo access, so you can login to Admin Console @ http://box/admin
 
 # Languages
 default_language: en

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -38,7 +38,7 @@ auto_admin: True
 # auto-created in roles/iiab-admin/tasks/main.yml, thereby disabling sudo-based
 # warnings on use of published passwords like pi/raspberry & iiab-admin/g0adm1n
 
-# If auto_admin: False, set iiab_admin_user (below) to an existing Linux user
+# If auto_admin: False, set iiab_admin_user (above) to an existing Linux user
 # that has sudo access, so you can login to Admin Console @ http://box/admin
 
 # Languages

--- a/vars/medium.localvars
+++ b/vars/medium.localvars
@@ -4,27 +4,24 @@
 # SEE EXAMPLE http://download.iiab.io/6.5/rpi/local_vars_big.yml
 # SEE EXAMPLE http://download.iiab.io/6.5/rpi/local_vars_min.yml
 
-# Original Idea: branch github.com/xsce/xsce-local for your deployment
+# Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
 download_timeout: 100
 
 # Users and Passwords
 
-# Uncomment the following if you don't want iiab_admin_user (by default
-# iiab-admin) to be auto-created in roles/iiab-admin/tasks/main.yml
-# Also disables sudo-based verification of published passwords.
-
-# no_admin: ""
-
-# If no_admin variable is established above (its actual value is IGNORED) also
-# set iiab_admin_user (below) to an existing Linux user that has sudo access.
-# That is the username you'll use to login to Admin Console @ http://box/admin
-
 iiab_admin_user: iiab-admin
-
 # Obtain a password hash with: python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 # iiab_admin_passw_hash:
+auto_admin: True
+
+# Set auto_admin: False if you don't want iiab_admin_user & wheel group to be
+# auto-created in roles/iiab-admin/tasks/main.yml, thereby disabling sudo-based
+# verification of published passwords like pi/raspberry & iiab-admin/g0adm1n
+
+# If auto_admin: False, set iiab_admin_user (below) to an existing Linux user
+# that has sudo access, so you can login to Admin Console @ http://box/admin
 
 iiab_hostname: box
 iiab_domain: lan

--- a/vars/medium.localvars
+++ b/vars/medium.localvars
@@ -18,7 +18,7 @@ auto_admin: True
 
 # Set auto_admin: False if you don't want iiab_admin_user & wheel group to be
 # auto-created in roles/iiab-admin/tasks/main.yml, thereby disabling sudo-based
-# verification of published passwords like pi/raspberry & iiab-admin/g0adm1n
+# warnings on use of published passwords like pi/raspberry & iiab-admin/g0adm1n
 
 # If auto_admin: False, set iiab_admin_user (below) to an existing Linux user
 # that has sudo access, so you can login to Admin Console @ http://box/admin

--- a/vars/medium.localvars
+++ b/vars/medium.localvars
@@ -20,7 +20,7 @@ auto_admin: True
 # auto-created in roles/iiab-admin/tasks/main.yml, thereby disabling sudo-based
 # warnings on use of published passwords like pi/raspberry & iiab-admin/g0adm1n
 
-# If auto_admin: False, set iiab_admin_user (below) to an existing Linux user
+# If auto_admin: False, set iiab_admin_user (above) to an existing Linux user
 # that has sudo access, so you can login to Admin Console @ http://box/admin
 
 iiab_hostname: box


### PR DESCRIPTION
Implements #636 

(To date, the top of https://github.com/iiab/iiab/blob/master/vars/medium.localvars & https://github.com/iiab/iiab/blob/master/vars/default_vars.yml were unnecessarily confusing, as these attempted to explain that "no_admin:" was undefined by default — and what happened when it was set to any value at all...

This has been replaced by "auto_admin: True" with much tigher security explanations at the top of both above files.)