### PR TITLE
Tweak to ansible install scripts diagnostics

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -85,7 +85,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
 
     echo -e '\n\nPPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" successfully saved to /etc/apt/sources.list.d/iiab-ansible.list'
     echo -e '\nIF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
-    grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:'
+    grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
     echo
 else
     echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -85,7 +85,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
 
     echo -e '\n\nPPA source "deb http://ppa.launchpad.net/ansible/ansible-2.6/ubuntu xenial main" successfully saved to /etc/apt/sources.list.d/iiab-ansible.list'
     echo -e '\nIF *OTHER* ANSIBLE SOURCES ARE ALSO IN THE LIST BELOW, PLEASE MANUALLY REMOVE THEM TO ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
-    grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:'
+    grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
     echo
 else
     echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"


### PR DESCRIPTION
As the user-facing diagnostics (at the every end of scripts/ansible, to display excess/stale sources in /etc/apt to newbie implementers) is using grep that was aborting...when grep [properly!] finds no duplicate sources (due to "bash -e" specified at the top of the script, hence aborting on 1st error).

Refs #1099, PRs #1102 #1103 #1104