### PR TITLE
Fix for #942 ? "mongod --repair" if /library/dbdata/mongodb/mongod.lock absent

### DIFF
--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,5 +1,6 @@
 mongodb_install: False
 mongodb_enabled: False
 
-mongodb_db_path: "{{ content_base }}/dbdata/mongodb"    # == /library/dbdata/mongodb/
 mongodb_conf: /etc/mongod.conf
+mongodb_db_path: "{{ content_base }}/dbdata/mongodb"    # == /library/dbdata/mongodb/
+mongodb_db_lock_file: "{{ mongodb_db_path }}/mongod.lock"

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -25,10 +25,11 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "{{ item.mode }}"
   with_items:
-    - { src: 'mongod.conf.j2', dest: "{{ mongodb_conf }}" }
-    - { src: 'mongodb.service.j2', dest: '/etc/systemd/system/mongodb.service' }
+    - { src: 'mongod.conf.j2', dest: "{{ mongodb_conf }}", mode: '0644' }
+    - { src: 'mongodb.service.j2', dest: '/etc/systemd/system/mongodb.service', mode: '0644' }
+    - { src: 'iiab-mongodb-repair-if-no-lock.j2', dest: '/usr/bin/iiab-mongodb-repair-if-no-lock', mode: '0755' }
 
 - name: Enable+restart systemd service if mongodb_enabled, with "systemctl daemon-reload" (in case mongodb.service changed?)
   systemd:

--- a/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
+++ b/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
@@ -3,5 +3,5 @@
 if [ ! -f {{ mongodb_db_lock_file }} ]; then
     /usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
 else
-    echo '"mongod --repair" cannot run when {{ mongodb_db_lock_file }} present.'
+    echo '"mongod --repair" cannot run when {{ mongodb_db_lock_file }} present.' >&2    # Output to STDERR but keep going, so /etc/systems/system/mongodb.service continues
 fi

--- a/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
+++ b/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -f {{ mongodb_db_lock_file }} ]; then
+    /usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
+else
+    echo '"mongod --repair" cannot run when {{ mongodb_db_lock_file }} present.'
+fi

--- a/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
+++ b/roles/mongodb/templates/iiab-mongodb-repair-if-no-lock.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ ! -f {{ mongodb_db_lock_file }} ]; then
-    /usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
-else
+if [ -f {{ mongodb_db_lock_file }} ]; then
     echo '"mongod --repair" cannot run when {{ mongodb_db_lock_file }} present.' >&2    # Output to STDERR but keep going, so /etc/systems/system/mongodb.service continues
+else
+    /usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
 fi

--- a/roles/mongodb/templates/mongodb.service.j2
+++ b/roles/mongodb/templates/mongodb.service.j2
@@ -1,14 +1,20 @@
 [Unit]
 Description=High-performance, schema-free document-oriented database
 After=syslog.target network.target
- 
+
 [Service]
 Type=simple
 User=mongodb
 Group=mongodb
-ExecStartPre=/usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}
+# FAILS (after power failures, etc) as --repair cannot run when lock file exists: (https://github.com/iiab/iiab/issues/942)
+#ExecStartPre=/usr/bin/mongod --repair --dbpath /library/dbdata/mongodb
+# FAILS as systemd cannot run bash here:
+#ExecStartPre=if [ ! -f /library/dbdata/mongodb/mongod.lock ]; then /usr/bin/mongod --repair --dbpath {{ mongodb_db_path }}; fi
+ExecStartPre=/usr/bin/iiab-mongodb-repair-if-no-lock
 ExecStart=/usr/bin/mongod -f {{ mongodb_conf }}
 ExecStop=/usr/bin/killall mongod
- 
+# killall's SIGTERM (15) seems fine, to induce a graceful stop.  This would work too:
+#ExecStop=mongod --dbpath {{ mongodb_db_path }} --shutdown
+
 [Install]
 WantedBy=multi-user.target

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -342,6 +342,8 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Sugarizer
+# Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
 sugarizer_enabled: False
 sugarizer_port: 8089

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
 sugarizer_enabled: True
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 

--- a/vars/local_vars_big_vpn.yml
+++ b/vars/local_vars_big_vpn.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
 sugarizer_enabled: True
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
 sugarizer_enabled: True
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 

--- a/vars/local_vars_medium_vpn.yml
+++ b/vars/local_vars_medium_vpn.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
 sugarizer_enabled: True
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: False
 sugarizer_enabled: False
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 

--- a/vars/local_vars_min_vpn.yml
+++ b/vars/local_vars_min_vpn.yml
@@ -190,11 +190,9 @@ pathagar_install: False
 pathagar_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
+# Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: False
 sugarizer_enabled: False
-# sugarizer_enabled is currently IGNORED as basic Sugarizer works w/o Journal!
-# https://github.com/iiab/iiab/issues/193 Subsequent "./runrole sugarizer" fail
-# https://github.com/iiab/iiab/issues/240 Sugarizer 0.8 to 0.9 ongoing issues
 
 # 8-MGMT-TOOLS
 


### PR DESCRIPTION
Needs testing.

Playbook installs & arranges for "chmod +x /usr/bin/iiab-mongodb-repair-if-no-lock" (which is called by /etc/systemd/system/mongodb.service).

Builds on:
- https://github.com/xsce/xsce/issues/879 on power failure mongodb is corrupt
- https://github.com/iiab/iiab/issues/254#issuecomment-404577658 What's causing 801MB /var/lib/mongodb ? [prealloc files nec for Sugarizer?] (@llaske offers possible strategies to beef up MongoDB reliability)
- PR https://github.com/iiab/iiab/pull/888#issuecomment-404370082 "sugarizer-server tweaks arising since Sugarizer 1.0"
- PR #919 MongoDB: many improvements for reliability
- #915 Yank power from MongoDB and see if Sugarizer 1.0 works on next boot(s)
https://github.com/iiab/iiab/issues/942#issuecomment-406864508 TK: MongoDB unit file's "mongod --repair" blocks on "dirty journal files" and "old lock file" (@jvonau suggests systemd cleanups)
- PR #946 MongoDB+Sugarizer's systemd cleaned/clarified, to help diagnose #942