### PR TITLE
fix6.5 - auto-enable hostapd (during Ethernet install of IIAB)

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -123,7 +123,7 @@
 
 - name: Set python_path (redhat)
   set_fact:
-    python_path: /usr/lib/python2.7/site-packages/
+    python_path: /lib/python2.7/site-packages/
   when: is_redhat
 
 - name: Set python_path (debuntu)

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -39,6 +39,7 @@
     - httpd
     - php
     - php-curl
+    - mod_authnz_external
 #    - php-sqlite
   tags:
     - download

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -14,7 +14,7 @@ device_gw2: ""
 
 iiab_wan_iface: "none"
 iiab_lan_iface: "none"
-#discovered_lan_iface: "none"
+discovered_lan_iface: "none"
 discovered_wired_iface: "none"
 discovered_wireless_iface: "none"
 #iiab_wired_lan_iface: "none"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -17,10 +17,10 @@ iiab_lan_iface: "none"
 discovered_lan_iface: "none"
 discovered_wired_iface: "none"
 discovered_wireless_iface: "none"
-#iiab_wired_lan_iface: "none"
-#iiab_wireless_lan_iface: "none"
 
 #Redhat
+iiab_wired_lan_iface: "none"
+iiab_wireless_lan_iface: "none"
 has_WAN: False
 has_ifcfg_gw: "none"
 has_wifi_gw: "none"

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -167,6 +167,26 @@
     iiab_wan_iface: "none"
   when: adapter_count.stdout|int >= "5" and device_gw == "none" and gui_wan_iface == "unset" and gui_static_wan is defined
 
+- name: Record IIAB_WAN_DEVICE to /etc/iiab/iiab.env
+  lineinfile:
+    dest: /etc/iiab/iiab.env
+    regexp: '^IIAB_WAN_DEVICE=*'
+    line: 'IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
+    state: present
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
+  tags:
+    - network
+
+- name: Record IIAB_LAN_DEVICE to /etc/iiab/iiab.env
+  lineinfile:
+    dest: /etc/iiab/iiab.env
+    regexp: '^IIAB_LAN_DEVICE=*'
+    line: 'IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
+    state: present
+  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
+  tags:
+    - network
+
 - name: Add location section to config file
   ini_file:
     dest: "{{ iiab_config_file }}"

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -130,7 +130,18 @@
 - name: LAN configured - 'Gateway' mode
   set_fact:
     iiab_network_mode: "Gateway"
-  when: iiab_lan_iface != "none" and iiab_wan_iface != "none"
+  when: (iiab_lan_iface != "none" and iiab_wan_iface != "none") or is_rpi
+
+- name: Force iiab_lan_iface if is_rpi
+  set_fact:
+    iiab_lan_iface: "br0"
+    iiab_wireless_lan_iface: "wlan0"
+  when: is_rpi
+
+- name: Enable hostapd if discovered_wireless_iface is not WAN
+  set_fact:
+    hostapd_enabled: True
+  when: is_rpi and iiab_wan_iface != discovered_wireless_iface
 
 # override with user_lan_iface setting if no longer in auto
 - name: Setting user LAN fact

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -29,7 +29,6 @@
     owner: root
     group: root
     mode: 0644
-  when: hostapd_enabled
 
 - name: Create /usr/bin/iiab-hotspot-on from template
   template:

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -14,6 +14,7 @@
 # clear all bridge ifcfg files
 - name: Now delete slave bridge ifcfg files
   shell: rm -f /etc/sysconfig/network-scripts/ifcfg-"{{ item }}"
+  ignore_errors: True
   when: num_lan_interfaces != 0 or iiab_wireless_lan_iface != "none"
   with_items:
     - "{{ ifcfg_slaves.stdout_lines }}"

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -132,27 +132,6 @@
   tags:
     - network
 
-# this is moving
-- name: Record IIAB_WAN_DEVICE to /etc/iiab/iiab.env
-  lineinfile:
-    dest: /etc/iiab/iiab.env
-    regexp: '^IIAB_WAN_DEVICE=*'
-    line: 'IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
-    state: present
-  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
-  tags:
-    - network
-
-- name: Record IIAB_LAN_DEVICE to /etc/iiab/iiab.env
-  lineinfile:
-    dest: /etc/iiab/iiab.env
-    regexp: '^IIAB_LAN_DEVICE=*'
-    line: 'IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
-    state: present
-  when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
-  tags:
-    - network
-
 #### end network layout
 - include_tasks: restart.yml
   when: not installing

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -20,10 +20,21 @@
     dest: /etc/dhcpcd.conf
     src: network/dhcpcd.conf.j2
 
+- name: New raspbian requires counry code -- check for it
+  shell: grep country /etc/wpa_supplicant/wpa_supplicant.conf
+  register: country_code
+
+- name: Put a country code if it does not exist
+  lineinfile: 
+    dest: /etc/wpa_supplicant/wpa_supplicant.conf
+    regexp: "^country.*"
+    line: country={{ host_country_code }}
+  when: country_code.stdout == ""
+
 - name: Copy the bridge script for RPi
   template:
     dest: /etc/network/interfaces.d/iiab
-    src: network/rpi.j2
+    src: network/iiab.j2
   when: iiab_lan_iface == "br0"
 
 - name: Stopping services
@@ -48,9 +59,12 @@
 - name: Restart hostapd if appropriate
   service:
     name: hostapd
-    enabled: yes
     state: restarted
-  when: hostapd_enabled and iiab_wireless_lan_iface is defined and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and iiab_wan_iface != discoveed_wireless_iface and iiab_network_mode != "Appliance"
+
+- name: Ansible is having a problem enabling services
+  shell: systemctl enable hostapd
+  when: hostapd_enabled and iiab_wan_iface != discoveed_wireless_iface and iiab_network_mode != "Appliance"
 
 #- name: dhcp_server may be affected - starting - user choice
 #  service: name={{ dhcp_service2 }} state=started

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -23,13 +23,18 @@
 - name: New raspbian requires counry code -- check for it
   shell: grep country /etc/wpa_supplicant/wpa_supplicant.conf
   register: country_code
+  ignore_errors: True
 
 - name: Put a country code if it does not exist
   lineinfile: 
     dest: /etc/wpa_supplicant/wpa_supplicant.conf
     regexp: "^country.*"
     line: country={{ host_country_code }}
-  when: country_code.stdout == ""
+  when: country_code is defined and country_code.stdout == ""
+
+- name: Enable the wifi with rfkill
+  shell: rfkill unblock 0
+  ignore_errors: True
 
 - name: Copy the bridge script for RPi
   template:
@@ -60,11 +65,11 @@
   service:
     name: hostapd
     state: restarted
-  when: hostapd_enabled and iiab_wan_iface != discoveed_wireless_iface and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and iiab_wan_iface != discovered_wireless_iface and iiab_network_mode != "Appliance"
 
 - name: Ansible is having a problem enabling services
   shell: systemctl enable hostapd
-  when: hostapd_enabled and iiab_wan_iface != discoveed_wireless_iface and iiab_network_mode != "Appliance"
+  when: hostapd_enabled and iiab_wan_iface != discovered_wireless_iface and iiab_network_mode != "Appliance"
 
 #- name: dhcp_server may be affected - starting - user choice
 #  service: name={{ dhcp_service2 }} state=started


### PR DESCRIPTION

### Description of changes proposed in this pull request.
Enable hostapd if wan is wired

### Smoke-tested in operating system.
2018-3-13 raspbian with new 4.14 kernel. Hostapd functions without a reboot, and survives a reboot. Also wifi functions headless when SD card is transferred to rpiW.

