### PR TITLE
Deprecate Unmaintained roles for IIAB 6.6 release

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -116,11 +116,11 @@
     postgresql_enabled: True
   when: moodle_enabled or pathagar_enabled
 
-- name: Turn on vars for Docker if SchoolTool is to be installed
-  set_fact:
-    docker_install: True
-    docker_enabled: True
-  when: schooltool_enabled or schooltool_install
+#- name: Turn on vars for Docker if SchoolTool is to be installed
+#  set_fact:
+#    docker_install: True
+#    docker_enabled: True
+#  when: schooltool_enabled or schooltool_install
 
 - name: Set python_path (redhat)
   set_fact:

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -33,11 +33,11 @@
   when: nextcloud_install
   tags: nextcloud
 
-- name: OWNCLOUD
-  include_role:
-    name: owncloud
-  when: owncloud_install
-  tags: owncloud
+#- name: OWNCLOUD
+#  include_role:
+#    name: owncloud
+#  when: owncloud_install
+#  tags: owncloud
 
 - name: WORDPRESS
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: PATHAGAR
   include_role:
     name: pathagar
-  when: pathagar_install
+  when: pathagar_install is defined and pathagar_install
   tags: pathagar
 
 - name: SUGARIZER

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -3,12 +3,6 @@
 - name: ...IS BEGINNING ======================================
   command: echo
 
-- name: TRANSMISSION
-  include_role:
-    name: transmission
-  when: transmission_install
-  tags: transmission
-
 - name: AWSTATS
   include_role:
     name: awstats

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: ...IS BEGINNING ====================================
   command: echo
-  
+
 - name: CALIBRE
   include_role:
     name: calibre
@@ -14,6 +14,12 @@
     name: calibre-web
   when: calibreweb_install
   tags: calibre-web
+
+- name: TRANSMISSION
+  include_role:
+    name: transmission
+  when: transmission_install
+  tags: transmission
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -428,6 +428,10 @@ transmission_password: changeme
 # schooltool_install: False
 # schooltool_enabled: False
 
+# Debian SchoolTool - nmaintained
+# debian_schooltool_install: False
+# debian_schooltool_enabled: False
+
 # Pathagar - unmaintained (consider Calibre or Calibre-Web above?)
 # pathagar_install: False
 # pathagar_enabled: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -420,6 +420,10 @@ transmission_username: Admin
 transmission_password: changeme
 
 
+# TeamViewer - unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
+# teamviewer_install: False
+# teamviewer_enabled: False
+
 # Docker - unmaintained
 # docker_install: False
 # docker_enabled: False
@@ -435,14 +439,6 @@ transmission_password: changeme
 # Pathagar - unmaintained (consider Calibre or Calibre-Web above?)
 # pathagar_install: False
 # pathagar_enabled: False
-
-# TeamViewer - unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
-# teamviewer_install: False
-# teamviewer_enabled: False
-
-# ownCloud - unmaintained
-# owncloud_install: False
-# owncloud_enabled: False
 
 # sugar-stats - unmaintained
 # sugar_stats_install: False
@@ -460,6 +456,10 @@ transmission_password: changeme
 # xovis_root: "/opt/xovis"
 # xovis_backup_dir: "/library/users"
 # xovis_chart_heading: "My School: Usage Data Visualization"
+
+# ownCloud - unmaintained
+# owncloud_install: False
+# owncloud_enabled: False
 
 # Ajenti - unmaintained
 # ajenti_install: False
@@ -490,3 +490,9 @@ is_rpi: False
 is_redhat: False
 is_fedora: False
 is_centos: False
+
+# How This Works:
+# 1. /opt/iiab/iiab/iiab-install copies scripts/local_facts.fact to /etc/ansible/facts.d/local_facts.fact
+# 2. Ansible runs /etc/ansible/facts.d/local_facts.fact to identify the OS
+# 3. ./iiab-install (iiab-stages.yml) or ./runrole (run-one-role.yml) or Admin Console (iiab-from-console.yml) invoke the correct /opt/iiab/iiab/vars/<OS>.yml
+# Longer Explanation: https://github.com/iiab/iiab/wiki/IIAB-Variables (Order of Execution and Precedence)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -348,10 +348,6 @@ osm_enabled: False
 # iiab_install: True
 # iiab_enabled: False
 
