### PR TITLE
[Debian 10] [Fixes #902] Generate correct os_ver for Debian 10/Buster Release 

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -23,6 +23,7 @@ case $OS_VER in
     "fedora-22" | \
     "debian-8"  | \
     "debian-9"  | \
+    "debian-10" | \
     "ubuntu-16" | \
     "ubuntu-17" | \
     "ubuntu-18" | \

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,0 +1,24 @@
+is_debuntu: True
+is_debian: True
+is_debian_10: True
+dns_service: bind9
+dhcp_service: isc-dhcp-server
+dns_user: bind
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_config_dir: apache2/sites-available
+apache_user: www-data
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_service: ssh
+php_version: 7.2
+postgresql_version: 10
+systemd_location: /lib/systemd/system
+# Upgrade OS's own Calibre to very latest:
+calibre_via_debs: True
+calibre_via_python: False

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -16,7 +16,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_service: ssh
-php_version: 7.2
+php_version: 7.1
 postgresql_version: 10
 systemd_location: /lib/systemd/system
 # Upgrade OS's own Calibre to very latest:


### PR DESCRIPTION
### Fixes Bug
Allows IIAB to install on future releases of Debian 10 / Buster Release, by correctly generating os_ver variable from VERSION_ID in /etc/*release files. 
Fixes #902 
### Description of changes proposed in this pull request.
Adds a new file in /vars/debian-10.yml 
Adds a new switch routine in scripts/local_facts.fact

### Smoke-tested in operating system.
Early preview of Debian 10 / Bester / Testing 

### Mention a team member for further information or comment using @ name
@holta 