### PR TITLE
Add Node-RED and Mosquitto (MQTT) IIAB playbooks for IoT

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -45,6 +45,12 @@
   when: wordpress_install
   tags: wordpress
 
+- name: MOSQUITTO
+  include_role:
+    name: mosquitto
+  when: mosquitto_install
+  tags: mosquitto
+
 - name: Recording STAGE 6 HAS COMPLETED ====================
   lineinfile:
     dest: /etc/iiab/iiab.env

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -51,6 +51,12 @@
   when: mosquitto_install
   tags: mosquitto
 
+- name: NODE-RED
+  include_role:
+    name: nodered
+  when: nodered_install
+  tags: nodered
+
 - name: Recording STAGE 6 HAS COMPLETED ====================
   lineinfile:
     dest: /etc/iiab/iiab.env

--- a/roles/mosquitto/README.rst
+++ b/roles/mosquitto/README.rst
@@ -1,0 +1,3 @@
+Adds the mosquitto pub-sub broker to the iiab. 
+
+Roughly follows this guide: https://www.digitalocean.com/community/tutorials/how-to-install-and-secure-the-mosquitto-mqtt-messaging-broker-on-ubuntu-16-04

--- a/roles/mosquitto/defaults/main.yml
+++ b/roles/mosquitto/defaults/main.yml
@@ -1,0 +1,4 @@
+mosquitto_install: True
+mosquitto_enabled: False
+mosquitto_user: admin
+mosquitto_password: g0adm1n

--- a/roles/mosquitto/defaults/main.yml
+++ b/roles/mosquitto/defaults/main.yml
@@ -1,4 +1,4 @@
 mosquitto_install: True
 mosquitto_enabled: False
-mosquitto_user: admin
+mosquitto_user: Admin
 mosquitto_password: g0adm1n

--- a/roles/mosquitto/tasks/main.yml
+++ b/roles/mosquitto/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install Mosquitto
-  package:  name={{ item }} 
-            state=present
+  package:
+    name: "{{ item }}"
+    state: present
   with_items:
     - mosquitto
     - mosquitto-clients

--- a/roles/mosquitto/tasks/main.yml
+++ b/roles/mosquitto/tasks/main.yml
@@ -1,0 +1,50 @@
+- name: Install Mosquitto
+  package:  name={{ item }} 
+            state=present
+  with_items:
+    - mosquitto
+    - mosquitto-clients
+  when: mosquitto_install
+  tags: download
+
+- name: Disable mosquitto
+  service:
+    name: mosquitto
+    enabled: no
+
+- name: Stop mosquitto
+  service:
+    name: mosquitto
+    state: stopped
+
+- name: Create mosquitto passwd file
+  file:
+    path: /etc/mosquitto/passwd
+    state: touch
+    mode: "u=rw,g=r,o=r"
+
+- name: Create mosquitto username/password
+  shell: mosquitto_passwd -b /etc/mosquitto/passwd "{{ mosquitto_user }}" "{{ mosquitto_password  }}"
+
+- name: Create mosquitto config file
+  template:
+    backup: yes
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  with_items:
+    - { src: 'websockets.conf.j2' , dest: '/etc/mosquitto/conf.d/websockets.conf', mode: '0755' }
+
+- name: Enable mosquitto
+  service:
+    name: mosquitto
+    enabled: yes
+  when: mosquitto_enabled
+
+- name: Start mosquitto
+  service:
+    name: mosquitto
+    state: started
+  when: mosquitto_enabled

--- a/roles/mosquitto/templates/websockets.conf.j2
+++ b/roles/mosquitto/templates/websockets.conf.j2
@@ -1,0 +1,3 @@
+listener 1883
+allow_anonymous false
+password_file /etc/mosquitto/passwd

--- a/roles/nodered/README.rst
+++ b/roles/nodered/README.rst
@@ -1,0 +1,1 @@
+Adds node-red and node-red dashboard to the schoolserver

--- a/roles/nodered/defaults/main.yml
+++ b/roles/nodered/defaults/main.yml
@@ -1,0 +1,4 @@
+nodered_install: True
+nodered_enabled: False
+nodered_user: admin
+nodered_password: g0adm1n

--- a/roles/nodered/defaults/main.yml
+++ b/roles/nodered/defaults/main.yml
@@ -1,4 +1,4 @@
 nodered_install: True
 nodered_enabled: False
