### PR TITLE
"npm install" fails with sudo, when installing Sugarizer 1.x

### DIFF
--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -95,6 +95,14 @@
     - npm
   when: internet_available and (is_ubuntu_18 or not is_debuntu)
 
+# 2018-07-15: TK Kang showed that "npm install" fails if run through sudo, with code EACCES, errno -13 (permission denied), "missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
+- name: Change ownership of /root/.npm from iiab-admin to root
+  file:
+    path: /root/.npm
+    owner: root
+    group: root
+    recurse: yes
+
 # 4. RUN "npm install" TO POPULATE ~35MB /opt/iiab/sugarizer-server/node_modules
 
 # Re-running "npm install" USED TO fail on Raspbian 9 if not other OS's.

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -96,7 +96,7 @@
   when: internet_available and (is_ubuntu_18 or not is_debuntu)
 
 # 2018-07-15: TK Kang showed that "npm install" fails if run through sudo, with code EACCES, errno -13 (permission denied), "Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
-- name: Change ownership of /root/.npm from iiab-admin to root
+- name: Change ownership of /root/.npm [from iiab-admin] to root
   file:
     path: /root/.npm
     owner: root

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -95,24 +95,13 @@
     - npm
   when: internet_available and (is_ubuntu_18 or not is_debuntu)
 
-# 2018-07-15: TK Kang showed that "npm install" fails if run through sudo, with code EACCES, errno -13 (permission denied), "Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
-- name: Change ownership of /root/.npm [from iiab-admin] to root
-  file:
-    path: /root/.npm
-    owner: root
-    group: root
-    recurse: yes
-
 # 4. RUN "npm install" TO POPULATE ~35MB /opt/iiab/sugarizer-server/node_modules
 
-# Re-running "npm install" USED TO fail on Raspbian 9 if not other OS's.
-# Several strategies to avoid re-running it:
+# Re-running "npm install" USED TO fail on Raspbian 9 if not other OS's?
+# Strategies considered to avoid re-running it:
 # OLD WAY 1: test & set flag node_modules_exists: True
 # OLD WAY 2: "creates: ..." checks for non-existence of /opt/iiab/sugarizer-server-1.0/node_modules
 # OLD WAY 3: set "register: git_sug_server_output" above, then as nec delete /opt/iiab/sugarizer-server-1.0/node_modules "when: git_sug_server_output.changed" and as nec run "npm install"
-
-# NEW WAY: run "npm install" every time, as modern versions of npm are
-# incremental, with sanity checks (as tested with npm 3.5.2 and 5.6.0)
 
 #- name: Check for /opt/iiab/{{ sugarizer_server_version }}/node_modules
 #  stat:
@@ -125,9 +114,27 @@
 #    node_modules_exists: True
 #  when: nmtest.stat is defined and nmtest.stat.exists
 
+# NEW WAY BELOW: run "npm install --allow-root" every time, as modern versions
+# of npm are incremental, with sanity checks (all 3 may work: but npm 6.2.0
+# is better than 5.6.0 better than 3.5.2
+
+# 2018-07-15: TK Kang & Holt confirmed sudo-driven "npm install" maxes out CPU
+# for hours.  Error code EACCES, errno -13 (permission denied):
+# "Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
+#
+# SOLUTION:
+# Implemented '--allow-root' below, as is critical for 1st run of sudo-driven
+# 'npm install' (causing it to create /root/.npm cache & lock files owned by
+# root:root instead of iiab-admin:iiab-admin) permitting it and IIAB install
+# scripts toactually complete :)
+#
+# CLARIF: something like 'chown -R root:root /root/.npm' cannot happen
+# synchronously with the 1st run of 'npm install' (when it's needed!)
+# nor is 'chown' functionality nec, now that --allow-root does the job)
+
 #- name: Create the express framework for Node.js (OS's other than Fedora 18)
