### PR TITLE
Sugarizer v1.0 migration

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -102,11 +102,11 @@
 #  when: elgg_enabled or rachel_enabled or owncloud_enabled or phpmyadmin_enabled or wordpress_enabled or iiab_menu_install
 
 # Commenting out MongoDB on a trial basis, for a more basic/lightweight Sugarizer, per https://github.com/iiab/iiab/pull/427
-# - name: Turn on mongodb if sugarizer enabled
-#   set_fact:
-#     mongodb_install: True
-#     mongodb_enabled: True
-#   when: sugarizer_enabled
+- name: Turn on mongodb if sugarizer enabled
+  set_fact:
+     mongodb_install: True
+     mongodb_enabled: True
+  when: sugarizer_enabled
 
 # There might be other db's
 - name: Turn on PostgreSQL if Moodle or Pathagar enabled

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -17,7 +17,7 @@
      - { path: '/library/dbdata/mongodb' }
      - { path: '/var/log/mongodb' }
 
-- name: Create systemd files
+- name: Move required files
   template: src={{ item.src }}
             dest={{ item.dest }}
             owner=root
@@ -25,9 +25,7 @@
             mode=0644
   with_items:
      - { src: 'mongodb.service' , dest: '/etc/systemd/system/' }
-     - { src: 'mongodb' , dest: '/etc/sysconfig/'}
      - { src: 'mongod.conf' , dest: '/etc/mongod.conf'}
-     - { src: 'mongod.conf' , dest: '/etc/mongodb.conf'}
 
 - name: enable services
   service: name={{ item.name }}
@@ -44,20 +42,6 @@
   with_items:
       - { name: mongodb }
   when: not mongodb_enabled
-
-# See https://github.com/iiab/iiab/issues/254 for other attempts to eliminate
-# these 256MB files. Brute Force Idea: rm /var/lib/mongodb/journal/prealloc.*
-- name: find /var/lib/mongodb/prealloc.* files to delete
-  find:
-    paths: /var/lib/mongodb/journal
-    patterns: prealloc.*
-  register: files_to_delete
-
-- name: delete prealloc files
-  file:
-    path: "{{ item.path }}"
-    state: absent
-  with_items: "{{ files_to_delete.files }}"
 
 - name: add mongodb to service list
   ini_file: dest="{{ service_filelist }}"

--- a/roles/mongodb/templates/mongod.conf
+++ b/roles/mongodb/templates/mongod.conf
@@ -18,13 +18,13 @@ pidfilepath = /var/run/mongodb/mongod.pid
 logpath = /var/log/mongodb/mongod.log
 
 # Alternative directory for UNIX domain sockets (defaults to /tmp)
-unixSocketPrefix = /var/run/mongodb
+# unixSocketPrefix = /var/run/mongodb
 
 # Directory for datafiles (defaults to /data/db/)
 dbpath = /library/dbdata/mongodb
 
 # Enable/Disable journaling (journaling is on by default for 64 bit)
-#journal = true
+journal = true
 #nojournal = true
 
 
@@ -37,7 +37,7 @@ dbpath = /library/dbdata/mongodb
 #verbose = v
 
 # Max number of simultaneous connections (1000000 by default)
-#maxConns = 1000000              
+maxConns = 1000              
 
 # Log to system's syslog facility instead of file or stdout (false by default)
 #syslog = true

--- a/roles/mongodb/templates/mongod.conf
+++ b/roles/mongodb/templates/mongod.conf
@@ -9,10 +9,10 @@ bind_ip = 127.0.0.1
 port = 27018
 
 # Fork server process (false by default)
-fork = true
+# fork = true
 
 # Full path to pidfile (if not set, no pidfile is created)
-pidfilepath = /var/run/mongodb/mongod.pid
+# pidfilepath = /var/run/mongodb/mongod.pid
 
 # Log file to send write to instead of stdout - has to be a file, not directory
 logpath = /var/log/mongodb/mongod.log

--- a/roles/mongodb/templates/mongod.conf
+++ b/roles/mongodb/templates/mongod.conf
@@ -37,7 +37,7 @@ journal = true
 #verbose = v
 
 # Max number of simultaneous connections (1000000 by default)
-maxConns = 1000              
+maxConns = 10000
 
 # Log to system's syslog facility instead of file or stdout (false by default)
 #syslog = true