-# Pathagar - similar to Calibre, but unmaintained
-pathagar_install: False
-pathagar_enabled: False
-
 # Sugarizer
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
@@ -429,7 +425,11 @@ vnstat_enabled: False
 
 # ================================================================
 
-# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
+# Pathagar - similar to Calibre and Calibre-Web, but unmaintained
+# pathagar_install: False
+# pathagar_enabled: False
+
+# TeamViewer - unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False
 # teamviewer_enabled: False
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -428,7 +428,7 @@ transmission_password: changeme
 # schooltool_install: False
 # schooltool_enabled: False
 
-# Debian SchoolTool - nmaintained
+# Debian SchoolTool - nnmaintained
 # debian_schooltool_install: False
 # debian_schooltool_enabled: False
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -153,15 +153,8 @@ wan_nameserver:
 # Our past convention was to install everything in all aggregates
 # And to enable everything in 1-PREP, 2-COMMON, and 3-BASE-SERVER
 
+
 # 1-PREP
-
-# Docker (lesser-supported)
-docker_install: False
-docker_enabled: False
-
-# SchoolTool - unmaintained
-schooltool_install: False
-schooltool_enabled: False
 
 # 2-COMMON
 
@@ -179,6 +172,7 @@ mysql_install: True
 mysql_enabled: True
 # mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0
 mysql_root_password: fixmysql
+
 
 # 4-SERVER-OPTIONS
 
@@ -237,6 +231,7 @@ iiab_usb_lib_show_all: False
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False
 
+
 # 5-XO-SERVICES
 
 # Lesser-supported XO services need additional testing.  Please contact
@@ -257,31 +252,8 @@ ejabberd_xs_enabled: False
 idmgr_install: False
 idmgr_enables: False
 
+
 # 6-GENERIC-APPS
-
-# Calibre E-Book Library
-# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
-# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-
-calibre_install: True
-calibre_enabled: True
-# vars/raspbian-9.yml tries the .deb upgrade of Calibre, overriding this default:
-calibre_via_debs: False
-calibre_unstable_debs: False
-# vars/<most-OS's>.yml use Calibre's python installer/upgrader (x86_64), overriding this default:
-calibre_via_python: False
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
-calibre_port: 8080
-# Change calibre to XYZ add your own mnemonic URL like: http://box/XYZ
-calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-
-# Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: True
-calibreweb_enabled: True
-calibreweb_port: 8083
-# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
-calibreweb_url: /books
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # DokuWiki
 dokuwiki_install: False
@@ -305,13 +277,10 @@ ejabberd_enabled: False
 nextcloud_install: True
 nextcloud_enabled: False
 
-# ownCloud
-owncloud_install: False
-owncloud_enabled: False
-
 # WordPress
 wordpress_install: True
 wordpress_enabled: False
+
 
 # 7-EDU-APPS
 
@@ -355,7 +324,61 @@ sugarizer_install: True
 sugarizer_enabled: False
 sugarizer_port: 8089
 
+
 # 8-MGMT-TOOLS
+
+# AWStats - summarizes http access logs
+awstats_install: True
+awstats_enabled: False
+
+# Monit
+monit_install: False
+monit_enabled: False
+watchdog:
+  - sshd
+  - idmgr
+  - ejabberd
+  - httpd
+  - postgresql
+  - squid
+
+# Munin
+munin_install: True
+munin_enabled: False
+
+# Handy for maintaining tables, but DANGEROUS if not locked down
+phpmyadmin_install: False
+phpmyadmin_enabled: False
+
+# vnStat
+vnstat_install: True
+vnstat_enabled: False
+
+
+# 9-LOCAL-ADDONS
+
+# Calibre E-Book Library
+# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
+# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
+calibre_install: True
+calibre_enabled: True
+# vars/raspbian-9.yml tries the .deb upgrade of Calibre, overriding this default:
+calibre_via_debs: False
+calibre_unstable_debs: False
+# vars/<most-OS's>.yml use Calibre's python installer/upgrader (x86_64), overriding this default:
+calibre_via_python: False
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_port: 8080
+# Change calibre to XYZ add your own mnemonic URL like: http://box/XYZ
+calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
+
+# Calibre-Web alternative to Calibre, offers a clean/modern UX
+calibreweb_install: True
+calibreweb_enabled: True
+calibreweb_port: 8083
+# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
+calibreweb_url: /books
+calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # Transmission is a BitTorrent downloader for large Content Packs etc
 transmission_install: False
