### PR TITLE
Calibre's newly removed by local_vars_medium.yml, but retain it in local_vars_big.yml

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -248,8 +248,8 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: False
-calibre_enabled: False
+calibre_install: True
+calibre_enabled: True
 # Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ


### PR DESCRIPTION
Builds on #1219 -> PR #1221 -> PR #1247

This will require occasional monitoring of BIG-sized IIAB installs on RPi, to confirm that Calibre-on-ARM is stabilizing as Debian 10 approaches in 2019, without too many dependency quagmires.

If however Calibre does not stabilize on Raspbian in coming months, it should be removed from local_vars_big.yml entirely.

While not all details have been posted in Sept & Oct 2018 (these latest issues are documented on tickets within https://github.com/iiab/iiab) extensive/important background was posted on Calibre's forums May-Aug 2018 here:
https://www.mobileread.com/forums/showthread.php?p=3707933