### PR TITLE
Revise Ansible recommendation from 2.5.5 to 2.6.0

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -12,7 +12,7 @@ echo -e 'Ensure you'"'"'re online before running this (/opt/iiab/iiab/scripts/an
 echo -e 'ALTERNATIVES: Run scripts/ansible-2.5.x or scripts/ansible-2.6.x "sloww food".\n\n'
 
 
-GOOD_VER="2.5.5"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.6.0"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we install/upgrade to THE latest (released version of) Ansible.
 CURR_VER="undefined"
 # below are unused for future use

--- a/scripts/ansible-2.5.x
+++ b/scripts/ansible-2.5.x
@@ -12,7 +12,7 @@ echo -e 'Ensure you'"'"'re online before running this (/opt/iiab/iiab/scripts/an
 echo -e 'ALTERNATIVES: Run scripts/ansible-2.6.x, or scripts/ansible for the latest.\n\n'
 
 
-GOOD_VER="2.5.5"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.6.0"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we attempt to install/upgrade/pin to the latest Ansible 2.5.x
 CURR_VER="undefined"
 # below are unused for future use

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -12,7 +12,7 @@ echo -e 'Ensure you'"'"'re online before running this (/opt/iiab/iiab/scripts/an
 echo -e 'ALTERNATIVES: Run scripts/ansible-2.5.x, or scripts/ansible for the latest.\n\n'
 
 
-GOOD_VER="2.5.5"      # Ansible version for OLPC XO laptops (pip install).
+GOOD_VER="2.6.0"      # Ansible version for OLPC XO laptops (pip install).
                       # On other OS's we attempt to install/upgrade/pin to the latest Ansible 2.6.x
 CURR_VER="undefined"
 # below are unused for future use


### PR DESCRIPTION
Even Ubuntu/Canonical has sanctioned/blessed Ansible 2.6.0 at https://launchpad.net/%7Eansible/+archive/ubuntu/ansible (immediately on Ansible 2.6.0's release day, such that IIAB's /opt/iiab/iiab/scripts/ansible install script just works!)

Unlike with Calibre 2.5.4 when they waited days, and 2.5.5 where they waited a full week to finally push/approve it.

Conclusion: running "scripts/ansible-2.6.x" is no longer necessary; simply running "scripts/ansible" will suffice to install Ansible 2.6.0 (same thing that happens when running IIAB's 1-liner install scripts at http://download.iiab.io.6.6).  As outlined by PPA/.deb repos listed in PR #855