-- name: Run 'npm install' to create /opt/iiab/{{ sugarizer_server_version }}/node_modules (CAN TAKE SEVERAL MINUTES)
-  command: npm install    # slightly safer than "shell:"
+- name: Run 'npm install --allow-root' to create /opt/iiab/{{ sugarizer_server_version }}/node_modules (CAN TAKE SEVERAL MINUTES)
+  command: npm install --allow-root    # "command:" a bit safer than "shell:"
   args:
     chdir: "{{ sugarizer_location }}/{{  sugarizer_server_version }}"
     #creates: "{{ sugarizer_location }}/{{ sugarizer_server_version }}/node_modules"    # OLD WAY 2

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -97,7 +97,7 @@
 
 # 4. RUN "npm install" TO POPULATE ~35MB /opt/iiab/sugarizer-server/node_modules
 
-# Re-running "npm install" USED TO fail on Raspbian 9 if not other OS's?
+# Re-running "npm install" USED TO fail on Raspbian 9 if not other OS's ?
 # Strategies considered to avoid re-running it:
 # OLD WAY 1: test & set flag node_modules_exists: True
 # OLD WAY 2: "creates: ..." checks for non-existence of /opt/iiab/sugarizer-server-1.0/node_modules

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -116,21 +116,20 @@
 
 # NEW WAY BELOW: run "npm install --allow-root" every time, as modern versions
 # of npm are incremental, with sanity checks (all 3 may work: but npm 6.2.0
-# is better than 5.6.0 better than 3.5.2
+# is better than 5.6.0. which is better than Ubuntu 18.04's 3.5.2).
 
 # 2018-07-15: TK Kang & Holt confirmed sudo-driven "npm install" maxes out CPU
-# for hours.  Error code EACCES, errno -13 (permission denied):
+# for hours, on diff OS's.  Error code EACCES, errno -13 (permission denied):
 # "Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
 #
-# SOLUTION:
-# Implemented '--allow-root' below, as is critical for 1st run of sudo-driven
-# 'npm install' (causing it to create /root/.npm cache & lock files owned by
-# root:root instead of iiab-admin:iiab-admin) permitting it and IIAB install
-# scripts toactually complete :)
+# SOLUTION: Implement '--allow-root' below, as is critical for 1st run of
+# sudo-driven 'npm install' (causing it to create /root/.npm cache & lock
+# files owned by root:root instead of iiab-admin:iiab-admin) permitting it
+# and IIAB install scripts to actually complete :)
 #
 # CLARIF: something like 'chown -R root:root /root/.npm' cannot happen
 # synchronously with the 1st run of 'npm install' (when it's needed!)
-# nor is 'chown' functionality nec, now that --allow-root does the job)
+# Nor is 'chown' functionality nec, now that --allow-root does the job.
 
 #- name: Create the express framework for Node.js (OS's other than Fedora 18)
 - name: Run 'npm install --allow-root' to create /opt/iiab/{{ sugarizer_server_version }}/node_modules (CAN TAKE SEVERAL MINUTES)

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -95,7 +95,7 @@
     - npm
   when: internet_available and (is_ubuntu_18 or not is_debuntu)
 
-# 2018-07-15: TK Kang showed that "npm install" fails if run through sudo, with code EACCES, errno -13 (permission denied), "missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
+# 2018-07-15: TK Kang showed that "npm install" fails if run through sudo, with code EACCES, errno -13 (permission denied), "Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules"
 - name: Change ownership of /root/.npm from iiab-admin to root
   file:
     path: /root/.npm


### PR DESCRIPTION
TK Kang showed that "npm install" fails if it (and IIAB 6.6 install scripts) are run with sudo.  Regardless if npm 5.6.0 or 6.2.0, on Raspbian on RPi 3 or on Debian 9.5 on x86_64.

One error he photographed shows:
```
Missing write access to /opt/iiab/sugarizer-server-1.0/node_modules
code EACCES
errno -13 (permission denied)
```
The PR (WIP) is an early proposed fix &mdash; changing ownership of /root/.npm (and everything inside it) from iiab-admin to root.