### PR TITLE
install Calibre via Debian .debs insteads of Raspbian .debs (fixes 831)

### DIFF
--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -19,7 +19,8 @@
 # HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!)
 
 - name: Upgrade to Calibre testing .deb's - target Raspbian (rpi)
-  command: scripts/calibre-install-latest-rpi.sh
+  #command: scripts/calibre-install-latest-rpi.sh  #fails with Calibre 3.24 & 3.25, and beyond?
+  command: scripts/calibre-install-latest.sh       #Debian approach works for now (3.24 & 3.25)
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)

--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -1,5 +1,5 @@
 elgg_xx: elgg
-elgg_version: "2.3.6"
+elgg_version: "2.3.7"
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg

--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -1,4 +1,4 @@
 phpmyadmin_install: False
 phpmyadmin_enabled: False
-phpmyadmin_name: "phpMyAdmin-4.8.0.1-all-languages"
+phpmyadmin_name: "phpMyAdmin-4.8.1-all-languages"
 phpmyadmin_name_zip: "{{ phpmyadmin_name }}.zip"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -4,7 +4,7 @@ echo -e '\nATTEMPTING TO INSTALL THE LATEST (RELEASED VERSION OF) ANSIBLE.'
 echo -e 'Ensure you'"'"'re online before running this script!'
 echo -e 'OR: consider scripts/ansible-2.4.x or scripts/ansible/2.5.x "slow food" instead.\n'
 
-GOOD_VER="2.5.3"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.5.4"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we install/upgrade to THE latest (released version of) Ansible.
 CURR_VER="undefined"
 # below are unused for future use

--- a/scripts/ansible-2.5.x
+++ b/scripts/ansible-2.5.x
@@ -4,7 +4,7 @@ echo -e '\nATTEMPTING TO INSTALL THE LATEST ANSIBLE 2.5.x'
 echo -e 'Ensure you'"'"'re online before running this script!'
 echo -e 'OR: consider scripts/ansible to keep up-to-date with Ansible'"'"'s evolution.\n'
 
-GOOD_VER="2.5.3"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.5.4"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we attempt to install/upgrade/pin to the latest Ansible 2.5.x
 CURR_VER="undefined"
 # below are unused for future use

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -3,7 +3,16 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Worked up to Calibre 3.23 from May 2018.
+# Calibre 3.24 and 3.25 fail to "apt install" in June 2018:
+#
+#   The following packages have unmet dependencies:
+#    calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed
+#   E: Unable to correct problems, you have held broken packages.
+#
+# Debian approach (calibre-install-latest.sh) is the workaround for now: https://github.com/iiab/iiab/pull/832
+# 
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/
 #   http://archive.raspbian.org/raspbian/pool/main/c/calibre/

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -10,7 +10,9 @@
 #    calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed
 #   E: Unable to correct problems, you have held broken packages.
 #
-# Debian approach (calibre-install-latest.sh) is the workaround for now: https://github.com/iiab/iiab/pull/832
+# Debian approach (calibre-install-latest.sh) is the workaround for now:
+#
+#   https://github.com/iiab/iiab/pull/833
 # 
 # Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #

--- a/scripts/calibre-install-latest.sh
+++ b/scripts/calibre-install-latest.sh
@@ -3,7 +3,7 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   https://packages.debian.org/search?keywords=calibre
 #   http://deb.debian.org/debian/pool/main/c/calibre/

--- a/scripts/calibre-install-unstable.sh
+++ b/scripts/calibre-install-unstable.sh
@@ -3,7 +3,7 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# Calibre 3.23 is the latest available from testing as of 2018-05-10:
+# Calibre 3.25 is the latest available from testing as of 2018-06-10:
 #
 #   https://packages.debian.org/search?keywords=calibre
 #   http://deb.debian.org/debian/pool/main/c/calibre/


### PR DESCRIPTION
This was tested on Raspbian Lite to fix #831

This PR834 (identical to PR #833) had been a stopgap solution for MEDIUM-sized and BIG-sized IIAB 6.5 (originally released on 2018-05-24) that allowed the installation Calibre 3.24 and 3.25 despite its broken Raspbian-flavor .debs

POSTSCRIPT: this was NOT a great solution, as it prevented the resulting IIAB microSD cards from booting inside RPi Zero W's.