### PR TITLE
Nextcloud 13.x -> 14.x, as 14.0.0 is now released

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -8,7 +8,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases/
-nextcloud_orig_src_file: latest-13.tar.bz2
+nextcloud_orig_src_file: latest-14.tar.bz2
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.


### PR DESCRIPTION
@floydianslips tested RC2 earlier this week, and tests are ongoing on other OS's.

Resolves #930