### PR TITLE
Clarify openvpn_handle variable and /etc/iiab/openvpn_handle

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -189,7 +189,9 @@ sshd_enabled: True
 openvpn_install: True
 openvpn_enabled: False
 
+# For /etc/iiab/openvpn_handle
 openvpn_handle: UNNAMED
+
 # cron seems necessary on CentOS:
 openvpn_cron_enabled: False
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: False
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 

--- a/vars/local_vars_big_vpn.yml
+++ b/vars/local_vars_big_vpn.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: True
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: False
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 

--- a/vars/local_vars_medium_vpn.yml
+++ b/vars/local_vars_medium_vpn.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: True
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: False
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 

--- a/vars/local_vars_min_vpn.yml
+++ b/vars/local_vars_min_vpn.yml
@@ -86,7 +86,9 @@ allow_apache_sudo: True
 openvpn_install: True
 openvpn_enabled: True
 
+# Set /etc/iiab/openvpn_handle in advance here:
 openvpn_handle: UNNAMED
+
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
 


### PR DESCRIPTION
Explanations added, clarifying that variable `openvpn_handle` can now be set in [local_vars.yml](http://wiki.laptop.org/go/IIAB/local_vars.yml) prior to IIAB installation.

Default value is `UNNAMED` (also within [default_vars.yml](https://github.com/iiab/iiab/blob/master/vars/default_vars.yml)).

Builds off PR #996