### PR TITLE
Nextcloud 12.x -> 13.x

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -8,7 +8,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases/
-nextcloud_orig_src_file: latest-12.tar.bz2
+nextcloud_orig_src_file: latest-13.tar.bz2
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -137,10 +137,10 @@
     password: "{{ nextcloud_dbpassword }}"
     priv: "{{ nextcloud_dbname }}.*:ALL,GRANT"
   with_items:
-        - "{{ nextcloud_dbhost }}"
-        - 127.0.0.1
-        - ::1
-        - localhost
+    - "{{ nextcloud_dbhost }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
   when: mysql_enabled and nextcloud_enabled
 
 

--- a/roles/nextcloud/tasks/nextcloud_enabled.yml
+++ b/roles/nextcloud/tasks/nextcloud_enabled.yml
@@ -1,49 +1,54 @@
- # This should go in computed_network.yml, but here for now
+# This should go in computed_network.yml, but here for now
 - name: Compute Nextcloud listen ip addr for nextcloud.conf
   set_fact:
-     nextcloud_required_ip: "{{ ansible_default_ipv4.network }}/{{ ansible_default_ipv4.netmask }}"
+    nextcloud_required_ip: "{{ ansible_default_ipv4.network }}/{{ ansible_default_ipv4.netmask }}"
   when: ansible_default_ipv4.network is defined
 
 - name: Enable Nextcloud by copying template to httpd config
-  template: src=nextcloud.conf.j2
-            dest=/etc/{{ apache_config_dir }}/nextcloud.conf
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: nextcloud.conf.j2
+    dest: "/etc/{{ apache_config_dir }}/nextcloud.conf"
+    owner: root
+    group: root
+    mode: 0644
   when: nextcloud_enabled
 
-- name: Enable Nextcloud
-  file: path=/etc/apache2/sites-enabled/nextcloud.conf
-        src=/etc/apache2/sites-available/nextcloud.conf
-        state=link
+- name: Enable Nextcloud (debuntu)
+  file:
+    path: /etc/apache2/sites-enabled/nextcloud.conf
+    src: /etc/apache2/sites-available/nextcloud.conf
+    state: link
   when: nextcloud_enabled and is_debuntu
 
-- name: For redhat, remove the config file
-  file: path=/etc/{{ apache_config_dir }}/nextcloud.conf
-        state=absent
+- name: Remove the config file if not nextcloud_enabled (redhat)
+  file:
+    path: "/etc/{{ apache_config_dir }}/nextcloud.conf"
+    state: absent
   when: not nextcloud_enabled and is_redhat
 
 - name: Restart Apache, so it picks up the new aliases
-  service: name={{ apache_service }} state=restarted
+  service:
+    name: "{{ apache_service }}"
+    state: restarted
 
 # the install wizard does not succeed if already installed
 - name: Determine if Nextcloud is installed
   shell: >
-         sudo -u {{ apache_user }} php
-         '{{ nextcloud_prefix }}/nextcloud/occ' status |
-         gawk '/installed:/ { print $3 }'
+    sudo -u {{ apache_user }} php
+    '{{ nextcloud_prefix }}/nextcloud/occ' status |
+    gawk '/installed:/ { print $3 }'
   register: returned
 
 - name: Run Nextcloud initial install wizard
   shell: >
-         cd {{ nextcloud_prefix }}/nextcloud;
-         sudo -u {{ apache_user }}  php occ maintenance:install
-         --database "mysql"
-         --database-name "{{ nextcloud_dbname }}"
-         --database-user "{{ nextcloud_dbuser }}"
-         --database-pass "{{ nextcloud_dbpassword }}"
-         --admin-user "{{ nextcloud_admin_user }}"
-         --admin-pass "{{ nextcloud_admin_password }}"
+    cd {{ nextcloud_prefix }}/nextcloud;
+    sudo -u {{ apache_user }} php occ maintenance:install
+    --database "mysql"
+    --database-name "{{ nextcloud_dbname }}"
+    --database-user "{{ nextcloud_dbuser }}"
+    --database-pass "{{ nextcloud_dbpassword }}"
+    --admin-user "{{ nextcloud_admin_user }}"
+    --admin-pass "{{ nextcloud_admin_password }}"
   when: nextcloud_enabled and returned.stdout == "false"
 
 - name: Allow access from all hosts and ips
@@ -54,22 +59,23 @@
 
 - name: Determine if Nextcloud user exists already
   shell: >
-         sudo -u {{ apache_user }} php
-         '{{ nextcloud_prefix }}/nextcloud/occ' user:list |
-         grep {{ nextcloud_user }} | wc | cut -d' ' -f1
+    sudo -u {{ apache_user }} php
+    '{{ nextcloud_prefix }}/nextcloud/occ' user:list |
+    grep {{ nextcloud_user }} | wc | cut -d' ' -f1
   register: returned_count
 
 # nextcloud wants to make users rather than just mysql users and not done
 - name: Create the default user
   shell: >
-        su -s /bin/sh {{ apache_user }} -c
-        'OC_PASS={{ nextcloud_user_password }};
-        php {{ nextcloud_prefix }}/nextcloud/occ user:add
-        --password-from-env --display-name={{ nextcloud_user }}
-        --group="users" {{ nextcloud_user }}'
+    su -s /bin/sh {{ apache_user }} -c
+    'OC_PASS={{ nextcloud_user_password }};
+    php {{ nextcloud_prefix }}/nextcloud/occ user:add
+    --password-from-env --display-name={{ nextcloud_user }}
+    --group="users" {{ nextcloud_user }}'
   when: nextcloud_enabled and returned_count == "0"
 
 - name: Remove Rewrite URL
-  lineinfile: regexp='overwrite.cli.url'
-              state=absent
-              dest="{{ nextcloud_prefix }}/nextcloud/config/config.php"
+  lineinfile:
+    regexp: "overwrite.cli.url"
+    state: absent
+    dest: "{{ nextcloud_prefix }}/nextcloud/config/config.php"


### PR DESCRIPTION
In support of #626 ("Test Nextcloud 13.0.0 vs 12.0.5 on RPi3, Zero W & PC (ETA 2018-02-06)") after @floydianslips's successful test of Nextcloud 13.0.0 on RPi3.