### PR TITLE
Encourage aggressive testing of "iiab_usb_lib_show_all: True" in coming days!

### DIFF
--- a/vars/medium.localvars
+++ b/vars/medium.localvars
@@ -94,6 +94,9 @@ cups_enabled: False
 samba_install: False
 samba_enabled: False
 
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+
 # 5-XO-SERVICES
 
 # Lesser-supported XO services need additional testing.  Please contact


### PR DESCRIPTION
This change to local_vars.yml can be reverted later as nec.

Builds off PR #721 that @jvonau inspired and co-designed with @georgejhunt who built it.

PS min/med/big versions of local_vars.yml were also changed here:
- http://download.iiab.io/6.5/rpi/
- http://download.iiab.io/6.6/rpi/
- http://wiki.iiab.io/local_vars.yml (reference doc)