### PR TITLE
Fallback to old gateway info when WAN is not detected 

### DIFF
--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -16,10 +16,10 @@
   when: openvpn_install
   tags: openvpn
 
-#- name: Configuring wondershaper
-#  include_tasks: roles/network/tasks/wondershaper.yml
-#  when: wondershaper_install
-#  tags: wondershaper, network
+- name: Installing dnsmasq
+  include_tasks: roles/network/tasks/dnsmasq.yml
+  when: dnsmasq_install
+  tags: base, domain, dnsmasq, network
 
 - name: Installing named
   include_tasks: roles/network/tasks/named.yml

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -117,6 +117,11 @@
                                                    # This workaround can and should evolve as IIAB 6.5 matures!
   when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
 
+- name: Use old gateway device info if not detected and using static ip
+  set_fact:
+    iiab_wan_iface: "{{ device_gw }}"
+  when: wan_ip != "dhcp" and iiab_wan_iface == "none"
+
 - name: No LAN configured - 'Appliance' mode
   set_fact:
     iiab_network_mode: "Appliance"

--- a/roles/network/tasks/dnsmasq.yml
+++ b/roles/network/tasks/dnsmasq.yml
@@ -1,6 +1,11 @@
 - name: Install dnsmasq
   package: name=dnsmasq state=present
 
+- name: Stop dnsmasq
+  service:
+    name: dnsmasq
+    state: stopped
+
 - name: Configure dhcpd
   template: src={{ item.src }}
             dest={{ item.dest }}
@@ -9,4 +14,11 @@
             mode={{ item.mode }}
   with_items:
    - { src: 'network/dnsmasq.service.rh', dest: '/etc/systemd/system/dnsmasq.service', mode: '0644' }
+   - { src: 'network/dnsmasq.conf.j2' dest: '/etc/dnsmasq.conf' mode: '644' }
 
+- name: Start dnsmasq
+  systemd:
+    name: dnsmasq
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/roles/network/tasks/dnsmasq.yml
+++ b/roles/network/tasks/dnsmasq.yml
@@ -13,7 +13,7 @@
             group=root
             mode={{ item.mode }}
   with_items:
-   - { src: 'network/dnsmasq.service.rh', dest: '/etc/systemd/system/dnsmasq.service', mode: '0644' }
+#   - { src: 'network/dnsmasq.service.rh', dest: '/etc/systemd/system/dnsmasq.service', mode: '0644' }
    - { src: 'network/dnsmasq.conf.j2' dest: '/etc/dnsmasq.conf' mode: '644' }
 
 - name: Start dnsmasq

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -46,7 +46,7 @@
   when: not dnsmasq_enabled and dnsmasq_install
 
 - name: dnsmasq copy config file to /etc
-  template: src=network/dnsmasq.conf.j2 dest=/etc/
+  template: src=network/dnsmasq.conf.j2 dest=/etc/dnsmasq.conf
   when: dnsmasq_enabled and dnsmasq_install
 
 - name: Enable dnsmasq

--- a/roles/network/templates/network/dnsmasq.conf.j2
+++ b/roles/network/templates/network/dnsmasq.conf.j2
@@ -4,8 +4,10 @@ bogus-priv
 #server=/{{ iiab_domain }}/{{ iiab_hostname }}
 # Add local-only domains here, queries in these domains are answered　from /etc/hosts or DHCP only.
 local=/{{ iiab_domain }}/
+{% if captive_portal_enabled == "True" %}
 # Make all host names resolve to the Raspberry Pi's IP address
-#address=/#/{{ lan_ip }}
+address=/#/{{ lan_ip }}
+{% endif %}
 # Specify the interface that will listen for DHCP and DNS requests
 interface={{ iiab_lan_iface }}
 # Set the domain for dnsmasq

--- a/roles/network/templates/network/dnsmasq.conf.j2
+++ b/roles/network/templates/network/dnsmasq.conf.j2
@@ -5,7 +5,7 @@ bogus-priv
 # Add local-only domains here, queries in these domains are answered　from /etc/hosts or DHCP only.
 local=/{{ iiab_domain }}/
 # Make all host names resolve to the Raspberry Pi's IP address
-address=/#/{{ lan_ip }}
+#address=/#/{{ lan_ip }}
 # Specify the interface that will listen for DHCP and DNS requests
 interface={{ iiab_lan_iface }}
 # Set the domain for dnsmasq


### PR DESCRIPTION
Fallback to old gateway info when WAN is not detected when configuring static ip. Otherwise WAN device becomes 'none'

### Fixes Bug
Adam's static setup while offline