-nodered_user: admin
+nodered_user: Admin
 nodered_password: g0adm1n

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -1,0 +1,62 @@
+- name: Install nodejs-legacy
+  package:  name={{ item }} 
+            state=present
+  with_items:
+    - nodejs-legacy
+  when: nodered_install
+  tags: download
+
+- name: Install npm
+  package:  name={{ item }} 
+            state=present
+  with_items:
+    - npm
+  when: nodered_install
+  tags: download
+
+- name: Install node-red packages globally.
+  shell: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
+
+- name: Create nodered usergroup
+  group:
+    name: nodered
+    state: present
+
+- name: Add the user nodered and add to nodered group
+  user:
+    name: nodered
+    group: nodered
+
+- name: Copy settings.js file with authentication
+  template:
+    backup: yes
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: nodered
+    group: nodered
+    mode: "{{ item.mode }}"
+  with_items:
+    - { src: 'settings.js.j2' , dest: '/home/nodered/.node-red/settings.js', mode: '0755' }
+
+- name: Create node-red systemd file
+  template:
+    backup: yes
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  with_items:
+    - { src: 'node-red.service.j2' , dest: '/etc/systemd/system/node-red.service', mode: '0755' }
+
+- name: Enable node-red
+  service:
+    name: node-red
+    enabled: yes
+  when: nodered_enabled
+
+- name: Start node-red
+  service:
+    name: node-red
+    state: started
+  when: nodered_enabled

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -1,14 +1,16 @@
 - name: Install nodejs-legacy
-  package:  name={{ item }} 
-            state=present
+  package:
+    name: "{{ item }}"
+    state: present
   with_items:
     - nodejs-legacy
   when: nodered_install
   tags: download
 
 - name: Install npm
-  package:  name={{ item }} 
-            state=present
+  package:
+    name: "{{ item }}"
+    state: present
   with_items:
     - npm
   when: nodered_install

--- a/roles/nodered/templates/node-red.service.j2
+++ b/roles/nodered/templates/node-red.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Node-RED
+After=syslog.target network.target
+
+[Service]
+ExecStart=/usr/local/bin/node-red-pi --max-old-space-size=128 -v
+Restart=on-failure
+KillSignal=SIGINT
+
+# log output to syslog as 'node-red'
+SyslogIdentifier=node-red
+StandardOutput=syslog
+
+# non-root user to run as
+WorkingDirectory=/home/nodered/
+User=nodered
+Group=nodered
+
+[Install]
+WantedBy=multi-user.target
+

