### PR TITLE
kiwix-tools 2018-05-24 -> 0.6.0 (2018-06-20)

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,9 +1,9 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: "kiwix-tools_linux-armhf-2018-05-24"
-kiwix_version_linux64: "kiwix-tools_linux-x86_64-2018-05-24"
-kiwix_version_i686: "kiwix-tools_linux-i586-2018-05-24"
+kiwix_version_armhf: "kiwix-tools_linux-armhf-0.6.0"
+kiwix_version_linux64: "kiwix-tools_linux-i586-0.6.0"
+kiwix_version_i686: "kiwix-tools_linux-x86_64-0.6.0"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:


### PR DESCRIPTION
Please test on all 3 platforms, those who can!

- armhf
- x86_64
- i586

Context: all 3 installers are now cached at http://download.iiab.io/packages/ (and also available at https://download.kiwix.org/release/kiwix-tools/), including kiwix-serve which is the piece we care about most :)