### PR TITLE
Revert "Comment out "mongod --repair" as interim workaround to #942 [MongoDB/Sugarizer]"

### DIFF
--- a/roles/mongodb/templates/mongodb.service.j2
+++ b/roles/mongodb/templates/mongodb.service.j2
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=simple
 User=mongodb
 Group=mongodb
-#ExecStartPre=/usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
+ExecStartPre=/usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
 ExecStart=/usr/bin/mongod -f {{ mongodb_conf }}
 ExecStop=/usr/bin/killall mongod
  


### PR DESCRIPTION
Reverts iiab/iiab#943 for now.

Reason: I cannot reproduce TK's MongoDB failure (https://github.com/iiab/iiab/issues/942) &mdash; @llaske & @jvonau have 2 theories that hint at the truth but I'm unable to confirm either is the cause.

In Short: we need to cast a wider net so people step forward and help identify what reproducible conditions cause "mongod --repair" to fail, if we are going to solve this.