### PR TITLE
Revert kolibri_exec_path to usr /usr/local/bin for now

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -11,7 +11,8 @@ kolibri_home: "{{ content_base }}/kolibri"
 kolibri_http_port: 8009
 kolibri_url: /kolibri/
 kolibri_path: "{{ iiab_base }}/kolibri"
-kolibri_exec_path: /usr/bin/kolibri
+# 2018-07-16: IIAB recommends /usr/bin but @arky says this isn't yet possible, due to pip
+kolibri_exec_path: /usr/local/bin/kolibri
 
 # Kolibri system user
 kolibri_user: kolibri

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Create a Kolibri system user and to www-data, disk groups
+- name: Create Linux user {{ kolibri_user }} and it to groups www-data, disk
   user:
     name: "{{ kolibri_user }}"
     groups:

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Create Linux user {{ kolibri_user }} and it to groups www-data, disk
+- name: Create Linux user {{ kolibri_user }} and add it to groups {{ apache_user }}, disk
   user:
     name: "{{ kolibri_user }}"
     groups:


### PR DESCRIPTION
Due to pip install being unable to use /usr/bin for now.

@arky explains @ https://github.com/iiab/iiab/pull/906#issuecomment-405321778

Builds on PR #903 as laid out in #841