### PR TITLE
host_country_code: US moved to local_vars.yml; download_timeout: 100 -> 200 for Haiti

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -44,7 +44,7 @@ hostapd_wait: 1
 host_wifi_mode: g
 host_channel: 6
 host_wireless_n: False
-# Below moved to /opt/iiab/iiab/vars/local_vars.yml (so implementer sets this).
+# Below moved to /opt/iiab/iiab/vars/local_vars.yml: (so implementer sets this)
 #host_country_code: US
 hostapd_secure: True
 hostapd_password: "iiab2017"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -44,7 +44,8 @@ hostapd_wait: 1
 host_wifi_mode: g
 host_channel: 6
 host_wireless_n: False
-host_country_code: US
+# Below moved to /opt/iiab/iiab/vars/local_vars.yml (so implementer sets this).
+#host_country_code: US
 hostapd_secure: True
 hostapd_password: "iiab2017"
 driver_name: nl80211

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -18,7 +18,7 @@ yum_packages_dir: "{{ iiab_base }}/yum-packages"
 downloads_dir: "{{ iiab_base }}/downloads"
 iiab_download_url: http://download.iiab.io/packages
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 100
+download_timeout: 200
 
 # Configuration File(s)
 iiab_config_file: /etc/iiab/iiab.ini
@@ -63,6 +63,8 @@ lan_netmask: 255.255.224.0
 # Internal Wi-Fi Access Point
 # Values are used if there is an internal Wi-Fi adapter and hostapd is enabled
 # The platform variable adapts install to specific hardware (raspberry pi=rpi2)
+# Raspbian req WiFi country since March 2018.  CHANGE IT IN vars/local_vars.yml
+host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
 host_channel: 6

--- a/vars/medium.localvars
+++ b/vars/medium.localvars
@@ -7,7 +7,7 @@
 # Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 100
+download_timeout: 200
 
 # Users and Passwords
 
@@ -29,6 +29,9 @@ iiab_domain: lan
 
 # Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
 iiab_home_url: /home
+
+# Raspbian requires WiFi country since March 2018.  Please set it here:
+host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
 host_channel: 6


### PR DESCRIPTION
1. Raspbian WiFi requires the country to be specified since March 2018.  Implementers should modify this (`host_country_code: US`) in /opt/iiab/iiab/vars/[local_vars.yml](http://wiki.laptop.org/go/IIAB/local_vars.yml)

2. For countries like Haiti, where there is (incredibly, regrettably) often more than 100 seconds of radio silence during IIAB install downloads of various packages (using Ansible's `get_url:`).