### PR TITLE
Deleting link requires 1 param not 2; named.yml cleanup

### DIFF
--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -1,6 +1,7 @@
 - name: Install named packages (debuntu)
-  package: name={{ item }}
-           state=present
+  package:
+    name: "{{ item }}"
+    state: present
   with_items:
    - bind9
    - bind9utils
@@ -9,8 +10,9 @@
     - download
 
 - name: Install named packages (OS's that are not debuntu)
-  package: name={{ item }}
-           state=present
+  package:
+    name: "{{ item }}"
+    state: present
   with_items:
    - bind
    - bind-utils
@@ -20,76 +22,87 @@
 
 # or we have to change the serial number in the config files.
 - name: Stop named before copying files
-  service: name={{ dns_service }} state=stopped
+  service:
+    name: "{{ dns_service }}"
+    state: stopped
   when: first_run and is_debuntu
 
 - name: Set folder permission
-  file: path={{ item }}
-        owner={{ dns_user }}
-        group=root
-        mode=0755
-        state=directory
+  file:
+    path: "{{ item }}"
+    owner: "{{ dns_user }}"
+    group: root
+    mode: 0755
+    state: directory
   with_items:
     - /var/named-iiab
     - /var/named-iiab/data
     - /etc/sysconfig/olpc-scripts/domain_config.d
 
 - name: Configure named
-  template: src={{ item.src }}
-            dest={{ item.dest }}
-            owner={{ item.owner }}
-            group=root
-            mode={{ item.mode }}
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner }}"
+    group: root
+    mode: "{{ item.mode }}"
   with_items:
