### PR TITLE
kiwix proxypassreverse

### DIFF
--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -1,1 +1,3 @@
 ProxyPass {{ kiwix_url }}  http://127.0.0.1:{{ kiwix_port }}{{ kiwix_url }}
+ProxyPass /kiwix  http://127.0.0.1:{{ kiwix_port }}{{ kiwix_url }}
+ProxyPassReverse {{ kiwix_url }}  http://127.0.0.1:{{ kiwix_port }}{{ kiwix_url }}


### PR DESCRIPTION
Smoke tested. At first http://box.lan/kiwix did not work. But then it did. May have been a startup, or cache issue. 

Always worked at http://10.10.123.206/kiwix or  http://10.10.123.206/kiwix/