### PR TITLE
Ansible 2.5.x breaks ./runtags: include_role to import_role in Stages 3-9?

### DIFF
--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -4,19 +4,19 @@
   command: echo
 
 - name: HTTPD
-  include_role:
+  import_role:
     name: httpd
   # has no "when: XXXXX_install" flag
   tags: base, httpd
 
 - name: IIAB-ADMIN
-  include_role:
+  import_role:
     name: iiab-admin
   # has no "when: XXXXX_install" flag
   tags: base, iiab-admin
 
 - name: MYSQL
-  include_role:
+  import_role:
     name: mysql
   # has no "when: XXXXX_install" flag
   tags: base, mysql

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -1,23 +1,29 @@
 # Base Server
 
 - name: ...IS BEGINNING =====================================
-  command: echo
+  shell: echo
 
-- name: HTTPD
-  import_role:
-    name: httpd
+- block:
+    - name: HTTPD
+      shell: echo
+    - import_role:
+        name: httpd
   # has no "when: XXXXX_install" flag
   tags: base, httpd
 
-- name: IIAB-ADMIN
-  import_role:
-    name: iiab-admin
+- block:
+    - name: IIAB-ADMIN
+      shell: echo
+    - import_role:
+        name: iiab-admin
   # has no "when: XXXXX_install" flag
   tags: base, iiab-admin
 
-- name: MYSQL
-  import_role:
-    name: mysql
+- block:
+    - name: MYSQL
+      shell: echo
+    - import_role:
+        name: mysql
   # has no "when: XXXXX_install" flag
   tags: base, mysql
 

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -25,18 +25,24 @@
 #  when: wondershaper_install
 #  tags: wondershaper, network
 
-- name: Installing named
-  include_tasks: roles/network/tasks/named.yml
+- block:
+    - name: Installing named
+      shell: echo
+    - import_tasks: roles/network/tasks/named.yml
   when: named_install
   tags: base, named, network, domain
 
-- name: Installing dhcpd
-  include_tasks: roles/network/tasks/dhcpd.yml
+- block:
+    - name: Installing dhcpd
+      shell: echo
+    - import_tasks: roles/network/tasks/dhcpd.yml
   when: dhcpd_install
   tags: base, dhcpd, network, domain
 
-- name: Installing Squid
-  include_tasks: roles/network/tasks/squid.yml
+- block:
+    - name: Installing Squid
+      shell: echo
+    - import_tasks: roles/network/tasks/squid.yml
   when: squid_install
   tags: base, squid, network, domain
 

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -101,6 +101,7 @@
     src: roles/1-prep/templates/iiab_env.py.j2
     dest: /etc/iiab/iiab_env.py
 
+# MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
 - name: Generate the offline documents
   command: /usr/bin/iiab-refresh-wiki-docs
   when: not nodocs

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -5,13 +5,13 @@
 
 # MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
 - name: SSHD
-  include_role:
+  import_role:
     name: sshd
   # has no "when: XXXXX_install" flag
   tags: base, sshd
 
 - name: OPENVPN
-  include_role:
+  import_role:
     name: openvpn
   when: openvpn_install
   tags: openvpn
@@ -44,37 +44,37 @@
 
 # MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
 - name: HOMEPAGE
-  include_role:
+  import_role:
     name: homepage
   # has no "when: XXXXX_install" flag
   tags: base, homepage
 
 - name: POSTGRESQL
-  include_role:
+  import_role:
     name: postgresql
   when: postgresql_install
   tags: postgresql, pathagar, moodle
 
 - name: AUTHSERVER
-  include_role:
+  import_role:
     name: authserver
   when: authserver_install
   tags: olpc, authserver
 
 - name: CUPS
-  include_role:
+  import_role:
     name: cups
   when: cups_install
   tags: cups
 
 - name: SAMBA
-  include_role:
+  import_role:
     name: samba
   when: samba_install
   tags: samba
 
 - name: USB-LIB
-  include_role:
+  import_role:
     name: usb-lib
   when: usb_lib_install
   tags: usb-lib

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -1,18 +1,22 @@
 # Server Options
 
 - name: ...IS BEGINNING ==================================
-  command: echo
+  shell: echo
 
 # MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
-- name: SSHD
-  import_role:
-    name: sshd
+- block:
+    - name: SSHD
+      shell: echo
+    - import_role:
+        name: sshd
   # has no "when: XXXXX_install" flag
   tags: base, sshd
 
