### PR TITLE
Sugarizer: faster and tighter git clone/pull using "depth: 1"

### DIFF
--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -12,6 +12,7 @@
     dest: "{{ sugarizer_location }}/{{ sugarizer_version }}"
     version: "{{ sugarizer_git_version }}"
     force: yes
+    depth: 1
   when: internet_available
 
 - name: Create symbolic link /opt/iiab/sugarizer -> /opt/iiab/{{ sugarizer_version }}
@@ -36,6 +37,7 @@
     dest: "{{ sugarizer_location }}/{{ sugarizer_server_version }}"
     version: "{{ sugarizer_server_git_version }}"
     force: yes
+    depth: 1
   when: internet_available
 
 - name: Create symbolic link /opt/iiab/sugarizer-server -> /opt/iiab/{ sugarizer_server_version }}


### PR DESCRIPTION
Downloading 700+ MB from https://github.com/llaske/sugarizer was not wise, more than half of which was stored in /opt/iiab/sugarizer-1.0/.git

This change (building on PR #888) will greatly speed up installs of MEDIUM-sized and BIG-sized [IIAB 6.6/master](http://download.iiab.io/6.6/) and dramatically reduce the disk/storage footprint too.

FWIW compare this to the older approach, which had its own brittleness/maintenance/hosting costs, using files like these:
- http://download.iiab.io/packages/sugarizer-1.0.tar.gz
- http://download.iiab.io/packages/sugarizer-server-1.0.tar.gz (does not work)