@@ -396,42 +419,26 @@ transmission_kalite_languages:
 transmission_username: Admin
 transmission_password: changeme
 
-# AWStats - summarizes http access logs
-awstats_install: True
-awstats_enabled: False
 
-# Monit
-monit_install: False
-monit_enabled: False
-watchdog:
-  - sshd
-  - idmgr
-  - ejabberd
-  - httpd
-  - postgresql
-  - squid
+# Docker - unmaintained
+# docker_install: False
+# docker_enabled: False
 
-# Munin
-munin_install: True
-munin_enabled: False
+# SchoolTool - unmaintained
+# schooltool_install: False
+# schooltool_enabled: False
 
-# Handy for maintaining tables, but DANGEROUS if not locked down
-phpmyadmin_install: False
-phpmyadmin_enabled: False
-
-# vnStat
-vnstat_install: True
-vnstat_enabled: False
-
-# ================================================================
-
-# Pathagar - similar to Calibre and Calibre-Web, but unmaintained
+# Pathagar - unmaintained (consider Calibre or Calibre-Web above?)
 # pathagar_install: False
 # pathagar_enabled: False
 
 # TeamViewer - unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False
 # teamviewer_enabled: False
+
+# ownCloud - unmaintained
+# owncloud_install: False
+# owncloud_enabled: False
 
 # sugar-stats - unmaintained
 # sugar_stats_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -131,32 +131,8 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+
 # 6-GENERIC-APPS
-
-# Calibre E-Book Library
-# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
-# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-
-calibre_install: True
-calibre_enabled: True
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
-calibre_port: 8080
-# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
-calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
-
-# Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: True
-calibreweb_enabled: True
-calibreweb_port: 8083
-# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
-calibreweb_url: /books
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 dokuwiki_install: True
 dokuwiki_enabled: True
@@ -175,6 +151,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
+
 
 # 7-EDU-APPS
 
@@ -207,12 +184,55 @@ pathagar_enabled: False
 sugarizer_install: True
 sugarizer_enabled: True
 
+
 # 8-MGMT-TOOLS
+
+awstats_install: True
+awstats_enabled: True
+
+monit_install: True
+monit_enabled: True
+
+munin_install: True
+munin_enabled: True
+
+# Handy for maintaining tables, but DANGEROUS if not locked down
+phpmyadmin_install: True
+phpmyadmin_enabled: False
+
+vnstat_install: True
+vnstat_enabled: True
+
+
+# 9-LOCAL-ADDONS
+
+# Calibre E-Book Library
+# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
+# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
+calibre_install: True
+calibre_enabled: True
+# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
+# calibre_via_debs: True
+calibre_unstable_debs: False
+# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
+# calibre_via_python: True
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_port: 8080
+# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
+calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
+# In addition to: http://box/books box/libros box/livres box/livros box/liv
+
+# Calibre-Web alternative to Calibre, offers a clean/modern UX
+calibreweb_install: True
+calibreweb_enabled: True
+calibreweb_port: 8083
+# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
+calibreweb_url: /books
+calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
-
 # A. Uncomment language(s) to download KA Lite videos to /library/transmission
 #    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:
@@ -231,21 +251,6 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
-awstats_install: True
-awstats_enabled: True
-
-monit_install: True
-monit_enabled: True
-
-munin_install: True
-munin_enabled: True
-
-# Handy for maintaining tables, but DANGEROUS if not locked down
-phpmyadmin_install: True
-phpmyadmin_enabled: False
-
-vnstat_install: True
-vnstat_enabled: True
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -178,10 +178,6 @@ moodle_enabled: True
 osm_install: True
 osm_enabled: True
 
-# Similar to Calibre, but unmaintained
-pathagar_install: False
-pathagar_enabled: False
-
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True
@@ -254,6 +250,10 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -69,6 +69,7 @@ dansguardian_enabled: True
 # wondershaper_install: False
 # wondershaper_enabled: False
 
+
 # 1-PREP
 
 # 2-COMMON
@@ -79,6 +80,7 @@ dansguardian_enabled: True
 allow_apache_sudo: True
 
 # roles/mysql runs here (mandatory)
+
 
 # 4-SERVER-OPTIONS
 
@@ -112,6 +114,7 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+
 
 # 5-XO-SERVICES
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -251,21 +251,13 @@ transmission_kalite_languages:
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False
 # teamviewer_enabled: False
 
 # Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False
