### PR TITLE
Fix syntax in Calibre role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,21 @@ language: python
 python: "2.7"
 
 # Use the new container infrastructure
+dist: trusty
 sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
 
 install:
   # Install ansible, ansible-lint and ansible-review
   - pip install ansible
   - pip install ansible-review
 
+  # Create ansible.cfg with correct roles_path and local_tmp
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; echo 'local_tmp = ~/.ansible/tmp'; } >> ansible.cfg"
+
   # Check ansible,  version
   - ansible --version
   - ansible-lint --version
   - ansible-review --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
 
 script:
   # Continuous integration: syntax check
@@ -32,10 +27,10 @@ script:
   - ansible-lint -p *yml
 
   #  Continous integration: ansible code review
-  - git ls-files *yml roles/ vars/ tests/  | xargs ansible-review
+  #- git ls-files *yml roles/ vars/ tests/  | xargs ansible-review
 
   # Continouse integration: ansible code review of changes between master and current branch
-  - git diff master | ansible-review
+  #- git diff master | ansible-review
 
 
 #notifications:

--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -19,7 +19,7 @@ calibre_sample_book: "Metamorphosis-jackson.epub"
 
 calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py"
 
-calibre_deb_url: {{ iiab_download_url }}    # http://download.iiab.io/packages
+calibre_deb_url: "{{ iiab_download_url }}"    # http://download.iiab.io/packages
 # Above URL must offer both .deb files below, corresponding with variable
 # value(s) further below: (for scripts/calibre-install-pinned-rpi.sh to run)
 # - calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)


### PR DESCRIPTION
### Fixes Bug

Travis CI failing on syntax check (`ansible-playbook tests/test.yml -i tests/inventory --syntax-check -vvv`)

### Description of changes proposed in this pull request.

Builds on #1217 by fixing the syntax error in `roles/calibre/defaults/main.yml`. `ansible-lint` still fails.

### Smoke-tested in operating system.

Travis CI

### Mention a team member for further information or comment using @ name

@arky @holta 