### PR TITLE
Moodle 3.1 -> 3.5 LTS TESTING (on Moodle's master branch for now)

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -2,7 +2,7 @@ moodle_version: 35
 #moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_repo_url: "git://git.moodle.org/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"
-moodle_user: moodle
+#moodle_user: moodle
 #moodle_install: True
 #moodle_enabled: False
 moodle_data: '{{ content_base }}/moodle'

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -1,5 +1,6 @@
 moodle_version: 35
-moodle_repo_url: "https://github.com/moodle/moodle.git"
+#moodle_repo_url: "https://github.com/moodle/moodle.git"
+moodle_repo_url: "git://git.moodle.org/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"
 moodle_user: moodle
 #moodle_install: True

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -1,9 +1,8 @@
-moodle_version: 31
+moodle_version: 35
 moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"
 moodle_user: moodle
-moodle_install: True
-moodle_enabled: False
+#moodle_install: True
+#moodle_enabled: False
 moodle_data: '{{ content_base }}/moodle'
 moodle_database_name: moodle
-

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -44,7 +44,8 @@
     dest: "{{ moodle_base }}"
     depth: 1
     force: yes
-    version: "MOODLE_{{ moodle_version }}_STABLE"
+    #version: "MOODLE_{{ moodle_version }}_STABLE"
+    version: master   #TEMPORARY DURING MAY 2018 TESTING
 #  ignore_errors: yes
   when: internet_available and moodle.stat.exists is defined and not moodle.stat.exists
 

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -1,5 +1,4 @@
----
-- name: Install Moodle required packages (OS's other than debunt)
+- name: Install Moodle required packages (OS's other than debuntu)
   package:
     name: "{{ item }}"
     state: present
@@ -107,7 +106,7 @@
   postgresql_user:
     name: Admin
     password: changeme
-    encrypted: yes   # Required by PostgresSQL 10.3+ e.g. on Ubuntu 18.04, see https://github.com/iiab/iiab/issues/759
+    encrypted: yes   # Required by PostgreSQL 10+ e.g. Ubuntu 18.04's PostgreSQL 10.3+, see https://github.com/iiab/iiab/issues/759
     role_attr_flags: NOSUPERUSER,NOCREATEROLE,NOCREATEDB
     state: present
   become: yes

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -114,7 +114,7 @@
 
 - name: Create database
   postgresql_db:
-    name: {{ moodle_database_name }}
+    name: "{{ moodle_database_name }}"
     encoding: utf8
     owner: Admin
     template: template1

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -15,10 +15,10 @@
     - python-psycopg2
     - php{{ php_version }}-pgsql
     - php{{ php_version }}-curl
-#    - php{{ php_version }}-zip
+    #- php{{ php_version }}-zip
     - php{{ php_version }}-gd
-#    - php{{ php_version }}-mbstring
-# mbstring is now included in php-cli
+    #- php{{ php_version }}-mbstring
+    # mbstring is now included in php-cli
     - php{{ php_version }}-cli
   when: is_debuntu
 
@@ -45,7 +45,7 @@
     force: yes
     #version: "MOODLE_{{ moodle_version }}_STABLE"
     version: master   # TEMPORARY DURING MAY 2018 TESTING
-#  ignore_errors: yes
+  #ignore_errors: yes
   when: internet_available and moodle.stat.exists is defined and not moodle.stat.exists
 
 - name: Prepare the downloaded directory so Apache can install config file
@@ -150,7 +150,7 @@
   when: config.stat.exists is defined and not config.stat.exists
 
 - name: Give Apache permission to read config file
-#  command: chown -R {{ apache_user }} {{ moodle_base }}
+  #command: chown -R {{ apache_user }} {{ moodle_base }}
   file:
     path: "{{ moodle_base }}/config.php"
     mode: 0644

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -70,7 +70,7 @@
     mode: 0770
     state: directory
 
-- name: Remove stock Moodle conf
+- name: Remove stock Moodle config file
   file:
     path: "/etc/{{ apache_config_dir }}/moodle.conf"
     state: absent
@@ -114,7 +114,7 @@
 
 - name: Create database
   postgresql_db:
-    name: moodle
+    name: {{ moodle_database_name }}
     encoding: utf8
     owner: Admin
     template: template1
@@ -140,7 +140,7 @@
     name: "{{ apache_service }}"
     state: restarted
 
-- name: See if the config.php file exists
+- name: See if config.php exists
   stat:
     path: "{{ moodle_base }}/config.php"
   register: config

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -44,7 +44,7 @@
     depth: 1
     force: yes
     #version: "MOODLE_{{ moodle_version }}_STABLE"
-    version: master   #TEMPORARY DURING MAY 2018 TESTING
+    version: master   # TEMPORARY DURING MAY 2018 TESTING
 #  ignore_errors: yes
   when: internet_available and moodle.stat.exists is defined and not moodle.stat.exists
 

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -1,5 +1,10 @@
 #!/bin/bash -x
 
+# May 2018: lowercase "--adminuser=admin" is still required for some odd
+# reason, otherwise one cannot login to http://box.lan/moodle
+# (with Admin/changeme).  At the same time --dbuser=Admin still begins with
+# a capital letter, in keeping with Internet-in-a-Box's other server apps.
+
 sudo -u {{ apache_user }} \
      /usr/bin/php {{ moodle_base }}/admin/cli/install.php \
      --wwwroot=http://{{ iiab_hostname }}.{{ iiab_domain }}/moodle \
@@ -9,7 +14,7 @@ sudo -u {{ apache_user }} \
      --dbuser=Admin --dbpass=changeme \
      --fullname=Your_School \
      --shortname=School \
-     --adminuser=admin --adminpass=changeme \   # May 2018: lowercase "admin" is still required, otherwise Admin/changeme fails at http://box.lan/moodle
+     --adminuser=admin --adminpass=changeme \
      --non-interactive \
      --agree-license \
      --allow-unstable   # TEMPORARY DURING MAY 2018 TESTING

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -1,8 +1,17 @@
 #!/bin/bash -x
-sudo -u {{ apache_user }} /usr/bin/php {{ moodle_base }}/admin/cli/install.php \
---wwwroot=http://{{ iiab_hostname }}.{{ iiab_domain }}/moodle --dataroot={{ moodle_data }} \
---dbtype=pgsql --dbname={{ moodle_database_name }} --dbuser=Admin --dbpass=changeme \
---fullname=Your_School --shortname=School \
---adminuser=Admin --adminpass=changeme \
---non-interactive --agree-license
+
+sudo -u {{ apache_user }} \
+     /usr/bin/php {{ moodle_base }}/admin/cli/install.php \
+     --wwwroot=http://{{ iiab_hostname }}.{{ iiab_domain }}/moodle \
+     --dataroot={{ moodle_data }} \
+     --dbtype=pgsql \
+     --dbname={{ moodle_database_name }} \
+     --dbuser=Admin --dbpass=changeme \
+     --fullname=Your_School \
+     --shortname=School \
+     --adminuser=admin --adminpass=changeme \
+     --non-interactive \
+     --agree-license \
+     --allow-unstable   #TEMPORARY DURING MAY 2018 TESTING
+
 chown {{ apache_user }}:{{ apache_user }} {{ moodle_base }}/config.php

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -9,9 +9,9 @@ sudo -u {{ apache_user }} \
      --dbuser=Admin --dbpass=changeme \
      --fullname=Your_School \
      --shortname=School \
-     --adminuser=admin --adminpass=changeme \
+     --adminuser=admin --adminpass=changeme \   # May 2018: lowercase "admin" is still required, otherwise Admin/changeme fails at http://box.lan/moodle
      --non-interactive \
      --agree-license \
-     --allow-unstable   #TEMPORARY DURING MAY 2018 TESTING
+     --allow-unstable   # TEMPORARY DURING MAY 2018 TESTING
 
 chown {{ apache_user }}:{{ apache_user }} {{ moodle_base }}/config.php

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -1,9 +1,9 @@
 #!/bin/bash -x
 
 # May 2018: lowercase "--adminuser=admin" is still required for some odd
-# reason, otherwise one cannot login to http://box.lan/moodle
-# (with Admin/changeme).  At the same time --dbuser=Admin still begins with
-# a capital letter, in keeping with Internet-in-a-Box's other server apps.
+# reason, otherwise one cannot login to http://box.lan/moodle (with
+# Admin/changeme).  At the same time --dbuser=Admin still begins with
+# a capital letter, in keeping with Internet-in-a-Box's other server apps?
 
 sudo -u {{ apache_user }} \
      /usr/bin/php {{ moodle_base }}/admin/cli/install.php \

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -3,6 +3,6 @@ sudo -u {{ apache_user }} /usr/bin/php {{ moodle_base }}/admin/cli/install.php \
 --wwwroot=http://{{ iiab_hostname }}.{{ iiab_domain }}/moodle --dataroot={{ moodle_data }} \
 --dbtype=pgsql --dbname={{ moodle_database_name }} --dbuser=Admin --dbpass=changeme \
 --fullname=Your_School --shortname=School \
---adminuser=admin --adminpass=changeme \
+--adminuser=Admin --adminpass=changeme \
 --non-interactive --agree-license
 chown {{ apache_user }}:{{ apache_user }} {{ moodle_base }}/config.php


### PR DESCRIPTION
Ref
#627 Moodle 3.1 -> 3.5 LTS - ETA May 14th 2018
#759 Moodle 3.1.11 LTS impossible on Ubuntu 18.04? (due to php7.2, even w/ encrypted password)