+# docker_install: False
+# docker_enabled: False
 
 # Unmaintained
 # schooltool_install: False
@@ -274,3 +266,15 @@ transmission_kalite_languages:
 # Unmaintained
 # debian_schooltool_install: False
 # debian_schooltool_enabled: False
+
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
+
+# Unmaintained
+# sugar_stats_install: False
+# sugar_stats_enabled: False
+
+# Unmaintained
+# xovis_install: False
+# xovis_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -131,32 +131,8 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+
 # 6-GENERIC-APPS
-
-# Calibre E-Book Library
-# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
-# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-
-calibre_install: True
-calibre_enabled: True
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
-calibre_port: 8080
-# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
-calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
-
-# Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: True
-calibreweb_enabled: True
-calibreweb_port: 8083
-# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
-calibreweb_url: /books
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 dokuwiki_install: False
 dokuwiki_enabled: False
@@ -175,6 +151,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
+
 
 # 7-EDU-APPS
 
@@ -207,12 +184,55 @@ pathagar_enabled: False
 sugarizer_install: True
 sugarizer_enabled: True
 
+
 # 8-MGMT-TOOLS
+
+awstats_install: True
+awstats_enabled: True
+
+monit_install: False
+monit_enabled: False
+
+munin_install: True
+munin_enabled: True
+
+# Handy for maintaining tables, but DANGEROUS if not locked down
+phpmyadmin_install: False
+phpmyadmin_enabled: False
+
+vnstat_install: True
+vnstat_enabled: True
+
+
+# 9-LOCAL-ADDONS
+
+# Calibre E-Book Library
+# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
+# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
+calibre_install: False
+calibre_enabled: False
+# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
+# calibre_via_debs: True
+calibre_unstable_debs: False
+# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
+# calibre_via_python: True
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_port: 8080
+# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
+calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
+# In addition to: http://box/books box/libros box/livres box/livros box/liv
+
+# Calibre-Web alternative to Calibre, offers a clean/modern UX
+calibreweb_install: False
+calibreweb_enabled: False
+calibreweb_port: 8083
+# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
+calibreweb_url: /books
+calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
-
 # A. Uncomment language(s) to download KA Lite videos to /library/transmission
 #    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:
@@ -231,21 +251,10 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
-awstats_install: True
-awstats_enabled: True
 
-monit_install: False
-monit_enabled: False
-
-munin_install: True
-munin_enabled: True
-
-# Handy for maintaining tables, but DANGEROUS if not locked down
-phpmyadmin_install: False
-phpmyadmin_enabled: False
-
-vnstat_install: True
-vnstat_enabled: True
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -178,10 +178,6 @@ moodle_enabled: False
 osm_install: True
 osm_enabled: True
 
-# Similar to Calibre, but unmaintained
-pathagar_install: False
-pathagar_enabled: False
-
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -209,8 +209,8 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: False
-calibre_enabled: False
+calibre_install: True
+calibre_enabled: True
 # Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
 # calibre_via_debs: True
 calibre_unstable_debs: False
@@ -223,8 +223,8 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # In addition to: http://box/books box/libros box/livres box/livros box/liv
 
 # Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
+calibreweb_install: True
+calibreweb_enabled: True
 calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -251,21 +251,13 @@ transmission_kalite_languages:
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False
 # teamviewer_enabled: False
 
 # Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False
+# docker_install: False
+# docker_enabled: False
 
 # Unmaintained
 # schooltool_install: False
@@ -274,3 +266,15 @@ transmission_kalite_languages:
 # Unmaintained
 # debian_schooltool_install: False
 # debian_schooltool_enabled: False
+
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
+
+# Unmaintained
+# sugar_stats_install: False
+# sugar_stats_enabled: False
+
+# Unmaintained
+# xovis_install: False
+# xovis_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -69,6 +69,7 @@ dansguardian_enabled: False
 # wondershaper_install: False
 # wondershaper_enabled: False
 
+
 # 1-PREP
 
 # 2-COMMON
@@ -79,6 +80,7 @@ dansguardian_enabled: False
 allow_apache_sudo: True
 
 # roles/mysql runs here (mandatory)
+
 
 # 4-SERVER-OPTIONS
 
@@ -112,6 +114,7 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+
 
 # 5-XO-SERVICES
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -251,21 +251,13 @@ transmission_kalite_languages:
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False
 # teamviewer_enabled: False
 
 # Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False
+# docker_install: False
+# docker_enabled: False
 
 # Unmaintained
 # schooltool_install: False
