### PR TITLE
Run kolibri migrations at install

### DIFF
--- a/roles/kolibri/README.rst
+++ b/roles/kolibri/README.rst
@@ -49,3 +49,10 @@ To return to using the systemd unit::
 
   kolibri stop
   systemctl start kolibri
+
+Known Issues
+-------------
+
+* Kolibri migrations can take a long time on a Raspberry Pi. These long running migrations could cause kolibri service timeouts. Try running migrations manually using 'kolibri manage migrate' command following the troubleshooting instructions above. Kolibri developers are trying to address this issue. (Refer https://github.com/learningequality/kolibri/issues/4310).
+
+* Loading channels can take a long time on a Raspberry Pi. When generating channel contents for Khan Academy, the step indicated as “Generating channel listing. This could take a few minutes…” could mean ~30 minutes. The device’s computation power is the bottleneck. You might get logged out while waiting, but this is harmless and the process will continue. Sit tight!

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -29,8 +29,8 @@
     extra_args: --no-cache-dir
   when: internet_available
 
-- name: Set kolibri default language
-  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
+- name: Run kolibri migrations
+  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" manage migrate
   ignore_errors: yes
   when: kolibri_provision
 

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -29,6 +29,32 @@
     extra_args: --no-cache-dir
   when: internet_available
 
+- name: Set kolibri default language
+  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
+  ignore_errors: yes
+  when: kolibri_provision
+
+- name: Set kolibri default language
+  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
+  ignore_errors: yes
+  when: kolibri_provision
+
+- name: Create kolibri default facility name, admin account and language
+  shell: >
+    export KOLIBRI_HOME="{{ kolibri_home }}" &&
+    "{{ kolibri_exec_path }}" manage provisiondevice --facility "{{ kolibri_facility }}"
+    --superusername "{{ kolibri_admin_user }}" --superuserpassword "{{ kolibri_admin_password }}"
+    --preset "{{ kolibri_preset }}" --language_id "{{ kolibri_language }}" --verbosity 0 --noinput
+  ignore_errors: yes
+  when: kolibri_provision
+
+- name: Change /library/kolibri directory permissions
+  file:
+    path: "{{ kolibri_home }}"
+    owner: "{{ kolibri_user }}"
+    group: "{{ apache_user }}"
+    recurse: yes
+
 - name: Create kolibri systemd service unit file
   template:
     src: "{{ item.src }}"
@@ -53,27 +79,6 @@
     enabled: no
     state: stopped
   when: not kolibri_enabled
-
-- name: Set kolibri default language
-  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
-  ignore_errors: yes
-  when: kolibri_provision
-
-- name: Create kolibri default facility name, admin account and language
-  shell: >
-    export KOLIBRI_HOME="{{ kolibri_home }}" &&
-    "{{ kolibri_exec_path }}" manage provisiondevice --facility "{{ kolibri_facility }}"
-    --superusername "{{ kolibri_admin_user }}" --superuserpassword "{{ kolibri_admin_password }}"
-    --preset "{{ kolibri_preset }}" --language_id "{{ kolibri_language }}" --verbosity 0 --noinput
-  ignore_errors: yes
-  when: kolibri_provision
-
-- name: Change /library/kolibri directory permissions
-  file:
-    path: "{{ kolibri_home }}"
-    owner: "{{ kolibri_user }}"
-    group: "{{ apache_user }}"
-    recurse: yes
 
 - name: Add 'kolibri' to list of services at /etc/iiab/iiab.ini
   ini_file:


### PR DESCRIPTION
### Fixes Bug
Refactor of Kolibri install. Move migrations to install time. Tentative fix for #1158 

### Description of changes proposed in this pull request.

Run Kolibri migrations during install not at first run. 

### Smoke-tested in operating system.
Debian 10
### Mention a team member for further information or comment using @ name
@holta 