--- a/roles/nodered/templates/settings.js.j2
+++ b/roles/nodered/templates/settings.js.j2
@@ -1,0 +1,245 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+// The `https` setting requires the `fs` module. Uncomment the following
+// to make it available:
+//var fs = require("fs");
+
+module.exports = {
+    // the tcp port that the Node-RED web server is listening on
+    uiPort: process.env.PORT || 1880,
+
+    // By default, the Node-RED UI accepts connections on all IPv4 interfaces.
+    // To listen on all IPv6 addresses, set uiHost to "::",
+    // The following property can be used to listen on a specific interface. For
+    // example, the following would only allow connections from the local machine.
+    //uiHost: "127.0.0.1",
+
+    // Retry time in milliseconds for MQTT connections
+    mqttReconnectTime: 15000,
+
+    // Retry time in milliseconds for Serial port connections
+    serialReconnectTime: 15000,
+
+    // Retry time in milliseconds for TCP socket connections
+    //socketReconnectTime: 10000,
+
+    // Timeout in milliseconds for TCP server socket connections
+    //  defaults to no timeout
+    //socketTimeout: 120000,
+
+    // Timeout in milliseconds for HTTP request connections
+    //  defaults to 120 seconds
+    //httpRequestTimeout: 120000,
+
+    // The maximum length, in characters, of any message sent to the debug sidebar tab
+    debugMaxLength: 1000,
+
+    // The maximum number of messages nodes will buffer internally as part of their
+    // operation. This applies across a range of nodes that operate on message sequences.
+    //  defaults to no limit. A value of 0 also means no limit is applied.
+    //nodeMaxMessageBufferLength: 0,
+
+    // To disable the option for using local files for storing keys and certificates in the TLS configuration
+    //  node, set this to true
+    //tlsConfigDisableLocalFiles: true,
+
+    // Colourise the console output of the debug node
+    //debugUseColors: true,
+
+    // The file containing the flows. If not set, it defaults to flows_<hostname>.json
+    //flowFile: 'flows.json',
+
+    // To enabled pretty-printing of the flow within the flow file, set the following
+    //  property to true:
+    //flowFilePretty: true,
+
+    // By default, credentials are encrypted in storage using a generated key. To
+    // specify your own secret, set the following property.
+    // If you want to disable encryption of credentials, set this property to false.
+    // Note: once you set this property, do not change it - doing so will prevent
+    // node-red from being able to decrypt your existing credentials and they will be
+    // lost.
+    //credentialSecret: "a-secret-key",
+
+    // By default, all user data is stored in the Node-RED install directory. To
+    // use a different location, the following property can be used
+    //userDir: '/home/nol/.node-red/',
+
+    // Node-RED scans the `nodes` directory in the install directory to find nodes.
+    // The following property can be used to specify an additional directory to scan.
+    //nodesDir: '/home/nol/.node-red/nodes',
+
+    // By default, the Node-RED UI is available at http://localhost:1880/
+    // The following property can be used to specify a different root path.
+    // If set to false, this is disabled.
+    //httpAdminRoot: '/admin',
+
+    // Some nodes, such as HTTP In, can be used to listen for incoming http requests.
+    // By default, these are served relative to '/'. The following property
+    // can be used to specifiy a different root path. If set to false, this is
+    // disabled.
+    //httpNodeRoot: '/red-nodes',
+
+    // The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
+    // to apply the same root to both parts.
+    //httpRoot: '/red',
+
+    // When httpAdminRoot is used to move the UI to a different root path, the
+    // following property can be used to identify a directory of static content
+    // that should be served at http://localhost:1880/.
+    //httpStatic: '/home/nol/node-red-static/',
+
+    // The maximum size of HTTP request that will be accepted by the runtime api.
+    // Default: 5mb
+    //apiMaxLength: '5mb',
+
+    // If you installed the optional node-red-dashboard you can set it's path
+    // relative to httpRoot
+    ui: { path: "ui" },
+
+    // Securing Node-RED
+    // -----------------
+    // To password protect the Node-RED editor and admin API, the following
+    // property can be used. See http://nodered.org/docs/security.html for details.
+    adminAuth: {
+        type: "credentials",
+        users: [{
+            username: "{{ nodered_user }}",
+            password: "{{ nodered_password }}",
+            permissions: "*"
+        }]
+    },
+
+    // To password protect the node-defined HTTP endpoints (httpNodeRoot), or
+    // the static content (httpStatic), the following properties can be used.
+    // The pass field is a bcrypt hash of the password.
+    // See http://nodered.org/docs/security.html#generating-the-password-hash
+    //httpNodeAuth: {user:"user",pass:"$2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN."},
+    //httpStaticAuth: {user:"user",pass:"$2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN."},
+
+    // The following property can be used to enable HTTPS
+    // See http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
+    // for details on its contents.
+    // See the comment at the top of this file on how to load the `fs` module used by
+    // this setting.
+    //
+    //https: {
+    //    key: fs.readFileSync('privatekey.pem'),
+    //    cert: fs.readFileSync('certificate.pem')
+    //},
+
+    // The following property can be used to cause insecure HTTP connections to
+    // be redirected to HTTPS.
+    //requireHttps: true
+
+    // The following property can be used to disable the editor. The admin API
+    // is not affected by this option. To disable both the editor and the admin
+    // API, use either the httpRoot or httpAdminRoot properties
+    //disableEditor: false,
+
+    // The following property can be used to configure cross-origin resource sharing
+    // in the HTTP nodes.
+    // See https://github.com/troygoode/node-cors#configuration-options for
+    // details on its contents. The following is a basic permissive set of options:
+    //httpNodeCors: {
+    //    origin: "*",
+    //    methods: "GET,PUT,POST,DELETE"
+    //},
+
+    // If you need to set an http proxy please set an environment variable
+    // called http_proxy (or HTTP_PROXY) outside of Node-RED in the operating system.
+    // For example - http_proxy=http://myproxy.com:8080
+    // (Setting it here will have no effect)
+    // You may also specify no_proxy (or NO_PROXY) to supply a comma separated
+    // list of domains to not proxy, eg - no_proxy=.acme.co,.acme.co.uk
+
+    // The following property can be used to add a custom middleware function
+    // in front of all http in nodes. This allows custom authentication to be
+    // applied to all http in nodes, or any other sort of common request processing.
+    //httpNodeMiddleware: function(req,res,next) {
+    //    // Handle/reject the request, or pass it on to the http in node by calling next();
+    //    // Optionally skip our rawBodyParser by setting this to true;
+    //    //req.skipRawBodyParser = true;
+    //    next();
+    //},
+
+    // The following property can be used to verify websocket connection attempts.
+    // This allows, for example, the HTTP request headers to be checked to ensure
+    // they include valid authentication information.
+    //webSocketNodeVerifyClient: function(info) {
+    //    // 'info' has three properties:
+    //    //   - origin : the value in the Origin header
+    //    //   - req : the HTTP request
+    //    //   - secure : true if req.connection.authorized or req.connection.encrypted is set
+    //    //
+    //    // The function should return true if the connection should be accepted, false otherwise.
+    //    //
+    //    // Alternatively, if this function is defined to accept a second argument, callback,
+    //    // it can be used to verify the client asynchronously.
+    //    // The callback takes three arguments:
+    //    //   - result : boolean, whether to accept the connection or not
+    //    //   - code : if result is false, the HTTP error status to return
+    //    //   - reason: if result is false, the HTTP reason string to return
+    //},
+
+    // Anything in this hash is globally available to all functions.
+    // It is accessed as context.global.
+    // eg:
+    //    functionGlobalContext: { os:require('os') }
+    // can be accessed in a function block as:
+    //    context.global.os
+
+    functionGlobalContext: {
+        // os:require('os'),
+        // jfive:require("johnny-five"),
+        // j5board:require("johnny-five").Board({repl:false})
+    },
+
+    // The following property can be used to order the categories in the editor
+    // palette. If a node's category is not in the list, the category will get
+    // added to the end of the palette.
+    // If not set, the following default order is used:
+    //paletteCategories: ['subflows', 'input', 'output', 'function', 'social', 'mobile', 'storage', 'analysis', 'advanced'],
+
+    // Configure the logging output
+    logging: {
+        // Only console logging is currently supported
+        console: {
+            // Level of logging to be recorded. Options are:
+            // fatal - only those errors which make the application unusable should be recorded
+            // error - record errors which are deemed fatal for a particular request + fatal errors
+            // warn - record problems which are non fatal + errors + fatal errors
+            // info - record information about the general running of the application + warn + error + fatal errors
+            // debug - record information which is more verbose than info + info + warn + error + fatal errors
+            // trace - record very detailed logging + debug + info + warn + error + fatal errors
+            // off - turn off all logging (doesn't affect metrics or audit)
+            level: "info",
+            // Whether or not to include metric events in the log output
+            metrics: false,
+            // Whether or not to include audit events in the log output
+            audit: false
+        }
+    },
+
+    // Customising the editor
+    editorTheme: {
+        projects: {
+            // To enable the Projects feature, set this value to true
+            enabled: false
+        }
+    }
+}

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: True
 wordpress_install: True
 wordpress_enabled: True
 
