### PR TITLE
AWStats icons broken: some confusion about alias name, add the other one

### DIFF
--- a/roles/awstats/templates/apache.conf
+++ b/roles/awstats/templates/apache.conf
@@ -32,6 +32,7 @@ ScriptAlias /awstats /usr/lib/cgi-bin
 # This provides worldwide access to everything in the directory
 # Security concerns: none known
 Alias /awstats-icon/ /usr/share/awstats/icon/
+Alias /awstatsicons/ /usr/share/awstats/icon/
 
 # This provides worldwide access to everything in the directory
 # Security concerns: none known


### PR DESCRIPTION
### Fixes Bug
icons in awstats broken
### Smoke-tested in operating system.
rpi3
### Mention a team member for further information or comment using @ name
@tim-moody  said icons were messed up. This change cleaned up the rendered page for me. Still not sure it this was the requested help. -- but it is a direct means of communicating.