### PR TITLE
Remove hardcoded remote_tmp and local_tmp in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,5 +3,3 @@
 
 [defaults]
 squash_actions = apk, apt, dnf, homebrew, openbsd_pkg, pacman, pkgng, yum, zypper, package
-remote_tmp = /root/.ansible/tmp
-local_tmp = /root/.ansible/tmp


### PR DESCRIPTION
Removing hardcoded paths from ansible.cfg. You should always let ansible subsystems to manage these paths. This breaks the TravisCI virtual environment.  

### Fixes Bug

Fixes https://github.com/iiab/iiab/issues/1066

### Description of changes proposed in this pull request.

It is generally a bad idea to hardcode user paths in ansible.cfg

### Smoke-tested in operating system.

TravisCI

### Mention a team member for further information or comment using @ name
@holta @aidan-fitz 