### PR TITLE
Set squid_install: & squid_enabled: False in BIG-sized local_vars.yml

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -105,8 +105,8 @@
 # Late 2017: Had commented out MongoDB on a trial basis, for a more basic/lightweight Sugarizer, per https://github.com/iiab/iiab/pull/427
 - name: Turn on both vars for MongoDB if sugarizer_enabled
   set_fact:
-     mongodb_install: True
-     mongodb_enabled: True
+    mongodb_install: True
+    mongodb_enabled: True
   when: sugarizer_enabled
 
 # There might be other db's

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -50,10 +50,11 @@
   when: postgresql_install
   tags: postgresql, pathagar, moodle
 
+# UNMAINTAINED
 - name: AUTHSERVER
   include_role:
     name: authserver
-  when: authserver_install
+  when: authserver_install is defined and authserver_install
   tags: olpc, authserver
 
 - name: CUPS

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -27,12 +27,14 @@
   when: moodle_install
   tags: olpc, moodle
 
+# UNMAINTAINED
 - name: OSM
   include_role:
     name: osm
   when: osm_install is defined and osm_install
   tags: osm
 
+# UNMAINTAINED
 - name: PATHAGAR
   include_role:
     name: pathagar

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -33,12 +33,14 @@
   when: phpmyadmin_install
   tags: phpmyadmin
 
+# UNMAINTAINED
 - name: SUGAR-STATS
   include_role:
     name: sugar-stats
   when: sugar_stats_install is defined and sugar_stats_install and ansible_distribution != "CentOS"
   tags: olpc, sugar-stats
 
+# UNMAINTAINED
 - name: TEAMVIEWER
   include_role:
     name: teamviewer
@@ -51,6 +53,7 @@
   when: vnstat_install
   tags: vnstat
 
+# UNMAINTAINED
 - name: XOVIS
   include_role:
     name: xovis

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -63,6 +63,9 @@ iiab_domain: lan
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
+# Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
+iiab_home_url: /home
+
 # Internal Wi-Fi Access Point
 # Values are used if there is an internal Wi-Fi adapter and hostapd is enabled
 # The platform variable adapts install to specific hardware (raspberry pi=rpi2)
@@ -210,24 +213,14 @@ squid_enabled: False
 dansguardian_install: False
 dansguardian_enabled: False
 
-# Homepage
-iiab_home_url: /home
-
-# You can change iiab_home_url in /etc/iiab/local_vars.yml to get a different
-# homepage.  For example one of the following: (if its service is enabled!)
-
-# iiab_home_url: /home
-# iiab_home_url: /wordpress
-# iiab_home_url: /wiki      # for dokuwiki
-# iiab_home_url: /mediawiki
-
 # PostgreSQL auto-installed by Moodle &/or Pathagar as nec, no need to touch!
 # roles/1-prep/tasks/computed_vars.yml, roles/4-server-options/tasks/main.yml
 postgresql_install: False
 postgresql_enabled: False
 
-authserver_install: False
-authserver_enabled: False
+# Unmaintained
+# authserver_install: False
+# authserver_enabled: False
 
 # Common UNIX Printing System (CUPS)
 cups_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -63,7 +63,7 @@ iiab_domain: lan
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
-# Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
+# Homepage: set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
 iiab_home_url: /home
 
 # Internal Wi-Fi Access Point

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -119,11 +119,9 @@ apache_high_php_limits: False
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
 
-# Squid
-squid_install: True
-squid_enabled: True
+squid_install: False
+squid_enabled: False
 
-# DansGuardian
 dansguardian_install: True
 dansguardian_enabled: True
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -29,7 +29,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 iiab_hostname: box
 iiab_domain: lan
 
-# Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
+# Homepage: set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
 iiab_home_url: /home
 
 # Raspbian requires WiFi country since March 2018.  Please set it here:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -119,11 +119,9 @@ apache_high_php_limits: False
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
 
-# Squid
 squid_install: False
 squid_enabled: False
 
-# DansGuardian
 dansguardian_install: False
 dansguardian_enabled: False
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -29,7 +29,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 iiab_hostname: box
 iiab_domain: lan
 
-# Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
+# Homepage: set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
 iiab_home_url: /home
 
 # Raspbian requires WiFi country since March 2018.  Please set it here:

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -119,11 +119,9 @@ apache_high_php_limits: False
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
 
-# Squid
 squid_install: False
 squid_enabled: False
 
-# DansGuardian
 dansguardian_install: False
 dansguardian_enabled: False
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -29,7 +29,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 iiab_hostname: box
 iiab_domain: lan
 
-# Set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
+# Homepage: set to /home or /wordpress or /mediawiki or /wiki (for DokuWiki)
 iiab_home_url: /home
 
 # Raspbian requires Wi-Fi country since March 2018.  Please set it here:


### PR DESCRIPTION
Fixes #1367 

Also: makes the deprecation of role authserver somewhat more explicit.

To be further discussed/enhanced during tmrw's http://minutes.iiab.io community/team call.