### PR TITLE
kiwix-tools 2017-12-27 -> 2018-02-26

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,6 +1,6 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/ (origin: http://download.kiwix.org/nightly/)
-kiwix_src_file_armhf: "kiwix-tools_armhf_2017-12-27.tar.gz"
-kiwix_src_file_linux64: "kiwix-tools_linux64_2017-12-27.tar.gz"
+kiwix_src_file_armhf: "kiwix-tools_armhf-2018-02-26.tar.gz"
+kiwix_src_file_linux64: "kiwix-tools_linux64-2018-02-26.tar.gz"
 kiwix_src_file_i686: "kiwix-0.10-linux-i686.tar.bz2"   # Published Oct 2016 ("experimental")
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"      # Published May 2014 ("use v0.9 to test legacy ZIM content")
 # KIWIX FOR i686 SHOULD BE REPLACED BEFORE FEB 2018: https://github.com/kiwix/kiwix-build/issues/94


### PR DESCRIPTION
Promotes Testing of:
- https://github.com/openzim/libzim/pull/117 Improve ordering of suggestions search results.
- https://github.com/kiwix/kiwix-tools/issues/119 kiwix-serve crash with 'Xapian::InvalidArgumentError'
- https://github.com/kiwix/kiwix-tools/issues/153 Last nighly of kiwix-serve still crash
- https://github.com/kiwix/kiwix-tools/issues/155 partial word searches like "pneumoni" can crash kiwix-serve (e.g. try a medical ZIM)"
  - https://github.com/iiab/iiab/issues/684 "partial word searches like "pneumoni" crash kiwix-serve"