### PR TITLE
Calibre 3.29 has serious dependency problems on Raspbian

### DIFF
--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -28,8 +28,9 @@
 #  when: is_rpi and internet_available
 
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
-  #command: scripts/calibre-install-latest-rpi-plus.sh    # NEC FOR Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
-  command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
+  #command: scripts/calibre-install-latest-rpi-plus.sh    # WORKS for Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
+  #command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
+  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only way that was not attempted: sid-like calibre-install-unstable.sh).   THO NOT BOOTABLE IN Zero W (#952)
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -30,7 +30,7 @@
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
   #command: scripts/calibre-install-latest-rpi-plus.sh    # WORKS for Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
   #command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
-  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only way that was not attempted: sid-like calibre-install-unstable.sh).   THO NOT BOOTABLE IN Zero W (#952)
+  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only way that was not attempted: sid-like calibre-install-unstable.sh).  THO NOT BOOTABLE IN Zero W (#952)
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -30,7 +30,7 @@
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
   #command: scripts/calibre-install-latest-rpi-plus.sh    # WORKS for Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
   #command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
-  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only way that was not attempted: sid-like calibre-install-unstable.sh).  THO NOT BOOTABLE IN Zero W (#952)
+  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only script that was not attempted: Sid-like calibre-install-unstable.sh).  CLARIF: RESULTING microSD's ARE NOT BOOTABLE IN Zero W (#952)
   when: is_rpi and internet_available
 
 - name: Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)

--- a/scripts/calibre-install-latest-rpi-plus.sh
+++ b/scripts/calibre-install-latest-rpi-plus.sh
@@ -12,7 +12,8 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# SEE COMMENTS AT THE TOP OF scripts/calibre-install-packages.sh
+# Might break future updates; you have been warned.
+# SEE NOTES AT TOP OF scripts/calibre-install-packages.sh
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -3,7 +3,8 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# SEE COMMENTS AT THE TOP OF scripts/calibre-install-packages.sh
+# Might break future updates; you have been warned.
+# SEE NOTES AT TOP OF scripts/calibre-install-packages.sh
 
 export DEBIAN_FRONTEND=noninteractive
 # Prepares to update to latest from raspbian testing

--- a/scripts/calibre-install-latest.sh
+++ b/scripts/calibre-install-latest.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+# Calibre 3.29 requires this approach, to overcome error:
+#
+#    calibre-bin : Depends: qtbase-abi-5-10-0 but it is not installable
+#   E: Unable to correct problems, you have held broken packages.
+#
+# Above error proved insurmountable when trying most all scripts in /opt/iiab/iiab/scripts -- even those that DID solve this error:
+#
+#    calibre : Depends: python-pyqt5 (>= 5.11.2+dfsg-1+b1)
+
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
-# SEE COMMENTS AT THE TOP OF scripts/calibre-install-packages.sh
+# SEE NOTES AT TOP OF scripts/calibre-install-packages.sh
 
 export DEBIAN_FRONTEND=noninteractive
 # Drags in stock desktop dependencies without too much from testing below

--- a/scripts/calibre-install-latest.sh
+++ b/scripts/calibre-install-latest.sh
@@ -12,6 +12,7 @@
 # Thanks to Jerry Vonau (https://github.com/jvonau) who made this critical
 # breakthrough possible!
 #
+# Might break future updates; you have been warned.
 # SEE NOTES AT TOP OF scripts/calibre-install-packages.sh
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/calibre-install-unstable.sh
+++ b/scripts/calibre-install-unstable.sh
@@ -11,6 +11,7 @@
 #   http://archive.raspbian.org/raspbian/pool/main/c/calibre/
 #
 # Might break future updates; you have been warned.
+# SEE NOTES AT TOP OF scripts/calibre-install-packages.sh
 
 export DEBIAN_FRONTEND=noninteractive
 # Prepares to update to latest from unstable


### PR DESCRIPTION
Calibre 3.29 is not easy to install on Raspbian &mdash; see notes at the top of [scripts/calibre-install-latest.sh](https://github.com/iiab/iiab/blob/master/scripts/calibre-install-latest.sh).  This serves as a correction for earlier misinformation at #952.

So: reverting to "large hammer" scripts/calibre-install-latest.sh appears to allow Calibre 3.29 to install on top of 2.75.1 on Raspbian.

(Naturally/Unfortunately such microSD cards are not bootable in RPi Zero W; you've been warned!)