### PR TITLE
bind9 and dnsmasq fighting over port 53

### DIFF
--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
-  when: named_install
+  when: named_install and not dnsmasq_enabled
   tags: base, named, network, domain
 
 - name: Installing captive portal


### PR DESCRIPTION
@jvonau -- This seems like an obvious and required fix, but check me. Seems that installing a package starts it up. Would you rather install named, and then disable it?