### PR TITLE
Avoiding OS's ancient version(s) of Calibre (blocks install on Ubuntu 16.04, slows others)

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -5,14 +5,15 @@
     path: "/usr/bin/calibre"
   register: calib_executable
 
-- name: Install Calibre via OS's package installer (IF /usr/bin/calibre MISSING)
-  package:
-    name: "{{ item }}"
-    state: latest
-  with_items:
-    - calibre
-    - calibre-bin
-  when: internet_available and (not calib_executable.stat.exists)
+# The 8 lines below appear unecessary as of 2018-06-26 -- as tested on RPi.
+#- name: Install Calibre via OS's package installer (IF /usr/bin/calibre MISSING)
+#  package:
+#    name: "{{ item }}"
+#    state: latest
+#  with_items:
+#    - calibre
+#    - calibre-bin
+#  when: internet_available and (not calib_executable.stat.exists)
 
 - name: Install Calibre experimental .debs IF calibre_via_debs (AND /usr/bin/calibre WAS MISSING)
   include_tasks: debs.yml

--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -5,7 +5,11 @@
     path: "/usr/bin/calibre"
   register: calib_executable
 
-# The 8 lines below appear unecessary as of 2018-06-26 -- as tested on RPi.
+# The 8 lines below were breaking IIAB installs on Ubuntu 16.04 as of early
+# July 2018 (https://github.com/iiab/iiab/issues/883) and were tested as
+# unecessary on Raspbian Lite on RPi 3 B+ (calibre_via-debs: True) and
+# Ubuntu 18.04 (calibre_via_python: True).  PR #856 is the fix for now.
+
 #- name: Install Calibre via OS's package installer (IF /usr/bin/calibre MISSING)
 #  package:
 #    name: "{{ item }}"


### PR DESCRIPTION
Tested to work on Raspbian Lite on RPi 3 B+, whose microSD was later moved to Zero W.

All other OS's use the [Python approach](https://github.com/iiab/iiab/blob/master/roles/calibre/tasks/py-installer.yml) (not the [.deb approach](https://github.com/iiab/iiab/blob/master/roles/calibre/tasks/debs.yml) used on RPi) to installing Calibre.