### PR TITLE
Transmission (BitTorrent) network activity caused SLOW IIAB installs :/

### DIFF
--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -3,6 +3,12 @@
 - name: ...IS BEGINNING ======================================
   command: echo
 
+- name: TRANSMISSION
+  include_role:
+    name: transmission
+  when: transmission_install
+  tags: transmission
+
 - name: AWSTATS
   include_role:
     name: awstats

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -15,12 +15,6 @@
   when: calibreweb_install
   tags: calibre-web
 
-- name: TRANSMISSION
-  include_role:
-    name: transmission
-  when: transmission_install
-  tags: transmission
-
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     dest: /etc/iiab/iiab.env

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -39,6 +39,7 @@
 - name: Add KA Lite torrent(s) to transmission-daemon's queue
   shell: >
     /usr/bin/transmission-remote
+    --start-paused
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
   with_items: "{{ transmission_kalite_languages }}"

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -36,7 +36,7 @@
     state: restarted
   when: transmission_enabled
 
-- name: Add KA Lite torrent(s) to transmission-daemon's queue
+- name: Add PAUSED KA Lite torrent(s) to transmission-daemon's queue
   shell: >
     /usr/bin/transmission-remote
     --start-paused

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -327,6 +327,45 @@ sugarizer_port: 8089
 
 # 8-MGMT-TOOLS
 
+# Transmission is a BitTorrent downloader for large Content Packs etc
+transmission_install: False
+transmission_enabled: False
+
+# Transmission download directory & general owner/group
+transmission_download_dir: "{{ content_base }}/transmission/"    # /library/transmission/
+transmission_user: debian-transmission
+transmission_group: root
+
+# Monitor downloads at http://box:9091 or http://box:9091/transmission using Admin/changeme
+transmission_http_port: 9091
+transmission_url : "/transmission/"
+transmission_peer_port: 51413
+
+# Provision Transmission with torrent(s) from http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
+transmission_provision: True
+transmission_kalite_version: 0.17
+
+# A. Uncomment language(s) in /etc/iiab/local_vars.yml to download KA Lite videos to /library/transmission
+transmission_kalite_languages:
+  - english
+  #- french
+  #- hindi
+  #- portugal-portuguese
+  #- brazilian-portuguese
+  #- spanish
+  #- swahili
+# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
+#    until the download is confirmed complete (can take hours if not days!)
+# C. Carefully move all videos/thumbnails into /library/ka-lite/content
+#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
+# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
+#    then click "Scan content folder for videos" (can take many minutes!)
+# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
+
+# Transmission administrative account
+transmission_username: Admin
+transmission_password: changeme
+
 # AWStats - summarizes http access logs
 awstats_install: True
 awstats_enabled: False
@@ -379,45 +418,6 @@ calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books
 calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
-
-# Transmission is a BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
-
-# Transmission download directory & general owner/group
-transmission_download_dir: "{{ content_base }}/transmission/"    # /library/transmission/
-transmission_user: debian-transmission
-transmission_group: root
-
-# Monitor downloads at http://box:9091 or http://box:9091/transmission using Admin/changeme
-transmission_http_port: 9091
-transmission_url : "/transmission/"
-transmission_peer_port: 51413
-
-# Provision Transmission with torrent(s) from http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
-transmission_provision: True
-transmission_kalite_version: 0.17
-
-# A. Uncomment language(s) in /etc/iiab/local_vars.yml to download KA Lite videos to /library/transmission
-transmission_kalite_languages:
-  - english
-  #- french
-  #- hindi
-  #- portugal-portuguese
-  #- brazilian-portuguese
-  #- spanish
-  #- swahili
-# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
-#    until the download is confirmed complete (can take hours or days!)
-# C. Carefully move all videos/thumbnails into /library/ka-lite/content
-#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
-# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
-#    then click "Scan content folder for videos" (can take many minutes!)
-# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
-
-# Transmission administrative account
-transmission_username: Admin
-transmission_password: changeme
 
 
 # TeamViewer - unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -186,6 +186,27 @@ sugarizer_enabled: True
 
 # 8-MGMT-TOOLS
 
+# BitTorrent downloader for large Content Packs etc
+transmission_install: False
+transmission_enabled: False
+# A. Uncomment language(s) to download KA Lite videos to /library/transmission
+#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
+transmission_kalite_languages:
+  - english
+  #- french
+  #- hindi
+  #- portugal-portuguese
+  #- brazilian-portuguese
+  #- spanish
+  #- swahili
+# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
+#    until the download is confirmed complete (can take hours if not days!)
+# C. Carefully move all videos/thumbnails into /library/ka-lite/content
+#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
+# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
+#    then click "Scan content folder for videos" (can take many minutes!)
+# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
+
 awstats_install: True
 awstats_enabled: True
 
@@ -228,27 +249,6 @@ calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books
 calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
