### PR TITLE
scripts/ansible needs dirmngr only; prereqs not needed: python-pip python-setuptools python-wheel patch

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -39,8 +39,8 @@ if [ ! `command -v ansible-playbook` ]; then   # "command -v" is POSIX compliant
     elif [ -f /etc/debian_version ] || (grep -qi raspbian /etc/*elease) ; then
         if ( ! grep -qi ansible /etc/apt/sources.list) && [ ! -f /etc/apt/sources.list.d/ansible ]; then
             apt update
-            apt -y install dirmngr
             #apt -y install dirmngr python-pip python-setuptools python-wheel patch
+            apt -y install dirmngr
             echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
                  >> /etc/apt/sources.list.d/iiab-ansible.list
             #echo "deb http://ppa.launchpad.net/ansible/ansible-2.4/ubuntu xenial main" \

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -39,7 +39,8 @@ if [ ! `command -v ansible-playbook` ]; then   # "command -v" is POSIX compliant
     elif [ -f /etc/debian_version ] || (grep -qi raspbian /etc/*elease) ; then
         if ( ! grep -qi ansible /etc/apt/sources.list) && [ ! -f /etc/apt/sources.list.d/ansible ]; then
             apt update
-            apt -y install dirmngr python-pip python-setuptools python-wheel patch
+            apt -y install dirmngr
+            #apt -y install dirmngr python-pip python-setuptools python-wheel patch
             echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
                  >> /etc/apt/sources.list.d/iiab-ansible.list
             #echo "deb http://ppa.launchpad.net/ansible/ansible-2.4/ubuntu xenial main" \

--- a/scripts/ansible-2.5.x
+++ b/scripts/ansible-2.5.x
@@ -39,7 +39,8 @@ if [ ! `command -v ansible-playbook` ]; then   # "command -v" is POSIX compliant
     elif [ -f /etc/debian_version ] || (grep -qi raspbian /etc/*elease) ; then
         if ( ! grep -qi ansible /etc/apt/sources.list) && [ ! -f /etc/apt/sources.list.d/ansible ]; then
             apt update
-            apt -y install dirmngr python-pip python-setuptools python-wheel patch
+            #apt -y install dirmngr python-pip python-setuptools python-wheel patch
+            apt -y install dirmngr
             #echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
             #     >> /etc/apt/sources.list.d/iiab-ansible.list
             echo "deb http://ppa.launchpad.net/ansible/ansible-2.5/ubuntu xenial main" \


### PR DESCRIPTION
Extensively tested over past 6 months.  Time to set it loose even further, so it gets tested in yet more scenarios as part of master.