### PR TITLE
Standardize Apache .conf & systemd unit files perms / ownership

### DIFF
--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -48,8 +48,8 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: "{{ item.mode }}"
-    owner: "{{ calibreweb_user }}"
-    group: "{{ apache_user }}"
+    owner: root
+    group: root
   with_items:
     - { src: 'calibre-web.service.j2', dest: '/etc/systemd/system/calibre-web.service', mode: '0644' }
     - { src: 'calibre-web.conf.j2', dest: '/etc/apache2/sites-available/calibre-web.conf', mode: '0644' }

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -43,7 +43,7 @@
     src: "{{ calibreweb_venv_path }}/lib/python2.7/site-packages"
     dest: "{{ calibreweb_venv_path }}/vendor"
 
-- name: Create Calibre-Web systemd service unit file and calibre-web.conf for Apache
+- name: Install systemd unit file calibre-web.service & Apache's calibre-web.conf, from templates
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -58,7 +58,7 @@
 #    state: absent
 #  when: is_debuntu
 
-- name: Create httpd config files
+- name: Install Apache's 010-iiab.conf & proxy_ajp.conf into /etc/apache2/sites-available, from templates
   template:
     backup: yes
     src: "{{ item.src }}"

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Install httpd required packages (debian)
+- name: Install Apache's required packages (debian)
   package:
     name: "{{ item }}"
     state: present
@@ -21,7 +21,7 @@
     name: "php{{ php_version }}-sqlite3"
   when: is_debian and ansible_distribution_major_version == "9"
 
-- name: Install httpd required packages (ubuntu)
+- name: Install Apache's required packages (ubuntu)
   package:
     name: "{{ item }}"
     state: present
@@ -37,7 +37,7 @@
     name: php{{ php_version }}-sqlite3
   when: is_ubuntu_18
 
-- name: Install httpd required packages (redhat)
+- name: Install Apache's required packages (redhat)
   package:
     name: "{{ item }}"
     state: present
@@ -133,7 +133,7 @@
     - /etc/apache2/sites-enabled/000-default.conf
   when: is_debuntu
 
-- name: Create http pid dir /var/run/{{ apache_user }}
+- name: Create Apache's pid dir /var/run/{{ apache_user }}
   file:
     path: "/var/run/{{ apache_user }}"
     mode: 0755
@@ -153,7 +153,7 @@
     state: present
     createhome: no
 
-- name: Create httpd log dir /var/log/{{ apache_service }}
+- name: Create Apache's log dir /var/log/{{ apache_service }}
   file:
     path: "/var/log/{{ apache_service }}"
     mode: 0755
@@ -161,7 +161,7 @@
     group: "{{ apache_user }}"
     state: directory
 
-- name: Enable httpd
+- name: Enable systemd service {{ apache_service }}
   service:
     name: "{{ apache_service }}"
     enabled: yes

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -67,7 +67,7 @@
     group: root
     mode: "{{ item.mode }}"
   with_items:
-    - { src: '010-iiab.conf.j2', dest: '/etc/{{ apache_config_dir }}/010-iiab.conf', mode: '0755' }
+    - { src: '010-iiab.conf.j2', dest: '/etc/{{ apache_config_dir }}/010-iiab.conf', mode: '0644' }
     - { src: 'proxy_ajp.conf.j2', dest: '/etc/{{ apache_config_dir }}/proxy_ajp.conf', mode: '0644' }
     #- { src: 'php.ini.j2', dest: '/etc/php.ini', mode: '0644' }    # @jvonau suggests removing this in https://github.com/iiab/iiab/issues/1147
 

--- a/roles/network/tasks/captive_portal.yml
+++ b/roles/network/tasks/captive_portal.yml
@@ -56,7 +56,7 @@
     dest: /etc/{{ apache_config_dir }}/captive-portal.conf
     owner: root
     group: root
-    mode: 0740
+    mode: 0644
   when: py_captive_portal_enabled
 
 - name: Enable Apache's captive-portal.conf if py_captive_portal_enabled (debuntu)


### PR DESCRIPTION
Refining Apache (roles/httpd), Calibre-Web (roles/calibre-web) and Captive Portal AKA py-captive-portal (roles/network/tasks/captive_portal.yml).

Ref: #1182