### PR TITLE
Turn on wlan0 promiscuous mode within network playbook...or much earlier?! (RPi)

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -18,6 +18,9 @@
 # Separate Idea, Not Without Risks: should WiFi-as-gateway detection logic
 # be encapsulated into roles/network/tasks/hostapd.yml in future?  Whereas
 # today "./runtags hostapd" doesn't exist & "./runtags AP" is UNSUPPORTED!
+- name: Turn on wlan0 promiscuous mode if is_rpi and not hostapd_enabled (mitigates Raspbian's WiFi bug / 10SEC disease @ https://github.com/iiab/iiab/issues/638)
+  shell: ip link set dev wlan0 promisc on
+  when: is_rpi and not hostapd_enabled
 
 #- name: RPi - reboot to AP post install - installed via wifi so the services are ready
 #  set_fact:


### PR DESCRIPTION
wlan0 promiscuous mode should be turned on much earlier during ./iiab-install, so that WiFi-to-Internet is far more stable on RPi when installing over WiFi!

Unfortunately [/usr/libexec/iiab-startup.sh at the end of Stage 2](https://github.com/iiab/iiab/blob/master/roles/2-common/templates/iiab-startup.sh) (2-common) does not do this &mdash; long before detected_network.yml is run.

So for now enabling this within the "network" playbook/stage (after Stage 9, equivalent to ./iiab-network) will have to do ?