-    - { src: 'roles/network/templates/named/named-iiab.conf.j2', dest: '/etc/named-iiab.conf', owner: "root" , mode: '0644' }
-    - { src: 'roles/network/templates/named/named.j2', dest: '/etc/sysconfig/named', owner: "root" , mode: '0644' }
-    - { src: 'roles/network/templates/named/named', dest: '/etc/sysconfig/olpc-scripts/domain_config.d/named', owner: "root" , mode: '0644' }
-    - { src: 'roles/network/templates/named/localdomain.zone', dest: '/var/named-iiab/localdomain.zone',owner: "{{ dns_user }}" , mode: '0644' }
-    - { src: 'roles/network/templates/named/localhost.zone', dest: '/var/named-iiab/localhost.zone', owner: "{{ dns_user }}" , mode: '0644' }
-    - { src: 'roles/network/templates/named/named.broadcast', dest: '/var/named-iiab/named.broadcast', owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.ip6.local', dest: '/var/named-iiab/named.ip6.local' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.local', dest: '/var/named-iiab/named.local' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.rfc1912.zones', dest: '/var/named-iiab/named.rfc1912.zones' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.root', dest: '/var/named-iiab/named.root' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.root.hints', dest: '/var/named-iiab/named.root.hints' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.zero', dest: '/var/named-iiab/named.zero' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.external.zone.db', dest: '/var/named-iiab/school.external.zone.db' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.internal.zone.16.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.16.in-addr.db' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.internal.zone.32.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.32.in-addr.db' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.internal.zone.48.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.48.in-addr.db' , owner: "{{ dns_user }}" , mode: '0644'}
+    - { src: 'roles/network/templates/named/named-iiab.conf.j2', dest: '/etc/named-iiab.conf', owner: "root", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.j2', dest: '/etc/sysconfig/named', owner: "root", mode: '0644' }
+    - { src: 'roles/network/templates/named/named', dest: '/etc/sysconfig/olpc-scripts/domain_config.d/named', owner: "root", mode: '0644' }
+    - { src: 'roles/network/templates/named/localdomain.zone', dest: '/var/named-iiab/localdomain.zone', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/localhost.zone', dest: '/var/named-iiab/localhost.zone', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.broadcast', dest: '/var/named-iiab/named.broadcast', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.ip6.local', dest: '/var/named-iiab/named.ip6.local', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.local', dest: '/var/named-iiab/named.local', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.rfc1912.zones', dest: '/var/named-iiab/named.rfc1912.zones', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.root', dest: '/var/named-iiab/named.root', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.root.hints', dest: '/var/named-iiab/named.root.hints', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.zero', dest: '/var/named-iiab/named.zero', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.external.zone.db', dest: '/var/named-iiab/school.external.zone.db', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.internal.zone.16.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.16.in-addr.db', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.internal.zone.32.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.32.in-addr.db', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.internal.zone.48.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.48.in-addr.db', owner: "{{ dns_user }}", mode: '0644' }
 # the following two files are not writeable by named, but bind 9.4 cannot discover that fact correctly
-    - { src: 'roles/network/templates/named/school.internal.zone.db', dest: '/var/named-iiab/school.internal.zone.db' , owner: "root" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.local.zone.db', dest: '/var/named-iiab/school.local.zone.db' , owner: "root" , mode: '0644'}
-    - { src: 'roles/network/templates/named/school.internal.zone.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.in-addr.db' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/dummy', dest: '/var/named-iiab/data/dummy' , owner: "{{ dns_user }}" , mode: '0644'}
-    - { src: 'roles/network/templates/named/named.blackhole', dest: '/var/named-iiab/named.blackhole' , owner: "{{ dns_user }}" , mode: '0644'}
+    - { src: 'roles/network/templates/named/school.internal.zone.db', dest: '/var/named-iiab/school.internal.zone.db', owner: "root", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.local.zone.db', dest: '/var/named-iiab/school.local.zone.db', owner: "root", mode: '0644' }
+    - { src: 'roles/network/templates/named/school.internal.zone.in-addr.db.j2', dest: '/var/named-iiab/school.internal.zone.in-addr.db', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/dummy', dest: '/var/named-iiab/data/dummy', owner: "{{ dns_user }}", mode: '0644' }
+    - { src: 'roles/network/templates/named/named.blackhole', dest: '/var/named-iiab/named.blackhole', owner: "{{ dns_user }}", mode: '0644' }
 
 - name: Substitute our unit file which uses $OPTIONS from sysconfig
-  template: src=roles/network/templates/named/{{ dns_service }}.service
-            dest=/etc/systemd/system/{{ dns_service }}.service
-            mode=0644
+  template:
+    src: "roles/network/templates/named/{{ dns_service }}.service"
+    dest: "/etc/systemd/system/{{ dns_service }}.service"
+    mode: 0644
 
-- name: The dns-jail redirect requires the named.blackhole,disabling recursion
+- name: The dns-jail redirect requires the named.blackhole, disabling recursion
 #        in named-iiab.conf, and the redirection of 404 error documents to /
-  template: src=roles/network/templates/named/dns-jail.conf dest=/etc/{{ apache_config_dir }}/
+  template:
+    src: roles/network/templates/named/dns-jail.conf
+    dest: "/etc/{{ apache_config_dir }}/"
   when: dns_jail_enabled
 
-- name: Separate enabling required for debuntu
-  file: src=/etc/{{ apache_config_dir }}/dns-jail.conf
-        path=/etc/{{ apache_service }}/sites-enabled/dns-jail.conf
-        state=link
+- name: Separate enabling required (debuntu)
+  file:
+    src: "/etc/{{ apache_config_dir }}/dns-jail.conf"
+    path: "/etc/{{ apache_service }}/sites-enabled/dns-jail.conf"
+    state: link
   when: is_debuntu and dns_jail_enabled
 
-- name: Separate enabling/disabling required (debuntu)
-  file: src=/etc/{{ apache_config_dir }}/dns-jail.conf
-        path=/etc/{{ apache_service }}/sites-enabled/dns-jail.conf
-        state=absent
+- name: Separate disabling required (debuntu)
+  file: 
+    path: "/etc/{{ apache_service }}/sites-enabled/dns-jail.conf"
+    state: absent
   when: is_debuntu and not dns_jail_enabled
 
 - name: Separate enabling/disabling required (OS's that are not debuntu)
-  file: path=/etc/{{ apache_config_dir }}/dns-jail.conf
-        state=absent
+  file:
+    path: "/etc/{{ apache_config_dir }}/dns-jail.conf"
+    state: absent
   when: not is_debuntu and not dns_jail_enabled
 
 - name: Start named after copying files
-  service: name={{ dns_service }} state=started
+  service:
+    name: "{{ dns_service }}"
+    state: started


### PR DESCRIPTION
Warning is: (will be an error in future versions of Ansible)
```
TASK [4-server-options : Separate enabling/disabling required (debuntu)] *******
 [WARNING]: The src option requires state to be 'link' or 'hard'.  This will
become an error in Ansible 2.10
```
Refs: #860, PR #893, https://github.com/iiab/iiab-admin-console/issues/81, PR https://github.com/iiab/iiab-admin-console/pull/82