### PR TITLE
iiab-install code cleanup (clarifies that /etc/iiab/local_vars.yml MUST already be in place)

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -16,8 +16,8 @@ if [ ! -f /etc/iiab/local_vars.yml ]; then
     echo -e "\n\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
     echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
     echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
-    echo -e "(3) NEED 4 SPEED?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
-    echo -e "    http://download.iiab.io\n" >&2
+    echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
+    echo -e "    http://download.iiab.io (click on a recent version number!)\n" >&2
     #case $OS in
     #    OLPC | fedora)
     #        echo -e "Please examine /opt/iiab/iiab/vars/local_vars_olpc.yml for XO laptops.\n" >&2

--- a/iiab-install
+++ b/iiab-install
@@ -13,11 +13,11 @@ MIN_RPI_KERN=4.9.59-v7+
 MIN_ANSIBLE_VER=2.5.6
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
-    echo -e '\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n' >&2
-    echo -e '(1) Please read http://wiki.iiab.io/local_vars.yml to learn more.' >&2
-    echo -e '(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars' >&2
-    echo -e '(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n' >&2
-    echo -e '    http://download.iiab.io  (click on "6.6" on a more recent version number!)\n' >&2
+    echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
+    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
+    echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
+    echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
+    echo -e '    http://download.iiab.io  (click on "6.6" or a more recent version!)\n' >&2
     #case $OS in
     #    OLPC | fedora)
     #        echo -e "Please examine /opt/iiab/iiab/vars/local_vars_olpc.yml for XO laptops.\n" >&2

--- a/iiab-install
+++ b/iiab-install
@@ -12,9 +12,27 @@ OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
 MIN_ANSIBLE_VER=2.5.6
 
-export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
-
 echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
+
+if [ ! -f /etc/iiab/local_vars.yml ]; then
+    echo -e "EXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
+    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
+    echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
+    echo -e "(3) NEED 4 SPEED?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
+    echo -e "    http://download.iiab.io\n" >&2
+    #case $OS in
+    #    OLPC | fedora)
+    #        echo -e "Please examine /opt/iiab/iiab/vars/local_vars_olpc.yml for XO laptops.\n" >&2
+    #        ;;
+    #    centos | debian | ubuntu | raspbian)
+    #        echo -e "Please consider /opt/iiab/iiab/vars/local_vars_medium.yml or similar.\n" >&2
+    #        ;;
+    #    *)
+    #        echo -e "EXITING: IIAB requires Raspbian, Debian, Ubuntu, CentOS or OLPC/Fedora.\n" >&2
+    #        ;;
+    #esac
+    exit 1
+fi
 
 if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
     mkdir -p /etc/ansible/facts.d
@@ -120,27 +138,10 @@ if [ "$STAGE" -lt 2 ] && [ "$1" == "--debug" ]; then
     echo -e "\n'--debug' *ignored* as STAGE (counter) < 2."
 fi
 
-# If /etc/iiab/local_vars.yml is missing, put a default file in place.
-if [ ! -f /etc/iiab/local_vars.yml ]; then
-    case $OS in
-        OLPC | fedora)
-            cp ./vars/local_vars_olpc.yml /etc/iiab/local_vars.yml
-            echo -e "\n/etc/iiab/local_vars.yml created from /opt/iiab/iiab/vars/local_vars_olpc.yml defaults."
-            ;;
-        centos | debian | ubuntu | raspbian)
-            cp ./vars/local_vars_medium.yml /etc/iiab/local_vars.yml
-            echo -e "\n/etc/iiab/local_vars.yml created from /opt/iiab/iiab/vars/local_vars_medium.yml defaults."
-            echo "See MIN/MEDIUM/BIG options @ http://wiki.iiab.io/local_vars.yml"
-            ;;
-        *)
-            echo -e "\nEXITING: IIAB requires Raspbian, Debian, Ubuntu, CentOS or OLPC/Fedora."
-            exit 1
-            ;;
-    esac
-fi
-
 echo -e "\nTRY TO RERUN './iiab-install' IF IT FAILS DUE TO CONNECTIVITY ISSUES ETC!"
 echo -e "\nRunning local playbooks....Stage 0 will now run....followed by Stages $(($STAGE + 1))-9"
+
+export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
 
 ansible -m setup -i $INVENTORY localhost --connection=local >> /dev/null
 ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local

--- a/iiab-install
+++ b/iiab-install
@@ -13,7 +13,7 @@ MIN_RPI_KERN=4.9.59-v7+
 MIN_ANSIBLE_VER=2.5.6
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
-    echo -e "\n\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
+    echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
     echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
     echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
     echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2

--- a/iiab-install
+++ b/iiab-install
@@ -12,10 +12,8 @@ OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
 MIN_ANSIBLE_VER=2.5.6
 
-echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
-
 if [ ! -f /etc/iiab/local_vars.yml ]; then
-    echo -e "EXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
+    echo -e "\n\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
     echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
     echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
     echo -e "(3) NEED 4 SPEED?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
@@ -33,6 +31,8 @@ if [ ! -f /etc/iiab/local_vars.yml ]; then
     #esac
     exit 1
 fi
+
+echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
 
 if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
     mkdir -p /etc/ansible/facts.d

--- a/iiab-install
+++ b/iiab-install
@@ -14,10 +14,10 @@ MIN_ANSIBLE_VER=2.5.6
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
     echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
-    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
+    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more" >&2
     echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
     echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
-    echo -e '    http://download.iiab.io  (click on "6.6" or a more recent version!)\n' >&2
+    echo -e '    http://download.iiab.io   (click on "6.6" or a more recent version!)\n' >&2
     #case $OS in
     #    OLPC | fedora)
     #        echo -e "Please examine /opt/iiab/iiab/vars/local_vars_olpc.yml for XO laptops.\n" >&2

--- a/iiab-install
+++ b/iiab-install
@@ -13,11 +13,11 @@ MIN_RPI_KERN=4.9.59-v7+
 MIN_ANSIBLE_VER=2.5.6
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
-    echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
-    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more." >&2
-    echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
-    echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
-    echo -e "    http://download.iiab.io (click on a recent version number!)\n" >&2
+    echo -e '\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n' >&2
+    echo -e '(1) Please read http://wiki.iiab.io/local_vars.yml to learn more.' >&2
+    echo -e '(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars' >&2
+    echo -e '(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n' >&2
+    echo -e '    http://download.iiab.io  (click on "6.6" on a more recent version number!)\n' >&2
     #case $OS in
     #    OLPC | fedora)
     #        echo -e "Please examine /opt/iiab/iiab/vars/local_vars_olpc.yml for XO laptops.\n" >&2


### PR DESCRIPTION
Fixes #960 (Tim's concern) decoupling/modularizing what should be 2 distinct tasks going forward:
1. grassroots/community implementers prepare and place their own /etc/iiab/local_vars.html into position
2. /opt/iiab/iiab/iiab-install (effectively) takes that as input, to carefully execute the ~9 stages needed to install IIAB

In short this is a code cleanup, as the 2 published / high-level approaches to installing Internet-in-a-Box remain the same:
- http://download.iiab.io/6.6
- https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch

Builds on PR #931 from 3-4 days ago.