### PR TITLE
Update http://box/maps & http://box/osm to point to new Vector Maps

### DIFF
--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -87,12 +87,14 @@
 
 - name: Set osm_path (redhat)
   set_fact:
-    osm_path: "{{ osm_venv }}/{{ python_path }}/iiab"
+    #osm_path: "{{ osm_venv }}/{{ python_path }}/iiab"
+    osm_path: "{{ osm_venv }}{{ python_path }}/iiab"
   when: osm_enabled and is_redhat
 
 - name: Set osm_path (debuntu)
   set_fact:
-    osm_path: "{{ osm_venv }}/lib/python2.7/site-packages/iiab"
+    #osm_path: "{{ osm_venv }}/lib/python2.7/site-packages/iiab"
+    osm_path: "{{ osm_venv }}lib/python2.7/site-packages/iiab"
   when: osm_enabled and is_debuntu
 
 - name: Point wsgi to virtual environment (all OS's)

--- a/roles/osm/templates/osm.conf.j2
+++ b/roles/osm/templates/osm.conf.j2
@@ -5,9 +5,12 @@ XSendFilePath /
 
 WSGIScriptAlias /iiab {{ doc_root }}/osm.wsgi
 
+# For old bitmap/raster tileset
 Alias /iiabstatic {{ osm_path }}/static
 Alias /osm {{ osm_path }}/static
-Alias /maps {{ osm_path }}/static
+
+# For new vector tileset, as documents @ http://download.iiab.io/content/OSM/vector-tiles/
+Alias /maps /library/www/html/modules/en-osm-omt-min/
 
 <Directory {{ osm_path }}/static>
 	require all granted

--- a/roles/osm/templates/osm.conf.j2
+++ b/roles/osm/templates/osm.conf.j2
@@ -8,7 +8,7 @@ WSGIScriptAlias /iiab {{ doc_root }}/osm.wsgi
 # For old bitmap/raster tileset
 Alias /iiabstatic {{ osm_path }}/static
 
-# For new vector tileset, as documents @ http://download.iiab.io/content/OSM/vector-tiles/
+# For new vector tileset, as documented @ http://FAQ.IIAB.IO ("How do I add zoomable maps for my region? ") & http://download.iiab.io/content/OSM/vector-tiles/
 Alias /maps /library/www/html/modules/en-osm-omt-min/
 Alias /osm /library/www/html/modules/en-osm-omt-min/
 

--- a/roles/osm/templates/osm.conf.j2
+++ b/roles/osm/templates/osm.conf.j2
@@ -7,10 +7,10 @@ WSGIScriptAlias /iiab {{ doc_root }}/osm.wsgi
 
 # For old bitmap/raster tileset
 Alias /iiabstatic {{ osm_path }}/static
-Alias /osm {{ osm_path }}/static
 
 # For new vector tileset, as documents @ http://download.iiab.io/content/OSM/vector-tiles/
 Alias /maps /library/www/html/modules/en-osm-omt-min/
+Alias /osm /library/www/html/modules/en-osm-omt-min/
 
 <Directory {{ osm_path }}/static>
 	require all granted


### PR DESCRIPTION
Revises IIAB's short/snappy URL's http://box/maps and http://box/osm to point to @georgejhunt's vector-based OpenStreetMap, now much-enhanced per #1035 ("Can OSM Vector Maps fill the entire screen?")

Documentation revised @ https://github.com/iiab/iiab-factory/blob/master/content/vector-tiles/README.md per https://github.com/iiab/iiab-factory/pull/43

PS legacy URL http://box/iiabstatic is preserved for its original purpose (static bitmaps/raster tileset).