### PR TITLE
Expand /opt/iiab/iiab/unmaintained-roles.txt to include 4 more (that DO have READMEs)

### DIFF
--- a/unmaintained-roles.txt
+++ b/unmaintained-roles.txt
@@ -1,3 +1,4 @@
+activity-server
 ajenti
 authserver
 debian_schooltool
@@ -6,6 +7,9 @@ ejabberd_xs
 idmgr
 moodle-1.9
 nodogsplash
+owncloud
 pathagar
+rachel
 schooltool
 sugar-stats
+xovis


### PR DESCRIPTION
FYI scripts/roles-needing-docs.py continues to work, even if these 4 (additional) unmaintained roles are extraneous to its functioning:
- activity-server
- owncloud
- rachel
- xovis

Builds on @aidan-fitz's #1200 PRs #1201 #1204