### PR TITLE
Delete link (our understanding of Ansible was flawed)

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -53,7 +53,6 @@
 - name: Remove the default apache2 config file (debuntu)
   file:
     path: /etc/apache2/sites-enabled/000-default.conf
-    src: /etc/apache2/sites-available/000-default.conf
     state: absent
   when: is_debuntu
 


### PR DESCRIPTION
Thanks @georgejhunt for reconfirming `src:` lines are erroneous (when deleting anything using Ansible's file module) and should be removed, per #860.

ASIDE: the same bug exists in IIAB Admin Console in these 2 places and should also be fixed before Ansible blocks our code entirely: https://github.com/iiab/iiab-admin-console/issues/81