### PR TITLE
MIN_ANSIBLE_VER 2.5.8. -> 2.6.4

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.5.8
+MIN_ANSIBLE_VER=2.6.4
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/iiab-install
+++ b/iiab-install
@@ -96,7 +96,7 @@ CURR_ANSIBLE_VER=0
 if [[ `command -v ansible` ]]; then        # "command -v" is POSIX compliant; it catches built-in commands like "cd"
     #CURR_ANSIBLE_VER=`ansible --version | head -1 | sed -e 's/.* //'`
     #CURR_ANSIBLE_VER=`ansible --version | head -1 | cut -f 2 -d " "`
-    CURR_ANSIBLE_VER=`ansible --version | head -1 | awk '{print $2}'`  # to match scripts/ansible
+    CURR_ANSIBLE_VER=`ansible --version | head -1 | awk '{print $2}'`    # to match scripts/ansible
     echo "Found Ansible "$CURR_ANSIBLE_VER""
 fi
 if version_gt $MIN_ANSIBLE_VER $CURR_ANSIBLE_VER ; then


### PR DESCRIPTION
To avoid compatibility problems in the months to come, as IIAB 6.6 is about to be released in not-so-many-day-if-not-hours.

(Ansible 2.6.4 was repeatedly tested on all mainline OS's since last week, without a problem.)

Refs: #1099 PRs #1102 #1103 #1104 #1105 #1106