### PR TITLE
Kiwix-tools code for i586

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -2,8 +2,8 @@
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
 kiwix_version_armhf: "kiwix-tools_linux-armhf-0.6.0"
-kiwix_version_linux64: "kiwix-tools_linux-i586-0.6.0"
-kiwix_version_i686: "kiwix-tools_linux-x86_64-0.6.0"
+kiwix_version_i686: "kiwix-tools_linux-i586-0.6.0"
+kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.6.0"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -2,8 +2,8 @@
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
 kiwix_version_armhf: "kiwix-tools_linux-armhf-0.6.0"
-kiwix_version_i686: "kiwix-tools_linux-i586-0.6.0"
 kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.6.0"
+kiwix_version_i686: "kiwix-tools_linux-i586-0.6.0"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:


### PR DESCRIPTION
Correct handling of i586/i686 kiwix-tools binaries.

### Fixes Bug
Kiwix install 64bit kiwix on Debian i686 machine.

$ lscpu | grep op-mode
CPU op-mode(s):        32-bit

$ file  /opt/iiab/kiwix/bin/kiwix-serve
/opt/iiab/kiwix/bin/kiwix-serve: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, for GNU/Linux 2.6.24, BuildID[sha1]=e88d71c8e5759d8df1632ec4e9e07bf715410a26, not stripped

### Description of changes proposed in this pull request.

Correctly installs the i585/i686 binaries on Debian 9 machine. 

### Smoke-tested in operating system.
Smoke-tested on Debian 9 i686 

### Mention a team member for further information or comment using @ name
@holta  Finally figured out the root cause of the kiwix problems on i586/i686 

https://github.com/iiab/iiab/issues/878