### PR TITLE
Revert PR #1248 removing Calibre local_vars_big.yml from for now

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -248,8 +248,8 @@ vnstat_enabled: True
 # Calibre E-Book Library
 # WARNING: CALIBRE INSTALLS GRAPHICAL LIBRARIES SIMILAR TO X WINDOWS & OPENGL
 # ON (HEADLESS, SERVER, LITE) OS'S THAT DON'T ALREADY HAVE THESE INSTALLED.
-calibre_install: True
-calibre_enabled: True
+calibre_install: False
+calibre_enabled: False
 # Change calibre_port to 8010 if you're using XO laptops needing above idmgr ?
 calibre_port: 8080
 # Change calibre to XYZ to add your own mnemonic URL like: http://box/XYZ


### PR DESCRIPTION
Both Calibre variables are being set to False for now in local_vars_big.yml because Calibre 3.33.1 once again does not install on Raspbian due to upstream dependencies:
```
root@box:~# apt -y install calibre calibre-bin
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 calibre : Depends: python-pyqt5 (>= 5.11.3+dfsg-1+b1) but it is not going to be installed
           Depends: python-pyqt5.qtwebkit but it is not going to be installed
           Depends: python-pyqt5.qtsvg but it is not going to be installed
 calibre-bin : Depends: qtbase-abi-5-11-0 but it is not installable
E: Unable to correct problems, you have held broken packages.
```
Refs:
- PR #1247 
- PR #1248
- https://www.mobileread.com/forums/showthread.php?p=3707933