### PR TITLE
Offer Calibre 3.33.1+ (or whatever is latest) if implementer opts in within local_vars.yml

### DIFF
--- a/roles/calibre/defaults/main.yml
+++ b/roles/calibre/defaults/main.yml
@@ -21,20 +21,10 @@ calibre_src_url: "https://raw.githubusercontent.com/kovidgoyal/calibre/master/se
 
 calibre_deb_url: "{{ iiab_download_url }}"    # http://download.iiab.io/packages
 # Above URL must offer both .deb files below: (for scripts/calibre-install-pinned-rpi.sh to run)
-calibre_deb_pin_version: 3.31.0+dfsg-1    # for calibre-bin_3.31.0+dfsg-1_armhf.deb (747K, 2018-09-12)
-calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}"    # for calibre-bin_3.31.0+dfsg-1+b1_armhf.deb (24M, 2018-09-07)
-#calibre_deb_pin_version: 3.32.0+dfsg-1 # for calibre_3.32.0+dfsg-1_all.deb (25M, 2018-09-28)
-##calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}" # for calibre-bin_3.32.0+dfsg-1_armhf.deb (707K, 2018-10-08) HAD WORKED 2018-10-08 BUT NO LONGER on 2018-10-10:
-##   The following packages have unmet dependencies:
-##     calibre-bin : Depends: libpodofo0.9.5 (>= 0.9.5-7) but it is not installable
-##     E: Unable to correct problems, you have held broken packages.
-#calibre_bin_deb_pin_version: 3.32.0+dfsg-1+b1 # for calibre-bin_3.32.0+dfsg-1+b1_armhf.deb (706K, 2018-10-08) FAILED ON 2018-10-08 (ERROR ABOVE), MYSTERIOUSLY WORKED ON 2018-10-10, FAILED ON 2018-10-12 -- THIS LATEST ERROR MIGHT RELATE TO SAMBA AND/OR THE NEW RASPBIAN 2018-10-09:
-# The following packages have unmet dependencies:
-#  pkg-config : Depends: libdpkg-perl but it is not going to be installed
-#  samba : Depends: update-inetd but it is not going to be installed
-# E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
+calibre_deb_pin_version: 3.33.1+dfsg-1    # for calibre_3.33.1+dfsg-1_all.deb (24M, 2018-10-21)
+calibre_bin_deb_pin_version: "{{ calibre_deb_pin_version }}"    # for calibre-bin_3.33.1+dfsg-1_armhf.deb (706K, 2018-10-23)
 
-# USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in /opt/iiab/iiab/vars/*)
+# USE TO TEST debs.yml (RASPBIAN APPROACH!) ON DEBIAN 9.X: (now handled by calibre_via_debs in each /opt/iiab/iiab/vars/<OS>.yml)
 #calibre_debs_on_debian: True
 # Enable unstable .deb's, not just testing .deb's: (moved to /etc/iiab/local_vars.yml & /opt/iiab/iiab/vars/default_vars.yml)
 #calibre_unstable_debs: False

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -1,54 +1,48 @@
-# roles/calibre/tasks/main.yml requires calibre_via_debs (to be True) before calling this script.
+# roles/calibre/tasks/main.yml requires calibre_via_debs (to be True) before
+# calling this script.  As of 2018-10-23 this is set in only 3 places:
+#
+# vars/raspbian-9.yml
+# vars/raspbian-8.yml
+# vars/debian-10.yml
 
-# MOVED UP TO roles/calibre/tasks/main.yml
-#- name: Start by installing OS's Calibre package
-#  package:
-#    name: "{{ item }}"
-#    state: latest
-#  with_items:
-#    - calibre
-#    - calibre-bin
-#  when: internet_available
+# If you want the latest Calibre, run the appropriate script below, standalone.
+# HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!) to
+# avoid ongoing dependency problems, as Calibre frequently demands the very
+# latest/unstable dependencies.
 
-# April/May 2018: Raspbian .deb's for the latest Calibre now appear
-# (http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/)
-# within about 10 days of Calibre's quasi-monthly releases
-# (https://calibre-ebook.com/whats-new).
-
-# If you want the latest Calibre, run the appropriate below script, standalone.
-# HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!)
+# FYI Raspbian .deb's for the latest Calibre can be downloaded from either:
+# http://raspbian.raspberrypi.org/raspbian/pool/main/c/calibre/
+# http://archive.raspbian.org/raspbian/pool/main/c/calibre/
+# ...within about 10 days after Calibre's quasi-monthly releases at:
+# https://calibre-ebook.com/whats-new
 
 #- name: Install packages that Raspbian .deb's had installed for Calibre 3.23 (rpi)
