### PR TITLE
Ramp up upload_max_filesize & post_max_size to 500M (if apache_high_php_limits: True, for WordPress & Moodle)

### DIFF
--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -2,5 +2,5 @@
 apache_allow_sudo: True
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 apache_high_php_limits: False

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -62,7 +62,7 @@
     #- { src: 'php.ini.j2', dest: '/etc/php.ini', mode: '0644' }    # @jvonau suggests removing this in https://github.com/iiab/iiab/issues/1147
 
 # For schools that use WordPress and/or Moodle intensively. See iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 - name: Enact high limits in /etc/php/{{ php_version }}/{{ apache_service }}/php.ini if using WordPress and/or Moodle intensively
   lineinfile:
     path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
@@ -70,8 +70,8 @@
     line: "{{ item.line }}"
   when: apache_high_php_limits
   with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 64M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 128M    ; default is 8M' }
+    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
+    - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
     - { regexp: '^memory_limit', line: 'memory_limit = 256M    ; default is 128M' }
     - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
     - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -188,7 +188,7 @@ exFAT_enabled: True
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 # For schools that use WordPress and/or Moodle intensively, see iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -96,7 +96,7 @@ openvpn_handle: ""
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 # For schools that use WordPress and/or Moodle intensively, see iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -96,7 +96,7 @@ openvpn_handle: ""
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 # For schools that use WordPress and/or Moodle intensively, see iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -96,7 +96,7 @@ openvpn_handle: ""
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 # For schools that use WordPress and/or Moodle intensively, see iiab/iiab #1147
-# WARNING: Enabling this (might) cause excess use of RAM or other resources?
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 


### PR DESCRIPTION
Increases these 2 settings for @ericnitschke & @kananigit, principally for WordPress:
```
upload_max_filesize = 2M (original/factory default)   ->   64M (Sept 2018)   ->   500M (new!)
post_max_size = 8M (original/factory default)   ->   128M (Sept 2018)   ->   500M (new!)
```
...when `apache_high_php_limits: True` is set in [local_vars.yml](http://wiki.laptop.org/go/IIAB/local_vars.yml) as explained within http://FAQ.IIAB.IO ("WordPress & Moodle Administration: What tips & tricks exist? ")

Refs: #1147 #1287