### PR TITLE
Kiwix 0.7.0 -> 0.7.0-1

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -1,9 +1,9 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: "kiwix-tools_linux-armhf-0.7.0"
-kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.7.0"
-kiwix_version_i686: "kiwix-tools_linux-i586-0.7.0"
+kiwix_version_armhf: "kiwix-tools_linux-armhf-0.7.0-1"
+kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.7.0-1"
+kiwix_version_i686: "kiwix-tools_linux-i586-0.7.0-1"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:


### PR DESCRIPTION
The 3 needed Kiwix packages are uploaded to: http://download.iiab.io/packages/