### PR TITLE
Check transmission_kalite_languages is undefined

### DIFF
--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -42,7 +42,8 @@
     --start-paused
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
-  with_items: "{{ transmission_kalite_languages | default('english') }}"
+  with_items: "{{ transmission_kalite_languages }}"
+  when: transmission_kalite_languages is defined and transmission_provision
   ignore_errors: yes
 
 - name: Disable transmission-daemon service

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -18,7 +18,7 @@
   systemd:
     name: transmission-daemon
     state: stopped
-  ignore_errors: yes  
+  ignore_errors: yes
 
 - name: Create transmission-daemon settings
   template:
@@ -42,9 +42,8 @@
     --start-paused
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
-  with_items: "{{ transmission_kalite_languages }}"
+  with_items: "{{ transmission_kalite_languages | default('english') }}"
   ignore_errors: yes
-  when: transmission_provision
 
 - name: Disable transmission-daemon service
   systemd:

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -43,7 +43,7 @@
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
   with_items: "{{ transmission_kalite_languages }}"
-  when: transmission_kalite_languages is defined and transmission_provision
+  when: transmission_enabled and transmission_provision and transmission_kalite_languages is defined
   ignore_errors: yes
 
 - name: Disable transmission-daemon service


### PR DESCRIPTION
Check if transmission_kalite_languages is defined.

https://github.com/iiab/iiab/issues/1193

### Fixes Bug

Proposed fix for bug #1193.

### Description of changes proposed in this pull request.

Check If there any languages are defined in transmission_kalite_languages. 

### Smoke-tested in operating system.

Debian 10

### Mention a team member for further information or comment using @ name

@holta 
