### PR TITLE
Calibre 3.30 -> 3.31 (awaiting raspbian .deb's)

### DIFF
--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -21,8 +21,8 @@ calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/se
 
 calibre_deb_url: http://download.iiab.io/packages
 # Must contain both packages for the pinned version, formatted as follows:
-# calibre_3.31.0+dfsg-1_all (25M, 2018-08-24)
-# calibre-bin_3.31.0+dfsg-1_armhf (742K, 2018-08-30)
+# calibre_3.31.0+dfsg-1_all (25M, 2018-09-07)
+# calibre-bin_3.31.0+dfsg-1_armhf (747K, 2018-09-12)
 calibre_deb_pin_version: 3.31.0+dfsg-1
 
 # USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)

--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -21,9 +21,9 @@ calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/se
 
 calibre_deb_url: http://download.iiab.io/packages
 # Must contain both packages for the pinned version, formatted as follows:
-# calibre_3.30.0+dfsg-1_all (25M, 2018-08-24)
-# calibre-bin_3.30.0+dfsg-1_armhf (742K, 2018-08-30)
-calibre_deb_pin_version: 3.30.0+dfsg-1
+# calibre_3.31.0+dfsg-1_all (25M, 2018-08-24)
+# calibre-bin_3.31.0+dfsg-1_armhf (742K, 2018-08-30)
+calibre_deb_pin_version: 3.31.0+dfsg-1
 
 # USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)
 #calibre_debs_on_debian: True

--- a/scripts/calibre-install-pinned-rpi.sh
+++ b/scripts/calibre-install-pinned-rpi.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Prepares to update to latest from raspbian testing
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
-# @jvonau explains that stale .deb's should be avoided as: "apt will pick the highest version to install after churning a bit..."
+# WARNING: you MUST remove old .deb's from /opt/iiab/downloads if upgrading Calibre in this way, SEE: http://FAQ.IIAB.IO "Can I upgrade or reinstall server apps?"
 apt -y install /opt/iiab/downloads/calibre*.deb
 #sed -i '$ d' /etc/apt/sources.list.d/rpi-testing.list    # Removes last line
 rm /etc/apt/sources.list.d/rpi-testing.list


### PR DESCRIPTION
Calibre 3.31 was released 2018-09-07, and its raspbian .debs will be published in the coming week or so, here:
http://archive.raspbian.org/raspbian/pool/main/c/calibre/
http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/

Which we'll then republish here: (if this build is confirmed to install cleanly on Raspbian)
http://download.iiab.io/packages/

Refs PRs: #1053 #1057 #1082
https://www.mobileread.com/forums/showthread.php?p=3707933