### PR TITLE
Fixes #917 [Kolibri systemd service says “active (exited)” instead of “active (running)”]

### DIFF
--- a/roles/kolibri/templates/kolibri.service.j2
+++ b/roles/kolibri/templates/kolibri.service.j2
@@ -2,7 +2,7 @@
 Description=Kolibri
 
 [Service]
-Type=oneshot
+Type=forking
 RemainAfterExit=yes
 Environment=KOLIBRI_USER={{ kolibri_user }}
 Environment=KOLIBRI_HOME={{ kolibri_home }}


### PR DESCRIPTION
@arky this changes "Type=oneshot" to "Type=forking" in systemd unit file &mdash; thanks much to @jvonau.

Tested on Raspbian Lite.

Please test on Ubuntu 18.04 and Debian 9.5, Thanks All!