### PR TITLE
Proposed rewrite of PR #1161: apache_raise_php_limits [revised to apache_high_php_limits] for WordPress & Moodle

### DIFF
--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -1,0 +1,3 @@
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -1,3 +1,6 @@
+# Make this False to disable http://box/common/services/power_off.php button:
+apache_allow_sudo: True
+
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
 apache_raise_php_limits: False

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -21,16 +21,16 @@
     name: "php{{ php_version }}-sqlite3"
   when: is_debian and ansible_distribution_major_version == "9"
 
--  name: Install httpd required packages (ubuntu)
-   package:
-     name: "{{ item }}"
-     state: present
-   with_items:
-     - apache2
-     - php
-   tags:
-     - download
-   when: is_ubuntu
+- name: Install httpd required packages (ubuntu)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - apache2
+    - php
+  tags:
+    - download
+  when: is_ubuntu
 
 - name: SQLite3 no longer included in another package (ubuntu-18)
   package:
@@ -70,6 +70,21 @@
     - { src: '010-iiab.conf.j2', dest: '/etc/{{ apache_config_dir }}/010-iiab.conf', mode: '0755' }
     - { src: 'proxy_ajp.conf.j2', dest: '/etc/{{ apache_config_dir }}/proxy_ajp.conf', mode: '0644' }
     #- { src: 'php.ini.j2', dest: '/etc/php.ini', mode: '0644' }    # @jvonau suggests removing this in https://github.com/iiab/iiab/issues/1147
+
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+- name: Raise php.ini limits if using WordPress and/or Moodle intensively
+  lineinfile:
+    path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  when: apache_raise_php_limits
+  with_items:
+    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 64M    ; default is 2M' }
+    - { regexp: '^post_max_size', line: 'post_max_size = 128M    ; default is 8M' }
+    - { regexp: '^memory_limit', line: 'memory_limit = 256M    ; default is 128M' }
+    - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
+    - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
 
 # remove symlinks for mpm-event, replace with mpm-prefork
 - name: Remove mpm event links (debuntu)

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -69,7 +69,7 @@
   with_items:
     - { src: '010-iiab.conf.j2', dest: '/etc/{{ apache_config_dir }}/010-iiab.conf', mode: '0755' }
     - { src: 'proxy_ajp.conf.j2', dest: '/etc/{{ apache_config_dir }}/proxy_ajp.conf', mode: '0644' }
-    - { src: 'php.ini.j2', dest: '/etc/php.ini', mode: '0644' }
+    #- { src: 'php.ini.j2', dest: '/etc/php.ini', mode: '0644' }    # @jvonau suggests removing this in https://github.com/iiab/iiab/issues/1147
 
 # remove symlinks for mpm-event, replace with mpm-prefork
 - name: Remove mpm event links (debuntu)
@@ -207,10 +207,10 @@
     src: 020_apache_poweroff.j2
     dest: /etc/sudoers.d/020_apache_poweroff
     mode: 0755
-  when: allow_apache_sudo
+  when: apache_allow_sudo
 
 - name: Remove apache_user permission to poweroff
   file:
     dest: /etc/sudoers.d/020_apache_poweroff
     state: absent
-  when: not allow_apache_sudo
+  when: not apache_allow_sudo

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -1,9 +1,13 @@
+#moodle_install: True
+#moodle_enabled: False
+
+# If using Moodle intensively, consider setting apache_raise_php_limits in:
+# /etc/iiab/local_vars.yml
+
 moodle_version: 35
 #moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_repo_url: "git://git.moodle.org/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"
 #moodle_user: moodle
-#moodle_install: True
-#moodle_enabled: False
 moodle_data: '{{ content_base }}/moodle'
 moodle_database_name: moodle

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -4,11 +4,6 @@ wordpress_enabled: True
 # If using WordPress intensively, consider setting apache_raise_php_limits in:
 # /etc/iiab/local_vars.yml
 
-See iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
-# roles/httpd/defaults/main.yml
-
 wordpress_download_base_url: https://wordpress.org
 wordpress_src: latest.tar.gz
 

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -1,9 +1,13 @@
 wordpress_install: True
 wordpress_enabled: True
 
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-wordpress_raise_php_limits: False
+# If using WordPress intensively, consider setting apache_raise_php_limits in:
+# /etc/iiab/local_vars.yml
+
+See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False
+# roles/httpd/defaults/main.yml
 
 wordpress_download_base_url: https://wordpress.org
 wordpress_src: latest.tar.gz

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -47,21 +47,6 @@
     mode: 0664
     keep_newer: yes
 
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-- name: Raise php.ini limits in schools that use WordPress intensively
-  lineinfile:
-    path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  when: wordpress_raise_php_limits
-  with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 64M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 128M    ; default is 8M' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 256M    ; default is 128M' }
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
-
 # - name: Rename /library/wordpress* to /library/wordpress
 #   shell: if [ ! -d {{ wp_abs_path }} ]; then mv {{ wp_abs_path }}* {{ wp_abs_path }}; fi
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -284,7 +284,7 @@ nextcloud_enabled: False
 # WordPress
 wordpress_install: True
 wordpress_enabled: False