--- a/roles/mongodb/templates/mongodb
+++ b/roles/mongodb/templates/mongodb
@@ -1,1 +1,0 @@
-OPTIONS=' -f /etc/mongod.conf '

--- a/roles/mongodb/templates/mongodb.service
+++ b/roles/mongodb/templates/mongodb.service
@@ -3,12 +3,10 @@ Description=High-performance, schema-free document-oriented database
 After=syslog.target network.target
  
 [Service]
-Type=forking
+Type=simple
 User=mongodb
 Group=mongodb
-PIDFile=/var/run/mongodb/mongod.pid
-#EnvironmentFile=/etc/sysconfig/mongodb 
-ExecStart=/usr/bin/mongod --fork -f /etc/mongod.conf
+ExecStart=/usr/bin/mongod  -f /etc/mongod.conf
  
 [Install]
 WantedBy=multi-user.target

--- a/roles/mongodb/templates/mongodb.service
+++ b/roles/mongodb/templates/mongodb.service
@@ -8,7 +8,7 @@ User=mongodb
 Group=mongodb
 PIDFile=/var/run/mongodb/mongod.pid
 #EnvironmentFile=/etc/sysconfig/mongodb 
-ExecStart=/usr/bin/mongod -f /etc/mongod.conf
+ExecStart=/usr/bin/mongod --fork -f /etc/mongod.conf
  
 [Install]
 WantedBy=multi-user.target

--- a/roles/mongodb/templates/mongodb.service
+++ b/roles/mongodb/templates/mongodb.service
@@ -7,7 +7,7 @@ Type=forking
 User=mongodb
 Group=mongodb
 PIDFile=/var/run/mongodb/mongod.pid
-EnvironmentFile=/etc/sysconfig/mongodb 
+#EnvironmentFile=/etc/sysconfig/mongodb 
 ExecStart=/usr/bin/mongod -f /etc/mongod.conf
  
 [Install]

--- a/roles/mongodb/templates/mongodb~HEAD
+++ b/roles/mongodb/templates/mongodb~HEAD
@@ -1,1 +1,0 @@
-OPTIONS=' -f /etc/mongod.conf '

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -57,6 +57,7 @@ services_externally_visible={{ services_externally_visible }}
 calibre_port={{ calibre_port }}
 kiwix_port={{ kiwix_port }}
 kalite_server_port={{ kalite_server_port }}
+sugarizer_port={{ sugarizer_port }}
 block_DNS={{ block_DNS }}
 captive_portal_enabled={{ captive_portal_enabled }}
 
@@ -89,6 +90,7 @@ if [ "$services_externally_visible" == "True" ]; then
     $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
+    $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
 fi
 
 if [ "$iiab_gateway_enabled" == "True" ]; then

--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -1,7 +1,6 @@
 sugarizer_install: True
 sugarizer_enabled: False
-sugarizer_location: '{{ doc_root }}'
-sugarizer_port: 8089
+sugarizer_location: /opt/iiab
 sugarizer_version: 'sugarizer-1.0'
 sugarizer_server_version: 'sugarizer-server-1.0'
 npm_exists: False

--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -2,4 +2,5 @@ sugarizer_install: True
 sugarizer_enabled: False
 sugarizer_location: '{{ doc_root }}'
 sugarizer_version: 'sugarizer-1.0'
+sugarizer_server_version: 'sugarizer-server-1.0'
 npm_exists: False

--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -1,5 +1,5 @@
 sugarizer_install: True
 sugarizer_enabled: False
 sugarizer_location: '{{ doc_root }}'
-sugarizer_version: 'sugarizer-0.9'
+sugarizer_version: 'sugarizer-1.0'
 npm_exists: False

--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -1,6 +1,7 @@
 sugarizer_install: True
 sugarizer_enabled: False
 sugarizer_location: '{{ doc_root }}'
+sugarizer_port: 8089
 sugarizer_version: 'sugarizer-1.0'
 sugarizer_server_version: 'sugarizer-server-1.0'
 npm_exists: False

--- a/roles/sugarizer/meta/main.yml
+++ b/roles/sugarizer/meta/main.yml
@@ -1,2 +1,2 @@
 dependencies:
-#    - { role: mongodb, tags: ['generic','mongodb'], when: sugarizer_install }
+    - { role: mongodb, tags: ['generic','mongodb'], when: sugarizer_install }

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -13,10 +13,33 @@
 #  command: tar xzf {{ downloads_dir }}/{{ sugarizer_version }}.tar.gz -C {{ sugarizer_location }}
 #           creates="{{ sugarizer_location }}/{{ sugarizer_version }}/index.html"
 
+- name: Download latest stable Server from location we control
+  get_url:
+    url: "{{ iiab_download_url }}/{{ sugarizer_server_version }}.tar.gz"
+    dest: "{{ downloads_dir }}/{{ sugarizer_server_version }}.tar.gz"
+    timeout: "{{ download_timeout }}"
+  when: internet_available
+
+- name: Untar to /library/www/html/{{ sugarizer_version }}
+  unarchive:
+    src: "{{ downloads_dir }}/{{ sugarizer_version }}.tar.gz"
+    dest: "{{ sugarizer_location }}"
+    creates: "{{ sugarizer_location }}/{{ sugarizer_version }}/index.html"
 - name: Create symbolic link /library/www/html/sugarizer
   file:
     src: "{{ sugarizer_location }}/{{ sugarizer_version }}"
     dest: "{{ sugarizer_location }}/sugarizer"
+    state: link
+
+- name: Untar to /library/www/html/{{ sugarizer_server_version }}
+  unarchive:
+    src: "{{ downloads_dir }}/{{ sugarizer_server_version }}.tar.gz"
+    dest: "{{ sugarizer_location }}"
+    creates: "{{ sugarizer_location }}/{{ sugarizer_server_version }}/index.html"
+- name: Create symbolic link /library/www/html/sugarizer
+  file:
+    src: "{{ sugarizer_location }}/{{ sugarizer_server_version }}"
+    dest: "{{ sugarizer_location }}/sugarizer-server"
     state: link
 
 - name: Set up Node.js 6.x apt sources (debuntu)
@@ -52,7 +75,7 @@
 # attempting to reinstall npm is broken on Raspbian 9
 - name: Check for Sugarizer already installed
   stat:
-    path: "{{ sugarizer_location }}/sugarizer/server/node_modules"
+    path: "{{ sugarizer_location }}/{{ sugarizer_server_version }}/node_modules"
   register: npm
   ignore_errors: true
 
@@ -70,7 +93,7 @@
     mode: 0644
   with_items:
     - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service'}
-    - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/sugarizer/server' }
+    - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini' }
 #     - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
 
 #- name: Create the symlink enabling the rewrite