-- name: OPENVPN
-  import_role:
-    name: openvpn
+- block:
+    - name: OPENVPN
+      shell: echo
+    - import_role:
+        name: openvpn
   when: openvpn_install
   tags: openvpn
 
@@ -43,39 +47,51 @@
 #  tags: base, network
 
 # MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
-- name: HOMEPAGE
-  import_role:
-    name: homepage
+- block:
+    - name: HOMEPAGE
+      shell: echo
+    - import_role:
+        name: homepage
   # has no "when: XXXXX_install" flag
   tags: base, homepage
 
-- name: POSTGRESQL
-  import_role:
-    name: postgresql
+- block:
+    - name: POSTGRESQL
+      shell: echo
+    - import_role:
+        name: postgresql
   when: postgresql_install
   tags: postgresql, pathagar, moodle
 
-- name: AUTHSERVER
-  import_role:
-    name: authserver
+- block:
+    - name: AUTHSERVER
+      shell: echo
+    - import_role:
+        name: authserver
   when: authserver_install
   tags: olpc, authserver
 
-- name: CUPS
-  import_role:
-    name: cups
+- block:
+    - name: CUPS
+      shell: echo
+    - import_role:
+        name: cups
   when: cups_install
   tags: cups
 
-- name: SAMBA
-  import_role:
-    name: samba
+- block:
+    - name: SAMBA
+      shell: echo
+    - import_role:
+        name: samba
   when: samba_install
   tags: samba
 
-- name: USB-LIB
-  import_role:
-    name: usb-lib
+- block:
+    - name: USB-LIB
+      shell: echo
+    - import_role:
+        name: usb-lib
   when: usb_lib_install
   tags: usb-lib
 

--- a/roles/5-xo-services/tasks/main.yml
+++ b/roles/5-xo-services/tasks/main.yml
@@ -4,19 +4,19 @@
   command: echo
 
 - name: ACTIVITY-SERVER
-  include_role:
+  import_role:
     name: activity-server
   when: activity_server_install
   tags: olpc, activity-server
 
 - name: EJABBERD_XS
-  include_role:
+  import_role:
     name: ejabberd_xs
   when: ejabberd_xs_install
   tags: olpc, ejabberd-xs
 
 - name: IDMGR
-  include_role:
+  import_role:
     name: idmgr
   when: idmgr_install
   tags: olpc, idmgr

--- a/roles/5-xo-services/tasks/main.yml
+++ b/roles/5-xo-services/tasks/main.yml
@@ -1,23 +1,29 @@
 # XO Services
 
 - name: ...IS BEGINNING =====================================
-  command: echo
+  shell: echo
 
-- name: ACTIVITY-SERVER
-  import_role:
-    name: activity-server
+- block:
+    - name: ACTIVITY-SERVER
+      shell: echo
+    - import_role:
+        name: activity-server
   when: activity_server_install
   tags: olpc, activity-server
 
-- name: EJABBERD_XS
-  import_role:
-    name: ejabberd_xs
+- block:
+    - name: EJABBERD_XS
+      shell: echo
+    - import_role:
+        name: ejabberd_xs
   when: ejabberd_xs_install
   tags: olpc, ejabberd-xs
 
-- name: IDMGR
-  import_role:
-    name: idmgr
+- block:
+    - name: IDMGR
+      shell: echo
+    - import_role:
+        name: idmgr
   when: idmgr_install
   tags: olpc, idmgr
 

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -1,47 +1,61 @@
 # Generic Apps
 
 - name: ...IS BEGINNING ====================================
-  command: echo
+  shell: echo
 
-- name: DOKUWIKI
-  import_role:
-    name: dokuwiki
+- block:
+    - name: DOKUWIKI
+      shell: echo
+    - import_role:
+        name: dokuwiki
   when: dokuwiki_install
   tags: dokuwiki
 
-- name: MEDIAWIKI
-  import_role:
-    name: mediawiki
+- block:
+    - name: MEDIAWIKI
+      shell: echo
+    - import_role:
+        name: mediawiki
   when: mediawiki_install
   tags: mediawiki
 
-- name: ELGG
-  import_role:
-    name: elgg
+- block:
+    - name: ELGG
+      shell: echo
+    - import_role:
+        name: elgg
   when: elgg_install
   tags: elgg
 
-- name: EJABBERD
-  import_role:
-    name: ejabberd
+- block:
+    - name: EJABBERD
+      shell: echo
+    - import_role:
+        name: ejabberd
   when: ejabberd_install
   tags: ejabberd
 