-
-# BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
-# A. Uncomment language(s) to download KA Lite videos to /library/transmission
-#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
-transmission_kalite_languages:
-  - english
-  #- french
-  #- hindi
-  #- portugal-portuguese
-  #- brazilian-portuguese
-  #- spanish
-  #- swahili
-# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
-#    until the download is confirmed complete (can take hours or days!)
-# C. Carefully move all videos/thumbnails into /library/ka-lite/content
-#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
-# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
-#    then click "Scan content folder for videos" (can take many minutes!)
-# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -186,6 +186,27 @@ sugarizer_enabled: True
 
 # 8-MGMT-TOOLS
 
+# BitTorrent downloader for large Content Packs etc
+transmission_install: False
+transmission_enabled: False
+# A. Uncomment language(s) to download KA Lite videos to /library/transmission
+#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
+transmission_kalite_languages:
+  - english
+  #- french
+  #- hindi
+  #- portugal-portuguese
+  #- brazilian-portuguese
+  #- spanish
+  #- swahili
+# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
+#    until the download is confirmed complete (can take hours if not days!)
+# C. Carefully move all videos/thumbnails into /library/ka-lite/content
+#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
+# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
+#    then click "Scan content folder for videos" (can take many minutes!)
+# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
+
 awstats_install: True
 awstats_enabled: True
 
@@ -228,27 +249,6 @@ calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books
 calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
-
-# BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
-# A. Uncomment language(s) to download KA Lite videos to /library/transmission
-#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
-transmission_kalite_languages:
-  - english
-  #- french
-  #- hindi
-  #- portugal-portuguese
-  #- brazilian-portuguese
-  #- spanish
-  #- swahili
-# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
-#    until the download is confirmed complete (can take hours or days!)
-# C. Carefully move all videos/thumbnails into /library/ka-lite/content
-#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
-# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
-#    then click "Scan content folder for videos" (can take many minutes!)
-# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -186,6 +186,27 @@ sugarizer_enabled: False
 
 # 8-MGMT-TOOLS
 
+# BitTorrent downloader for large Content Packs etc
+transmission_install: False
+transmission_enabled: False
+# A. Uncomment language(s) to download KA Lite videos to /library/transmission
+#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
+transmission_kalite_languages:
+  - english
+  #- french
+  #- hindi
+  #- portugal-portuguese
+  #- brazilian-portuguese
+  #- spanish
+  #- swahili
+# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
+#    until the download is confirmed complete (can take hours if not days!)
+# C. Carefully move all videos/thumbnails into /library/ka-lite/content
+#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
+# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
+#    then click "Scan content folder for videos" (can take many minutes!)
+# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
+
 awstats_install: True
 awstats_enabled: True
 
@@ -228,27 +249,6 @@ calibreweb_port: 8083
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books
 calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
-
-# BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
-# A. Uncomment language(s) to download KA Lite videos to /library/transmission
-#    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
-transmission_kalite_languages:
-  - english
-  #- french
-  #- hindi
-  #- portugal-portuguese
-  #- brazilian-portuguese
-  #- spanish
-  #- swahili
-# B. Monitor BitTorrent downloads at http://box:9091 using Admin/changeme
-#    until the download is confirmed complete (can take hours or days!)
-# C. Carefully move all videos/thumbnails into /library/ka-lite/content
-#    (DO NOT OVERWRITE SUBFOLDERS assessment, locale, srt !)
-# D. Log in to KA Lite at http://box:8008/updates/videos/ using Admin/changeme
-#    then click "Scan content folder for videos" (can take many minutes!)
-# E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)


### PR DESCRIPTION
### Fixes Bug

Slow IIAB installs remained, even after I moved roles/transmission to be the very final role/playbook running at the [end of Stage 9](https://github.com/iiab/iiab/blob/master/roles/9-local-addons/tasks/main.yml#L18-L22).

### Description of changes proposed in this pull request.

1) BitTorrent download(s) are hereby paused the very moment they're set up, by adding the `--start-paused` flag to the `/usr/bin/transmission-remote -n user:passwd -a URL.torrent` command in roles/transmission/tasks/main.yml

2) These BitTorrent download(s) are later started near the very end of http://download.iiab.io/6.6/install.txt, using:
```
if (systemctl -q is-active transmission-daemon) then
    transmission-remote -n Admin:changeme -t all --start
fi
# Start BitTorrent downloads for KA Lite, if install added. SEE http://box:9091
```

3) If `./runrole transmission` or `./iiab-install` are run independently of install scripts like http://download.iiab.io/6.6/install.txt, then the torrent download(s) need to be unpaused manually.  Either at http://box:9091 or using the same command-line as in (2.) above:
```
transmission-remote -n Admin:changeme -t all --start
```

_FINALLY: the possibility of moving transmission back from (end of) Stage 9 to (beginning of) Stage 8 [was considered & enacted]._

[Builds on #884 -> PR #1011 -> PR #1044]

### Smoke-tested in operating system.

Ubuntu 18.04 & Raspbian

### Mention a team member for further information or comment using @ name

@arky 