### PR TITLE
Correct URI for IIAB license file

### DIFF
--- a/roles/httpd/files/html/credits.html
+++ b/roles/httpd/files/html/credits.html
@@ -38,7 +38,7 @@
 
   It is licensed under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.<br><br>
 
-  Licensing information may be found at  <a href="http://github.com/XSCE/iiab/blob/master/LICENSE">github.com/XSCE/iiab/blob/master/LICENSE</a>.<br>
+  Licensing information may be found at  <a href="http://github.com/XSCE/iiab/blob/master/LICENSE.md">github.com/XSCE/iiab/blob/master/LICENSE.md</a>.<br>
 
 </BODY>
 <script type="text/javascript" src="incl/xs-portal.js"></script>

--- a/roles/httpd/files/html/credits.html
+++ b/roles/httpd/files/html/credits.html
@@ -10,35 +10,35 @@
 <BODY>
   <h1>Internet-in-a-Box Credits</h1>
 
-  Internet-in-a-Box includes a variety of educational and other content and applications which are attributed as follows:<br><br>
+  Internet-in-a-Box includes a variety of educational content and applications which are attributed as follows:<br><br>
 
-  All Wikipedia content is available for free at  <a href="http://www.wikipedia.org/">www.wikipedia.org</a>.<br>
-  All other Wikimedia content is available for free via links at  <a href="http://www.wikimedia.org/">www.wikimedia.org</a>.<br>
-  All Khan Academy content is available for free at  <a href="http://www.khanacademy.org/">www.khanacademy.org</a>.<br>
-  All CK-12 content is available for free at  <a href="http://www.ck-12.org/">www.ck-12.org</a>.<br>
-  All PhET Interactive Simulations content is available for free at  <a href="http://phet.colorado.edu">phet.colorado.edu</a>.<br>
-  All MedLine content is available for free at  <a href="http://www.nlm.nih.gov/medlineplus/">www.nlm.nih.gov/medlineplus</a>.<br>
-  All Hesperian content is available for free at  <a href="http://www.hesperian.org/">www.hesperian.org</a>.<br>
-  All Gutenberg content is available for free at  <a href="http://www.gutenberg.org/">www.gutenberg.org</a>.<br>
-  All OLPC content is available for free at  <a href="http://wiki.laptop.org/go/Library_grid">www.laptop.org</a>.<br>
-  All MIT Scratch content is available for free at  <a href="http://scratch.mit.edu">scratch.mit.edu</a>.<br>
-  All UNESCO's IICBA content is available for free at  <a href="http://www.eng.unesco-iicba.org/elibrary">www.eng.unesco-iicba.org</a>.<br>
-  All Math Expression content is available for free at  <a href="http://www.mathexpression.com">www.mathexpression.com</a>.<br>
-  All Music Theory content is available for free at  <a href="http://www.musictheory.net">www.musictheory.net</a>.<br><br>
+  All Wikipedia content is available for free at  <a href="https://www.wikipedia.org/">www.wikipedia.org</a>.<br>
+  All other Wikimedia content is available for free via links at  <a href="https://www.wikimedia.org/">www.wikimedia.org</a>.<br>
+  All Khan Academy content is available for free at  <a href="https://www.khanacademy.org/">www.khanacademy.org</a>.<br>
+  All CK-12 content is available for free at  <a href="https://www.ck-12.org/">www.ck-12.org</a>.<br>
+  All PhET Interactive Simulations content is available for free at  <a href="https://phet.colorado.edu">phet.colorado.edu</a>.<br>
+  All MedLine content is available for free at  <a href="https://medlineplus.gov/">medlineplus.gov</a>.<br>
+  All Hesperian content is available for free at  <a href="https://hesperian.org/">hesperian.org</a>.<br>
+  All Gutenberg content is available for free at  <a href="https://www.gutenberg.org/">www.gutenberg.org</a>.<br>
+  All OLPC content is available for free at  <a href="http://wiki.laptop.org/go/Collections">wiki.laptop.org</a>.<br>
+  All MIT Scratch content is available for free at  <a href="https://scratch.mit.edu">scratch.mit.edu</a>.<br>
+  All UNESCO's IICBA content is available for free at  <a href="http://www.iicba.unesco.org/">www.iicba.unesco.org/</a>.<br>
+  All Math Expression content is available for free at  <a href="https://www.mathexpression.com/">www.mathexpression.com</a>.<br>
+  All Music Theory content is available for free at  <a href="https://www.musictheory.net/">www.musictheory.net</a>.<br><br>
 
   Internet-in-a-Box also includes the work of content aggregators which we gratefully acknowledge:<br><br>
 
