### PR TITLE
Officially transition from Nextcloud 14 to 15

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -8,7 +8,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
-nextcloud_orig_src_file: latest-14.tar.bz2
+nextcloud_orig_src_file: latest-15.tar.bz2
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.


### PR DESCRIPTION
Implements #1048 as soon as https://download.nextcloud.com/server/releases/latest-15.tar.bz2 goes live "tmrw" (2018-12-10)