### PR TITLE
Clean up daemon-reload in {2-common, KA Lite, Kolibri}

### DIFF
--- a/roles/2-common/tasks/udev.yml
+++ b/roles/2-common/tasks/udev.yml
@@ -22,12 +22,7 @@
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
 # ubuntu 16.04 comes with ansible 2.0.0.2 -- no systemd module
-- name: Ask systemd to recognize the changes
-  shell: systemctl daemon-reload
-  when: udev_unit.stat.exists is defined and udev_unit.stat.exists
-
-# ubuntu 16.04 comes with ansible 2.0.0.2 -- no systemd module
-- name: Ask systemd to recognize the changes (daemon-reloard)
+- name: Ask systemd to reread the unit files (daemon-reload)
   systemd:
     daemon_reload: yes
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists

--- a/roles/2-common/tasks/udev.yml
+++ b/roles/2-common/tasks/udev.yml
@@ -22,7 +22,7 @@
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
 # ubuntu 16.04 comes with ansible 2.0.0.2 -- no systemd module
-- name: Ask systemd to reread the unit files (daemon-reload)
+- name: Ask systemd to reread unit files (daemon-reload)
   systemd:
     daemon_reload: yes
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists

--- a/roles/2-common/tasks/udev.yml
+++ b/roles/2-common/tasks/udev.yml
@@ -26,6 +26,12 @@
   shell: systemctl daemon-reload
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
+# ubuntu 16.04 comes with ansible 2.0.0.2 -- no systemd module
+- name: Ask systemd to recognize the changes (daemon-reloard)
+  systemd:
+    daemon_reload: yes
+  when: udev_unit.stat.exists is defined and udev_unit.stat.exists
+
 - name: Restart so systemd recognizes the changes
   shell: systemctl restart systemd-udevd.service
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -23,8 +23,9 @@
 - include_tasks: install.yml
   when: kalite_installed is defined and not kalite_installed.stat.exists and not is_F18
 
-- name: Ask systemd to reread the unit files
-  shell: systemctl daemon-reload
+- name: Ask systemd to reread the unit files (daemon-reload)
+  systemd:
+    daemon_reload: yes
   when: not kalite_installed.stat.exists
 
 - include_tasks: setup-f18.yml

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -23,7 +23,7 @@
 - include_tasks: install.yml
   when: kalite_installed is defined and not kalite_installed.stat.exists and not is_F18
 
-- name: Ask systemd to reread the unit files (daemon-reload)
+- name: Ask systemd to reread unit files (daemon-reload)
   systemd:
     daemon_reload: yes
   when: not kalite_installed.stat.exists

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -26,7 +26,7 @@
     extra_args: --no-cache-dir
   when: internet_available
 
-- name: Create kolibri systemd service file
+- name: Create kolibri systemd service unit file
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -34,7 +34,11 @@
     owner: root
     group: root
   with_items:
-    - { src: 'kolibri.service.j2' , dest: '/etc/systemd/system/kolibri.service', mode: '0644' }
+    - { src: 'kolibri.service.j2', dest: '/etc/systemd/system/kolibri.service', mode: '0644' }
+
+- name: Ask systemd to reread unit files (daemon-reload)
+  systemd:
+    daemon_reload: yes
 
 - name: Set kolibri default language
   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"


### PR DESCRIPTION
CLARIF for @arky: "systemctl daemon-reload" was sometimes necessary when Kolibri playbook was being re-run &mdash; it was not completing without this.