### PR TITLE
mysql -> mariadb & ssh -> openssh-server in vars/ubuntu-18.yml & others

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -135,21 +135,24 @@
 # For various reasons the mysql service cannot be enabled on Fedora 20, but
 # 'mariadb', which is its real name can.  On Fedora 18 we need to use 'mysqld'.
 
-- name: "Set mysql_service: mariadb by default"
-  set_fact:
-    mysql_service: mariadb
+# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
+#- name: "Set mysql_service: mariadb by default"
+#  set_fact:
+#    mysql_service: mariadb
 
 - name: "Set mysql_service: mysqld etc (Fedora 18)"
   set_fact:
-    mysql_service: mysqld
+    # BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
+    #mysql_service: mysqld
     no_NM_reload: True
     is_F18: True
   when: (ansible_distribution_release == "based on Fedora 18" or ansible_distribution_version == "18") and ansible_distribution == "Fedora"
 
-- name: "Set mysql_service: mysql (debuntu)"
-  set_fact:
-    mysql_service: mysql
-  when: is_debuntu
+# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
+#- name: "Set mysql_service: mysql (debuntu)"
+#  set_fact:
+#    mysql_service: mysql
+#  when: is_debuntu
 
 - name: "Set iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}"
   set_fact:
@@ -206,6 +209,10 @@
       value:  "{{ first_run }}"
     - option: local_tz
       value:  "{{ local_tz }}"
+    - option: no_NM_reload
+      value: "{{ no_NM_reload }}"
+    - option: is_F18
+      value: "{{ is_F18 }}"
     - option: FQDN_changed
       value:  "{{ FQDN_changed }}"
 

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -33,7 +33,7 @@
     state: present
   when: is_debuntu
 
-- name: "Install 23 common packages: acpid, bridge-utils, bzip2, curl, gawk, hostapd, htop, i2c-tools, logrotate, make, mlocate, netmask, net-tools, ntfs-3g, openssh-server, pandoc, rsync, sudo, tar, unzip, usbmount, usbutils, wget"
+- name: "Install 22 common packages: acpid, bridge-utils, bzip2, curl, gawk, hostapd, htop, i2c-tools, logrotate, make, mlocate, netmask, net-tools, ntfs-3g, pandoc, rsync, sudo, tar, unzip, usbmount, usbutils, wget"
   package:
     name:
       - acpid
@@ -52,7 +52,7 @@
       - netmask
       - net-tools
       - ntfs-3g
-      - openssh-server
+      #- openssh-server    # ssh (Raspbian) or openssh-server (other OS's) already installed by 1-prep's roles/sshd/tasks/main.yml
       - pandoc
       - rsync
       - sudo

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Install ssh daemon
+  package:
+    name: "{{ sshd_package }}"
+    state: present
+  when: sshd_enabled
+
 - name: Disable root login with password
   lineinfile:
     dest: /etc/ssh/sshd_config

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -10,6 +10,7 @@
     regexp: '^PermitRootLogin'
     line: 'PermitRootLogin without-password'
     state: present
+  when: sshd_enabled
 #TODO: use handler to reload ssh
 
 - name: Create root .ssh
@@ -31,14 +32,14 @@
     force: no
   when: sshd_enabled
 
-- name: Enable & start sshd
+- name: Enable & start ssh daemon
   service:
     name: "{{ sshd_service }}"
     enabled: yes
     state: started
   when: sshd_enabled
 
-- name: Disable sshd
+- name: Disable ssh daemon
   service:
     name: "{{ sshd_service }}"
     enabled: no

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -14,6 +14,7 @@ systemctl_program: /usr/bin/systemctl
 mysql_service: mariadb
 dhcp_service: dhcpd
 apache_log: /var/log/httpd/access_log
+sshd_package: openssh-server
 sshd_service: sshd
 php_version: 7.0
 postgresql_version: 9.5

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -15,6 +15,7 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
 sshd_service: ssh
 php_version: 7.1
 postgresql_version: 10

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -14,6 +14,7 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mysql
 apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
 sshd_service: ssh
 php_version: 5
 postgresql_version: 9.4

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -13,9 +13,9 @@ apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd
 systemctl_program: /bin/systemctl
-mysql_service: mysql
+mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
-sshd_service: ssh
+sshd_service: openssh-server
 php_version: 7.0
 postgresql_version: 9.6
 systemd_location: /lib/systemd/system

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -15,7 +15,8 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
-sshd_service: openssh-server
+sshd_package: openssh-server
+sshd_service: ssh
 php_version: 7.0
 postgresql_version: 9.6
 systemd_location: /lib/systemd/system

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -14,6 +14,7 @@ mysql_service: mysqld
 apache_log: /var/log/httpd/access_log
 apache_log_dir: /var/log/httpd
 php_version: 5
+sshd_package: openssh-server
 sshd_service: sshd
 nextcloud_install: False
 nextcloud_enabled: False

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -10,7 +10,7 @@ apache_log_dir: /var/log/httpd
 smb_service: smb
 nmb_service: nmb
 systemctl_program: /usr/bin/systemctl
-mysql_service: mariadb
+mysql_service: mysqld
 apache_log: /var/log/httpd/access_log
 apache_log_dir: /var/log/httpd
 php_version: 5

--- a/vars/fedora-22.yml
+++ b/vars/fedora-22.yml
@@ -12,6 +12,7 @@ nmb_service: nmb
 systemctl_program: /usr/bin/systemctl
 mysql_service: mariadb
 apache_log: /var/log/httpd/access_log
+sshd_package: openssh-server
 sshd_service: sshd
 systemd_location: /usr/lib/systemd/system
 # Upgrade OS's own Calibre to very latest:

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -16,6 +16,7 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mysql
 apache_log: /var/log/apache2/access.log
+sshd_package: ssh
 sshd_service: ssh
 php_version: 5
 postgresql_version: 9.4

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -15,7 +15,7 @@ apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd
 systemctl_program: /bin/systemctl
-mysql_service: mysql
+mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_service: ssh
 php_version: 7.0

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -17,6 +17,7 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
+sshd_package: ssh
 sshd_service: ssh
 php_version: 7.0
 postgresql_version: 9.6

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -15,6 +15,7 @@ nmb_service: nmbd
 systemctl_program: /bin/systemctl
 mysql_service: mysql
 apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
 sshd_service: ssh
 php_version: 7.0
 postgresql_version: 9.5

--- a/vars/ubuntu-17.yml
+++ b/vars/ubuntu-17.yml
@@ -15,6 +15,7 @@ systemctl_program: /bin/systemctl
 # issue raised 
 mysql_service: mysql
 apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
 sshd_service: ssh
 php_version: 7.1
 postgresql_version: 9.6

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -16,7 +16,8 @@ systemctl_program: /bin/systemctl
 # issue raised 
 mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
-sshd_service: openssh-server
+sshd_package: openssh-server
+sshd_service: ssh
 php_version: 7.2
 # "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
 postgresql_version: 10

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -14,9 +14,9 @@ smb_service: smbd
 nmb_service: nmbd
 systemctl_program: /bin/systemctl
 # issue raised 
-mysql_service: mysql
+mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
-sshd_service: ssh
+sshd_service: openssh-server
 php_version: 7.2
 # "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
 postgresql_version: 10


### PR DESCRIPTION
Fixes #1346 hopefully &mdash; and updates several /opt/iiab/iiab/vars/[OS].yml files which were badly out of date.