### PR TITLE
Revert "Lokole: change admin to Admin per IIAB app norms"

### DIFF
--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -1,6 +1,6 @@
 # Info needed to install Lokole
 lokole_version: "0.1.26"
-lokole_admin_user: Admin
+lokole_admin_user: admin
 lokole_admin_password: changeme
 lokole_install_path: "{{ content_base }}/lokole"    # /library/lokole
 lokole_venv: "{{ lokole_install_path }}/venv"       # /library/lokole/venv

--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -1,6 +1,6 @@
 # Info needed to install Lokole
 lokole_version: "0.1.26"
-lokole_admin_user: admin
+lokole_admin_user: admin    # lowercase seems nec here (even though uppercase Admin/changeme is IIAB's OOB recommendation!)
 lokole_admin_password: changeme
 lokole_install_path: "{{ content_base }}/lokole"    # /library/lokole
 lokole_venv: "{{ lokole_install_path }}/venv"       # /library/lokole/venv


### PR DESCRIPTION
Reverts iiab/iiab#1353 as this managed to break http://box/lokole logins attempted with Admin/changeme

(Apologies @aidan-fitz & @c-w the original ` lokole_admin_user: admin` was indeed appropriate!)

Ref #1293