### PR TITLE
Refactor iiab-startup.yml & iiab-startup.sh (for iiab-hotspot-on|off & iiab.ini)

### DIFF
--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -7,20 +7,20 @@
   template:
     src: iiab-startup.service
     dest: /etc/systemd/system/
-  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+  when: not startup_unit.stat.exists
 
 - name: Copy template script to /usr/libexec/iiab-startup.sh
   template:
     src: iiab-startup.sh
     dest: /usr/libexec/
     mode: 0755
-  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+  when: not startup_unit.stat.exists
 
 - name: Do a systemd daemon-reload
   # shell: systemctl daemon-reload
   systemd:
     daemon_reload: yes
-  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+  when: not startup_unit.stat.exists
 
 - name: Enable & restart the systemd service
   # shell: systemctl restart iiab-startup.service
@@ -28,4 +28,4 @@
   service:
     enabled: yes
     restarted: yes
-  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
+  when: not startup_unit.stat.exists

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -1,26 +1,31 @@
-- name: Does systemd startup service exist
-  stat: path="{{ systemd_location }}/iiab-startup.service"
+- name: Does systemd iiab-startup.service exist?
+  stat:
+    path: "{{ systemd_location }}/iiab-startup.service"
   register: startup_unit
 
-- name: Copy startup service to /etc/systemd/system
-  template: src=iiab-startup.service
-            dest=/etc/systemd/system/
+- name: Copy iiab-startup.service to /etc/systemd/system
+  template:
+    src: iiab-startup.service
+    dest: /etc/systemd/system/
   when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
 
-- name: Copy startup script
-  template: src=iiab-startup.sh
-            dest=/usr/libexec/
-            mode=0755
+- name: Copy template script to /usr/libexec/iiab-startup.sh
+  template:
+    src: iiab-startup.sh
+    dest: /usr/libexec/
+    mode: 0755
   when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
 
-- name: Ask systemd to recognize the changes
-  shell: systemctl daemon-reload
+- name: Do a systemd daemon-reload
+  # shell: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
   when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
 
-- name: Restart so systemd recognizes the changes
-  shell: systemctl restart iiab-startup.service
-  when: startup_unit.stat.exists is defined and not startup_unit.stat.exists
-
-- name: Enable the reload service
-  shell: systemctl enable iiab-startup.service
+- name: Enable & restart the systemd service
+  # shell: systemctl restart iiab-startup.service
+  # shell: systemctl enable iiab-startup.service
+  service:
+    enabled: yes
+    restarted: yes
   when: startup_unit.stat.exists is defined and not startup_unit.stat.exists

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -10,7 +10,7 @@
     mode: 0755
   when: not startup_script.stat.exists
 
-- name: Copy iiab-startup.service to /etc/systemd/system
+- name: Copy iiab-startup.service to {{ systemd_location }}
   template:
     src: iiab-startup.service
     dest: "{{ systemd_location }}"

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -16,16 +16,13 @@
     mode: 0755
   when: not startup_unit.stat.exists
 
-- name: Do a systemd daemon-reload
+- name: Enable & restart the systemd service after daemon-reload
   # shell: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-  when: not startup_unit.stat.exists
-
-- name: Enable & restart the systemd service
   # shell: systemctl restart iiab-startup.service
   # shell: systemctl enable iiab-startup.service
-  service:
+  systemd:
+    name: iiab-startup
+    daemon_reload: yes
     enabled: yes
     restarted: yes
   when: not startup_unit.stat.exists

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -1,20 +1,20 @@
-- name: Does systemd iiab-startup.service exist?
+- name: Does /usr/libexec/iiab-startup.sh exist?
   stat:
-    path: "{{ systemd_location }}/iiab-startup.service"
-  register: startup_unit
-
-- name: Copy iiab-startup.service to /etc/systemd/system
-  template:
-    src: iiab-startup.service
-    dest: /etc/systemd/system/
-  when: not startup_unit.stat.exists
+    path: /usr/libexec/iiab-startup.sh
+  register: startup_script
 
 - name: Copy template script to /usr/libexec/iiab-startup.sh
   template:
     src: iiab-startup.sh
     dest: /usr/libexec/
     mode: 0755
