### PR TITLE
box.lan NOT iiab-server.lan

### DIFF
--- a/roles/network/tasks/hosts.yml
+++ b/roles/network/tasks/hosts.yml
@@ -10,7 +10,7 @@
   lineinfile:
     path: /etc/hosts
     regexp: '^172\.18\.96\.1'
-    line: '172.18.96.1     {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box iiab-server.lan'
+    line: '172.18.96.1     {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box box.lan'
     state: present
   when: iiab_lan_iface != "none" and not installing
 
@@ -18,7 +18,7 @@
   lineinfile:
     path: /etc/hosts
     regexp: '^127\.0\.0\.1'
-    line: '127.0.0.1     localhost.localdomain localhost {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box iiab-server.lan'
+    line: '127.0.0.1     localhost.localdomain localhost {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box box.lan'
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
Trying to clean up the top issue at #1182 (Captive Portal improvements checklist).