### PR TITLE
move install of iiab_env.py into base

### DIFF
--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -21,6 +21,11 @@
     state: restarted
   when: not installing
 
+- name: Create a Python interface to iiab.env
+  template:
+    src: roles/1-prep/templates/iiab_env.py.j2
+    dest: /etc/iiab/iiab_env.py
+
 - name: Recording STAGE 3 HAS COMPLETED =====================
   lineinfile:
     dest: "{{ iiab_env_file }}"

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -74,12 +74,6 @@
   when: usb_lib_install
   tags: usb-lib
 
-# MANDATORY SO PERHAPS THIS BELONGS IN 3-BASE-SERVER ?
-- name: Create a Python interface to iiab.env
-  template:
-    src: roles/1-prep/templates/iiab_env.py.j2
-    dest: /etc/iiab/iiab_env.py
-
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed at the beginning of Stage 3 = roles/3-base-server/tasks/main.yml, which ran Apache playbook = roles/httpd/tasks/main.yml)
   command: /usr/bin/iiab-refresh-wiki-docs
   when: not nodocs


### PR DESCRIPTION
installing iiab_env.py was happening too late for captive-portal to use during it's startup. 
There was already a comment in the code suggesting the move
Not smoke tested with a new install.