### PR TITLE
Fix #1252 lightdm looping logins (due to xsession-errors, which deviate from official bash syntax)

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -74,7 +74,7 @@ fi
 # Subroutine compares software version numbers.  Generates rare false positives
 # like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
 # a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
-version_gt () { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
 
 # Verify that Raspbian is running a recent enough kernel.  As Raspbian
 # updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.

--- a/iiab-install
+++ b/iiab-install
@@ -74,7 +74,7 @@ fi
 # Subroutine compares software version numbers.  Generates rare false positives
 # like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
 # a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
-function version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+version_gt () { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
 
 # Verify that Raspbian is running a recent enough kernel.  As Raspbian
 # updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.

--- a/roles/iiab-admin/templates/lxde_ssh_warn.sh
+++ b/roles/iiab-admin/templates/lxde_ssh_warn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-check_user_pwd () {
+check_user_pwd() {
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
@@ -10,7 +10,7 @@ check_user_pwd () {
 }
 
 # credit to the folks at raspberry pi foundatioon
-check_hash () {
+check_hash() {
    if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
    if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
    #test -x /usr/bin/mkpasswd || return 0

--- a/roles/iiab-admin/templates/lxde_ssh_warn.sh
+++ b/roles/iiab-admin/templates/lxde_ssh_warn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function check_user_pwd() {
+check_user_pwd () {
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)

--- a/roles/iiab-admin/templates/profile_ssh_warn.sh
+++ b/roles/iiab-admin/templates/profile_ssh_warn.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-check_user_pwd () {
+# bash syntax "function check_user_pwd() {" was removed, as it prevented all
+# lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
+check_user_pwd() {
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
@@ -10,7 +12,7 @@ check_user_pwd () {
 }
 
 # credit to the folks at raspberry pi foundatioon
-check_hash () {
+check_hash() {
     if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
     if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
     #SHADOW="$(sudo -n grep -E '^iiab-admin:' /etc/shadow 2>/dev/null)"

--- a/roles/iiab-admin/templates/profile_ssh_warn.sh
+++ b/roles/iiab-admin/templates/profile_ssh_warn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function check_user_pwd() {
+check_user_pwd () {
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)


### PR DESCRIPTION
/home/pi/.xsession-errors showed the precise "errors" in /etc/profile.d/profile_ssh_warn.sh (despite the word "function" being legal/offical syntax in bash!)

In the past these kinds of syntax worked: (and still works in most other contexts, to define a function in bash)
```
function function_name {
   <commands>
}
```
```
function function_name() {
   <commands>
}
```
However both above don't work in this particular situation (#1252) even despite [bash's official documentation](https://www.gnu.org/software/bash/manual/html_node/Shell-Functions.html).  So syntax like the following is now required:
```
function_name() {
   <commands>
}
```
```
function_name () {
   <commands>
}
```