### PR TITLE
Recommend Ansible 2.5.5+

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -5,7 +5,7 @@ echo -e 'Ensure you'"'"'re online before running this! (/opt/iiab/iiab/scripts/a
 echo -e 'INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch'
 echo -e 'ALTERNATIVES: Consider scripts/ansible-2.5.x "slow food" instead.\n'
 
-GOOD_VER="2.5.4"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.5.5"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we install/upgrade to THE latest (released version of) Ansible.
 CURR_VER="undefined"
 # below are unused for future use

--- a/scripts/ansible-2.5.x
+++ b/scripts/ansible-2.5.x
@@ -5,7 +5,7 @@ echo -e 'Ensure you'"'"'re online before running this! (/opt/iiab/iiab/scripts/a
 echo -e 'INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch'
 echo -e 'ALTERNATIVE: Consider scripts/ansible to keep up-to-date as Ansible evolves.\n'
 
-GOOD_VER="2.5.4"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.5.5"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we attempt to install/upgrade/pin to the latest Ansible 2.5.x
 CURR_VER="undefined"
 # below are unused for future use


### PR DESCRIPTION
https://launchpad.net/~ansible/+archive/ubuntu/ansible just caught up to https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.5 a week later!  So Ansible 2.5.4 will upgrade to 2.5.5 on most all machines (RPi and Ubuntu) where "apt update" then "apt dist-upgrade" is run.

RELATED: the recommendation in STEP5 of https://github.com/iiab/iiab/wiki/IIAB-Installation was also changed to Ansible 2.5.5 (or higher).