### PR TITLE
php-stem cleanup for Debian 9 x86_64? (Do Debian 10, Ubuntu 18.04 & i686 presumably all fail?)

### DIFF
--- a/roles/httpd/tasks/php-stem.yml
+++ b/roles/httpd/tasks/php-stem.yml
@@ -29,7 +29,8 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: not is_rpi
+  when: is_debian and (ansible_machine == "x86_64")
+#  when: not is_rpi
 
 # No need to do this twice?  Happens later @ https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml#L24-L28
 #- name: Restart apache2 / httpd

--- a/roles/httpd/tasks/php-stem.yml
+++ b/roles/httpd/tasks/php-stem.yml
@@ -29,9 +29,10 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: is_debian and (ansible_machine == "x86_64")
-# Fails on Ubuntu 18.04 as of 2018-07-28: https://github.com/iiab/iiab/issues/829
+  when: is_debian_9 and (ansible_machine == "x86_64")
+# Presumably fails on Debian 8 & 10?
 # Fails on Debian i686 as of 2018-08-07: https://github.com/iiab/iiab/issues/983
+# Fails on Ubuntu 18.04 as of 2018-07-28: https://github.com/iiab/iiab/issues/829
 
 # No need to do this twice?  Happens later @ https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml#L24-L28
 #- name: Restart apache2 / httpd

--- a/roles/httpd/tasks/php-stem.yml
+++ b/roles/httpd/tasks/php-stem.yml
@@ -30,7 +30,8 @@
     #mode: ????
     remote_src: yes
   when: is_debian and (ansible_machine == "x86_64")
-#  when: not is_rpi
+# Fails on Ubuntu 18.04 as of 2018-07-28: https://github.com/iiab/iiab/issues/829
+# Fails on Debian i686 as of 2018-08-07: https://github.com/iiab/iiab/issues/983
 
 # No need to do this twice?  Happens later @ https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml#L24-L28
 #- name: Restart apache2 / httpd

--- a/roles/httpd/tasks/php-stem.yml
+++ b/roles/httpd/tasks/php-stem.yml
@@ -21,7 +21,7 @@
     remote_src: yes
   when: is_rpi
 
-- name: Download & unpack php-stem.x86.tar to / (not rpi)
+- name: Download & unpack php-stem.x86.tar to / (debian-9 on x86_64 only)
   unarchive:
     src: http://download.iiab.io/packages/php-stem.x64.tar
     dest: /


### PR DESCRIPTION
Presumably fixes #983, building on #829?

Thanks @tim-moody, @jvonau & @arky for reviewing!