### PR TITLE
basic cleanup/refactoring of ./runtags & roles/1-prep/templates/iiab.env.j2

### DIFF
--- a/roles/1-prep/templates/iiab.env.j2
+++ b/roles/1-prep/templates/iiab.env.j2
@@ -1,5 +1,5 @@
 # This is a configuration file for IIAB
-# It can sourced in a shell script or read into an application
+# It can be sourced in a shell script or read into an application
 IIAB_BASE_PATH={{ iiab_base }}
 IIAB_DIR={{ iiab_dir }}
 IIAB_RELEASE={{ iiab_base_ver }}

--- a/runtags
+++ b/runtags
@@ -1,19 +1,19 @@
 #!/bin/bash
-# running from a git repo
-PLAYBOOK="iiab.yml"
+
 INVENTORY="ansible_hosts"
+PLAYBOOK="iiab.yml"
+#PLAYBOOK="iiab-stages.yml"
 CWD=`pwd`
 
 export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 
-if [ ! -f $PLAYBOOK ]
-then
- echo "IIAB Playbook not found."
- echo "Please run this command from the top level of the git repo."
- echo "Exiting."
- exit
+if [ ! -f $PLAYBOOK ]; then
+    echo "Exiting: IIAB Playbook not found."
+    echo "Please run this in /opt/iiab/iiab (top level of the git repo)."
+    exit 1
 fi
 
+# Is the following stanza nec?
 if [ ! -f /etc/iiab/config_vars.yml ]; then
     mkdir -p /etc/iiab
     echo "{}" > /etc/iiab/config_vars.yml
@@ -21,31 +21,27 @@ fi
 
 tags=$(echo $1 | tr "," "\n")
 
-if [ "$tags" == "" ]
-then
-  echo " usage: ./runtags <tagname>"
-  echo " usage: ./runtags <tagname1>,<tagname2>,<tagname3>"
-  echo " Can take a single value or a comma-separated list (no spaces within the list!)"
-  echo " Now retrieving a list of possible Ansible playbook and tagname values..."
-  ansible-playbook -i ansible_hosts iiab.yml --connection=local --list-tag
-  exit 0
+if [ "$tags" == "" ]; then
+    echo " usage: ./runtags <tagname>"
+    echo " usage: ./runtags <tagname1>,<tagname2>,<tagname3>"
+    echo " Can take a single value or a comma-separated list (no spaces within the list!)"
+    echo " Now retrieving a list of possible Ansible playbook and tagname values..."
+    ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local --list-tags
+    exit 0
 fi
 
 found="N"
 
-for tag in $tags
-do
-  if [ "$tag" == "0-init" ]
-  then
-    found="Y"
-  fi
+for tag in $tags; do
+    if [ "$tag" == "0-init" ]; then
+        found="Y"
+    fi
 done
 
 taglist=$1
 
-if [ "$found" == "N" ]
-then
-  taglist="0-init,"$taglist
+if [ "$found" == "N" ]; then
+    taglist="0-init,"$taglist
 fi
 
-ansible-playbook -i ansible_hosts iiab.yml --connection=local --tags="""$taglist"""
+ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local --tags=$taglist


### PR DESCRIPTION
Regardless whether an ./runtags fix-for-Ansible-2.5 approaches like PR #712 ("Ansible 2.5.x breaks ./runtags: include_role to import_role in Stages 3-9?") or PR #716 ("install.yml in every core IIAB role - also fixes ./runtags for Ansible 2.5") move forward or not.