### PR TITLE
Proposed fix to http://box/books for Calibre-Web

### DIFF
--- a/roles/calibre-web/templates/calibre-web.conf.j2
+++ b/roles/calibre-web/templates/calibre-web.conf.j2
@@ -1,8 +1,8 @@
 #<VirtualHost *:80>    # This line (which used to work) prevented http://box/books from working as of October 2018 (https://github.com/iiab/iiab/issues/1196)
-#    <Location "{{ calibreweb_url }}" >    # This line appears unnecessary
+#    <Location "{{ calibreweb_url }}" >                            # Line unnec when "/proxy" added to Proxy* directives below
 RequestHeader set X-SCRIPT-NAME {{ calibreweb_url }}
-RequestHeader set X-SCHEME http
-ProxyPass http://localhost:{{ calibreweb_port }}/
-ProxyPassReverse http://localhost:{{ calibreweb_port }}/
+RequestHeader set X-SCHEME http                                    # Line unnec?
+ProxyPass /books http://localhost:{{ calibreweb_port }}/
+ProxyPassReverse /books http://localhost:{{ calibreweb_port }}/    # Line unnec?
 #    </Location>
 #</VirtualHost>

--- a/roles/calibre-web/templates/calibre-web.conf.j2
+++ b/roles/calibre-web/templates/calibre-web.conf.j2
@@ -1,8 +1,19 @@
-#<VirtualHost *:80>    # This line (which used to work) prevented http://box/books from working as of October 2018 (https://github.com/iiab/iiab/issues/1196)
-#    <Location "{{ calibreweb_url }}" >                            # Line unnec when "/proxy" added to Proxy* directives below
+# Used to work (in August 2018) but prevented http://box/books from working (in October 2018, https://github.com/iiab/iiab/issues/1196)
+#<VirtualHost *:80>
+
+# Unnec when "/proxy" is added to Proxy* directives further below
+#    <Location "{{ calibreweb_url }}" >
+
 RequestHeader set X-SCRIPT-NAME {{ calibreweb_url }}
-RequestHeader set X-SCHEME http                                    # Line unnec?
+
+# Appears unnec:
+RequestHeader set X-SCHEME http
+
 ProxyPass /books http://localhost:{{ calibreweb_port }}/
-ProxyPassReverse /books http://localhost:{{ calibreweb_port }}/    # Line unnec?
+
+# Appears unnec:
+ProxyPassReverse /books http://localhost:{{ calibreweb_port }}/
+
 #    </Location>
+
 #</VirtualHost>

--- a/roles/calibre-web/templates/calibre-web.conf.j2
+++ b/roles/calibre-web/templates/calibre-web.conf.j2
@@ -1,8 +1,8 @@
-<VirtualHost *:80>
-    <Location "{{ calibreweb_url }}" >
-        RequestHeader set X-SCRIPT-NAME {{ calibreweb_url }}
-        RequestHeader set X-SCHEME http
-        ProxyPass http://localhost:{{ calibreweb_port }}/
-        ProxyPassReverse http://localhost:{{ calibreweb_port }}/
-    </Location>
-</VirtualHost>
+#<VirtualHost *:80>    # This line (which used to work) prevented http://box/books from working as of October 2018 (https://github.com/iiab/iiab/issues/1196)
+#    <Location "{{ calibreweb_url }}" >    # This line appears unnecessary
+RequestHeader set X-SCRIPT-NAME {{ calibreweb_url }}
+RequestHeader set X-SCHEME http
+ProxyPass http://localhost:{{ calibreweb_port }}/
+ProxyPassReverse http://localhost:{{ calibreweb_port }}/
+#    </Location>
+#</VirtualHost>


### PR DESCRIPTION
This was tested on Ubuntu 18.04.1 &mdash; testing is ongoing on Raspbian Lite and other OS's.

@arky please review!  I hope this (or what evolves out of it) is a more permanent/complete fix for #1196

Sadly we still do not know what code suddenly broke http://box/books in very recent weeks :/