### PR TITLE
Move .ansible/tmp from /library/working -> /root (proposed fix for #812)

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,5 +3,5 @@
 
 [defaults]
 squash_actions = apk, apt, dnf, homebrew, openbsd_pkg, pacman, pkgng, yum, zypper, package
-remote_tmp = /library/working/.ansible/tmp
-local_tmp = /library/working/.ansible/tmp
+remote_tmp = /root/.ansible/tmp
+local_tmp = /root/.ansible/tmp


### PR DESCRIPTION
Proposed fix for #812 'http://box pages "Forbidden" on RPi (lastest master)'