-#  #command: scripts/calibre-install-latest-rpi.sh  # FAILS with Calibre 3.24+ ("calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed") since June 2018.
-#  command: scripts/calibre-install-packages.sh     # BORROWED package list from /var/log/apt/history.log (that resulted from 2018-05-22 install of Calibre 3.23 using calibre-install-latest-rpi.sh).
+#  command: scripts/calibre-install-packages.sh    # BORROWED package list from /var/log/apt/history.log (that resulted from 2018-05-22 install of Calibre 3.23 using calibre-install-latest-rpi.sh).
 #  when: is_rpi and internet_available
 
 #- name: Upgrade to latest Calibre using Debian's own .deb's from testing (rpi)
-#  command: scripts/calibre-install-latest.sh       # NECESSARY since Calibre 3.24 (BEWARE installing libc6 will prevent boot in RPi Zero W, i.e. if calibre-install-packages.sh isn't run above!)
+#  command: scripts/calibre-install-latest.sh    # WAS NEC with Calibre 3.24+ & Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only script that was not attempted: Sid-like calibre-install-unstable.sh).  CLARIF: RESULTING microSD's ARE NOT BOOTABLE IN Zero W (#952) due to libc6 or similar.e.g. if calibre-install-packages.sh isn't run above?
+#  #command: scripts/calibre-install-latest-rpi-plus.sh    # WORKED for Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
 #  when: is_rpi and internet_available
 
-#- name: Upgrade to latest Calibre using .deb's from testing (rpi)
-#  #command: scripts/calibre-install-latest-rpi-plus.sh    # WORKS for Calibre 3.27.1 on 2018-07-22 (#948 -> PR #950) THO NOT BOOTABLE IN Zero W (#952).  Similar to Calibre 3.24.x & 3.25 in June 2018, which had used calibre-install-packages.sh then Debian's own calibre-install-latest.sh
-#  #command: scripts/calibre-install-latest-rpi.sh    # WORKS for Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x
-#  command: scripts/calibre-install-latest.sh    # REQUIRED for Calibre 3.29 on 2018-08-21 (PR #1015), as all above strategies failed (only script that was not attempted: Sid-like calibre-install-unstable.sh).  CLARIF: RESULTING microSD's ARE NOT BOOTABLE IN Zero W (#952)
+- name: Upgrade to latest Calibre using .deb's from testing (rpi)
+  command: scripts/calibre-install-latest-rpi.sh    # WORKED for Calibre 3.33.1 on 2018-10-23.  And Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x.  FAILED with Calibre 3.24+ ("calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed") since June 2018.
+  when: is_rpi and internet_available
+
+#- name: Download PINNED version {{ calibre_deb_pin_version }} of calibre & calibre-bin (rpi)
+#  get_url:
+#    url: "{{ calibre_deb_url }}/{{ item }}"
+#    dest: "{{ downloads_dir }}/{{ item }}"
+#    mode: 0644
+#    timeout: "{{ download_timeout }}"
+#  with_items:
+#    - calibre_{{ calibre_deb_pin_version }}_all.deb
+#    - calibre-bin_{{ calibre_bin_deb_pin_version }}_armhf.deb
 #  when: is_rpi and internet_available
-
-- name: Download PINNED version {{ calibre_deb_pin_version }} of calibre & calibre-bin (rpi)
-  get_url:
-    url: "{{ calibre_deb_url }}/{{ item }}"
-    dest: "{{ downloads_dir }}/{{ item }}"
-    mode: 0644
-    #force: no
-    #backup: no
-    timeout: "{{ download_timeout }}"
-  with_items:
-    - calibre_{{ calibre_deb_pin_version }}_all.deb
-    - calibre-bin_{{ calibre_bin_deb_pin_version }}_armhf.deb
-  when: is_rpi and internet_available
-
-- name: Install/Upgrade both, to PINNED version {{ calibre_deb_pin_version }} while using additional .deb's from testing (rpi)
-  command: scripts/calibre-install-pinned-rpi.sh    # RECOMMENDED for Calibre 3.30 on 2018-08-30, so IIAB microSD will be bootable in RPi Zero W
-  when: is_rpi and internet_available
+#
+#- name: Install/Upgrade both, to PINNED version {{ calibre_deb_pin_version }} using additional .deb's from testing (rpi)
+#  command: scripts/calibre-install-pinned-rpi.sh    # Worked for Calibre 3.33.1 on 2018-10-23, e.g. so IIAB microSD bootable in RPi Zero W
+#  when: is_rpi and internet_available
 
 - name: Install/Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)
   command: scripts/calibre-install-latest.sh

