### PR TITLE
KA Lite & Elgg README, linked from FAQ.IIAB.IO

### DIFF
--- a/roles/elgg/README.rst
+++ b/roles/elgg/README.rst
@@ -48,3 +48,10 @@ There are a number of seemingly similar usernames and passwords in this installa
 * elgg_admin_user - the Elgg (not MySQL) user that is the administrator
 
 * elgg_admin_password - the password for elgg_admin_user
+
+More Tips & Tricks
+------------------
+
+If you're online, please see "Elgg Administration: What tips & tricks exist? " at: http://FAQ.IIAB.IO
+
+If you're offline, Internet-in-a-Box's FAQ (Frequently Asked Questions) is here: http://box/info

--- a/roles/kalite/README.rst
+++ b/roles/kalite/README.rst
@@ -50,8 +50,8 @@ To return to using the systemd unit:
 
 *In late 2017, Internet-in-a-Box added a virtual environment (/usr/local/kalite/venv/) to keep KA Lite's Python package/dependency risks under control.  As such the command* `/usr/bin/kalite <https://github.com/iiab/iiab/blob/master/roles/kalite/templates/kalite.sh.j2>`_ *is a wrapper to this virtualenv.*
 
-Tips & Tricks
--------------
+More Tips & Tricks
+------------------
 
 If you're online, please see "KA Lite Administration: What tips & tricks exist?" at: http://FAQ.IIAB.IO
 

--- a/roles/kalite/README.rst
+++ b/roles/kalite/README.rst
@@ -53,6 +53,6 @@ To return to using the systemd unit:
 Tips & Tricks
 -------------
 
-Please see "KA Lite Administration: What tips & tricks exist?" at: http://FAQ.IIAB.IO
+If you're online, please see "KA Lite Administration: What tips & tricks exist?" at: http://FAQ.IIAB.IO
 
-If you are offline, click on the FAQ (Frequently Asked Questions) here: http://box/info
+If you're offline, Internet-in-a-Box's FAQ (Frequently Asked Questions) is here: http://box/info

--- a/roles/kalite/README.rst
+++ b/roles/kalite/README.rst
@@ -49,3 +49,10 @@ To return to using the systemd unit:
 * systemctl start kalite-serve
 
 *In late 2017, Internet-in-a-Box added a virtual environment (/usr/local/kalite/venv/) to keep KA Lite's Python package/dependency risks under control.  As such the command* `/usr/bin/kalite <https://github.com/iiab/iiab/blob/master/roles/kalite/templates/kalite.sh.j2>`_ *is a wrapper to this virtualenv.*
+
+Tips & Tricks
+-------------
+
+Please see "KA Lite Administration: What tips & tricks exist?" at: http://FAQ.IIAB.IO
+
+If you are offline, click on the FAQ (Frequently Asked Questions) here: http://box/info


### PR DESCRIPTION
https://github.com/iiab/iiab/tree/master/roles/kalite#ka-lite-readme is improved so that it can be useful to many more people, and listed more prominently off of http://FAQ.IIAB.IO in places like:
- http://wiki.laptop.org/go/IIAB/FAQ#What_can_I_do_with_E-books_and_Internet-in-a-Box.3F
- http://wiki.laptop.org/go/IIAB/FAQ#KA_Lite_Administration:_What_tips_.26_tricks_exist.3F

Same for https://github.com/iiab/iiab/tree/master/roles/elgg#elgg-readme &mdash; the best such documentation for our most ruggedized+useful IIAB roles/playbooks is increasingly surfaced.

Refs: #658 https://github.com/iiab/iiab/issues/1200#issuecomment-435687342