### PR TITLE
http://box/kiwix was failing

### DIFF
--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -1,4 +1,10 @@
-RewriteEngine on
-RewriteRule ^{{ kiwix_alias_url }}$ {{ kiwix_url }} [R]
+# 2018-08-31: FAILS to enable http://box/kiwix
+#RewriteEngine on
+#RewriteRule ^{{ kiwix_alias_url }}$ {{ kiwix_url }} [R]
 
-ProxyPass {{ kiwix_alias_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}
+# 2018-08-31: SUCCEEDS in enabling http://box/kiwix
+RedirectMatch ^{{ kiwix_alias_url }}$ {{ kiwix_url }}
+
+#ProxyPreserveHost On
+ProxyPass {{ kiwix_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}
+#ProxyPassReverse {{ kiwix_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}

--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^{{ kiwix_alias_url }}$ {{ kiwix_url }} [R]
 
-ProxyPass {{ kiwix_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}
+ProxyPass {{ kiwix_alias_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}

--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -5,6 +5,7 @@
 # 2018-08-31: SUCCEEDS in enabling http://box/kiwix
 RedirectMatch ^{{ kiwix_alias_url }}$ {{ kiwix_url }}
 
+# 2018-08-31: SUCCEEDS in enabling http://box/kiwix/ & http://box/kiwix/zim & http://box/kiwix/zim/
 #ProxyPreserveHost On
 ProxyPass {{ kiwix_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}
 #ProxyPassReverse {{ kiwix_url }} http://127.0.0.1:{{ kiwix_port}}{{ kiwix_url }}


### PR DESCRIPTION
I'm no expert but I found this tweak to @tim-moody's PR #985 by looking at @arky's PR #980, and so all 4 URL's now seem to work at last:
- http://box/kiwix
- http://box/kiwix/
- http://box/kiwix/zim
- http://box/kiwix/zim/

PS we're not trying to solve the following today (#852 orig/clean/short URL for privacy etc) but FYI 4 of these 7 unproxied URL's currently fail:
- http://box:3000 FAILS (worked prior to June 2018)
- http://box:3000/zim FAILS (worked prior to June 2018)
- http://box:3000/zim/ FAILS (worked prior to June 2018)
- http://box:3000/kiwix FAILS (not sure this ever worked)
- http://box:3000/kiwix/ WORKS
- http://box:3000/kiwix/zim WORKS
- http://box:3000/kiwix/zim/ WORKS