### PR TITLE
kiwix-tools 0.5.0 (2018-04-23) -> 2018-05-24 fixes FT search w/ internal index

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,9 +1,9 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: "kiwix-tools_linux-armhf-0.5.0"
-kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.5.0"
-kiwix_version_i686: "kiwix-tools_linux-i586-0.5.0"
+kiwix_version_armhf: "kiwix-tools_linux-armhf-2018-05-24"
+kiwix_version_linux64: "kiwix-tools_linux-x86_64-2018-05-24"
+kiwix_version_i686: "kiwix-tools_linux-i586-2018-05-24"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:


### PR DESCRIPTION
Functionally tested on IIAB 6.5 on all 5 OS's:
- Raspbian Desktop
- Raspbian Lite
- Ubuntu 18.04 LTS/Desktop
- Ubuntu 18.04 LTS/Lite
- Ubuntu 16.04 LTS/Desktop

Thanks @kelson42 for suggesting I try http://download.kiwix.org/nightly/ !  Solves the problem that was erroneously described at #817, until [clarified further below](https://github.com/iiab/iiab/issues/817#issuecomment-391939900).