@@ -81,8 +104,8 @@
 - name: Create the express framework for Node.js (OS's other than Fedora 18)
   shell: npm install
   args:
-    chdir: "{{ sugarizer_location }}/sugarizer/server"
-    creates: "{{ sugarizer_location }}/sugarizer/server/node_modules"
+    chdir: "{{ sugarizer_location }}/{{  sugarizer_server_version }}"
+    creates: "{{ sugarizer_location }}/{{ sugarizer_server_version }}/server/node_modules"
   when: not is_F18 and not npm_exists
 
 - name: Create the express framework for Node.js (Fedora 18)

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -5,7 +5,7 @@
     timeout: "{{ download_timeout }}"
   when: internet_available
 
-- name: Untar to /library/www/html/{{ sugarizer_version }}
+- name: Untar to {{ sugarizer_version }}
   unarchive:
     src: "{{ downloads_dir }}/{{ sugarizer_version }}.tar.gz"
     dest: "{{ sugarizer_location }}"
@@ -20,7 +20,7 @@
     timeout: "{{ download_timeout }}"
   when: internet_available
 
-- name: Untar to /library/www/html/{{ sugarizer_version }}
+- name: Untar to /{{ sugarizer_version }}
   unarchive:
     src: "{{ downloads_dir }}/{{ sugarizer_version }}.tar.gz"
     dest: "{{ sugarizer_location }}"
@@ -94,7 +94,7 @@
   with_items:
     - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service'}
     - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini' }
-     - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
+    - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
 
 - name: Create the symlink enabling the rewrite
   file: src=/etc/apache2/sites-available/sugarizer.conf

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -54,11 +54,12 @@
   stat:
     path: "{{ sugarizer_location }}/sugarizer/server/node_modules"
   register: npm
+  ignore_errors: true
 
 - name: Set a flag to abort second attempt to install
   set_fact:
     npm_exists: True
-  when: npm.stat.exists is defined and npm.stat.exists
+  when: npm.stat is defined and npm.stat.exists
 
 - name: Create systemd files and copy our ini file
   template:

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -94,12 +94,12 @@
   with_items:
     - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service'}
     - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini' }
-#     - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
+     - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
 
-#- name: Create the symlink enabling the rewrite
-#  file: src=/etc/apache2/sites-available/sugarizer.conf
-#        dest=/etc/apache2/sites-enabled/sugarizer.conf
-#        state=link
+- name: Create the symlink enabling the rewrite
+  file: src=/etc/apache2/sites-available/sugarizer.conf
+        dest=/etc/apache2/sites-enabled/sugarizer.conf
+        state=link
 
 - name: Create the express framework for Node.js (OS's other than Fedora 18)
   shell: npm install

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Wipe any previous sugarizer installation
+  shell: "rm -rf {{ doc_root }}/sugarizer*"
+  when: sugarizer_version == "sugarizer-1.0"
+
 - name: Download latest stable Sugarizer from location we control
   get_url:
     url: "{{ iiab_download_url }}/{{ sugarizer_version }}.tar.gz"

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -88,13 +88,14 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
     owner: root
     group: root
-    mode: 0644
   with_items:
-    - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service'}
-    - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini' }
-    - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available' }
+    - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service', mode: '0644' }
+    - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini', mode: '0644' }
+    - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available',mode: '0644' }
+    - { src: 'start-sugarizer.sh' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/', mode: '0755' }
 
 - name: Create the symlink enabling the rewrite
   file: src=/etc/apache2/sites-available/sugarizer.conf

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -95,7 +95,6 @@
     - { src: 'sugarizer.service.j2' , dest: '/etc/systemd/system/sugarizer.service', mode: '0644' }
     - { src: 'sugarizer.ini' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/env/sugarizer.ini', mode: '0644' }
     - { src: 'sugarizer.conf' , dest: '/etc/apache2/sites-available',mode: '0644' }
-    - { src: 'start-sugarizer.sh' , dest: '{{ sugarizer_location }}/{{ sugarizer_server_version }}/', mode: '0755' }
 
 - name: Create the symlink enabling the rewrite
   file: src=/etc/apache2/sites-available/sugarizer.conf

--- a/roles/sugarizer/templates/start-sugarizer.sh
+++ b/roles/sugarizer/templates/start-sugarizer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# shim to daemonize node sugarizer.js, declare log target, return 0
+cd /opt/iiab/sugarizer-server
+nohup /bin/node sugarizer.js >> /var/log/sugarizer.log &
+exit 0

--- a/roles/sugarizer/templates/start-sugarizer.sh
+++ b/roles/sugarizer/templates/start-sugarizer.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# shim to daemonize node sugarizer.js, declare log target, return 0
-cd /opt/iiab/sugarizer-server
-nohup /bin/node sugarizer.js >> /var/log/sugarizer.log &
-exit 0

--- a/roles/sugarizer/templates/sugarizer.conf
+++ b/roles/sugarizer/templates/sugarizer.conf
@@ -1,3 +1,3 @@
-RewriteRule       ^/sugarizer(.*)$  http://localhost:{{ sugaarizer_port }}/sugarizer$1 [P,L]
-ProxyPassReverse  /sugarizer        http://localhost:{{ sugarizer_port }}/sugarizer
+RewriteRule       ^/sugarizer(.*)$  http://localhost:"{{ sugarizer_port }}/sugarizer$1" [P,L]
+ProxyPassReverse  /sugarizer        http://localhost:"{{ sugarizer_port }}/sugarizer"
 ProxyRequests     Off

--- a/roles/sugarizer/templates/sugarizer.conf
+++ b/roles/sugarizer/templates/sugarizer.conf
@@ -1,3 +1,2 @@
-RewriteRule       ^/sugarizer(.*)$  http://localhost:"{{ sugarizer_port }}/sugarizer$1" [P,L]
-ProxyPassReverse  /sugarizer        http://localhost:"{{ sugarizer_port }}/sugarizer"
-ProxyRequests     Off
+RewriteEngine on
+RewriteRule       ^/sugarizer(.*)$  http://localhost:8089$1 [PT]

--- a/roles/sugarizer/templates/sugarizer.conf
+++ b/roles/sugarizer/templates/sugarizer.conf
@@ -1,3 +1,3 @@
-RewriteRule       ^/sugarizer(.*)$  http://localhost:8089/sugarizer$1 [P,L]
-ProxyPassReverse  /sugarizer        http://localhost:8010/sugarizer
+RewriteRule       ^/sugarizer(.*)$  http://localhost:{{ sugaarizer_port }}/sugarizer$1 [P,L]
+ProxyPassReverse  /sugarizer        http://localhost:{{ sugarizer_port }}/sugarizer
 ProxyRequests     Off

--- a/roles/sugarizer/templates/sugarizer.ini
+++ b/roles/sugarizer/templates/sugarizer.ini
@@ -1,7 +1,20 @@
-; Sugarizer configuration file
+[information]
+name = Sugarizer Server
+description = Your Sugarizer Server
 
 [web]
 port = 8089
+
+[security]
+min_password_size = 4
+max_age = 172800000
+https = false
+certificate_file = ../server.crt
+key_file = ../server.key
+strict_ssl = false
+
+[client]
+path = ../sugarizer/
 
 [database]
 server = localhost
@@ -11,13 +24,16 @@ name = sugarizer
 [presence]
 port = 8039
 
+[statistics]
+active = true
+
 [collections]
 users = users
 journal = journal
+stats = stats
 
 [activities]
 activities_directory_name = activities
-activities_path = ../activities
 template_directory_name = ActivityTemplate
 activity_info_path = activity/activity.info
-favorites = org.sugarlabs.GearsActivity,org.sugarlabs.MazeWebActivity,org.olpcfrance.PaintActivity,org.olpcfrance.TamTamMicro,org.olpcfrance.MemorizeActivity,org.olpg-france.physicsjs,org.sugarlabs.CalculateActivity,org.sugarlabs.TurtleBlocksJS,org.sugarlabs.Clock,,org.olpcfrance.RecordActivity,org.olpcfrance.Abecedarium,org.olpcfrance.KAView,org.olpcfrance.FoodChain,org.olpc-france.labyrinthjs,org.olpcfrance.TankOp,org.sugarlabs.ChatPrototype,org.olpcfrance.Gridpaint,org.olpc-france.LOLActivity,org.sugarlabs.StopwatchActivity,org.sugarlabs.GTDActivity,org.sugarlabs.Markdown,org.laptop.WelcomeWebActivity
+favorites = org.sugarlabs.GearsActivity,org.sugarlabs.MazeWebActivity,org.olpcfrance.PaintActivity,org.olpcfrance.TamTamMicro,org.olpcfrance.MemorizeActivity,org.olpg-france.physicsjs,org.sugarlabs.CalculateActivity,org.sugarlabs.TurtleBlocksJS,org.sugarlabs.Clock,org.sugarlabs.SpeakActivity,org.sugarlabs.moon,org.olpcfrance.RecordActivity,org.olpcfrance.Abecedarium,org.olpcfrance.videoviewer,org.olpcfrance.FoodChain,org.olpc-france.labyrinthjs,org.olpcfrance.TankOp,org.sugarlabs.ChatPrototype,org.olpcfrance.Gridpaint,org.olpc-france.LOLActivity,org.olpcfrance.sharednotes,org.sugarlabs.ColorMyWorldActivity,com.homegrownapps.xoeditor,com.homegrownapps.reflection,com.homegrownapps.abacus,org.sugarlabs.Blockrain,org.sugarlabs.StopwatchActivity,com.homegrownapps.flip,org.somosazucar.JappyActivity,org.olpcfrance.qrcode,org.sugarlabs.Markdown,org.sugarlabs.gameOfLife,org.sugarlabs.Scratch,org.sugarlabs.FotoToonJs

--- a/roles/sugarizer/templates/sugarizer.ini
+++ b/roles/sugarizer/templates/sugarizer.ini
@@ -3,7 +3,7 @@ name = Sugarizer Server
 description = Your Sugarizer Server
 
 [web]
-port = 8089
+port = {{ sugarizer_port }}
 
 [security]
 min_password_size = 4

--- a/roles/sugarizer/templates/sugarizer.service.j2
+++ b/roles/sugarizer/templates/sugarizer.service.j2
@@ -1,4 +1,4 @@
-[unit]
+[Unit]
 Description=Node.js Sugarizer Server
 Requires=After=mongodb.service       # Requires the mongodb service to run first
 

--- a/roles/sugarizer/templates/sugarizer.service.j2
+++ b/roles/sugarizer/templates/sugarizer.service.j2
@@ -1,15 +1,16 @@
 [unit]
 Description=Node.js Sugarizer Server
-# Requires=After=mongodb.service       # Requires the mongodb service to run first
+Requires=After=mongodb.service       # Requires the mongodb service to run first
 
 [Service]
-WorkingDirectory={{ sugarizer_location }}/sugarizer-server/
-ExecStart=start-sugarizer.sh
+WorkingDirectory=/opt/iiab/sugarizer-server/
+ExecStart=/usr/bin/node /opt/iiab/sugarizer-server/sugarizer.js
+Type=forking
 Restart=always
-#RestartSec=10                       # Restart service after 10 seconds if node service crashes
-#StandardOutput=syslog               # Output to syslog
-#StandardError=syslog                # Output to syslog
-#SyslogIdentifier=sugarizer
+RestartSec=10
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sugarizer
 #User=<alternate user>
 #Group=<alternate group>
 #Environment=NODE_ENV=production

--- a/roles/sugarizer/templates/sugarizer.service.j2
+++ b/roles/sugarizer/templates/sugarizer.service.j2
@@ -5,7 +5,7 @@ Requires=After=mongodb.service       # Requires the mongodb service to run first
 [Service]
 WorkingDirectory=/opt/iiab/sugarizer-server/
 ExecStart=/usr/bin/node /opt/iiab/sugarizer-server/sugarizer.js
-Type=forking
+Type=simple
 Restart=always
 RestartSec=10
 StandardOutput=syslog

--- a/roles/sugarizer/templates/sugarizer.service.j2
+++ b/roles/sugarizer/templates/sugarizer.service.j2
@@ -3,16 +3,16 @@ Description=Node.js Sugarizer Server
 # Requires=After=mongodb.service       # Requires the mongodb service to run first
 
 [Service]
-WorkingDirectory={{ sugarizer_location }}/sugarizer/server/
-ExecStart=/usr/bin/node sugarizer.js
+WorkingDirectory={{ sugarizer_location }}/sugarizer-server/
+ExecStart=start-sugarizer.sh
 Restart=always
 #RestartSec=10                       # Restart service after 10 seconds if node service crashes
-StandardOutput=syslog               # Output to syslog
-StandardError=syslog                # Output to syslog
-SyslogIdentifier=sugarizer
+#StandardOutput=syslog               # Output to syslog
+#StandardError=syslog                # Output to syslog
+#SyslogIdentifier=sugarizer
 #User=<alternate user>
 #Group=<alternate group>
-Environment=NODE_ENV=production
+#Environment=NODE_ENV=production
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/sugarizer/templates/sugarizer.service.j2
+++ b/roles/sugarizer/templates/sugarizer.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Node.js Sugarizer Server
-Requires=After=mongodb.service       # Requires the mongodb service to run first
+Requires=mongodb.service
+After=mongodb.service       # Requires the mongodb service to run first
 
 [Service]
 WorkingDirectory=/opt/iiab/sugarizer-server/

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -320,6 +320,7 @@ pathagar_enabled: False
 # Sugarizer
 sugarizer_install: True
 sugarizer_enabled: False
+sugarizer_port: 8089
 
 # 8-MGMT-TOOLS
 


### PR DESCRIPTION
### Description of changes proposed in this pull request.
This PR upgrades to the most recent sugarizer [implementing #798]

### Smoke-tested in operating system.
2018-04-18 stretch lite. 

Known issues: the proxy from apache /sugarizer to localhost:8089 does not work. But then the kiwix, and kalite proxies do not work either.  I remember that I had them working once. But I've lost the magic sauce.

Tim's menu system goes directly to the desired port, so maybe it does not matter.