### PR TITLE
Extend systemd Timeout so Calibre can boot in RPi Zero W

### DIFF
--- a/roles/calibre/templates/calibre-serve.service.j2
+++ b/roles/calibre/templates/calibre-serve.service.j2
@@ -5,6 +5,7 @@ After=syslog.target network.target local-fs.target
 [Service]
 Type=forking
 PIDFile=/var/run/calibre.pid
+TimeoutStartSec=400
 ExecStart=/usr/bin/calibre-server --daemonize --log=/var/log/calibre.log --pidfile=/var/run/calibre.pid --port={{ calibre_port }} {{ calibre_dbpath }}
 
 [Install]


### PR DESCRIPTION
Extended to 400 seconds in roles/calibre/templates/calibre-serve.service.j2 (placed in /etc/systemd/system/calibre-serve.service during IIAB installation) which is just more than 6 minutes:
```
TimeoutStartSec=400
```
Not sure what the default timeout was, but /usr/bin/calibre-server ("systemctl status calibre-serve.service") had consistently been failing to launch and then timing out within 2-to-3min.