### PR TITLE
Captive Portal: patch capture-wsgi.py to test Android 7.x, 8.x, 9.x

### DIFF
--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -234,7 +234,7 @@ def android(environ, start_response):
         logger.debug("system < 6:%s"%system_version)
         location = '/android_splash'
         set_204after(ip,0)
-    elif system_version.startswith('7'):
+    elif system_version[:1] >= '7':
         location = "http://" + fully_qualified_domain_name + "/home"
     else:
         #set_204after(ip,20)


### PR DESCRIPTION
Fixes #1323 ...we hope?!

Thanks to @georgejhunt

Seems to work for Android 8.1 but needs further testing to make sure this does not break Captive Portal where it worked in the past e.g. on @floydianslips' Google's Pixel XL phone running Android 9.