### PR TITLE
perhaps debian moved hwclock from /usr/sbin to /sbin

### DIFF
--- a/roles/1-prep/templates/92-rtc-i2c.rules
+++ b/roles/1-prep/templates/92-rtc-i2c.rules
@@ -1,3 +1,3 @@
 # /etc/udev/rules.d/92-rtc-i2c.rules
 #
-ACTION=="add", SUBSYSTEM=="rtc", ATTRS{hctosys}=="0", RUN+="/usr/sbin/hwclock -s --utc"
+ACTION=="add", SUBSYSTEM=="rtc", ATTRS{hctosys}=="0", RUN+="/sbin/hwclock -s --utc"


### PR DESCRIPTION
### Fixes Bug
hwclock was not being transferred to system
### Description of changes proposed in this pull request.

### Smoke-tested in operating system.
Not adequately tested. I had already used raspi-config to enable  i2c. Not yet clear whether this is required.
### Mention a team member for further information or comment using @ name
