### PR TITLE
install Calibre via Debian .debs insteads of Raspbian .debs (fixes 831)

### DIFF
--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -19,7 +19,8 @@
 # HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!)
 
 - name: Upgrade to Calibre testing .deb's - target Raspbian (rpi)
-  command: scripts/calibre-install-latest-rpi.sh
+  #command: scripts/calibre-install-latest-rpi.sh  #fails with Calibre 3.24 & 3.25, and beyond?
+  command: scripts/calibre-install-latest.sh       #Debian approach works for now (3.24 & 3.25)
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -3,7 +3,16 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Worked up to Calibre 3.23 from May 2018.
+# Calibre 3.24 and 3.25 fail to "apt install" in June 2018:
+#
+#   The following packages have unmet dependencies:
+#    calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed
+#   E: Unable to correct problems, you have held broken packages.
+#
+# Debian approach (calibre-install-latest.sh) is the workaround for now: https://github.com/iiab/iiab/pull/832
+# 
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/
 #   http://archive.raspbian.org/raspbian/pool/main/c/calibre/

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -10,7 +10,9 @@
 #    calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed
 #   E: Unable to correct problems, you have held broken packages.
 #
-# Debian approach (calibre-install-latest.sh) is the workaround for now: https://github.com/iiab/iiab/pull/832
+# Debian approach (calibre-install-latest.sh) is the workaround for now:
+#
+#   https://github.com/iiab/iiab/pull/833
 # 
 # Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #

--- a/scripts/calibre-install-latest.sh
+++ b/scripts/calibre-install-latest.sh
@@ -3,7 +3,7 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   https://packages.debian.org/search?keywords=calibre
 #   http://deb.debian.org/debian/pool/main/c/calibre/

--- a/scripts/calibre-install-unstable.sh
+++ b/scripts/calibre-install-unstable.sh
@@ -3,7 +3,7 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   https://packages.debian.org/search?keywords=calibre
 #   http://deb.debian.org/debian/pool/main/c/calibre/


### PR DESCRIPTION
Should fix #831 &mdash; needs testing!

Applicable to IIAB 6.5 and IIAB 6.6/master.