### PR TITLE
Vpn

### DIFF
--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -72,7 +72,7 @@
     - { src: 'announce', dest: '/etc/openvpn/scripts/announce', mode: '0755' }
     - { src: 'announcer.j2', dest: '/etc/openvpn/scripts/announcer', mode: '0755' }
     - { src: 'silence', dest: '/etc/openvpn/scripts/silence', mode: '0755' }
-    - { src: 'xscenet.conf.j2', dest: '/etc/openvpn/xscenet.conf', mode: '0644' }
+    - { src: 'xscenet.conf.j2', dest: '/etc/openvpn/client/xscenet.conf', mode: '0644' }
     - { src: 'iiab-remote-on.j2', dest: '/usr/bin/iiab-remote-on', mode: '0755' }
     - { src: 'iiab-remote-off', dest: '/usr/bin/iiab-remote-off', mode: '0755' }
     - { src: 'openvpn_handle.j2', dest: '/etc/iiab/openvpn_handle', mode: '0644' }
@@ -161,33 +161,42 @@
 #    /lib/systemd/systemd-sysv-install  sets /etc/rc*.d/S|K01openvpn
 #                                       e.g. when "systemctl enable openvpn"
 
-- name: Enable & (Re)Start PARENT service openvpn, which (re)starts CHILD service openvpn@xscenet (& actual tunnel)
+- name: Disable & Stop openvpn's sysinit routine
   systemd:
     name: openvpn
-    daemon_reload: yes
-    enabled: yes
-    state: restarted    # 2018-09-02: Should we be concerned that "systemctl status openvpn" often shows "active (exited)" ?  If so we might consider "state: started" or "state: reloaded" instead?
-  when: openvpn_enabled
+    enabled: no
+    state: stopped
+# The above runs /lib/systemd/systemd-sysv-install on Debian/Raspbian to fiddle with
+# /etc/rc*.d/S|K01openvpn that starts really early in the boot process before the network is even
+# ready to use. Lets not do that.
 
-- name: Enable hourly cron job for OpenVPN (starts CHILD service openvpn@xscenet, typically for CentOS only?)
+- name: Enable hourly cron job for OpenVPN (starts CHILD service openvpn-client@xscenet, typically for CentOS only?)
   lineinfile:
     path: /etc/crontab
     # CONSIDER "restart" not just "start" if something stronger is confirmed needed?
-    line: "25 *  *  *  * root (/usr/bin/systemctl start openvpn@xscenet.service) > /dev/null"
+    line: "25 *  *  *  * root (/usr/bin/systemctl start openvpn-client@xscenet.service) > /dev/null"
   when: openvpn_enabled and openvpn_cron_enabled
 
 - name: Remove hourly cron job for OpenVPN (typically for CentOS only?)
   lineinfile:
     path: /etc/crontab
-    regexp: "openvpn@xscenet"
+    regexp: "openvpn-client@xscenet"
     # Potentially DANGEROUS as others use systemctl too:
     #regexp: ".*/usr/bin/systemctl*"
     state: absent
   when: not openvpn_enabled or not openvpn_cron_enabled
 
-- name: Disable & Stop PARENT service openvpn, which stops CHILD service openvpn@xscenet (& actual tunnel)
+- name: Enable & (Re)Start openvpn-client@xscenet tunnel
   systemd:
-    name: openvpn
+    name: openvpn-client@xscenet.service
+    daemon_reload: yes
+    enabled: yes
+    state: started
+  when: openvpn_enabled
+
+- name: Disable & Stop openvpn-client@xscenet tunnel
+  systemd:
+    name: openvpn-client@xscenet.service
     enabled: no
     state: stopped
   when: not openvpn_enabled

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -166,6 +166,7 @@
     name: openvpn
     enabled: no
     state: stopped
+  when: is_debuntu
 # The above runs /lib/systemd/systemd-sysv-install on Debian/Raspbian to fiddle with
 # /etc/rc*.d/S|K01openvpn that starts really early in the boot process before the network is even
 # ready to use. Lets not do that.

--- a/roles/openvpn/templates/iiab-remote-off
+++ b/roles/openvpn/templates/iiab-remote-off
@@ -19,8 +19,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-systemctl disable openvpn
-systemctl stop openvpn
+systemctl disable openvpn-client@xscenet
+systemctl stop openvpn-client@xscenet
 
 sleep 5
 ps -e | grep openvpn    # 2018-09-05: "ps -e | grep vpn" no longer works (nor would "pgrep vpn") when invoked from iiab-vpn-off (as filename itself causes [multiple] "vpn" instances to appear in process list!)

--- a/roles/openvpn/templates/iiab-remote-on.j2
+++ b/roles/openvpn/templates/iiab-remote-on.j2
@@ -20,8 +20,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-systemctl enable openvpn
-systemctl start openvpn
+systemctl enable openvpn-client@xscenet
+systemctl start openvpn-client@xscenet
 
 sleep 5
 ping -c 2 {{ openvpn_server_virtual_ip }}    # 10.8.0.1


### PR DESCRIPTION
This is a bit of a can of worms between the OS's methods to launch openvpn, some are a very legacy approach. Lets stay with the systemd @ way for maximum compatibility across the various distros.