-  RACHEL is a curation of selected offline content at  <a href="http://www.rachel.worldpossible.org/">www.rachel.worldpossible.org</a>.<br>
-  Kiwix is a Zim server and repository of Wikimedia and other content in a compressed Zim file format at <a href="http://www.kiwix.org/">www.kiwix.org</a>.<br>
-  KA Lite is a server and repository of Khan Academy content in various languages at  <a href="http://learningequality.org/ka-lite/">learningequality.org/ka-lite</a>.<br><br>
+  RACHEL is a curation of selected offline content at  <a href="http://oer2go.org/">oer2go.org</a>.<br>
+  Kiwix is a ZIM server and repository of Wikimedia and other content in a compressed ZIM file format at <a href="http://www.kiwix.org/">www.kiwix.org</a>.<br>
+  KA Lite is a server and repository of Khan Academy content in various languages at  <a href="https://learningequality.org/ka-lite/">learningequality.org/ka-lite</a>.<br><br>
 
-  Internet-in-a-Box also contains a number of applications each of which has its own attribution information which is included.<br><br>
+  Internet-in-a-Box also contains a number of applications each of which has its own attribution information, which is included.<br><br>
 
-  This Internet-in-a-Box distribution resides at <a href="http://github.com/iiab/iiab">github.com/iiab/iiab</a>.<br><br>
+  This Internet-in-a-Box distribution resides at <a href="https://github.com/iiab/iiab">github.com/iiab/iiab</a>.<br><br>
 
   It is licensed under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.<br><br>
 
-  Licensing information may be found at  <a href="http://github.com/iiab/iiab/blob/master/LICENSE.md">github.com/iiab/iiab/blob/master/LICENSE.md</a>.<br>
+  Licensing information may be found at  <a href="https://github.com/iiab/iiab/blob/master/LICENSE.md">github.com/iiab/iiab/blob/master/LICENSE.md</a>.<br>
 
 </BODY>
 <script type="text/javascript" src="incl/xs-portal.js"></script>

--- a/roles/httpd/files/html/credits.html
+++ b/roles/httpd/files/html/credits.html
@@ -24,8 +24,11 @@
   All MIT Scratch content is available for free at  <a href="https://scratch.mit.edu">scratch.mit.edu</a>.<br>
   All UNESCO's IICBA content is available for free at  <a href="http://www.iicba.unesco.org/">www.iicba.unesco.org/</a>.<br>
   All Math Expression content is available for free at  <a href="https://www.mathexpression.com/">www.mathexpression.com</a>.<br>
-  All Music Theory content is available for free at  <a href="https://www.musictheory.net/">www.musictheory.net</a>.<br><br>
-
+  All Music Theory content is available for free at  <a href="https://www.musictheory.net/">www.musictheory.net</a>.<br>
+  All HealthPhone content is available for free at  <a href="http://www.healthphone.org/">www.healthphone.org</a>.<br>
+  All Centers for Disease Control content is available for free at  <a href="https://www.cdc.gov/">www.cdc.gov</a>.<br>
+  All Global Emergency Medicine Wiki content is available for free at  <a href="https://wikem.org/wiki/Main_Page">wikem.org/wiki/Main_Page</a>.<br><br>
+  
   Internet-in-a-Box also includes the work of content aggregators which we gratefully acknowledge:<br><br>
 
   RACHEL is a curation of selected offline content at  <a href="http://oer2go.org/">oer2go.org</a>.<br>

--- a/roles/httpd/files/html/credits.html
+++ b/roles/httpd/files/html/credits.html
@@ -10,7 +10,7 @@
 <BODY>
   <h1>Internet-in-a-Box Credits</h1>
 
-  The XSCE School Server known as Internet-in-a-Box includes a variety of educational and other content and applications which are attributed as follows:<br><br>
+  Internet-in-a-Box includes a variety of educational and other content and applications which are attributed as follows:<br><br>
 
   All Wikipedia content is available for free at  <a href="http://www.wikipedia.org/">www.wikipedia.org</a>.<br>
   All other Wikimedia content is available for free via links at  <a href="http://www.wikimedia.org/">www.wikimedia.org</a>.<br>
@@ -34,11 +34,11 @@
 
   Internet-in-a-Box also contains a number of applications each of which has its own attribution information which is included.<br><br>
 
-  This Internet-in-a-Box distribution resides at <a href="http://github.com/XSCE/iiab">github.com/XSCE/iiab</a>.<br><br>
+  This Internet-in-a-Box distribution resides at <a href="http://github.com/iiab/iiab">github.com/iiab/iiab</a>.<br><br>
 
   It is licensed under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.<br><br>
 
-  Licensing information may be found at  <a href="http://github.com/XSCE/iiab/blob/master/LICENSE.md">github.com/XSCE/iiab/blob/master/LICENSE.md</a>.<br>
+  Licensing information may be found at  <a href="http://github.com/iiab/iiab/blob/master/LICENSE.md">github.com/iiab/iiab/blob/master/LICENSE.md</a>.<br>
 
 </BODY>
 <script type="text/javascript" src="incl/xs-portal.js"></script>


### PR DESCRIPTION
Correct the URI  http://github.com/XSCE/iiab/blob/master/LICENSE to http://github.com/XSCE/iiab/blob/master/LICENSE.md

