### PR TITLE
Open Kolibri port in iptables, for on-campus browsing on WAN side of IIAB (e.g. http://192.168.0.x:8009)

### DIFF
--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -75,7 +75,7 @@
    state: stopped
   when: dhcpd_install
 
-- name: dnsmasq may be affected - stopping dnsmasq
+- name: dhcpd_server may be affected - stopping dnsmasq
   service:
     name: dnsmasq
     state: stopped

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -71,8 +71,8 @@
 # dhcpd_server release the interface
 - name: dhcpd_server may be affected - stopping dhcpd
   service:
-   name: dhcpd
-   state: stopped
+    name: dhcpd
+    state: stopped
   when: dhcpd_install
 
 - name: dhcpd_server may be affected - stopping dnsmasq

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -21,52 +21,64 @@
 #           state=present
 
 - name: For upgrades from earlier IIAB 6.2, remove br0 file
-  file: path=/etc/network/interfaces.d/br0
-        state=absent
+  file:
+    path: /etc/network/interfaces.d/br0
+    state: absent
   when: iiab_lan_iface != "br0" and wan_ip == "dhcp"
 
 - name: Supply resolvconf.conf
-  template: dest=/etc/resolvconf.conf
-            src=network/resolvconf.j2
+  template:
+    dest: /etc/resolvconf.conf
+    src: network/resolvconf.j2
 
 - name: Supply dhcpcd.conf
-  template: dest=/etc/dhcpcd.conf
-            src=network/dhcpcd.conf.j2
+  template:
+    dest: /etc/dhcpcd.conf
+    src: network/dhcpcd.conf.j2
   when: dhcpcd_result == "enabled"
 
 - name: Copy the bridge script
-  template: dest=/etc/network/interfaces.d/iiab
-            src=network/systemd.j2
+  template:
+    dest: /etc/network/interfaces.d/iiab
+    src: network/systemd.j2
   when: not is_rpi and (iiab_lan_iface == "br0" or wan_ip != "dhcp" or gui_static_wan_ip == "undefined")
 
 - name: Copy the bridge script for RPi
-  template: dest=/etc/network/interfaces.d/iiab
-            src=network/rpi.j2
+  template:
+    dest: /etc/network/interfaces.d/iiab
+    src: network/rpi.j2
   when: is_rpi and iiab_lan_iface == "br0"
 
-- name: Workaround auto issue on Debian-9
-  template: dest=/etc/network/interfaces.d/patch_auto
-            src=network/debian-auto.j2
+- name: Workaround auto issue (debian-9)
+  template:
+    dest: /etc/network/interfaces.d/patch_auto
+    src: network/debian-auto.j2
   when: iiab_wan_iface != "none" and is_debian_9
 
-- name: Clearing out /etc/network/interfaces for static addresses (is_debian_9)
+- name: Clearing out /etc/network/interfaces for static addresses (debian-9)
   lineinfile:
-      state: absent
-      path: /etc/network/interfaces
-      regexp: "{{ iiab_wan_iface }}"
+    state: absent
+    path: /etc/network/interfaces
+    regexp: "{{ iiab_wan_iface }}"
   when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian_9
 
-- name: bind may be affected
-  service: name={{ dns_service }} state=stopped
+- name: BIND may be affected
+  service:
+    name: "{{ dns_service }}"
+    state: stopped
   when: named_install and dnsmasq_enabled
 
 # dhcpd_server release the interface
 - name: dhcpd_server may be affected - stopping dhcpd
-  service: name=dhcpd state=stopped
+  service:
+   name: dhcpd
+   state: stopped
   when: dhcpd_install
 
-- name: dhcpd_server may be affected - stopping dnsmasq
-  service: name=dnsmasq state=stopped
+- name: dnsmasq may be affected - stopping dnsmasq
+  service:
+    name: dnsmasq
+    state: stopped
   when: dnsmasq_install
 
 - name: Reload systemd
@@ -75,9 +87,13 @@
 
 # now pick up denyinterfaces
 - name: Restart dhcpcd
-  service: name=dhcpcd state=restarted
+  service:
+    name: dhcpcd
+    state: restarted
   when: dhcpcd_result == "enabled"
 
 - name: Restart the networking service
-  service: name=networking  state=restarted
+  service:
+    name: networking
+    state: restarted
   when: not nobridge is defined and not no_net_restart

--- a/roles/network/tasks/down-debian.yml
+++ b/roles/network/tasks/down-debian.yml
@@ -5,7 +5,7 @@
 #     dest: /etc/resolvconf.conf
 #    src: network/resolvconf.j2
 
-- name: bind may be affected
+- name: BIND may be affected
   service:
     name: "{{ dns_service }}"
     state: stopped

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -26,16 +26,22 @@
   with_items:
     - "{{ discovered_lan_iface }}"
 
-- name: bind may be affected
-  service: name={{ dns_service }} state=stopped
+- name: BIND may be affected
+  service:
+    name: "{{ dns_service }}"
+    state: stopped
   when: named_install and dnsmasq_enabled
 
 - name: dhcpd_server may be affected - stopping dhcpd
-  service: name=dhcpd state=stopped
+  service:
+    name: dhcpd
+    state: stopped
   when: dhcpd_install
 
 - name: dhcpd_server may be affected - stopping dnsmasq
-  service: name=dnsmasq state=stopped
+  service:
+    name: dnsmasq
+    state: stopped
   when: dnsmasq_install
 
 - name: Stop the LAN/Bridge deleting iiab-LAN
@@ -65,15 +71,17 @@
 
 # can be more than one wired interface
 - name: Wired enslaving ## lan_list_result ## to Bridge
-  template: src=network/ifcfg-slave.j2
-            dest=/etc/sysconfig/network-scripts/ifcfg-{{ item|trim }}
+  template:
+    src: network/ifcfg-slave.j2
+    dest: "/etc/sysconfig/network-scripts/ifcfg-{{ item|trim }}"
   when: iiab_lan_iface == "br0" and item|trim != iiab_wireless_lan_iface and item|trim != iiab_wan_iface
   with_items:
-      - "{{ lan_list_result.stdout_lines }}"
+    - "{{ lan_list_result.stdout_lines }}"
 
 - name: WiFi enslaving {{ iiab_wireless_lan_iface }} to Bridge
-  template: src=network/wifi-slave.j2
-            dest=/etc/sysconfig/network-scripts/ifcfg-{{ iiab_wireless_lan_iface }}
+  template:
+    src: network/wifi-slave.j2
+    dest: "/etc/sysconfig/network-scripts/ifcfg-{{ iiab_wireless_lan_iface }}"
   when: iiab_lan_iface == "br0" and iiab_wireless_lan_iface != "none"
   tags:
     - network
@@ -81,7 +89,7 @@
 - include_tasks: enable_wan.yml
   when: not installing and not iiab_demo_mode
 
-- name: ask systemd to reread the unit files, picks up changes done
+- name: Ask systemd to reread the unit files, picks up changes done
   systemd:
     daemon_reload: yes
   when: not installing
@@ -111,7 +119,7 @@
   ignore_errors: True
   when: iiab_lan_iface == "br0" and item|trim != iiab_wireless_lan_iface and item|trim != iiab_wan_iface and not iiab_demo_mode
   with_items:
-      - "{{ lan_list_result.stdout_lines }}"
+    - "{{ lan_list_result.stdout_lines }}"
 
 #- name: restart hostapd when wifi is present
 #  service: name=hostapd state=started

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -65,8 +65,9 @@
 #  when: iiab_wan_iface != "none" and not has_WAN and has_ifcfg_gw == "none" and xo_model == "none" and not iiab_demo_mode
 
 - name: Configuring LAN interface as iiab_lan_iface
-  template: src=network/ifcfg.j2
-            dest=/etc/sysconfig/network-scripts/ifcfg-LAN
+  template:
+    src: network/ifcfg.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-LAN
   when: iiab_lan_iface != "none"
 
 # can be more than one wired interface

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -1,4 +1,4 @@
-- name: restart hostapd when wifi is present
+- name: Restart hostapd when WiFi is present
   systemd:
     name: hostapd
     state: restarted

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -57,6 +57,7 @@ services_externally_visible={{ services_externally_visible }}
 calibre_port={{ calibre_port }}
 kiwix_port={{ kiwix_port }}
 kalite_server_port={{ kalite_server_port }}
+kolibri_port={{ kolibri_port }}
 sugarizer_port={{ sugarizer_port }}
 block_DNS={{ block_DNS }}
 captive_portal_enabled={{ captive_portal_enabled }}
@@ -90,6 +91,7 @@ fi
 if [ "$services_externally_visible" == "True" ]; then
     $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
+    $IPTABLES -A INPUT -p tcp --dport $kolibri_server_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
 fi

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -63,7 +63,7 @@ block_DNS={{ block_DNS }}
 captive_portal_enabled={{ captive_portal_enabled }}
 py_captive_portal_enabled={{ py_captive_portal_enabled }}
 
-echo "Lan is $lan and WAN is $wan"
+echo "LAN is $lan and WAN is $wan"
 #
 # delete all existing rules.
 #

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -57,7 +57,7 @@ services_externally_visible={{ services_externally_visible }}
 calibre_port={{ calibre_port }}
 kiwix_port={{ kiwix_port }}
 kalite_server_port={{ kalite_server_port }}
-kolibri_port={{ kolibri_port }}
+kolibri_http_port={{ kolibri_http_port }}
 sugarizer_port={{ sugarizer_port }}
 block_DNS={{ block_DNS }}
 captive_portal_enabled={{ captive_portal_enabled }}
@@ -91,7 +91,7 @@ fi
 if [ "$services_externally_visible" == "True" ]; then
     $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $kolibri_server_port -m state --state NEW -i $wan -j ACCEPT
+    $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
 fi

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -316,6 +316,7 @@ kalite_password: kalite
 # Kolibri
 kolibri_install: False
 kolibri_enabled: False
+kolibri_http_port: 8009
 
 # Kiwix
 kiwix_install: True

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -172,6 +172,7 @@ kalite_cron_enabled: True
 
 kolibri_install: False
 kolibri_enabled: False
+kolibri_http_port: 8009
 
 kiwix_install: True
 kiwix_enabled: True

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -172,7 +172,6 @@ kalite_cron_enabled: True
 
 kolibri_install: False
 kolibri_enabled: False
-kolibri_http_port: 8009
 
 kiwix_install: True
 kiwix_enabled: True


### PR DESCRIPTION
VPN access to http://10.8.0.x:8009 and http://localhost:8089 work on RPi 3, but http://192.168.0.x:8009 doesn't(*) due to iptables.

Hopefully this PR Fixes #911 ?

(*) However http://192.168.0.x:8089 seems to work on VM's and similar, where 192.168.0.x is the "only" IP address (i.e. no AP hotspot exists, or none was configured...)