### PR TITLE
Experimental fix for serious OpenVPN flaw

### DIFF
--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -154,7 +154,7 @@
 # /etc/iiab/openvpn_handle to xscenet.net -- and
 # "systemctl restart openvpn@xscenet" was failing completely (no matter how
 # many times it was run) to transmit /etc/iiab/openvpn_handle to xscenet.net
-- name: Enable & (Re)Start PARENT service openvpn (it starts CHILD service openvpn@xscenet & tunnel)
+- name: Enable & (Re)Start PARENT service openvpn, which (re)starts CHILD service openvpn@xscenet (& actual tunnel)
   systemd:
     name: openvpn
     daemon_reload: yes
@@ -177,7 +177,7 @@
     state: absent
   when: not openvpn_enabled or not openvpn_cron_enabled
 
-- name: Disable & Stop PARENT service openvpn (it stops CHILD service openvpn@xscenet & tunnel)
+- name: Disable & Stop PARENT service openvpn, which stops CHILD service openvpn@xscenet (& actual tunnel)
   systemd:
     name: openvpn
     enabled: no

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -154,9 +154,10 @@
 # /etc/iiab/openvpn_handle to xscenet.net -- and
 # "systemctl restart openvpn@xscenet" was failing completely (no matter how
 # many times it was run) to transmit /etc/iiab/openvpn_handle to xscenet.net
-- name: Enable & (Re)Start openvpn@xscenet tunnel
+- name: Enable & (Re)Start PARENT service openvpn (it starts CHILD service openvpn@xscenet & tunnel)
   systemd:
-    name: openvpn@xscenet.service
+    name: openvpn
+    daemon_reload: yes
     enabled: yes
     state: restarted
   when: openvpn_enabled
@@ -176,9 +177,9 @@
     state: absent
   when: not openvpn_enabled or not openvpn_cron_enabled
 
-- name: Disable & Stop openvpn@xscenet tunnel
+- name: Disable & Stop PARENT service openvpn (it stops CHILD service openvpn@xscenet & tunnel)
   systemd:
-    name: openvpn@xscenet.service
+    name: openvpn
     enabled: no
     state: stopped
   when: not openvpn_enabled

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -162,7 +162,7 @@
     state: restarted
   when: openvpn_enabled
 
-- name: Enable hourly cron job for OpenVPN (typically for CentOS only?)
+- name: Enable hourly cron job for OpenVPN (starts CHILD service openvpn@xscenet, typically for CentOS only?)
   lineinfile:
     path: /etc/crontab
     line: "25 *  *  *  * root (/usr/bin/systemctl start openvpn@xscenet.service) > /dev/null"

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -162,13 +162,13 @@
     state: restarted
   when: openvpn_enabled
 
-- name: Enable hourly cron job for OpenVPN
+- name: Enable hourly cron job for OpenVPN (typically for CentOS only?)
   lineinfile:
     path: /etc/crontab
     line: "25 *  *  *  * root (/usr/bin/systemctl start openvpn@xscenet.service) > /dev/null"
   when: openvpn_enabled and openvpn_cron_enabled
 
-- name: Remove hourly cron job for OpenVPN
+- name: Remove hourly cron job for OpenVPN (typically for CentOS only?)
   lineinfile:
     path: /etc/crontab
     regexp: "openvpn@xscenet"
@@ -208,7 +208,7 @@
   - option: name
     value: OpenVPN
   - option: description
-    value: "OpenVPN is a means of connecting to other machines anywhere on the internet, via a middleman server, using Virtual Private Network techniques to create secure connections."
+    value: "OpenVPN enables live/remote support by connecting machines anywhere on the Internet, via a middleman server, using Virtual Private Network (VPN) techniques to create secure connections."
   - option: enabled
     value: "{{ openvpn_enabled }}"
 # openvpn_handle variable can no longer be left completely undefined of August 2018 (EMPTY STRING "" IS TOLERATED, in which case OpenVPN server should use /etc/iiab/uuid in lieu of the handle)

--- a/roles/openvpn/templates/xscenet.conf.j2
+++ b/roles/openvpn/templates/xscenet.conf.j2
@@ -1,4 +1,4 @@
-# Sample client-side OpenVPN config file for connecting to multi-client server.
+# Sample client-side OpenVPN config file for connecting to multi-client server
 #
 # Adapted from http://openvpn.sourceforge.net/20notes.html
 #


### PR DESCRIPTION
This is _a_ possible fix to a structural flaw that's existed in our OpenVPN code for years, and manifested itself as OpenVPN accidentally turning on, even when @tim-moody & @kananigit had set their [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/local_vars.yml) to: 
```
openvpn_install: True
openvpn_enabled: False
```
Testing ongoing...