### PR TITLE
Revert "Avoiding OS's ancient version(s) of Calibre (blocks install on Ubuntu 16.04, slows others)"

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -5,19 +5,14 @@
     path: "/usr/bin/calibre"
   register: calib_executable
 
-# The 8 lines below were breaking IIAB installs on Ubuntu 16.04 as of early
-# July 2018 (https://github.com/iiab/iiab/issues/883) and were tested as
-# unecessary on Raspbian Lite on RPi 3 B+ (calibre_via-debs: True) and
-# Ubuntu 18.04 (calibre_via_python: True).  PR #856 is the fix for now.
-
-#- name: Install Calibre via OS's package installer (IF /usr/bin/calibre MISSING)
-#  package:
-#    name: "{{ item }}"
-#    state: latest
-#  with_items:
-#    - calibre
-#    - calibre-bin
-#  when: internet_available and (not calib_executable.stat.exists)
+- name: Install Calibre via OS's package installer (IF /usr/bin/calibre MISSING)
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - calibre
+    - calibre-bin
+  when: internet_available and (not calib_executable.stat.exists)
 
 - name: Install Calibre experimental .debs IF calibre_via_debs (AND /usr/bin/calibre WAS MISSING)
   include_tasks: debs.yml


### PR DESCRIPTION
Reverts iiab/iiab#856 as it (predictably) failed on a fresh install on Ubuntu 18.04/Server.

So: install onto Ubuntu 16.04 still appear DOA, due to Ubuntu 16.04's current failure to install its very own recommendation (Calibre 2.55) if the OS was updated using apt.