### PR TITLE
calibre-bin 3.32 was updated upstream (and now works)

### DIFF
--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -20,13 +20,13 @@ calibre_sample_book: "Metamorphosis-jackson.epub"
 calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py"
 
 calibre_deb_url: "{{ iiab_download_url }}"    # http://download.iiab.io/packages
-# Above URL must offer both .deb files below, corresponding with variable
-# value(s) further below: (for scripts/calibre-install-pinned-rpi.sh to run)
-# - calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)
-# - calibre-bin_3.32.0+dfsg-1_armhf.deb (707K, 2018-10-08) WORKS DESPITE BEING
-#   PUBLISHED 11+ HRS BEFORE NON-WORKING calibre-bin_3.32.0+dfsg-1+b1_armhf.deb
-calibre_deb_pin_version: 3.32.0+dfsg-1
-calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}"
+# Above URL must offer both .deb files below: (for scripts/calibre-install-pinned-rpi.sh to run)
+calibre_deb_pin_version: 3.32.0+dfsg-1 # for calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)
+#calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}" # for calibre-bin_3.32.0+dfsg-1_armhf.deb (707K, 2018-10-08) HAD WORKED 2018-10-08 BUT NO LONGER on 2018-10-10:
+#   The following packages have unmet dependencies:
+#     calibre-bin : Depends: libpodofo0.9.5 (>= 0.9.5-7) but it is not installable
+#     E: Unable to correct problems, you have held broken packages.
+calibre_bin_deb_pin_version: 3.32.0+dfsg-1+b1 # for calibre-bin_3.32.0+dfsg-1+b1_armhf.deb (706K, 2018-10-08) SEEMS TO WORK AS OF 2018-10-10, THOUGH MYSTERIOUSLY IT HAD NOT WORKED ON 2018-10-08
 
 # USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)
 #calibre_debs_on_debian: True


### PR DESCRIPTION
Smoke-tested with a manual install on a fresh Raspbian Lite.

Refs #1171 PR #1199