### PR TITLE
Clean roles/calibre/defaults/main.yml for Calibre 3.32

### DIFF
--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -19,12 +19,14 @@ calibre_sample_book: "Metamorphosis-jackson.epub"
 
 calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py"
 
-calibre_deb_url: http://download.iiab.io/packages
-# Must contain both packages, corresponding with variable value(s) below, for scripts/calibre-install-pinned-rpi.sh to run:
-# calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)
-# calibre-bin_3.32.0+dfsg-1_armhf.deb (707K, 2018-10-08) WORKS DESPITE BEING 11H EARLIER?  FAILS: calibre-bin_3.32.0+dfsg-1+b1_armhf.deb (707K, 2018-10-08)
+calibre_deb_url: {{ iiab_download_url }}    # http://download.iiab.io/packages
+# Above URL must offer both .deb files below, corresponding with variable
+# value(s) further below: (for scripts/calibre-install-pinned-rpi.sh to run)
+# - calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)
+# - calibre-bin_3.32.0+dfsg-1_armhf.deb (707K, 2018-10-08) WORKS DESPITE BEING
+#   PUBLISHED 11+ HRS BEFORE NON-WORKING calibre-bin_3.32.0+dfsg-1+b1_armhf.deb
 calibre_deb_pin_version: 3.32.0+dfsg-1
-calibre_bin_deb_pin_version: 3.32.0+dfsg-1
+calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}"
 
 # USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)
 #calibre_debs_on_debian: True


### PR DESCRIPTION
[Calibre 3.32](https://calibre-ebook.com/whats-new) is now confirmed working on a fresh install of [IIAB 6.7](http://download.iiab.io/6.7/) / master.

This PR makes roles/calibre/defaults/main.yml more understandable on RPi, in support of both:
- /opt/iiab/iiab/roles/calibre/tasks/[debs.yml](https://github.com/iiab/iiab/blob/master/roles/calibre/tasks/debs.yml)
- /opt/iiab/iiab/scripts/[calibre-install-pinned-rpi.sh](https://github.com/iiab/iiab/blob/master/scripts/calibre-install-pinned-rpi.sh)

Builds on #1171 -> PR #1187