### PR TITLE
Calibre 3.28 (from "raspbian testing" w/o Debian .deb's) permits IIAB to boot+work in Zero W

### DIFF
--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -28,7 +28,7 @@
 #  when: is_rpi and internet_available
 
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
-  #command: scripts/calibre-install-latest-rpi-plus.sh    # NEC FOR Calibre 3.27.1+ on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W.  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
+  #command: scripts/calibre-install-latest-rpi-plus.sh    # NEC FOR Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
   command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
   when: is_rpi and internet_available
 

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -28,8 +28,8 @@
 #  when: is_rpi and internet_available
 
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
-  command: scripts/calibre-install-latest-rpi-plus.sh    # HOPE IT WORKS FOR Calibre 3.27.1+ starting 2018-07-22 -- PLEASE TEST IF BOOTABLE IN Zero W?
-  #command: scripts/calibre-install-latest-rpi.sh    # WORKED FOR Calibre 3.26.x (Calibre 3.24.x & 3.25 required above prereq calibre-install-packages.sh then Debian's own calibre-install-latest.sh to be bootable in Zero W)
+  #command: scripts/calibre-install-latest-rpi-plus.sh    # NEC FOR Calibre 3.27.1+ on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W.  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
+  command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)


### PR DESCRIPTION
Let's hope Calibre .deb's (and dependencies) remain stable+working here in coming months:
http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/
http://archive.raspbian.org/raspbian/pool/main/c/calibre/

Unlike the painful situation over the past 2 months, as documented here!
https://www.mobileread.com/forums/showthread.php?p=3707933