### PR TITLE
Fix 3 URL's that GoDaddy broke

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -24,7 +24,7 @@ if [ ! -f /etc/iiab/local_vars.yml ]; then
     fi
 
     echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
-    echo -e "(1) Please read http://wiki.iiab.io/local_vars.yml to learn more" >&2
+    echo -e "(1) Please read http://wiki.laptop.org/go/IIAB/local_vars.yml to learn more" >&2
     echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
     echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
     echo -e '    http://download.iiab.io   (click on "6.6" or a more recent version!)\n' >&2

--- a/roles/transmission/README.rst
+++ b/roles/transmission/README.rst
@@ -17,7 +17,7 @@ Caveat emptor!  (That's Latin for "Buyer Beware")
 Using It
 --------
 
-Install Transmission by setting 'transmission_install' and 'transmission_enabled' to True in `/etc/iiab/local_vars.yml <http://wiki.iiab.io/local_vars.yml>`_ — carefully choosing language(s) for KA Lite videos you want to download — and then run::
+Install Transmission by setting 'transmission_install' and 'transmission_enabled' to True in `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/local_vars.yml>`_ — carefully choosing language(s) for KA Lite videos you want to download — and then run::
 
   cd /opt/iiab/iiab
   ./runrole transmission
@@ -59,7 +59,7 @@ Adding Torrents
 
 Transmission can facilitate provisioning content onto your IIAB, e.g. by adding thousands of KA Lite videos from places like: http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 
-Please read the lettered instructions (A, B, C, D) in `/etc/iiab/local_vars.yml <http://wiki.iiab.io/local_vars.yml>`_ and 'KA Lite Administration: What tips & tricks exist?' at http://FAQ.IIAB.IO outlining how to use Transmission to download and then install KA Lite content.
+Please read the lettered instructions (A, B, C, D) in `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/local_vars.yml>`_ and 'KA Lite Administration: What tips & tricks exist?' at http://FAQ.IIAB.IO outlining how to use Transmission to download and then install KA Lite content.
 
 You can also download other torrents using Transmission's web interface, or by typing 'transmission-remote' at the command-line::
 


### PR DESCRIPTION
In all 3 cases, http://wiki.iiab.io/local_vars.yml (that used to work, until GoDaddy.com broke it about a week ago) documentation is revised to...

http://wiki.laptop.org/go/IIAB/local_vars.yml