### PR TITLE
Cap3 [captive-portal under Apache; disconnected from wsgi & iptables]

### DIFF
--- a/roles/captive-portal/tasks/main.yml
+++ b/roles/captive-portal/tasks/main.yml
@@ -10,6 +10,7 @@
   file:
     path: /opt/iiab/captive-portal
     state: directory
+    owner: "{{ apache_user }}"
 
 - name: 'Copy scripts: checkurls, capture-wsgi.py'
   template:

--- a/roles/captive-portal/tasks/main.yml
+++ b/roles/captive-portal/tasks/main.yml
@@ -43,13 +43,13 @@
 - name: Run iiab-uncatch to generate diversion lists for dnsmasq and apache2
   shell: /usr/bin/iiab-uncatch
      
-- name: Install systemd unit file captive-portal.service from template
-  template:
-    src: roles/captive-portal/templates/captive-portal.service.j2
-    dest: /etc/systemd/system/captive-portal.service
-    owner: root
-    group: root
-    mode: 0644
+#- name: Install systemd unit file captive-portal.service from template
+#  template:
+#    src: roles/captive-portal/templates/captive-portal.service.j2
+#    dest: /etc/systemd/system/captive-portal.service
+#    owner: root
+#    group: root
+#    mode: 0644
 
 - name: Install Apache's captive-portal.conf from template if captive_portal_enabled
   template:
@@ -74,20 +74,20 @@
     state: link
   when: captive_portal_enabled and is_debuntu
 
-- name: Enable & Start systemd service captive-portal.service if captive_portal_enabled
-  systemd:
-    name: captive-portal.service
-    daemon-reload: yes
-    enabled: yes
-    state: started
-  when: captive_portal_enabled
+#- name: Enable & Start systemd service captive-portal.service if captive_portal_enabled
+#  systemd:
+#    name: captive-portal.service
+#    daemon-reload: yes
+#    enabled: yes
+#    state: started
+#  when: captive_portal_enabled
 
-- name: Disable & Stop captive-portal.service if not captive_portal_enabled
-  systemd:
-    name: captive-portal.service
-    enabled: no
-    state: stopped
-  when: not captive_portal_enabled
+#- name: Disable & Stop captive-portal.service if not captive_portal_enabled
+#  systemd:
+#    name: captive-portal.service
+#    enabled: no
+#    state: stopped
+#  when: not captive_portal_enabled
 
 - name: Disable Apache's captive-portal.conf if not captive_portal_enabled (debuntu)
   file:

--- a/roles/captive-portal/tasks/main.yml
+++ b/roles/captive-portal/tasks/main.yml
@@ -6,6 +6,22 @@
     - python-dateutil
     - sqlite3    # @georgehunt hopes to move this to 2-common (or more like stage 3-base-server, alongside MySQL) in October 2018
 
+- name: Install wsgi (debuntu)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libapache2-mod-wsgi
+  when: is_debuntu
+
+- name: Install wsgi (not debuntu)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - mod_wsgi
+  when: not is_debuntu
+
 - name: Create directory /opt/iiab/captive-portal for scripts & templates
   file:
     path: /opt/iiab/captive-portal

--- a/roles/captive-portal/templates/001-captive-portal.conf
+++ b/roles/captive-portal/templates/001-captive-portal.conf
@@ -1,7 +1,7 @@
 <VirtualHost _default_:80>
    ErrorLog /var/log/apache2/error.log
    CustomLog /var/log/apache2/access.log combined
-   <Directory {{ doc_root }}>
+   <Directory /library/www/html>
        Options Indexes FollowSymLinks
        AllowOverride None
        Require all granted
@@ -18,7 +18,26 @@
 	# However, you must set it for any further virtual host explicitly.
 	ServerName iiab.io
    Include /etc/apache2/capture
-   ProxyPreserveHost On
-   ProxyPass / http://box.lan:{{ captive_portal_port }}/
-   ProxyPassReverse / http://box.lan:{{ captive_portal_port }}/
+#   ProxyPreserveHost On
+#   ProxyPass / http://box.lan:9090/
+#   ProxyPassReverse / http://box.lan:9090/
+   ErrorLog /var/log/apache2/cp_error.log
+WSGIScriptAlias / /opt/iiab/captive-portal/capture-wsgi.py
+#WSGIScriptAlias / /opt/iiab/captive-portal/test.py
+WSGIScriptReloading On
+   <Directory /opt/iiab/captive-portal>
+       AllowOverride None
+       Require all granted
+   </Directory>
+
+</VirtualHost>
+
+<VirtualHost 127.0.0.1:80>
+   ErrorLog /var/log/apache2/error.log
+   CustomLog /var/log/apache2/access.log combined
+   <Directory /library/www/html>
+       Options Indexes FollowSymLinks
+       AllowOverride None
+       Require all granted
+   </Directory>
 </VirtualHost>

