### PR TITLE
Rename var apache_raise_php_limits to apache_high_php_limits [for WordPress & Moodle]

### DIFF
--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -3,4 +3,4 @@ apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
+apache_high_php_limits: False

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -73,12 +73,12 @@
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-- name: Raise php.ini limits if using WordPress and/or Moodle intensively
+- name: Enact high limits in /etc/php/{{ php_version }}/{{ apache_service }}/php.ini if using WordPress and/or Moodle intensively
   lineinfile:
     path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
-  when: apache_raise_php_limits
+  when: apache_high_php_limits
   with_items:
     - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 64M    ; default is 2M' }
     - { regexp: '^post_max_size', line: 'post_max_size = 128M    ; default is 8M' }

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -1,7 +1,7 @@
 #moodle_install: True
 #moodle_enabled: False
 
-# If using Moodle intensively, consider setting apache_raise_php_limits in:
+# If using Moodle intensively, consider setting apache_high_php_limits in:
 # /etc/iiab/local_vars.yml
 
 moodle_version: 35

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -1,7 +1,7 @@
 wordpress_install: True
 wordpress_enabled: True
 
-# If using WordPress intensively, consider setting apache_raise_php_limits in:
+# If using WordPress intensively, consider setting apache_high_php_limits in:
 # /etc/iiab/local_vars.yml
 
 wordpress_download_base_url: https://wordpress.org

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -167,7 +167,7 @@ apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
+apache_high_php_limits: False
 
 # roles/iiab-admin runs here
 
@@ -284,7 +284,7 @@ nextcloud_enabled: False
 # WordPress
 wordpress_install: True
 wordpress_enabled: False
-# If using WordPress intensively, consider setting apache_raise_php_limits above
+# If using WordPress intensively, consider setting apache_high_php_limits above
 
 
 # 7-EDU-APPS
@@ -314,7 +314,7 @@ iiab_zim_path: /library/zims
 # Moodle
 moodle_install: False
 moodle_enabled: False
-# If using Moodle intensively, consider setting apache_raise_php_limits above
+# If using Moodle intensively, consider setting apache_high_php_limits above
 
 # Sugarizer
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -81,7 +81,7 @@ apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
+apache_high_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -158,7 +158,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
-# If using WordPress intensively, consider setting apache_raise_php_limits above
+# If using WordPress intensively, consider setting apache_high_php_limits above
 
 
 # 7-EDU-APPS
@@ -178,7 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: True
 moodle_enabled: True
-# If using Moodle intensively, consider setting apache_raise_php_limits above
+# If using Moodle intensively, consider setting apache_high_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -81,7 +81,7 @@ apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
+apache_high_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -158,7 +158,7 @@ nextcloud_enabled: True
 
 wordpress_install: True
 wordpress_enabled: True
-# If using WordPress intensively, consider setting apache_raise_php_limits above
+# If using WordPress intensively, consider setting apache_high_php_limits above
 
 
 # 7-EDU-APPS
@@ -178,7 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: False
 moodle_enabled: False
-# If using Moodle intensively, consider setting apache_raise_php_limits above
+# If using Moodle intensively, consider setting apache_high_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -81,7 +81,7 @@ apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
 # WARNING: Enabling this (might) cause excess use of RAM or other resources?
-apache_raise_php_limits: False
+apache_high_php_limits: False
 
 # roles/mysql runs here (mandatory)
 
@@ -158,7 +158,7 @@ nextcloud_enabled: False
 
 wordpress_install: False
 wordpress_enabled: False
-# If using WordPress intensively, consider setting apache_raise_php_limits above
+# If using WordPress intensively, consider setting apache_high_php_limits above
 
 
 # 7-EDU-APPS
@@ -178,7 +178,7 @@ kiwix_enabled: True
 # Warning: Moodle is a serious LMS, that takes a while to install
 moodle_install: False
 moodle_enabled: False
-# If using Moodle intensively, consider setting apache_raise_php_limits above
+# If using Moodle intensively, consider setting apache_high_php_limits above
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957


### PR DESCRIPTION
Variable is renamed to more accurately say what it does.

Builds on #1147 & PRs #1161 #1165.

Thanks @kananigit & @ericnitschke for ongoing testing &mdash; hopefully this is the final word or close ?