-- name: NEXTCLOUD
-  import_role:
-    name: nextcloud
+- block:
+    - name: NEXTCLOUD
+      shell: echo
+    - import_role:
+        name: nextcloud
   when: nextcloud_install
   tags: nextcloud
 
-- name: OWNCLOUD
-  import_role:
-    name: owncloud
+- block:
+    - name: OWNCLOUD
+      shell: echo
+    - import_role:
+        name: owncloud
   when: owncloud_install
   tags: owncloud
 
-- name: WORDPRESS
-  import_role:
-    name: wordpress
+- block:
+    - name: WORDPRESS
+      shell: echo
+    - import_role:
+        name: wordpress
   when: wordpress_install
   tags: wordpress
 

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -4,43 +4,43 @@
   command: echo
 
 - name: DOKUWIKI
-  include_role:
+  import_role:
     name: dokuwiki
   when: dokuwiki_install
   tags: dokuwiki
 
 - name: MEDIAWIKI
-  include_role:
+  import_role:
     name: mediawiki
   when: mediawiki_install
   tags: mediawiki
 
 - name: ELGG
-  include_role:
+  import_role:
     name: elgg
   when: elgg_install
   tags: elgg
 
 - name: EJABBERD
-  include_role:
+  import_role:
     name: ejabberd
   when: ejabberd_install
   tags: ejabberd
 
 - name: NEXTCLOUD
-  include_role:
+  import_role:
     name: nextcloud
   when: nextcloud_install
   tags: nextcloud
 
 - name: OWNCLOUD
-  include_role:
+  import_role:
     name: owncloud
   when: owncloud_install
   tags: owncloud
 
 - name: WORDPRESS
-  include_role:
+  import_role:
     name: wordpress
   when: wordpress_install
   tags: wordpress

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -1,41 +1,53 @@
 # Educational Apps
 
 - name: ...IS BEGINNING ========================================
-  command: echo
+  shell: echo
 
-- name: KALITE
-  import_role:
-    name: kalite
+- block:
+    - name: KALITE
+      shell: echo
+    - import_role:
+        name: kalite
   when: kalite_install
   tags: kalite
 
-- name: KIWIX
-  import_role:
-    name: kiwix
+- block:
+    - name: KIWIX
+      shell: echo
+    - import_role:
+        name: kiwix
   when: kiwix_install
   tags: kiwix
 
-- name: MOODLE
-  import_role:
-    name: moodle
+- block:
+    - name: MOODLE
+      shell: echo
+    - import_role:
+        name: moodle
   when: moodle_install
   tags: olpc, moodle
 
-- name: OSM
-  import_role:
-    name: osm
+- block:
+    - name: OSM
+      shell: echo
+    - import_role:
+        name: osm
   when: osm_install
   tags: osm
 
-- name: PATHAGAR
-  import_role:
-    name: pathagar
+- block:
+    - name: PATHAGAR
+      shell: echo
+    - import_role:
+        name: pathagar
   when: pathagar_install
   tags: pathagar
 
-- name: SUGARIZER
-  import_role:
-    name: sugarizer
+- block:
+    - name: SUGARIZER
+      shell: echo
+    - import_role:
+        name: sugarizer
   when: sugarizer_install
   tags: sugarizer
 

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -4,37 +4,37 @@
   command: echo
 
 - name: KALITE
-  include_role:
+  import_role:
     name: kalite
   when: kalite_install
   tags: kalite
 
 - name: KIWIX
-  include_role:
+  import_role:
     name: kiwix
   when: kiwix_install
   tags: kiwix
 
 - name: MOODLE
-  include_role:
+  import_role:
     name: moodle
   when: moodle_install
   tags: olpc, moodle
 
 - name: OSM
-  include_role:
+  import_role:
     name: osm
   when: osm_install
   tags: osm
 
 - name: PATHAGAR
-  include_role:
+  import_role:
     name: pathagar
   when: pathagar_install
   tags: pathagar
 
 - name: SUGARIZER
-  include_role:
+  import_role:
     name: sugarizer
   when: sugarizer_install
   tags: sugarizer

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -1,53 +1,69 @@
 # Assessment and Monitoring Tools
 
 - name: ...IS BEGINNING ======================================
-  command: echo
+  shell: echo
 
-- name: AWSTATS
-  import_role:
-    name: awstats
+- block:
+    - name: AWSTATS
+      shell: echo
+    - import_role:
+        name: awstats
   when: awstats_install
   tags: awstats
