### PR TITLE
Mandate Ansible 2.5.6 as an absolute minimum

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -68,9 +68,11 @@ if [[ `command -v ansible` ]]; then        # "command -v" is POSIX compliant; it
 fi
 if version_gt $MIN_ANSIBLE_VER $CURR_ANSIBLE_VER ; then
     echo -e "\nEXITING: Ansible "$MIN_ANSIBLE_VER" or higher required."
-    echo "PLEASE RUN './scripts/ansible' to install the latest Ansible from PPA or RPM."
-    echo "'ansible --version' and 'apt -a list ansible' can also be useful here.  Try"
-    echo "to remove prior versions with 'apt purge ansible' or 'pip uninstall ansible'."
+    echo
+    echo "REMOVE PRIOR VERSIONS using 'apt purge ansible' and/or 'pip uninstall ansible'."
+    echo "THEN RUN 'scripts/ansible' to install the latest Ansible from PPA or RPM."
+    echo "'ansible --version' and 'apt -a list ansible' can also be very useful."
+    echo
     echo "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 fi

--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.4.1.0
+MIN_ANSIBLE_VER=2.5.6
 
 export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
 


### PR DESCRIPTION
Warning also strengthened & clarified -- see Lines 72-74 of /opt/iiab/iiab/iiab-install especially:
```
REMOVE PRIOR VERSIONS using 'apt purge ansible' and/or 'pip uninstall ansible'.
THEN RUN 'scripts/ansible' to install the latest Ansible from PPA or RPM.
'ansible --version' and 'apt -a list ansible' can also be very useful.
```