### PR TITLE
Longer version #s for calibre_deb_pin_version e.g. 3.30+dfsg-1

### DIFF
--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -23,7 +23,7 @@ calibre_deb_url: http://download.iiab.io/packages
 # Must contain both packages for the pinned version, formatted as follows:
 # calibre_3.30.0+dfsg-1_all (25M, 2018-08-24)
 # calibre-bin_3.30.0+dfsg-1_armhf (742K, 2018-08-30)
-calibre_deb_pin_version: 3.30.0
+calibre_deb_pin_version: 3.30.0+dfsg-1
 
 # USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)
 #calibre_debs_on_debian: True

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -42,8 +42,8 @@
     #backup: no
     timeout: "{{ download_timeout }}"
   with_items:
-    - calibre_{{ calibre_deb_pin_version }}+dfsg-1_all.deb
-    - calibre-bin_{{ calibre_deb_pin_version }}+dfsg-1_armhf.deb
+    - calibre_{{ calibre_deb_pin_version }}_all.deb
+    - calibre-bin_{{ calibre_deb_pin_version }}_armhf.deb
   when: is_rpi and internet_available
 
 - name: Install/Upgrade both, to PINNED version {{ calibre_deb_pin_version }} while using additional .deb's from testing (rpi)


### PR DESCRIPTION
Implements @jvonau's suggestion @ https://github.com/iiab/iiab/pull/1057#issuecomment-417884311