### PR TITLE
Ubuntu 18.04's PostgreSQL 10.3 requires Moodle encrypt (hash) its password

### DIFF
--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -106,6 +106,7 @@
   postgresql_user:
     name: Admin
     password: changeme
+    encrypted: yes   # Required by PostgresSQL 10.3+ e.g. on Ubuntu 18.04
     role_attr_flags: NOSUPERUSER,NOCREATEROLE,NOCREATEDB
     state: present
   become: yes

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -106,7 +106,7 @@
   postgresql_user:
     name: Admin
     password: changeme
-    encrypted: yes   # Required by PostgresSQL 10.3+ e.g. on Ubuntu 18.04
+    encrypted: yes   # Required by PostgresSQL 10.3+ e.g. on Ubuntu 18.04, see https://github.com/iiab/iiab/issues/759
     role_attr_flags: NOSUPERUSER,NOCREATEROLE,NOCREATEDB
     state: present
   become: yes


### PR DESCRIPTION
Smoke-tested on Ubuntu 18.04 LTS.

Of course Moodle 3.11.1 still doesn't work for the reasons explained in #759 (php7.2 is more strict, not permitting Moodle versions prior to 3.4)