### PR TITLE
Readability: 1-prep/tasks/raspberry_pi.yml, iiab-admin/tasks/*, httpd/tasks/*, network/tasks/restart.yml, homepage/tasks/main.yml & calibre-web/tasks/main.yml

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -1,4 +1,4 @@
-# Setup specific to the Raspberry Pi
+# Specific to Raspberry Pi
 
 - name: Install udev rule /etc/udev/rules.d/92-rtc-i2c.rules from template, to transfer hwclock to system clock at dev creation, if rtc_id is defined and rtc_id != "none"
   template:
@@ -10,22 +10,22 @@
   when: rtc_id is defined and rtc_id != "none"
 
 # RTC requires a change to the device tree (and reboot)
-- name: Check for need to enable i2c-rtc device in /boot/config.txt (requires reboot!)
+- name: Enable i2c-rtc device (with "dtoverlay=i2c-rtc,{{ rtc_id }}=on" in /boot/config.txt) if rtc_id != "none" (requires reboot!)
   lineinfile:
-    dest: /boot/config.txt
+    path: /boot/config.txt
     line: "dtoverlay=i2c-rtc,{{ rtc_id }}=on"
     state: present
   register: rpiconfig    # HMMM REGISTER "rpiconfig" IS *COMPLETELY UNUSED* AS OF 2018-11-02
-  when: rtc_id != "none"
+  when: rtc_id is defined and rtc_id != "none"
 
-- name: Install udev rule /etc/udev/rules.d/92-rtc-i2c.rules from template, to transfer hwclock to system clock at dev creation, if rtc_id != "none"
-  template:
-    src: 92-rtc-i2c.rules
-    dest: /etc/udev/rules.d/92-rtc-i2c.rules
-    owner: root
-    group: root
-    mode: 0644
-  when: rtc_id != "none"
+#- name: Install udev rule /etc/udev/rules.d/92-rtc-i2c.rules from template, to transfer hwclock to system clock at dev creation, if rtc_id != "none"
+#  template:
+#    src: 92-rtc-i2c.rules
+#    dest: /etc/udev/rules.d/92-rtc-i2c.rules
+#    owner: root
+#    group: root
+#    mode: 0644
+#  when: rtc_id != "none"
 
 - name: Install latest ntp package
   package:
@@ -34,16 +34,19 @@
 
 - name: Increase swap file size (to CONF_SWAPSIZE=500 in /etc/dphys-swapfile) as kalite pip download fails (debuntu)
   lineinfile:
+    path: /etc/dphys-swapfile
     regexp: "^CONF_SWAPSIZE"
     line: CONF_SWAPSIZE=500
-    path: /etc/dphys-swapfile
   when: is_debuntu
 
-- name: Restart the swap service (debuntu)
-  command: /etc/init.d/dphys-swapfile restart
+- name: Restart swap service "dphys-swapfile" (debuntu)
+  #command: /etc/init.d/dphys-swapfile restart
+  service:    # A rare/legacy service that is NOT systemd
+    name: dphys-swapfile
+    state: restarted
   when: is_debuntu
 
-- name: Add RPi rootfs resizing systemd service
+- name: Install RPi rootfs resizing (iiab-rpi-max-rootfs.sh) and its systemd service (iiab-rpi-root-resize.service), from templates
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -54,7 +57,7 @@
     - { src: 'iiab-rpi-max-rootfs.sh', dest: '/usr/sbin/iiab-rpi-max-rootfs.sh', mode: '0755'}
     - { src: 'iiab-rpi-root-resize.service', dest: '/etc/systemd/system/iiab-rpi-root-resize.service', mode: '0644'}
 
-- name: Enable rootfs resizing service
-  service:
+- name: Enable RPi rootfs resizing (systemd service iiab-rpi-root-resize.service)
+  systemd:
     name: iiab-rpi-root-resize
     enabled: yes

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -10,7 +10,7 @@
   when: rtc_id is defined and rtc_id != "none"
 
 # RTC requires a change to the device tree (and reboot)
-- name: Enable i2c-rtc device (with "dtoverlay=i2c-rtc,{{ rtc_id }}=on" in /boot/config.txt) if rtc_id != "none" (requires reboot!)
+- name: Enable i2c-rtc device (with "dtoverlay=i2c-rtc,{{ rtc_id }}=on" in /boot/config.txt, requires reboot!) if rtc_id != "none"
   lineinfile:
     path: /boot/config.txt
     line: "dtoverlay=i2c-rtc,{{ rtc_id }}=on"

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -10,7 +10,7 @@
   when: rtc_id is defined and rtc_id != "none"
 
 # RTC requires a change to the device tree (and reboot)
-- name: Enable i2c-rtc device (with "dtoverlay=i2c-rtc,{{ rtc_id }}=on" in /boot/config.txt, requires reboot!) if rtc_id != "none"
+- name: Enable i2c-rtc device (with "dtoverlay=i2c-rtc,{{ rtc_id }}=on" in /boot/config.txt, requires reboot!) if rtc_id is defined and rtc_id != "none"
   lineinfile:
     path: /boot/config.txt
     line: "dtoverlay=i2c-rtc,{{ rtc_id }}=on"

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -11,7 +11,7 @@
     - "{{ calibreweb_config }}"
 
 ## TODO: Calibre-web future release might get into pypi https://github.com/janeczku/calibre-web/issues/456
-- name: Download Calibre-Web github repository
+- name: Download Calibre-Web github repository to {{ calibreweb_venv_path }}
   git:
     repo: https://github.com/janeczku/calibre-web.git
     dest: "{{ calibreweb_venv_path }}"
@@ -30,29 +30,29 @@
 #  ignore_errors: True
 ##
 # Implementing this with Ansible command module for now.
-- name: Download Calibre-Web dependencies into virtual environment
+- name: Download Calibre-Web dependencies (using pip) into virtual environment
   pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"
     virtualenv_site_packages: no
   when: internet_available
 
-- name: Symlink 'vendor' to site-packages for python to keep cps.py happy
+- name: Symlink {{ calibreweb_venv_path }}/vendor to {{ calibreweb_venv_path }}/lib/python2.7/site-packages to keep cps.py happy
   file:
-    state: link
     src: "{{ calibreweb_venv_path }}/lib/python2.7/site-packages"
     dest: "{{ calibreweb_venv_path }}/vendor"
+    state: link
 
-- name: Install systemd unit file calibre-web.service & Apache's calibre-web.conf, from templates
+- name: Install unit file /etc/systemd/system/calibre-web.service & /etc/apache2/sites-available/calibre-web.conf for http://box{{ calibreweb_url }}, from templates
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    mode: "{{ item.mode }}"
     owner: root
     group: root
+    mode: 0644
   with_items:
-    - { src: 'calibre-web.service.j2', dest: '/etc/systemd/system/calibre-web.service', mode: '0644' }
-    - { src: 'calibre-web.conf.j2', dest: '/etc/apache2/sites-available/calibre-web.conf', mode: '0644' }
+    - { src: 'calibre-web.service.j2', dest: '/etc/systemd/system/calibre-web.service' }
+    - { src: 'calibre-web.conf.j2', dest: '/etc/apache2/sites-available/calibre-web.conf' }
 
 - name: Does /library/calibre-web/metadata.db exist?
   stat:
@@ -73,7 +73,7 @@
   when: not metadatadb.stat.exists
   #when: calibreweb_provision
 
-- name: Provision/Copy default admin settings to /library/calibre-web/config/app.db IF metadata.db did not exist
+- name: Provision/Copy default admin settings to {{ calibreweb_config }}/app.db IF metadata.db did not exist    # {{ calibreweb_config }} is /library/calibre-web/config
   copy:
     src: roles/calibre-web/files/app.db
     dest: "{{ calibreweb_config }}"
@@ -84,7 +84,7 @@
   when: not metadatadb.stat.exists
   #when: calibreweb_provision
 
-- name: Enable and restart 'calibre-web' systemd service
+- name: Enable & Restart 'calibre-web' systemd service
   systemd:
     name: calibre-web
     daemon_reload: yes
@@ -117,7 +117,7 @@
 #  command: apachectl -k graceful
 #  when: not calibreweb_enabled
 
-- name: Restart Apache service {{ apache_service }}
+- name: Restart Apache systemd service ({{ apache_service }})
   systemd:
     name: "{{ apache_service }}"    # httpd or apache2
     state: restarted

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Create home directory
+- name: Create dir {{ doc_root }}/home
   file:
     path: "{{ doc_root }}/home"
     owner: "{{ apache_user }}"
@@ -6,14 +6,14 @@
     mode: 0755
     state: directory
 
-- name: Install admin homepage into apache2
+- name: Install /etc/{{ apache_config_dir }}/iiab-homepage.conf from template, for http://box redirect to http://box/home/
   template:
     src: iiab-homepage.conf
     dest: "/etc/{{ apache_config_dir }}/iiab-homepage.conf"
 
-- name: Enable the home page
+- name: Symlink /etc/apache2/sites-enabled/iiab-homepage.conf to /etc/{{ apache_config_dir }}/iiab-homepage.conf (debuntu)
   file:
     src: "/etc/{{ apache_config_dir }}/iiab-homepage.conf"
-    dest: /etc/apache2/sites-enabled/iiab-homepage.conf
+    path: /etc/apache2/sites-enabled/iiab-homepage.conf
     state: link
   when: is_debuntu

--- a/roles/httpd/tasks/html.yml
+++ b/roles/httpd/tasks/html.yml
@@ -1,4 +1,4 @@
-- name: Copy css files to /library/www/html/common/css
+- name: Copy css files to {{ doc_root }}/common/css    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/css"
@@ -8,7 +8,7 @@
   with_fileglob:
     - html/css/*.css
 
-- name: Copy js files to /library/www/html/common/js
+- name: Copy js files to {{ doc_root }}/common/js    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/js"
@@ -18,7 +18,7 @@
   with_fileglob:
     - html/js/*.js
 
-- name: Copy fonts files to /library/www/html/common/fonts
+- name: Copy fonts files to {{ doc_root }}/common/fonts    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/fonts"
@@ -28,7 +28,7 @@
   with_fileglob:
     - html/fonts/*
 
-- name: Copy html files to /library/www/html/common/html
+- name: Copy html files to {{ doc_root }}/common/html    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/html"
@@ -38,7 +38,7 @@
   with_fileglob:
     - html/html/*
 
-- name: Copy assets files to /library/www/html/common/assets
+- name: Copy assets files to {{ doc_root }}/common/assets    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/assets"
@@ -49,7 +49,7 @@
     - html/assets/*
 
 # copy all services, even if not permissioned elsewhere
-- name: Copy services files to /library/www/html/common/services
+- name: Copy services files to {{ doc_root }}/common/services    # doc_root is /library/www/html
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/services"
@@ -59,10 +59,10 @@
   with_fileglob:
     - html/services/*
 
-- name: Create symlink from /library/www/html/common/assets/iiab.ini to {{ iiab_ini_file }}
+- name: Symlink {{ doc_root }}/common/assets/iiab.ini to {{ iiab_ini_file }}    # doc_root is /library/www/html
   file:
     src: "{{ iiab_ini_file }}"
-    dest: "{{ doc_root }}/common/assets/iiab.ini"
+    path: "{{ doc_root }}/common/assets/iiab.ini"
     owner: root
     group: root
     state: link

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -149,7 +149,7 @@
     group: "{{ apache_user }}"
     state: directory
 
-- name: Enable {{ apache_service }} systemd service
+- name: Enable Apache systemd service ({{ apache_service }})
   service:
     name: "{{ apache_service }}"
     enabled: yes
@@ -163,7 +163,7 @@
     state: directory
 
 # SEE https://github.com/iiab/iiab/issues/1143 as the old roles/osm playbook is rarely used as of late 2018 (if anybody still uses roles/osm, they can overwrite osm.conf using the original osm playbook, or in other ways)
-- name: Copy osm.conf to /etc/{{ apache_config_dir }} for http://box/maps (all OS's)
+- name: Install /etc/{{ apache_config_dir }}/osm.conf for http://box/maps (all OS's)
   copy:
     src: osm.conf
     dest: "/etc/{{ apache_config_dir }}"
@@ -172,7 +172,7 @@
     mode: 0644
     backup: yes
 
-- name: Create osm.conf symlink from sites-enabled to sites-available (debuntu)
+- name: Symlink /etc/apache2/sites-enabled/osm.conf to /etc/{{ apache_config_dir }}/osm.conf (debuntu)
   file:
     src: "/etc/{{ apache_config_dir }}/osm.conf"
     path: /etc/apache2/sites-enabled/osm.conf
@@ -184,7 +184,7 @@
   tags:
     - base
 
-# Fixes search @ http://box/modules/es-wikihow - see https://github.com/iiab/iiab/issues/829
+# Partially fixes search @ http://box/modules/es-wikihow (on RPi anyway) see https://github.com/iiab/iiab/issues/829
 - include_tasks: php-stem.yml
   tags:
     - base
@@ -195,14 +195,14 @@
     dest: /usr/bin/iiab-refresh-wiki-docs
     mode: 0755
 
-- name: Give {{ apache_user }} (per variable apache_user) permission to poweroff
+- name: Give {{ apache_user }} (per variable apache_user) permission to poweroff, installing /etc/sudoers.d/020_apache_poweroff from template
   template:
     src: 020_apache_poweroff.j2
     dest: /etc/sudoers.d/020_apache_poweroff
     mode: 0755
   when: apache_allow_sudo
 
-- name: Remove {{ apache_user }} (per variable apache_user) permission to poweroff
+- name: Remove {{ apache_user }} (per variable apache_user) permission to poweroff, removing /etc/sudoers.d/020_apache_poweroff
   file:
     path: /etc/sudoers.d/020_apache_poweroff
     state: absent

--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -1,4 +1,4 @@
-- name: Create user {{ iiab_admin_user }} for Admin Console; set password from hardcoded hash if newly creating account
+- name: Create user {{ iiab_admin_user }} for Admin Console; set password from iiab_admin_pwd_hash if newly creating account
   user:
     name: "{{ iiab_admin_user }}"
     password: "{{ iiab_admin_pwd_hash }}"

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -7,7 +7,7 @@
   tags:
     - base
 
-- name: Add 'iiab-admin' to list at {{ iiab_ini_file }}
+- name: Add 'iiab-admin' variable values to {{ iiab_ini_file }}
   ini_file:
     dest: "{{ iiab_ini_file }}"
     section: iiab-admin
@@ -21,7 +21,7 @@
     - option: iiab_admin_user
       value: "{{ iiab_admin_user }}"
 
-- name: Set up to issue warning if iiab-admin password is still default
+- name: Install /etc/profile.d/profile_ssh_warn.sh from template, to issue warnings if iiab-admin password is still default
   template:
     src: profile_ssh_warn.sh
     dest: /etc/profile.d/
@@ -31,14 +31,14 @@
     path: /home/pi/.config/lxsession
   register: lx
 
-- name: Do the same if running on Raspbian
+- name: "Likewise for Raspbian, installing: /home/pi/.config/lxsession/LXDE-pi/lxde_ssh_warn.sh"
   template:
     src: lxde_ssh_warn.sh
     dest: /home/pi/.config/lxsession/LXDE-pi/
   when: lx.stat.isdir is defined and lx.stat.isdir and is_rpi and is_debuntu
 
-- name: Put an autostart line to check for default password in LXDE (raspbian)
+- name: Put line in /home/pi/.config/lxsession/LXDE-pi/autostart to run the above (raspbian)
   lineinfile:
+    path: /home/pi/.config/lxsession/LXDE-pi/autostart
     line: "@/home/pi/.config/lxsession/LXDE-pi/lxde_ssh_warn.sh"
-    dest: /home/pi/.config/lxsession/LXDE-pi/autostart
   when: lx.stat.isdir is defined and lx.stat.isdir and is_rpi and is_debuntu

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -5,45 +5,45 @@
   when: iiab_wireless_lan_iface is defined and hostapd_enabled and iiab_network_mode != "Appliance"
 
 - name: Start named service
-  service:
+  systemd:
     name: "{{ dns_service }}"
     state: restarted
   when: named_enabled and named_install
 
 - name: Stop Squid service
-  service:
+  systemd:
     name: "{{ proxy }}"
     state: stopped
   async: 120
   when: squid_install
 
 - name: Stop DansGuardian
-  service:
+  systemd:
     name: dansguardian
     state: stopped
   when: dansguardian_install
 
-- name: Restart DansGuardian - except Ubuntu which needs reboot to activate
-  service:
+- name: Restart DansGuardian service (dansguardian) except Ubuntu which needs reboot to activate
+  systemd:
     name: dansguardian
     state: restarted
   when: dansguardian_enabled and dansguardian_install and ( not is_ubuntu and iiab_stage|int < 4 )
 
 # Squid get re-loaded with dispatcher.d
-- name: Restart Squid service
-  service:
+- name: Restart Squid service ({{ proxy }})
+  systemd:
     name: "{{ proxy }}"
     state: restarted
   when: squid_enabled and squid_install
 
-- name: Restart Wondershaper service
-  service:
+- name: Restart Wondershaper service (wondershaper)
+  systemd:
     name: wondershaper
     state: restarted
   when: wondershaper_enabled
 
-- name: Restart avahi service
-  service:
+- name: Restart Avahi service (avahi-daemon)
+  systemd:
     name: avahi-daemon
     state: restarted
 
@@ -56,7 +56,7 @@
 - name: Waiting {{ hostapd_wait }} seconds for network to stabilize
   shell: sleep {{ hostapd_wait }}
 
-- name: Run iptables
+- name: Run /usr/bin/iiab-gen-iptables
   command: /usr/bin/iiab-gen-iptables
 
 - name: Checking if WiFi slave is active
@@ -71,7 +71,7 @@
   when: hostapd_enabled and wifi_slave.stdout is defined and wifi_slave.stdout == 0
 
 - name: dhcp_server may be affected - starting - user choice
-  service:
+  systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
   when: iiab_network_mode != "Appliance"


### PR DESCRIPTION
Just a reminder that roles/1-prep/tasks/raspberry_pi.yml focuses on:
- rtc-i2c udev rule
- ntp
- swap for KA Lite
- rootfs resizing

This PR also enhances Ansible output readability for:
- roles/iiab-admin/tasks/main.yml
- roles/iiab-admin/tasks/admin-user.yml
- roles/httpd/tasks/main.yml
- roles/httpd/tasks/html.yml
- roles/network/tasks/restart.yml
- roles/calibre-web/tasks/main.yml

Builds on PR #1280