### PR TITLE
Elgg 2.3.7 -> 2.3.8

### DIFF
--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -1,5 +1,5 @@
 elgg_xx: elgg
-elgg_version: "2.3.7"
+elgg_version: "2.3.8"
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg


### PR DESCRIPTION
Uses the newly released: http://download.iiab.io/packages/elgg-2.3.8.zip

Its (very short) Releases Notes are here: https://elgg.org/blog/view/2794751/elgg-238-released