### PR TITLE
Recommend Ansible 2.7.5

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.6.10
+MIN_ANSIBLE_VER=2.6.11
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.4"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.4"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.7.x
+++ b/scripts/ansible-2.7.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.4"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The new Ansible 2.7.5 was smoke-tested on Ubuntu and Raspbian.

Its changelog:
https://github.com/ansible/ansible/blob/v2.7.5/changelogs/CHANGELOG-v2.7.rst