### PR TITLE
delay usbmount's actions during boot to be as late as possible

### DIFF
--- a/roles/usb-lib/templates/usbmount@.service.j2
+++ b/roles/usb-lib/templates/usbmount@.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 BindTo=%i.device
 After=%i.device
+After=rc-local.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
delay usbmount's actions during boot to be as late as possible.

Live tested during meeting.