### PR TITLE
Strengthen keyserver.ubuntu.com warning, as this still fails regularly when installing Ansible

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -2,7 +2,7 @@
 
 echo -e '\n\nSTRONGLY RECOMMENDED PREREQUISITE: (1) remove all prior versions of Ansible using "apt purge ansible" and/or "pip uninstall ansible" and (2) clear out all lines containing ansible from /etc/apt/sources.list and /etc/apt/sources.list.d/*\n'
 
-echo -e 'WARNING: repeatedly re-run "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367" if this part of the script fails due to network/mirrors.\n'
+echo -e 'IF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367"\n'
 
 echo -e 'COMPLETE INSTALL INSTRUCTIONS:\nhttps://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n'
 

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -2,7 +2,7 @@
 
 echo -e '\n\nSTRONGLY RECOMMENDED PREREQUISITE: (1) remove all prior versions of Ansible using "apt purge ansible" and/or "pip uninstall ansible" and (2) clear out all lines containing ansible from /etc/apt/sources.list and /etc/apt/sources.list.d/*\n'
 
-echo -e 'WARNING: repeatedly re-run "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367" if this part of the script fails due to network/mirrors.\n'
+echo -e 'IF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367"\n'
 
 echo -e 'COMPLETE INSTALL INSTRUCTIONS:\nhttps://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n'
 


### PR DESCRIPTION
@floydianslips requested this: as some are still falling in this annoying trap, month after month, apparently caused by Ubuntu's unreliable hosting/mirrors for the needed apt key.

Warning also strengthened herein:
http://download.iiab.io/6.6/prep.txt
http://download.iiab.io/6.6/prep+teamviewer.txt