### PR TITLE
wlan0 promiscuous much earlier during ./iiab-install (for WiFi-based installs on RPi)

### DIFF
--- a/roles/2-common/templates/iiab-startup.sh
+++ b/roles/2-common/templates/iiab-startup.sh
@@ -1,23 +1,38 @@
 #!/bin/bash
-# put initialization that needs to happen at every startup for IIAB here
+
+# /usr/libexec/iiab-startup.sh is AUTOEXEC.BAT for IIAB
+# (put initializations here, if needed on every boot)
 
 if [ ! -f /etc/iiab/uuid ]; then
-   uuidgen > /etc/iiab/uuid
+    uuidgen > /etc/iiab/uuid
+    echo "/etc/iiab/uuid was MISSING, so a new one was generated."
 fi
 
 # Temporary promiscuous-mode workaround for RPi's WiFi "10SEC disease"
-# Set wlan0 to promiscuous on boot if needed as gateway (i.e. AP's OFF)
-# Scripts iiab-hotspot-on + iiab-hotspot-off SHOULD toggle this boot flag!
+# Sets wlan0 to promiscuous on boot if needed as gateway (i.e. AP's OFF).
+# Manually run iiab-hotspot-[on|off] to toggle AP & boot flag hostapd_enabled
 # https://github.com/iiab/iiab/issues/638#issuecomment-355455454
 if [[ $(grep -i raspbian /etc/*release) &&
         #($(grep "hostapd_enabled = False" /etc/iiab/config_vars.yml) ||
             #((! $(grep "hostapd_enabled = True" /etc/iiab/config_vars.yml)) &&
-                 $(grep "^hostapd_enabled = False" /etc/iiab/iiab.ini) ]];
+                 ! $(grep "^hostapd_enabled = True" /etc/iiab/iiab.ini) ]];
+                 # NEGATED LOGIC HELPS FORCE PROMISCUOUS MODE EARLY IN INSTALL
+                 # (when computed_network.yml has not yet populated iiab.ini)
+
+                 # RESULT: WiFi-installed IIAB should have wlan0 properly in
+                 # promiscuous mode Even On Reboots (if 2-common completed!)
+
+                 # CAUTION: roles/network/tasks/main.yml (e.g. if you run
+                 # ./iiab-network, "./runtags network", or ./iiab-install)
+                 # can toggle your hostapd_enabled setting if it detects a
+                 # different "primary gateway" (eth0 vs. wlan0 vs. none) to the
+                 # Internet -- even if you have not run iiab-hotspot-on|off !
             #)
         #)
    #]];
 then
     ip link set dev wlan0 promisc on
+    echo "wlan0 promiscuous mode ON, internal AP OFF: github.com/iiab/iiab/issues/638"
 fi
 
 exit 0

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -18,9 +18,6 @@
 # Separate Idea, Not Without Risks: should WiFi-as-gateway detection logic
 # be encapsulated into roles/network/tasks/hostapd.yml in future?  Whereas
 # today "./runtags hostapd" doesn't exist & "./runtags AP" is UNSUPPORTED!
-- name: Turn on wlan0 promiscuous mode if is_rpi and not hostapd_enabled (mitigates Raspbian's WiFi bug / 10SEC disease @ https://github.com/iiab/iiab/issues/638)
-  shell: ip link set dev wlan0 promisc on
-  when: is_rpi and not hostapd_enabled
 
 #- name: RPi - reboot to AP post install - installed via wifi so the services are ready
 #  set_fact:


### PR DESCRIPTION
Reverts PR #652 doing the same thing much earlier on during ./iiab-install

Uses /usr/libexec/iiab-startup.sh to act on absence of "hostapd_enabled = True" in /etc/iiab/iiab.ini

Builds off PRs #635, #649 & #651 to work around Raspbian WiFi bug (10SEC disease) @ #638