### PR TITLE
kiwix-tools 2018-02-26 -> 0.4.0 for armhf & linux64

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,9 +1,14 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/ (origin: http://download.kiwix.org/nightly/)
-kiwix_src_file_armhf: "kiwix-tools_armhf-0.4.0.tar.gz"
-kiwix_src_file_linux64: "kiwix-tools_linux64-0.4.0.tar.gz"
-kiwix_src_file_i686: "kiwix-0.10-linux-i686.tar.bz2"   # Published Oct 2016 ("experimental")
+
+kiwix_version_armhf: "kiwix-tools_armhf-0.4.0"
+kiwix_version_linux64: "kiwix-tools_linux64-0.4.0"
+kiwix_version_i686: "kiwix-0.10-linux-i686"            # Published Oct 2016 ("experimental")
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"      # Published May 2014 ("use v0.9 to test legacy ZIM content")
-# KIWIX FOR i686 SHOULD BE REPLACED BEFORE FEB 2018: https://github.com/kiwix/kiwix-build/issues/94
+# KIWIX FOR i686 SHOULD BE REPLACED IN EARLY 2018: https://github.com/kiwix/kiwix-build/issues/94
+
+kiwix_src_file_armhf: "{{ kiwix_version_armhf }}.tar.gz"
+kiwix_src_file_linux64: "{{ kiwix_version_linux64 }}.tar.gz"
+kiwix_src_file_i686: "{{ kiwix_version_i686 }}.tar.bz2"
 
 kiwix_port: 3000
 # Expected to be used soon for Kiwix proxy:

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,6 +1,6 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/ (origin: http://download.kiwix.org/nightly/)
-kiwix_src_file_armhf: "kiwix-tools_armhf-2018-02-26.tar.gz"
-kiwix_src_file_linux64: "kiwix-tools_linux64-2018-02-26.tar.gz"
+kiwix_src_file_armhf: "kiwix-tools_armhf-0.4.0.tar.gz"
+kiwix_src_file_linux64: "kiwix-tools_linux64-0.4.0.tar.gz"
 kiwix_src_file_i686: "kiwix-0.10-linux-i686.tar.bz2"   # Published Oct 2016 ("experimental")
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"      # Published May 2014 ("use v0.9 to test legacy ZIM content")
 # KIWIX FOR i686 SHOULD BE REPLACED BEFORE FEB 2018: https://github.com/kiwix/kiwix-build/issues/94

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -60,26 +60,38 @@
 # 2. INSTALL KIWIX-TOOLS EXECUTABLES IF kiwix_force_install
 # (We get a whole web server for i686 but only kiwix execs for linux64 & armhf)
 
-- name: Unarchive Kiwix binaries to permanent location (NOT i686)
-  unarchive:
-    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
-    dest: "{{ kiwix_path }}/bin"
-    owner: root
-    group: root
-  when: kiwix_src_bin_only and kiwix_force_install
-
-- name: Unarchive kiwix*i686.tar.bz2 to /tmp (i686)
+- name: Unarchive kiwix-tools .tar.gz or .tar.bz2 to /tmp
   unarchive:
     src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
     dest: /tmp
-    # dest: "{{ iiab_base }}"
     owner: root
     group: root
-  when: not kiwix_src_bin_only and kiwix_force_install
+  when: kiwix_force_install
 
-- name: Move /tmp/kiwix*i686/bin/* to permanent location /opt/iiab/kiwix/bin (i686)
-  shell: "mv /tmp/kiwix*i686/bin/* {{ kiwix_path }}/bin/"
-  when: not kiwix_src_bin_only and kiwix_force_install
+- name: Move /tmp/{{ kiwix_src_dir }}/bin/* to permanent location /opt/iiab/kiwix/bin
+  shell: "mv /tmp/{{ kiwix_src_dir }}/bin/* {{ kiwix_path }}/bin/"
+  when: kiwix_force_install
+
+#- name: Unarchive Kiwix binaries to permanent location (NOT i686)
+#  unarchive:
+#    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
+#    dest: "{{ kiwix_path }}/bin"
+#    owner: root
+#    group: root
+#  when: kiwix_src_bin_only and kiwix_force_install
+
+#- name: Unarchive kiwix*i686.tar.bz2 to /tmp (i686)
+#  unarchive:
+#    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
+#    dest: /tmp
+#    # dest: "{{ iiab_base }}"
+#    owner: root
+#    group: root
+#  when: not kiwix_src_bin_only and kiwix_force_install
+#
+#- name: Move /tmp/kiwix*i686/bin/* to permanent location /opt/iiab/kiwix/bin (i686)
+#  shell: "mv /tmp/kiwix*i686/bin/* {{ kiwix_path }}/bin/"
+#  when: not kiwix_src_bin_only and kiwix_force_install
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU
 

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -68,9 +68,13 @@
     group: root
   when: kiwix_force_install
 
-- name: Move /tmp/{{ kiwix_src_dir }}/bin/* to permanent location /opt/iiab/kiwix/bin
+- name: Move /tmp/{{ kiwix_src_dir }}/* to permanent location /opt/iiab/kiwix/bin (armhf & linux64)
+  shell: "mv /tmp/{{ kiwix_src_dir }}/* {{ kiwix_path }}/bin/"
+  when: kiwix_force_install and not kiwix_src_contains_bin
+
+- name: Move /tmp/{{ kiwix_src_dir }}/bin/* to permanent location /opt/iiab/kiwix/bin (i686)
   shell: "mv /tmp/{{ kiwix_src_dir }}/bin/* {{ kiwix_path }}/bin/"
-  when: kiwix_force_install
+  when: kiwix_force_install and kiwix_src_contains_bin
 
 #- name: Unarchive Kiwix binaries to permanent location (NOT i686)
 #  unarchive:

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -2,21 +2,21 @@
   set_fact:
      kiwix_src_dir: "{{ kiwix_version_armhf }}"
      kiwix_src_file: "{{ kiwix_src_file_armhf }}"
-     #kiwix_src_bin_only: True
+     kiwix_src_contains_bin: False
   when: ansible_machine == "armv7l" or ansible_machine == "armv6l"
   
 - name: "Set Kiwix filename to d/l: {{ kiwix_src_file_linux64 }} (x86_64)"
   set_fact:
      kiwix_src_dir: "{{ kiwix_version_linux64 }}"
      kiwix_src_file: "{{ kiwix_src_file_linux64 }}"
-     #kiwix_src_bin_only: True
+     kiwix_src_contains_bin: False
   when: ansible_machine == "x86_64"
 
 - name: "Set Kiwix filename to d/l: {{ kiwix_src_file_i686 }} (i686)"
   set_fact:
      kiwix_src_dir: "{{ kiwix_version_i686 }}"
      kiwix_src_file: "{{ kiwix_src_file_i686 }}"
-     #kiwix_src_bin_only: False
+     kiwix_src_contains_bin: True
   when: ansible_machine == "i686"
 # COMMENT OUT LINE ABOVE TO TEST i686 CODE PATH ON X86_64 (WORKS NOV 2017)
 

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -1,19 +1,22 @@
 - name: "Set Kiwix filename to d/l: {{ kiwix_src_file_armhf }} (armv6l or armv71)"
   set_fact:
+     kiwix_src_dir: "{{ kiwix_version_armhf }}"
      kiwix_src_file: "{{ kiwix_src_file_armhf }}"
-     kiwix_src_bin_only: True
+     #kiwix_src_bin_only: True
   when: ansible_machine == "armv7l" or ansible_machine == "armv6l"
   
 - name: "Set Kiwix filename to d/l: {{ kiwix_src_file_linux64 }} (x86_64)"
   set_fact:
+     kiwix_src_dir: "{{ kiwix_version_linux64 }}"
      kiwix_src_file: "{{ kiwix_src_file_linux64 }}"
-     kiwix_src_bin_only: True
+     #kiwix_src_bin_only: True
   when: ansible_machine == "x86_64"
 
 - name: "Set Kiwix filename to d/l: {{ kiwix_src_file_i686 }} (i686)"
   set_fact:
+     kiwix_src_dir: "{{ kiwix_version_i686 }}"
      kiwix_src_file: "{{ kiwix_src_file_i686 }}"
-     kiwix_src_bin_only: False
+     #kiwix_src_bin_only: False
   when: ansible_machine == "i686"
 # COMMENT OUT LINE ABOVE TO TEST i686 CODE PATH ON X86_64 (WORKS NOV 2017)
 


### PR DESCRIPTION
kiwix-tools 0.4.0 were published today: (March 27, 2018)
http://download.kiwix.org/release/kiwix-tools/

i686 is not included unfortunately, but @avni is trying hard to make that happen here:
https://github.com/kiwix/kiwix-tools/issues/170

Cached here for IIAB installation purposes:
http://download.iiab.io/packages/kiwix-tools_armhf-0.4.0.tar.gz
http://download.iiab.io/packages/kiwix-tools_linux64-0.4.0.tar.gz

(resolving #709 "Consider the latest kiwix-tools prior to IIAB 6.5 final release")