@@ -274,3 +266,15 @@ transmission_kalite_languages:
 # Unmaintained
 # debian_schooltool_install: False
 # debian_schooltool_enabled: False
+
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
+
+# Unmaintained
+# sugar_stats_install: False
+# sugar_stats_enabled: False
+
+# Unmaintained
+# xovis_install: False
+# xovis_enabled: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -131,32 +131,8 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+
 # 6-GENERIC-APPS
-
-# Calibre E-Book Library
-# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
-# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-
-calibre_install: False
-calibre_enabled: False
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
-calibre_port: 8080
-# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
-calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
-
-# Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
-calibreweb_port: 8083
-# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
-calibreweb_url: /books
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 dokuwiki_install: False
 dokuwiki_enabled: False
@@ -175,6 +151,7 @@ nextcloud_enabled: False
 
 wordpress_install: False
 wordpress_enabled: False
+
 
 # 7-EDU-APPS
 
@@ -198,14 +175,11 @@ moodle_enabled: False
 osm_install: False
 osm_enabled: False
 
-# Similar to Calibre, but unmaintained
-pathagar_install: False
-pathagar_enabled: False
-
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957
 sugarizer_install: False
 sugarizer_enabled: False
+
 
 # 8-MGMT-TOOLS
 
@@ -246,6 +220,39 @@ phpmyadmin_enabled: False
 
 vnstat_install: True
 vnstat_enabled: True
+
+
+# 9-LOCAL-ADDONS
+
+# Calibre E-Book Library
+# WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
+# ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
+
+calibre_install: False
+calibre_enabled: False
+# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
+# calibre_via_debs: True
+calibre_unstable_debs: False
+# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
+# calibre_via_python: True
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_port: 8080
+# Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
+calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
+# In addition to: http://box/books box/libros box/livres box/livros box/liv
+
+# Calibre-Web alternative to Calibre, offers a clean/modern UX
+calibreweb_install: False
+calibreweb_enabled: False
+calibreweb_port: 8083
+# http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
+calibreweb_url: /books
+calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
+
+
+# Unmaintained (consider Calibre or Calibre-Web above?)
+# pathagar_install: False
+# pathagar_enabled: False
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -69,6 +69,7 @@ dansguardian_enabled: False
 # wondershaper_install: False
 # wondershaper_enabled: False
 
+
 # 1-PREP
 
 # 2-COMMON
@@ -79,6 +80,7 @@ dansguardian_enabled: False
 allow_apache_sudo: True
 
 # roles/mysql runs here (mandatory)
+
 
 # 4-SERVER-OPTIONS
 
@@ -112,6 +114,7 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+
 
 # 5-XO-SERVICES
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -183,28 +183,6 @@ sugarizer_enabled: False
 
 # 8-MGMT-TOOLS
 
-# BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
-
-# A. Uncomment language(s) to download KA Lite videos to /library/transmission
-#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
-transmission_kalite_languages:
-  - english
-  #- french
-  #- hindi
-  #- portugal-portuguese
-  #- brazilian-portuguese
-  #- spanish
-  #- swahili
-# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
-#    until the download is confirmed complete (can take hours or days!)
-# C. Carefully move all videos/thumbnails into /library/ka-lite/content
-#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
-# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
-#    then click "Scan content folder for videos" (can take many minutes!)
-# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
-
 awstats_install: True
 awstats_enabled: True
 
@@ -227,7 +205,6 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-
 calibre_install: False
 calibre_enabled: False
 # Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
@@ -248,6 +225,27 @@ calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books
 calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
+
+# BitTorrent downloader for large Content Packs etc
+transmission_install: False
+transmission_enabled: False
+# A. Uncomment language(s) to download KA Lite videos to /library/transmission
+#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
+transmission_kalite_languages:
+  - english
+  #- french
+  #- hindi
+  #- portugal-portuguese
+  #- brazilian-portuguese
+  #- spanish
+  #- swahili
+# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
+#    until the download is confirmed complete (can take hours or days!)
+# C. Carefully move all videos/thumbnails into /library/ka-lite/content
+#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
+# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
+#    then click "Scan content folder for videos" (can take many minutes!)
+# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
 # Unmaintained (consider Calibre or Calibre-Web above?)


### PR DESCRIPTION
Testing is ongoing, on a BIG-sized IIAB 6.6/master on Raspbian Lite.