### PR TITLE
Correctly force minor upgrades of Nextcloud if /opt/nextcloud/version.php removed

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -19,7 +19,7 @@
     url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }}"
     dest: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     timeout: "{{ download_timeout }}"
-    #force: yes
+    force: yes
     #validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
   when: internet_available and nextcloud_force_install
   #async: 1800


### PR DESCRIPTION
This will allow minor upgrades of Nextcloud (e.g. 15.0.0 to 15.0.1) to proceed as expected (when implementer deleted /opt/nextcloud/version.php) by overwriting the download e.g. /opt/iiab/downloads/nextcloud_latest-15.tar.bz2

This fix uses the "force:" tag described in https://docs.ansible.com/ansible/latest/modules/get_url_module.html