### PR TITLE
Turn off installation of Calibre until v3.33+ hopefully works on Raspbian 2018-10-09

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -409,7 +409,7 @@ calibre_via_debs: False
 calibre_unstable_debs: False
 # vars/<most-OS's>.yml use Calibre's python installer/upgrader (x86_64), overriding this default:
 calibre_via_python: False
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ add your own mnemonic URL like: http://box/XYZ
 calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -402,8 +402,8 @@ vnstat_enabled: False
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: True
-calibre_enabled: True
+calibre_install: False
+calibre_enabled: False
 # vars/raspbian-9.yml tries the .deb upgrade of Calibre, overriding this default:
 calibre_via_debs: False
 calibre_unstable_debs: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -413,6 +413,7 @@ calibre_via_python: False
 calibre_port: 8080
 # Change calibre to XYZ add your own mnemonic URL like: http://box/XYZ
 calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
+# Avoid collisions with calibreweb_url: below!
 
 # WARNING: Calibre-Web (below) depends on Calibre's own /usr/bin/ebook-convert
 # program, so we recommend you also install Calibre (above!)

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -232,18 +232,13 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: True
-calibre_enabled: True
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_install: False
+calibre_enabled: False
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
 calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
+# Avoid collisions with calibreweb_url: below!
 
 # WARNING: Calibre-Web (below) depends on Calibre's own /usr/bin/ebook-convert
 # program, so we recommend you also install Calibre (above!)

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -232,18 +232,13 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: True
-calibre_enabled: True
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+calibre_install: False
+calibre_enabled: False
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
 calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
+# Avoid collisions with calibreweb_url: below!
 
 # WARNING: Calibre-Web (below) depends on Calibre's own /usr/bin/ebook-convert
 # program, so we recommend you also install Calibre (above!)

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -234,16 +234,11 @@ vnstat_enabled: True
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
 calibre_install: False
 calibre_enabled: False
-# Try .deb upgrade of Calibre (like vars/raspbian-9.yml already does)
-# calibre_via_debs: True
-calibre_unstable_debs: False
-# Try python x86_64 upgrade of Calibre (like vars/<most-OS's>.yml already do)
-# calibre_via_python: True
-# Change calibre_port to 8010 if you're using XO laptops needing above idmgr
+# Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ
 calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
-# In addition to: http://box/books box/libros box/livres box/livros box/liv
+# Avoid collisions with calibreweb_url: below!
 
 # WARNING: Calibre-Web (below) depends on Calibre's own /usr/bin/ebook-convert
 # program, so we recommend you also install Calibre (above!)


### PR DESCRIPTION
This PR turns off the installation of Calibre entirely for now.  This is overkill as Calibre works fine on Ubuntu, Debian, etc &mdash; but it's the easy workaround for now.

Context: @floydianslips & @jvonau helped reconfirm in /var/log/dpkg.log that Calibre 3.32 was causing severe damage to the newly released Raspbian 2018-10-09 (removing git, perl, apache2, etc).

Prior to the release of Raspbian 2018-10-09 on 2018-10-11, IIAB's scripts/calibre-install-pinned-rpi.sh worked to install Calibre 3.32 just fine.

Reverting IIAB's installer to try to install Calibre 3.31 stopped the destructive damage (PR #1220) &mdash; but no longer installs Calibre 3.31 (as also worked earlier this week, on the earlier Raspbian 2018-06-27).

So let's hope that Calibre 3.33 (or higher) can be installed on the new Raspbian in coming weeks...

Refs: #1171 #1219 PRs #1199 #1209 #1220