### PR TITLE
dnsmasq hack (in roles/captive-portal/tasks/main.yml) so iiab-install runs on Ubuntu 16.04

### DIFF
--- a/roles/captive-portal/tasks/main.yml
+++ b/roles/captive-portal/tasks/main.yml
@@ -124,8 +124,23 @@
     name: apache2
     state: restarted
 
-- name: Restart dnsmasq
-  systemd: 
+#- name: Restart dnsmasq
+#  systemd:
+#    name: dnsmasq
+#    state: restarted
+#  when: dnsmasq_enabled
+
+# ABOVE DOES NOT WORK ON UBUNTU 16.04 -- what follows is a crude hack (seems to work!)
+
+- name: Stop dnsmasq
+  systemd:
     name: dnsmasq
-    state: restarted
+    state: stopped
   when: dnsmasq_enabled
+
+- name: Start dnsmasq
+  systemd:
+    name: dnsmasq
+    state: started
+  when: dnsmasq_enabled
+  


### PR DESCRIPTION
@jvonau it's not just ./iiab-network, but also now "iiab-install --reinstall" that can no longer be run on Ubuntu 16.04 sadly:
```
TASK [4-server-options : Restart dnsmasq] **************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Unable to restart service dnsmasq: Job for dnsmasq.service failed because a timeout was exceeded. See \"systemctl status dnsmasq.service\" and \"journalctl -xe\" for details.\n"}
```
Oddly while `systemctl restart dnsmasq` doesn't work... chaining together `systemctl stop dnsmasq` followed by `systemctl start dnsmasq` does generally work (!)

Question: is there any harm if I revise https://github.com/iiab/iiab/blob/master/roles/captive-portal/tasks/main.yml#L127-L131 to use the 2-steps above instead of the dnsmasq restart?  Or is another surgical strike truly needed, e.g. from your #1311 or any other?  (Not that Ubuntu 16.04 support needs to be comprehensive [it certainly doesn't!] but if Anish can still use it a tiny bit longer why not.)