-  
-- name: MONIT
-  import_role:
-    name: monit
+
+- block:
+    - name: MONIT
+      shell: echo
+    - import_role:
+        name: monit
   when: monit_install
   tags: monit
 
-- name: MUNIN
-  import_role:
-    name: munin
+- block:
+    - name: MUNIN
+      shell: echo
+    - import_role:
+        name: munin
   when: munin_install
   tags: munin
 
-- name: PHPMYADMIN
-  import_role:
-    name: phpmyadmin
+- block:
+    - name: PHPMYADMIN
+      shell: echo
+    - import_role:
+        name: phpmyadmin
   when: phpmyadmin_install
   tags: phpmyadmin
 
-- name: SUGAR-STATS
-  import_role:
-    name: sugar-stats
+- block:
+    - name: SUGAR-STATS
+      shell: echo
+    - import_role:
+        name: sugar-stats
   when: sugar_stats_install and ansible_distribution != "CentOS"
   tags: olpc, sugar-stats
 
-- name: TEAMVIEWER
-  import_role:
-    name: teamviewer
+- block:
+    - name: TEAMVIEWER
+      shell: echo
+    - import_role:
+        name: teamviewer
   when: teamviewer_install
   tags: teamviewer
 
-- name: VNSTAT
-  import_role:
-    name: vnstat
+- block:
+    - name: VNSTAT
+      shell: echo
+    - import_role:
+        name: vnstat
   when: vnstat_install
   tags: vnstat
 
-- name: XOVIS
-  import_role:
-    name: xovis
+- block:
+    - name: XOVIS
+      shell: echo
+    - import_role:
+        name: xovis
   when: xovis_install and ansible_distribution != "CentOS"
   tags: xovis
 

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -4,49 +4,49 @@
   command: echo
 
 - name: AWSTATS
-  include_role:
+  import_role:
     name: awstats
   when: awstats_install
   tags: awstats
   
 - name: MONIT
-  include_role:
+  import_role:
     name: monit
   when: monit_install
   tags: monit
 
 - name: MUNIN
-  include_role:
+  import_role:
     name: munin
   when: munin_install
   tags: munin
 
 - name: PHPMYADMIN
-  include_role:
+  import_role:
     name: phpmyadmin
   when: phpmyadmin_install
   tags: phpmyadmin
 
 - name: SUGAR-STATS
-  include_role:
+  import_role:
     name: sugar-stats
   when: sugar_stats_install and ansible_distribution != "CentOS"
   tags: olpc, sugar-stats
 
 - name: TEAMVIEWER
-  include_role:
+  import_role:
     name: teamviewer
   when: teamviewer_install
   tags: teamviewer
 
 - name: VNSTAT
-  include_role:
+  import_role:
     name: vnstat
   when: vnstat_install
   tags: vnstat
 
 - name: XOVIS
-  include_role:
+  import_role:
     name: xovis
   when: xovis_install and ansible_distribution != "CentOS"
   tags: xovis

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -1,7 +1,7 @@
 # Local Add-ons
 
 - name: ...IS BEGINNING ====================================
-  command: echo
+  shell: echo
   
 - block:
     - name: CALIBRE

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -3,9 +3,11 @@
 - name: ...IS BEGINNING ====================================
   command: echo
   
-- name: CALIBRE
-  import_role:
-    name: calibre
+- block:
+    - name: CALIBRE
+      shell: echo
+    - import_role:
+        name: calibre
   when: calibre_install
   tags: calibre
 

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -4,7 +4,7 @@
   command: echo
   
 - name: CALIBRE
-  include_role:
+  import_role:
     name: calibre
   when: calibre_install
   tags: calibre


### PR DESCRIPTION
This PR restores `./runtags` functionality on Ansible 2.5.0 for PR #711.  (It's one way &mdash; read below for other possible solutions.)

Thanks to @jvonau, who found that attributes (incl tags) are no longer inherited (to tasks within `include_role:`) in Ansible 2.5:

https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html#dynamic-includes-and-attribute-inheritance

This PR attempts to use `import_role:` instead of `include_role:` to keep code tight.

Another way to solve this would have been to preserve `include_role:` but encapsulate the actual contents of every role within [`block: ... tags: ACTUALTAG`](http://docs.ansible.com/ansible/latest/playbooks_blocks.html) in each tasks/main.yml [blocks are logical grouping of tasks, introduced by Ansible 2.0].