### PR TITLE
Create Lokole admin user during setup

### DIFF
--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -1,5 +1,7 @@
 # Info needed to install Lokole
-lokole_version: "0.1.24"
+lokole_version: "0.1.26"
+lokole_admin_user: admin
+lokole_admin_password: changeme
 lokole_install_path: "{{ content_base }}/lokole"    # /library/lokole
 lokole_venv: "{{ lokole_install_path }}/venv"       # /library/lokole/venv
 

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -53,6 +53,13 @@
   tags:
     - configure
 
+- name: Create admin user
+  shell: |
+    . {{ lokole_run_directory }}/webapp_secrets.sh
+    {{ lokole_venv }}/bin/manage.py createadmin --name='{{ lokole_admin_user }}' --password='{{ lokole_admin_password }}'
+  tags:
+    - configure
+
 - name: Install unit file /etc/systemd/system/lokole.service from template
   template:
     src: lokole.service.j2


### PR DESCRIPTION
### Description of changes proposed in this pull request.

Add a default admin account when setting up Lokole as per https://github.com/iiab/iiab/pull/1305#discussion_r236069663.

### Smoke-tested in operating system.

By @aidan-fitz 

### Mention a team member for further information or comment using @ name

@holta 