### PR TITLE
Enable Debian 9 rsyslog service

### DIFF
--- a/roles/2-common/tasks/debian.yml
+++ b/roles/2-common/tasks/debian.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Debian 9 rsyslog server when sugarizer is enabled.
+  package:
+    name: rsyslog
+    state: present
+  when: sugarizer_enabled
+- name: Enable Debian 9 rsyslog service when sugarizer is enabled.
+  service:
+    name: rsyslog
+    enabled: yes
+    state: started
+  when: sugarizer_enabled

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -9,6 +9,9 @@
 - include_tasks: fedora.yml
   when: ansible_distribution == "Fedora"
 
+- include_tasks: debian.yml
+  when: is_debian
+
 - include_tasks: prep.yml
   when: not is_debuntu
 


### PR DESCRIPTION
Ensure that rsyslog service is installed and enabled when sugarizer is
enabled.

Fixes #869 https://github.com/iiab/iiab/issues/869

### Fixes Bug

### Description of changes proposed in this pull request.
When sugarizer is enabled this change installs rsyslog package and starts the service. 

### Smoke-tested in operating system.

Smoked-tested on Debian 9

TASK [2-common : include_tasks] ************************************************
included: /opt/iiab/iiab/roles/2-common/tasks/debian.yml for 127.0.0.1

TASK [2-common : Install Debian 9 rsyslog server when sugarizer is enabled.] ***
changed: [127.0.0.1]

TASK [2-common : Enable Debian 9 rsyslog service when sugarizer is enabled.] ***
ok: [127.0.0.1]

TASK [2-common : include_tasks] ************************************************
skipping: [127.0.0.1]

TASK [2-common : include_tasks] ************************************************
skipping: [127.0.0.1]

$ sudo systemctl list-units |grep rsys
rsyslog.service                                                                          loaded active running   System Logging Service                                            
