### PR TITLE
recurse into apache log directory with www-data

### DIFF
--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -31,6 +31,7 @@
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
     state: directory
+    recurse: true
     force: true
   with_items:
     - "{{ awstats_data_dir }}"


### PR DESCRIPTION
### Fixes Bug
/var/log/apache2 was owned by www-data, but the actual log files were not, because files module does not recurse by default

tested