--- a/roles/captive-portal/templates/001-captive-portal.conf
+++ b/roles/captive-portal/templates/001-captive-portal.conf
@@ -1,7 +1,7 @@
 <VirtualHost _default_:80>
    ErrorLog /var/log/apache2/error.log
    CustomLog /var/log/apache2/access.log combined
-   <Directory /library/www/html>
+   <Directory {{ doc_root }}>
        Options Indexes FollowSymLinks
        AllowOverride None
        Require all granted
@@ -19,8 +19,8 @@
 	ServerName iiab.io
    Include /etc/apache2/capture
 #   ProxyPreserveHost On
-#   ProxyPass / http://box.lan:9090/
-#   ProxyPassReverse / http://box.lan:9090/
+#   ProxyPass / http://box.lan:{{ captive_portal_port }}/
+#   ProxyPassReverse / http://box.lan:{{ captive_portal_port }}/
    ErrorLog /var/log/apache2/cp_error.log
 WSGIScriptAlias / /opt/iiab/captive-portal/capture-wsgi.py
 #WSGIScriptAlias / /opt/iiab/captive-portal/test.py

--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -78,7 +78,7 @@ sys.stdout = sl
 stderr_logger = logging.getLogger('STDERR')
 sl = StreamToLogger(stderr_logger, logging.ERROR)
 sys.stderr = sl
-PORT=9090
+PORT={{ captive_portal_port }}
 
 
 # Define globals

--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -230,7 +230,7 @@ def android(environ, start_response):
         logger.debug("system < 6:%s"%system_version)
         location = '/android_splash'
         set_204after(ip,0)
-    elif system_version.startswith('8'):
+    elif system_version.startswith('7'):
         location = "http://" + fully_qualified_domain_name + "/home"
     else:
         #set_204after(ip,20)

--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -228,6 +228,8 @@ def android(environ, start_response):
     else: 
         ip = environ['REMOTE_ADDR'].strip()
     system,system_version = platform_info(ip)
+    if not system_version:
+        put_302(environ, start_response)
     if system_version[0:1] < '6':
         logger.debug("system < 6:%s"%system_version)
         location = '/android_splash'
@@ -390,10 +392,12 @@ def put_204(environ, start_response):
 def put_302(environ, start_response):
     status = '302 Moved Temporarily'
     response_body = ''
+    location = "http://" + fully_qualified_domain_name + "/home"
     response_headers = [('Content-type','text/html'),
+            ('Location',location), 
             ('Content-Length',str(len(response_body)))]
     start_response(status, response_headers)
-    logger.debug("in function  put_204: sending 204 html response")
+    logger.debug("in function  put_302: sending 302 html response")
     return [response_body]
 
 def parse_agent(agent):

--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -179,8 +179,10 @@ def set_lasttimestamp(ip):
 #  ###################  Action routines based on OS  ################3
 def microsoft_splash(environ,start_response):
     en_txt={ 'message':"Click on the button to go to the IIAB home page",\
+            "FQDN": fully_qualified_domain_name, \
             'btn1':"GO TO IIAB HOME PAGE",'doc_root':get_iiab_env("WWWROOT")}
     es_txt={ 'message':"Haga clic en el botón para ir a la página de inicio de IIAB",\
+            "FQDN": fully_qualified_domain_name, \
             'btn1':"IIAB",'doc_root':get_iiab_env("WWWROOT")}
     txt = en_txt
     if lang == "en":

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -62,7 +62,6 @@ transmission_http_port={{ transmission_http_port }}
 transmission_peer_port={{ transmission_peer_port }}
 sugarizer_port={{ sugarizer_port }}
 block_DNS={{ block_DNS }}
-captive_portal_enabled={{ captive_portal_enabled }}
 
 echo "LAN is $lan and WAN is $wan"
 #
@@ -111,9 +110,8 @@ if [  "$gw_block_https" == "True" ]; then
 fi
 
 # Allow outgoing connections from the LAN side.
-if ! [ "$captive_portal_enabled" == "True" ]; then
-    $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
-fi
+$IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
+
 # Don't forward from the outside to the inside.
 $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
 $IPTABLES -A INPUT -i $wan -j DROP
@@ -121,10 +119,6 @@ $IPTABLES -A INPUT -i $wan -j DROP
 if [ "$block_DNS" == "True" ]; then
     $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
     $IPTABLES -t nat -A PREROUTING -i $lan -p udp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
-fi
-
-if [ "$captive_portal_enabled" == "True" ]; then
-    $IPTABLES  -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:{{ captive_portal_port }}
 fi
 
 if [ "$HTTPCACHE_ON" == "True" ]; then


### PR DESCRIPTION
Removes systemd startup of debug wsgi service, and puts the captive portal under apache.
Removes any reference to captive-portal in iptables
Tested, and works, on mac, windows 7,10, iphone, android 5,7
I did a fresh install, found errors, and corrected them. But did not again confirm that a fresh install was flawless. I ran out of time and patience