### PR TITLE
Check transmission_kalite_languages is not none (avoids null/empty list)

### DIFF
--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -43,7 +43,7 @@
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
   with_items: "{{ transmission_kalite_languages }}"
-  when: transmission_enabled and transmission_provision and transmission_kalite_languages is defined
+  when: transmission_enabled and transmission_provision and transmission_kalite_languages is defined and transmission_kalite_languages is not none
   ignore_errors: yes
 
 - name: Disable transmission-daemon service

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -350,7 +350,7 @@ transmission_kalite_version: 0.17
 
 # A. Uncomment language(s) in /etc/iiab/local_vars.yml to download KA Lite videos to /library/transmission
 transmission_kalite_languages:
-  - english
+  #- english
   #- french
   #- hindi
   #- portugal-portuguese

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -331,8 +331,8 @@ sugarizer_port: 8089
 # 8-MGMT-TOOLS
 
 # Transmission is a BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
+transmission_install: True
+transmission_enabled: True
 
 # Transmission download directory & general owner/group
 transmission_download_dir: "{{ content_base }}/transmission/"    # /library/transmission/

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -190,12 +190,12 @@ sugarizer_enabled: True
 # 8-MGMT-TOOLS
 
 # BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
+transmission_install: True
+transmission_enabled: True
 # A. Uncomment language(s) to download KA Lite videos to /library/transmission
 #    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:
-  - english
+  #- english
   #- french
   #- hindi
   #- portugal-portuguese

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -190,12 +190,12 @@ sugarizer_enabled: True
 # 8-MGMT-TOOLS
 
 # BitTorrent downloader for large Content Packs etc
-transmission_install: False
-transmission_enabled: False
+transmission_install: True
+transmission_enabled: True
 # A. Uncomment language(s) to download KA Lite videos to /library/transmission
 #    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:
-  - english
+  #- english
   #- french
   #- hindi
   #- portugal-portuguese

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -195,7 +195,7 @@ transmission_enabled: False
 # A. Uncomment language(s) to download KA Lite videos to /library/transmission
 #    using http://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:
-  - english
+  #- english
   #- french
   #- hindi
   #- portugal-portuguese


### PR DESCRIPTION
(1) Fixes #1193 

Earlier attempt (PR #1216) did not change anything.

The reason is that variable `transmission_kalite_languages` is in fact defined in local_vars.yml (as null, taking the place of a zero-length list) as can be reconfirmed by a `debug:` command showing this variable's value as: `null`

When a variable is truly undefined, a `debug:` command instead shows its value as: `"VARIABLE IS NOT DEFINED!"`

Arguably Ansible is not that intelligent in its list handling, and should have known not to invoke the `/usr/bin/transmission-remote -a <URL>` command when given a null/empty list as input.  In any case...

FIX: the `when:` clause now correctly avoids null/empty lists, by verifying that `transmission_kalite_languages is not none`

(2) This PR also revises defaults so that:

A. Transmission (BitTorrent) is turned on as part of [MEDIUM-sized](https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml) and [BIG-sized](https://github.com/iiab/iiab/blob/master/vars/local_vars_big.yml) IIAB installs.

B. The ~43 GB download of English KA Lite videos is no longer on by default.  Reason: implementers can easily uncomment any of these 7 languages in /etc/iiab/local_vars.yml on an as-needed basis, prior to running `cd /opt/iiab/iiab; ./runrole transmission` or similar.

(3) Variable `transmission_provision:` doesn't add any value as of today, in my opinion.  But I left it in place as it's possible that in future a blanket toggle (much like `transmission_enabled:`) could have more purpose e,g, if Transmission catches on across many other content-thirsty IIAB services/apps (far beyond just KA Lite!?)