### PR TITLE
Moodle 3.5beta+ (master) -> MOODLE_35_STABLE

### DIFF
--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -43,8 +43,8 @@
     dest: "{{ moodle_base }}"
     depth: 1
     force: yes
-    #version: "MOODLE_{{ moodle_version }}_STABLE"
-    version: master   # TEMPORARY DURING MAY 2018 TESTING
+    version: "MOODLE_{{ moodle_version }}_STABLE"
+    #version: master   # TEMPORARY DURING MAY 2018 TESTING, installed 3.5beta+ = https://download.moodle.org/releases/development/
   #ignore_errors: yes
   when: internet_available and moodle.stat.exists is defined and not moodle.stat.exists
 


### PR DESCRIPTION
ETA to merge this is Thursday 2018-05-17 when Moodle 3.5 will be released, according to https://docs.moodle.org/dev/Moodle_3.5_release_notes

Ref #770