### PR TITLE
Revert "TEMP Fixes #954 [download.nextcloud.com's SSL/TLS cert expired 2018-07-22 preventing MEDIUM+BIG IIAB installs]"

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -18,6 +18,7 @@
     url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }}"
     dest: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     force: yes
+    #validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
     timeout: "{{ download_timeout }}"
   when: internet_available and nextcloud_force_install
   async: 900

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -18,7 +18,6 @@
     url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }}"
     dest: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     force: yes
-    validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
     timeout: "{{ download_timeout }}"
   when: internet_available and nextcloud_force_install
   async: 900


### PR DESCRIPTION
Reverts iiab/iiab#955

Merge this after Nextcloud cleans up their act, renewing their web cert for https://download.nextcloud.com (hopefully in not too many days!)