-# If using Moodle intensively, consider setting apache_raise_php_limits above
+# If using WordPress intensively, consider setting apache_raise_php_limits above
 
 
 # 7-EDU-APPS

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -160,10 +160,14 @@ wan_nameserver:
 
 # 3-BASE-SERVER
 
-# Make this False to disable http://box/common/services/power_off.php button:
-allow_apache_sudo: True
+# roles/httpd (Apache configuration) runs here
 
-# roles/httpd runs here
+# Make this False to disable http://box/common/services/power_off.php button:
+apache_allow_sudo: True
+
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False
 
 # roles/iiab-admin runs here
 
@@ -280,9 +284,7 @@ nextcloud_enabled: False
 # WordPress
 wordpress_install: True
 wordpress_enabled: False
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-wordpress_raise_php_limits: False
+# If using Moodle intensively, consider setting apache_raise_php_limits above
 
 
 # 7-EDU-APPS
@@ -312,6 +314,7 @@ iiab_zim_path: /library/zims
 # Moodle
 moodle_install: False
 moodle_enabled: False
+# If using Moodle intensively, consider setting apache_raise_php_limits above
 
 # Sugarizer
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -77,7 +77,11 @@ dansguardian_enabled: True
 # 3-BASE-SERVER
 
 # Make this False to disable http://box/common/services/power_off.php button:
-allow_apache_sudo: True
+apache_allow_sudo: True
+
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -154,9 +158,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-wordpress_raise_php_limits: False
+# If using WordPress intensively, consider setting apache_raise_php_limits above
 
 
 # 7-EDU-APPS
@@ -176,6 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: True
 moodle_enabled: True
+# If using Moodle intensively, consider setting apache_raise_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -77,7 +77,11 @@ dansguardian_enabled: False
 # 3-BASE-SERVER
 
 # Make this False to disable http://box/common/services/power_off.php button:
-allow_apache_sudo: True
+apache_allow_sudo: True
+
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -154,9 +158,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-wordpress_raise_php_limits: False
+# If using WordPress intensively, consider setting apache_raise_php_limits above
 
 
 # 7-EDU-APPS
@@ -176,6 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: False
 moodle_enabled: False
+# If using Moodle intensively, consider setting apache_raise_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -77,7 +77,11 @@ dansguardian_enabled: False
 # 3-BASE-SERVER
 
 # Make this False to disable http://box/common/services/power_off.php button:
-allow_apache_sudo: True
+apache_allow_sudo: True
+
+# For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
+# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+apache_raise_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -154,9 +158,7 @@ nextcloud_enabled: False
 
 wordpress_install: False
 wordpress_enabled: False
-# For schools that use WordPress intensively.  WARNING: Enabling this (might)
-# cause excess use of RAM or other resources?  github.com/iiab/iiab/issues/1147
-wordpress_raise_php_limits: False
+# If using WordPress intensively, consider setting apache_raise_php_limits above
 
 
 # 7-EDU-APPS
@@ -176,6 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: False
 moodle_enabled: False
+# If using Moodle intensively, consider setting apache_raise_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957


### PR DESCRIPTION
The httpd playbook now has the option of setting high limits in /etc/php/7.x/apache2/php.ini (for WordPress & Moodle) if you set <strike>apache_raise_php_limits</strike> _[since renamed to apache_high_php_limits]_ in /etc/iiab/local_vars.yml

This was formerly done in the wordpress playbook.

This PR also:
- renames variable `allow_apache_sudo` to `apache_allow_sudo` in [roles/httpd/defaults/main.yml](https://github.com/iiab/iiab/blob/master/roles/httpd/defaults/main.yml) and elsewhere (as before, this is for easy poweroff in low-electricity environments etc, in the newly created roles/httpd/defaults/main.yml)
- removes /etc/php.ini entirely, following @jvonau suggestion at https://github.com/iiab/iiab/issues/1147#issuecomment-423796167
- does not set the TZ (time zone) in this context (Apache's php.ini) as there are indications this may no longer be necessary years later &mdash; _I'm not sure [roles/0-init/tasks/tz.yml](https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/tz.yml) is used anywhere at this time?_  See https://github.com/iiab/iiab/pull/70 "Timezone handling" [with Elgg and MySQL]

Builds on #1147 PR #1161 _[since modified by PR #1166]_