--- a/scripts/calibre-install-latest-rpi-plus.sh
+++ b/scripts/calibre-install-latest-rpi-plus.sh
@@ -27,8 +27,7 @@ rm /etc/apt/sources.list.d/debian-testing.list
 # Prepares to update from raspbian testing
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
-apt -y install sqlite3    # workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
-apt -y install calibre calibre-bin
+apt -y install sqlite3    # Appears no longer nec as of 2018-10-23.  Was required in Sept 2018 as workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 rm /etc/apt/sources.list.d/rpi-testing.list
 # Clears the cache of rpi/testing
 apt update

--- a/scripts/calibre-install-latest-rpi-plus.sh
+++ b/scripts/calibre-install-latest-rpi-plus.sh
@@ -27,6 +27,7 @@ rm /etc/apt/sources.list.d/debian-testing.list
 # Prepares to update from raspbian testing
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
+apt -y install sqlite3    # workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 apt -y install calibre calibre-bin
 rm /etc/apt/sources.list.d/rpi-testing.list
 # Clears the cache of rpi/testing

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -10,6 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Prepares to update to latest from raspbian testing
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
+apt -y install sqlite3    # workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 apt -y install calibre calibre-bin
 #sed -i '$ d' /etc/apt/sources.list.d/rpi-testing.list    # Removes last line
 rm /etc/apt/sources.list.d/rpi-testing.list

--- a/scripts/calibre-install-latest-rpi.sh
+++ b/scripts/calibre-install-latest-rpi.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Prepares to update to latest from raspbian testing
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
-apt -y install sqlite3    # workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
+apt -y install sqlite3    # Appears no longer nec as of 2018-10-23.  Was required in Sept 2018 as workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 apt -y install calibre calibre-bin
 #sed -i '$ d' /etc/apt/sources.list.d/rpi-testing.list    # Removes last line
 rm /etc/apt/sources.list.d/rpi-testing.list

--- a/scripts/calibre-install-pinned-rpi.sh
+++ b/scripts/calibre-install-pinned-rpi.sh
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
 # WARNING: you MUST remove old .deb's from /opt/iiab/downloads if upgrading Calibre in this way, SEE: http://FAQ.IIAB.IO "Can I upgrade or reinstall server apps?"
-apt -y install sqlite3    # workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
+apt -y install sqlite3    # Appears no longer required as of 2018-10-23.  Was nec in Sept 2018 as workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 apt -y install /opt/iiab/downloads/calibre*.deb
 #sed -i '$ d' /etc/apt/sources.list.d/rpi-testing.list    # Removes last line
 rm /etc/apt/sources.list.d/rpi-testing.list

--- a/scripts/calibre-install-pinned-rpi.sh
+++ b/scripts/calibre-install-pinned-rpi.sh
@@ -11,8 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo "deb http://raspbian.raspberrypi.org/raspbian/ testing main" > /etc/apt/sources.list.d/rpi-testing.list
 apt update
 # WARNING: you MUST remove old .deb's from /opt/iiab/downloads if upgrading Calibre in this way, SEE: http://FAQ.IIAB.IO "Can I upgrade or reinstall server apps?"
-apt -y install sqlite3    # Appears no longer required as of 2018-10-23.  Was nec in Sept 2018 as workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
-apt -y install /opt/iiab/downloads/calibre*.deb
+apt -y install sqlite3    # Appears no longer nec as of 2018-10-23.  Was required in Sept 2018 as workaround for https://github.com/iiab/iiab/issues/1139 that blocked install of Admin Console
 #sed -i '$ d' /etc/apt/sources.list.d/rpi-testing.list    # Removes last line
 rm /etc/apt/sources.list.d/rpi-testing.list
 # Clears the cache of rpi/testing


### PR DESCRIPTION
This PR also pins scripts/calibre-install-pinned-rpi.sh to Calibre 3.33.1 if some folks still want that.

HOWEVER/NOTE: retesting every release of Calibre (every 2-3 weeks typically) is a bad use of my time, so the default install is now reverting from scripts/calibre-install-pinned-rpi.sh to scripts/calibre-install-latest-rpi.sh _(each of which occasionally fail due to upstream dependency churn, so might as well let implementers experiment with the very latest Calibre at their own discretion...)_