### PR TITLE
vars/ubuntu-18.yml requires "postgresql_version: 10" not 10.3

### DIFF
--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -18,5 +18,6 @@ mysql_service: mysql
 apache_log: /var/log/apache2/access.log
 sshd_service: ssh
 php_version: 7.2
-postgresql_version: 10.3
+# "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
+postgresql_version: 10
 systemd_location: /lib/systemd/system


### PR DESCRIPTION
Smoke-tested on Ubuntu 18.04 LTS