### PR TITLE
rpi-test: wpa_supplicant AP mode simultaneous with WiFi as client

### DIFF
--- a/rpi/09-clone
+++ b/rpi/09-clone
@@ -1,0 +1,8 @@
+iw dev uap0 info
+if [ $? -ne 0 ]; then
+    MAC=`iw dev wlan0 info | grep addr | sed -e s/addr//`
+    ip link set wlan0 address b8:27:99:12:34:56 2>1 > /dev/null
+    iw dev wlan0 interface add uap0 type __ap 2>1 > /dev/null
+    ip link set uap0 address "$MAC" 2>1 > /dev/null
+fi
+

--- a/rpi/11-set-freq
+++ b/rpi/11-set-freq
@@ -1,0 +1,4 @@
+sleep 2
+FREQ=`iw wlan0 info|grep channel|cut -d' ' -f9`
+sed -i -e "s/^frequency.*/frequency=$FREQ /" /etc/wpa_supplicant/wpa_supplicant-uap0.conf
+

--- a/rpi/50-hostapd
+++ b/rpi/50-hostapd
@@ -1,0 +1,6 @@
+if [ "$interface" = "uap0" ]; then
+    syslog info "50-hostapd-uap0"
+#    systemctl restart wpa_supplicant@wlan0
+    brctl addif br0 uap0  2>/dev/null
+fi
+

--- a/rpi/readme.txt
+++ b/rpi/readme.txt
@@ -1,0 +1,9 @@
+09-clone goes in scripts
+11-set-freq goes in scripts
+50-hostapd goes in /lib/dhcpcd/dhcpcd-hooks/
+wpa_supplicant-uap0.conf /etc/wpa_supplicant/
+wpa_supplicant@.service goes in /etc/systemd/system 
+systemctl enable wpa_supplicant@.service
+
+11-set-freq needs to have a fallback should wlan0 not in use as upstream
+wlan0-timer needs to be called from /etc/rc.local or setup a unit file firing after dhcpcd

--- a/rpi/wlan0-timer
+++ b/rpi/wlan0-timer
@@ -1,0 +1,2 @@
+sleep 10
+systemctl -q is-enabled wpa_supplicant@wlan0 && systemctl restart wpa_supplicant@wlan0

--- a/rpi/wpa_supplicant-uap0.conf
+++ b/rpi/wpa_supplicant-uap0.conf
@@ -1,0 +1,11 @@
+ctrl_interface=DIR=/var/run/wpa_supplicant2 GROUP=netdev
+country=US
+#update_config=1
+
+network={
+        ssid="JV2"
+        key_mgmt=NONE
+        mode=2
+        frequency=2437
+}
+

--- a/rpi/wpa_supplicant@.service
+++ b/rpi/wpa_supplicant@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=WPA supplicant daemon (interface-specific version)
+Requires=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+Before=network.target dhcpcd.service
+Wants=network.target
+
+# NetworkManager users will probably want the dbus version instead.
+
+[Service]
+Type=simple
+ExecStartPre=/bin/bash /opt/iiab/iiab/scripts/09-clone
+ExecStart=/sbin/wpa_supplicant -c/etc/wpa_supplicant/wpa_supplicant.conf -Dnl80211,wext -i%I
+ExecStartPost=/bin/bash /opt/iiab/iiab/scripts/11-set-freq
+
+[Install]
+Alias=multi-user.target.wants/wpa_supplicant@%i.service


### PR DESCRIPTION
Just testing using wpa_supplicant to create AP mode without hostapd, allows upstream wifi to be used at same time 