### PR TITLE
Adding 'no-cache-dir' extra arguments

### DIFF
--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -23,6 +23,7 @@
   pip:
     name: kolibri
     state: latest
+    extra_args: --no-cache-dir
   when: internet_available
 
 - name: Create kolibri systemd service file


### PR DESCRIPTION
Perhaps using no-cache-dir will preview out-of-memory errors on
Raspberry Pi.

### Fixes Bug  #908

### Description of changes proposed in this pull request.
Adds a extra argument to pip install task. 

### Smoke-tested in operating system.
None
### Mention a team member for further information or comment using @ name
@holta 