### PR TITLE
install Ansible 2.4.2 on RPi/Deb/Ubuntu from download.iiab.io (until 2.4.3 fixed!)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -3,7 +3,7 @@
 # Installs or upgrades to the best possible Ansible release, so iiab-install
 # can proceed.  Ensure you're online before running this script!
 
-GOOD_VER="2.4.3"      # Ansible version for OLPC, for pip.
+GOOD_VER="2.4.2"      # Ansible version for OLPC, for pip.
                       # On other OS's we install/upgrade to the latest Ansible.
                       # Pin all to 2.4.x in future, if really/truly nec?
 CURR_VER="undefined"
@@ -20,7 +20,7 @@ if ! which ansible-playbook ; then
         yum -y install ca-certificates nss epel-release
         yum -y install git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
         yum -y install python-pip python-setuptools python-wheel patch
-        yum -y install http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.3.0-1.el7.ans.noarch.rpm
+        yum -y install http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.2.0-1.el7.ans.noarch.rpm
         # FOUND="true"
         # FAMILY="redhat"
 #    elif [ -f /etc/fedora-release ]; then
@@ -81,8 +81,13 @@ fi
 
 if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/olpc-release ]; then
     echo "Using apt to check for updates, then install/upgrade ansible"
-    apt update
-    apt -y install ansible
+    # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. DETAILS @ https://github.com/iiab/iiab/issues/669
+    cd /tmp
+    wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
+    apt install ./ansible_2.4.2.0-1ppa~xenial_all.deb
+    # UNCOMMENT THE FOLLOWING 2 LINES IF ANSIBLE'S LATEST RELEASES IMPROVE
+    #apt update
+    #apt -y install ansible
 fi
 
 # needed?

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -84,7 +84,7 @@ if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/o
     # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. DETAILS @ https://github.com/iiab/iiab/issues/669
     cd /tmp
     wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
-    apt install ./ansible_2.4.2.0-1ppa~xenial_all.deb
+    apt -y install ./ansible_2.4.2.0-1ppa~xenial_all.deb
     # UNCOMMENT THE FOLLOWING 2 LINES IF ANSIBLE'S LATEST RELEASES IMPROVE
     #apt update
     #apt -y install ansible

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -84,7 +84,7 @@ if [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/o
     # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. DETAILS @ https://github.com/iiab/iiab/issues/669
     cd /tmp
     wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
-    apt -y install ./ansible_2.4.2.0-1ppa~xenial_all.deb
+    apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
     # UNCOMMENT THE FOLLOWING 2 LINES IF ANSIBLE'S LATEST RELEASES IMPROVE
     #apt update
     #apt -y install ansible


### PR DESCRIPTION
Mitigates Ansible 2.4.3 memory issue/bug summarized @ #669

(Does more than just revert PR #666 ...so as to ensure Ansible 2.4.2-rather-than-the-latest is installed on Raspbian ...and also on Ubuntu/Debian too FWIW, even if those will presumably run out of memory much more rarely?)