### PR TITLE
DokuWiki 2017-02-19e -> 2018-04-22

### DIFF
--- a/roles/dokuwiki/defaults/main.yml
+++ b/roles/dokuwiki/defaults/main.yml
@@ -1,4 +1,4 @@
 dokuwiki_url: /wiki
 dokuwiki_install: True
 dokuwiki_enabled: False
-dokuwiki_version: "dokuwiki-2017-02-19e"
+dokuwiki_version: "dokuwiki-2018-04-22"

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -11,8 +11,15 @@
     dest: /library
     creates: "/library/{{ dokuwiki_version }}/VERSION"
 
-- name: Symlink /library/dokuwiki* to /library/dokuwiki
-  shell: if [ ! -d /library/dokuwiki ]; then ln -sf /library/{{ dokuwiki_version }} /library/dokuwiki; fi
+- name: Symlink /library/{{ dokuwiki_version }} from /library/dokuwiki
+  #shell: if [ ! -d /library/dokuwiki ]; then ln -sf /library/{{ dokuwiki_version }} /library/dokuwiki; fi
+  #shell: ln -sf /library/{{ dokuwiki_version }} /library/dokuwiki
+  #BOTH LINES ABOVE FAIL TO UPDATE LINK; Ansible approach below works
+  file:
+    path: /library/dokuwiki
+    src: /library/{{ dokuwiki_version }}
+    state: link
+    force: yes
 
 - name: Install config file for DokuWiki in Apache
   template:


### PR DESCRIPTION
### Fixes Bug

Prior DokuWiki was more than 14 months old, and the playbook was always broken on updates (it failed to update symbolic link /library/dokuwiki).

### Description of changes proposed in this pull request.

Aside: a fixed URL download from https://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz likely makes sense in future, rather than a hard-coded version number (currently moving to `dokuwiki_version: "dokuwiki-2018-04-22"`) in defaults/main.yml

Such that we always try grab the very latest stable version, as has proved more effective and more secure for other IIAB playbooks like WordPress, KA Lite, Nextcloud and Moodle over the past 6 months.

CLARIF: after merging, this playbook will download/install DokuWiki [2018-04-22 "Greebo"](https://www.dokuwiki.org/changes#release_2018-04-22_release_greebo) from http://download.iiab.io/packages/dokuwiki-2018-04-22.tgz

### Smoke-tested in operating system.

Ubuntu 16.04 LTS: http://box.lan/wiki loads, but I'm not sure how to log in.

### Mention a team member for further information or comment using @ name

@m-anish please review if possible.