+mosquitto_install: True
+mosquitto_enabled: True
+
+nodered_install: True
+nodered_enabled: True
+
 # 7-EDU-APPS
 
 kalite_install: True

--- a/vars/local_vars_big_vpn.yml
+++ b/vars/local_vars_big_vpn.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: True
 wordpress_install: True
 wordpress_enabled: True
 
+mosquitto_install: True
+mosquitto_enabled: True
+
+nodered_install: True
+nodered_enabled: True
+
 # 7-EDU-APPS
 
 kalite_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: True
 wordpress_install: True
 wordpress_enabled: True
 
+mosquitto_install: True
+mosquitto_enabled: False
+
+nodered_install: True
+nodered_enabled: False
+
 # 7-EDU-APPS
 
 kalite_install: True

--- a/vars/local_vars_medium_vpn.yml
+++ b/vars/local_vars_medium_vpn.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: True
 wordpress_install: True
 wordpress_enabled: True
 
+mosquitto_install: True
+mosquitto_enabled: False
+
+nodered_install: True
+nodered_enabled: False
+
 # 7-EDU-APPS
 
 kalite_install: True

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: False
 wordpress_install: False
 wordpress_enabled: False
 
+mosquitto_install: False
+mosquitto_enabled: False
+
+nodered_install: False
+nodered_enabled: False
+
 # 7-EDU-APPS
 
 kalite_install: True

--- a/vars/local_vars_min_vpn.yml
+++ b/vars/local_vars_min_vpn.yml
@@ -155,6 +155,12 @@ nextcloud_enabled: False
 wordpress_install: False
 wordpress_enabled: False
 
+mosquitto_install: False
+mosquitto_enabled: False
+
+nodered_install: False
+nodered_enabled: False
+
 # 7-EDU-APPS
 
 kalite_install: True


### PR DESCRIPTION
Mosquitto is a pub-sub broker that a large number of IOT devices and sensors use. 
Node-red provides easy to make dashboards with a drag and drop interface, and a user-facing dashboard. 

With this functionality, the IIAB can serve as a broker to various sensors and actuators that may be connected to the network of which IIAB is a part of or manages. 

This set of playbooks have been tested to work on Intel-NUC on ubuntu 16.04, and are fairly straightforward, so I assume they should work on other iiab supported platforms too. 