### PR TITLE
TravisCI Refactoring: Remove patch for local_tmp and linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,32 +6,22 @@ python: "2.7"
 dist: trusty
 sudo: false
 
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
 install:
-  # Install ansible, ansible-lint and ansible-review
+  # Install ansible
   - pip install ansible
-  - pip install ansible-review
 
   # Create ansible.cfg with correct roles_path and local_tmp
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; echo 'local_tmp = ~/.ansible/tmp'; } >> ansible.cfg"
-
-  # Check ansible,  version
-  - ansible --version
-  - ansible-lint --version
-  - ansible-review --version
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
 script:
-  # Continuous integration: syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check -vvv
-
-  # Continous integration: ansible-list
-  - ansible-lint -p *yml
-
-  #  Continous integration: ansible code review
-  #- git ls-files *yml roles/ vars/ tests/  | xargs ansible-review
-
-  # Continouse integration: ansible code review of changes between master and current branch
-  #- git diff master | ansible-review
-
+  #  Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
 #notifications:
-#  webhooks:
+#  webhooks:  https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
This TravisCI patch simpifies the TravisCI file, by removing unnecessary
patch for local_tmp and also removing linting checks.

The linting checks would be handled later with Ansible testing
framework.

### Fixes Bug

Reverting some the patch applied for https://github.com/iiab/iiab/issues/1212 

### Description of changes proposed in this pull request.

Simplify TravisCI checks. Remove linting. 

### Smoke-tested in operating system.

TravisCI 


### Mention a team member for further information or comment using @ name

@holta 