### PR TITLE
debian does not install sudo by default, and iiab-admin was moved bef…

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -5,7 +5,9 @@
 
 - name: Install uuid-runtime package (debuntu)
   package:
-    name: uuid-runtime
+    name: 
+      - uuid-runtime
+      - sudo
     state: present
   when: is_debuntu
 


### PR DESCRIPTION
all that was required to apply min and big to debian 9.6
reason: sudo is required by our iiab-admin role, and not installed by default 