-  when: not startup_unit.stat.exists
+  when: not startup_script.stat.exists
+
+- name: Copy iiab-startup.service to /etc/systemd/system
+  template:
+    src: iiab-startup.service
+    dest: "{{ systemd_location }}"
+  when: not startup_script.stat.exists
 
 - name: Enable & restart the systemd service after daemon-reload
   # shell: systemctl daemon-reload
@@ -25,4 +25,4 @@
     daemon_reload: yes
     enabled: yes
     state: restarted
-  when: not startup_unit.stat.exists
+  when: not startup_script.stat.exists

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -24,5 +24,5 @@
     name: iiab-startup
     daemon_reload: yes
     enabled: yes
-    restarted: yes
+    state: restarted
   when: not startup_unit.stat.exists

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -5,7 +5,9 @@ if [ ! -f /etc/iiab/uuid ]; then
    uuidgen > /etc/iiab/uuid
 fi
 
-# Temporary promiscuous-mode workaround for WiFi "10SEC disease"
+# Temporary promiscuous-mode workaround for RPi's WiFi "10SEC disease"
+# Set wlan0 to promiscuous on boot if needed as gateway (i.e. AP's OFF)
+# Scripts iiab-hotspot-on + iiab-hotspot-off SHOULD toggle this boot flag!
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if [[ $(grep -i raspbian /etc/*release) &&
          ($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -10,11 +10,11 @@ fi
 # Scripts iiab-hotspot-on + iiab-hotspot-off SHOULD toggle this boot flag!
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if [[ $(grep -i raspbian /etc/*release) &&
-         ($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||
-             ((! $(grep "hostapd_enabled = True" /etc/iiab/config_vars.yml)) &&
+        #($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||
+            #((! $(grep "hostapd_enabled = True" /etc/iiab/config_vars.yml)) &&
                  $(grep "hostapd_enabled = False" /etc/iiab/iiab.ini)
-             )
-         )
+            #)
+        #)
    ]];
 then
     ip link set dev wlan0 promisc on

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -5,8 +5,17 @@ if [ ! -f /etc/iiab/uuid ]; then
    uuidgen > /etc/iiab/uuid
 fi
 
-# Experimental/Temporary workaround for WiFi "10SEC disease"
+# Temporary promiscuous-mode workaround for WiFi "10SEC disease"
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
-if grep -qi raspbian /etc/*release; then ip link set dev wlan0 promisc on; fi
+if [[ $(grep -i raspbian /etc/*release) &&
+         ($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||
+             ((! $(grep "hostapd_enabled = True" /etc/iiab/config_vars.yml)) &&
+                 $(grep "hostapd_enabled = False" /etc/iiab/iiab.ini)
+             )
+         )
+   ]];
+then
+    ip link set dev wlan0 promisc on
+fi
 
 exit 0

--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -12,7 +12,7 @@ fi
 if [[ $(grep -i raspbian /etc/*release) &&
         #($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||
             #((! $(grep "hostapd_enabled = True" /etc/iiab/config_vars.yml)) &&
-                 $(grep "hostapd_enabled = False" /etc/iiab/iiab.ini)
+                 $(grep "^hostapd_enabled = False" /etc/iiab/iiab.ini)
             #)
         #)
    ]];

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -3,7 +3,7 @@
 # ifcfg-rh acts on /etc/sys*/net*/ifcfg-* where we search for devices.
 - name: Setting XO has WiFi gateway
   set_fact:
-     user_wan_iface: "{{ discovered_wan_iface }}"
+    user_wan_iface: "{{ discovered_wan_iface }}"
   when: discovered_wan_iface != "none" and xo_model != "none" and has_ifcfg_gw == "none"
 
 #- name: Checking for NetworkManager-config-server
@@ -22,7 +22,7 @@
 
 - name: XO laptop wants USB WiFi interface as AP mode
   set_fact:
-     iiab_wireless_lan_iface: "{{ discovered_lan_iface }}"
+    iiab_wireless_lan_iface: "{{ discovered_lan_iface }}"
   when: num_wifi_interfaces >= "2" and xo_model != "none" and discovered_wan_iface != "none" and discovered_wireless_iface == "eth0"
 
 # static backout suppy new template file
@@ -34,7 +34,7 @@
 
 - name: Undo gui-static-wan by requesting new template file
   set_fact:
-     has_WAN: False
+    has_WAN: False
   when: gui_static_wan_ip != "unset" and not gui_static_wan
 
 # figure out more than one interfaces to detect.
@@ -77,7 +77,7 @@
 
 - name: Setting user_lan_iface for 'LanController' for single interface
   set_fact:
-     user_lan_iface: "{{ discovered_wan_iface }}"
+    user_lan_iface: "{{ discovered_wan_iface }}"
   when: discovered_wan_iface != "none" and num_lan_interfaces == "0" and gui_desired_network_role is defined and gui_desired_network_role == "LanController"
 
 # override with user_wan_iface setting if no longer in auto
@@ -108,10 +108,10 @@
 
 # make it so number 2 vars should use user_wan_iface but we can cover a single
 # wired if dhcp fails the interface should revert to LAN, static address should
-# stick around but testing gateway response is not preformed.
+# stick around but testing gateway response is not performed.
 - name: User wants single wired interface as static or dhcp gateway
   set_fact:
-     user_wan_iface: "{{ discovered_lan_iface }}"
+    user_wan_iface: "{{ discovered_lan_iface }}"
   when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
 
 - name: No LAN configured - 'Appliance' mode
@@ -154,30 +154,31 @@
   when: adapter_count.stdout|int >= "5" and device_gw == "none" and gui_wan_iface == "unset" and gui_static_wan is defined
 
 - name: Add location section to config file
-  ini_file: dest='{{ iiab_config_file }}'
-            section=computed_network
-            option='{{ item.option }}'
-            value='{{ item.value }}'
+  ini_file:
+    dest: "{{ iiab_config_file }}"
+    section: computed_network
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
   with_items:
-  - option: 'iiab_wan_enabled'
-    value: '{{ iiab_wan_enabled }}'
-  - option: 'user_wan_iface'
-    value: '{{ user_wan_iface }}'
-  - option: 'iiab_wan_iface'
-    value: '{{ iiab_wan_iface }}'
-  - option: 'iiab_lan_enabled'
-    value: '{{ iiab_lan_enabled }}'
-  - option: 'user_lan_iface'
-    value: '{{ user_lan_iface }}'
-  - option: 'iiab_lan_iface'
-    value: '{{ iiab_lan_iface }}'
-  - option: 'iiab_network_mode'
-    value: '{{ iiab_network_mode }}'
-  - option: 'hostapd_enabled'
-    value: '{{ hostapd_enabled }}'
-  - option: 'host_ssid'
-    value: '{{ host_ssid }}'
-  - option: 'host_wifi_mode'
-    value: '{{ host_wifi_mode }}'
-  - option: 'host_channel'
-    value: '{{ host_channel }}'
+  - option: iiab_wan_enabled
+    value: "{{ iiab_wan_enabled }}"
+  - option: user_wan_iface
+    value: "{{ user_wan_iface }}"
+  - option: iiab_wan_iface
+    value: "{{ iiab_wan_iface }}"
+  - option: iiab_lan_enabled
+    value: "{{ iiab_lan_enabled }}"
+  - option: user_lan_iface
+    value: "{{ user_lan_iface }}"
+  - option: iiab_lan_iface
+    value: "{{ iiab_lan_iface }}"
+  - option: iiab_network_mode
+    value: "{{ iiab_network_mode }}"
+  - option: hostapd_enabled
+    value: "{{ hostapd_enabled }}"
+  - option: host_ssid
+    value: "{{ host_ssid }}"
+  - option: host_wifi_mode
+    value: "{{ host_wifi_mode }}"
+  - option: host_channel
+    value: "{{ host_channel }}"

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -111,7 +111,10 @@
 # stick around but testing gateway response is not performed.
 - name: User wants single wired interface as static or dhcp gateway
   set_fact:
-    user_wan_iface: "{{ discovered_wan_iface }}"   # Jan 2018: discovered_lan_iface was UNDEFINED on WiFi-installed RPi
+    user_wan_iface: "{{ discovered_wan_iface }}"   # Jan 2018: Holt discovered_lan_iface was UNDEFINED on WiFi-installed
+                                                   # RPi (when re-running ./iiab-network) so "discovered_wan_iface" is a
+                                                   # workaround -- please see https://github.com/iiab/iiab/pull/649
+                                                   # This workaround can and should evolve as IIAB 6.5 matures!
   when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
 
 - name: No LAN configured - 'Appliance' mode

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -111,7 +111,7 @@
 # stick around but testing gateway response is not performed.
 - name: User wants single wired interface as static or dhcp gateway
   set_fact:
-    user_wan_iface: "{{ discovered_lan_iface }}"
+    user_wan_iface: "{{ discovered_wan_iface }}"   # Jan 2018: discovered_lan_iface was UNDEFINED on WiFi-installed RPi
   when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
 
 - name: No LAN configured - 'Appliance' mode

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -11,9 +11,13 @@
     no_net_restart: True      # used below in (1) sysd-netd-debian.yml,
                               # (2) debian.yml, (3) rpi_debian.yml
   when: discovered_wireless_iface == iiab_wan_iface and not reboot_to_AP
-# Idea, Not Without Risks: should WiFi-as-gateway detection logic
-# be encapsulated into roles/network/tasks/hostapd.yml in future?
-# Today "./runtags hostapd" doesn't exist & "./runtags AP" is at yr own risk.
+# EITHER WAY: hostapd_enabled's state is RECORDED into /etc/iiab/iiab.ini
+# (by computed_ntetwork.yml below) for later use by...
+# /usr/libexec/iiab-startup.sh, iiab-hotspot-off & iiab-hotspot-on
+#
+# Separate Idea, Not Without Risks: should WiFi-as-gateway detection logic
+# be encapsulated into roles/network/tasks/hostapd.yml in future?  Whereas
+# today "./runtags hostapd" doesn't exist & "./runtags AP" is UNSUPPORTED!
 
 #- name: RPi - reboot to AP post install - installed via wifi so the services are ready
 #  set_fact:

--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -8,6 +8,11 @@ systemctl daemon-reload
 systemctl restart dhcpcd
 systemctl restart networking
 
-# Experimental/Temporary workaround for WiFi "10SEC disease"
+# Temporary promiscuous-mode workaround for RPi's WiFi "10SEC disease"
+# Set wlan0 to promiscuous when needed as gateway (i.e. AP's OFF)
+# SEE ALSO iiab-hotspot-on + /usr/libexec/iiab-startup.sh
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
-if grep -qi raspbian /etc/*release; then ip link set dev wlan0 promisc on; fi
+if grep -qi raspbian /etc/*release; then
+    ip link set dev wlan0 promisc on
+    sed -i -e "s/hostapd_enabled.*/hostapd_enabled = False/" /etc/iiab/iiab.ini
+fi

--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -16,4 +16,4 @@ if grep -qi raspbian /etc/*release; then
     ip link set dev wlan0 promisc on
 fi
 
-sed -i -e "s/hostapd_enabled.*/hostapd_enabled = False/" /etc/iiab/iiab.ini
+sed -i -e "s/^hostapd_enabled.*/hostapd_enabled = False/" /etc/iiab/iiab.ini

--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -14,5 +14,6 @@ systemctl restart networking
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if grep -qi raspbian /etc/*release; then
     ip link set dev wlan0 promisc on
-    sed -i -e "s/hostapd_enabled.*/hostapd_enabled = False/" /etc/iiab/iiab.ini
 fi
+
+sed -i -e "s/hostapd_enabled.*/hostapd_enabled = False/" /etc/iiab/iiab.ini

--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -9,7 +9,7 @@ systemctl restart dhcpcd
 systemctl restart networking
 
 # Temporary promiscuous-mode workaround for RPi's WiFi "10SEC disease"
-# Set wlan0 to promiscuous when needed as gateway (i.e. AP's OFF)
+# Set wlan0 to promiscuous when AP's OFF (for possible WiFi gateway)
 # SEE ALSO iiab-hotspot-on + /usr/libexec/iiab-startup.sh
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if grep -qi raspbian /etc/*release; then

--- a/roles/network/templates/network/iiab-hotspot-on
+++ b/roles/network/templates/network/iiab-hotspot-on
@@ -15,5 +15,6 @@ systemctl start dhcpd
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if grep -qi raspbian /etc/*release; then
     ip link set dev wlan0 promisc off
-    sed -i -e "s/hostapd_enabled.*/hostapd_enabled = True/" /etc/iiab/iiab.ini
 fi
+
+sed -i -e "s/hostapd_enabled.*/hostapd_enabled = True/" /etc/iiab/iiab.ini

--- a/roles/network/templates/network/iiab-hotspot-on
+++ b/roles/network/templates/network/iiab-hotspot-on
@@ -8,3 +8,12 @@ systemctl restart dhcpcd
 systemctl restart networking
 systemctl start hostapd
 systemctl start dhcpd
+
+# Temporary promiscuous-mode workaround for RPi's WiFi "10SEC disease"
+# Disable "promiscuous" on wlan0 when AP (i.e. no WiFi gateway)
+# SEE ALSO iiab-hotspot-off + /usr/libexec/iiab-startup.sh
+# https://github.com/iiab/iiab/issues/638#issuecomment-355455454
+if grep -qi raspbian /etc/*release; then
+    ip link set dev wlan0 promisc off
+    sed -i -e "s/hostapd_enabled.*/hostapd_enabled = True/" /etc/iiab/iiab.ini
+fi

--- a/roles/network/templates/network/iiab-hotspot-on
+++ b/roles/network/templates/network/iiab-hotspot-on
@@ -17,4 +17,4 @@ if grep -qi raspbian /etc/*release; then
     ip link set dev wlan0 promisc off
 fi
 
-sed -i -e "s/hostapd_enabled.*/hostapd_enabled = True/" /etc/iiab/iiab.ini
+sed -i -e "s/^hostapd_enabled.*/hostapd_enabled = True/" /etc/iiab/iiab.ini


### PR DESCRIPTION
- Clarified comments
- Refactored per modern Ansible norms
- hostapd_enabled has its live state stored in /etc/iiab/iiab.ini and /usr/libexec/iiab-startup.sh uses this toggle as a trigger on boot, to turn on wlan0's promiscuous mode if AP off, so WiFi-gateway-to-Internet, circumventing Raspbian's WiFi bug #638 (10SEC disease)
- /usr/bin/iiab-hotspot-on and /usr/bin/iiab-hotspot-on modify /etc/iiab/iiab.ini accordingly
- In response to @tim-moody's [question](https://github.com/iiab/iiab/pull/647#issuecomment-355462646) you are indeed correct this will not be auto-upgraded, unless the operator deletes /usr/libexec/iiab-startup.sh &mdash; so I've documented that at http://FAQ.IIAB.IO [Item 22](http://wiki.laptop.org/go/IIAB/FAQ#Can_I_upgrade_or_reinstall_server_apps.3F) &mdash; for better or for worse this approach protects human operators' manual customization to /usr/libexec/iiab-startup.sh
- Smoke-tested on Ubuntu 16.04 LTS (with both code paths)