### PR TITLE
Auto-install /etc/tmpfiles.d/iiab.conf during IIAB install process, for Ubermix

### DIFF
--- a/roles/1-prep/files/iiab.conf
+++ b/roles/1-prep/files/iiab.conf
@@ -1,0 +1,3 @@
+d /var/log/apache2 1750 www-data www-data
+d /var/log/munin/ 1755 munin adm
+d /var/log/mongodb 1755 mongodb root

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -39,6 +39,23 @@
   set_fact:
     uuid: "{{ stored_uuid.stdout_lines[0] }}"
 
+- name: Does directory /ro exist? (indicating OS is Ubermix)
+  stat:
+    path: /ro
+  register: ro_dir
+
+# - debug:
+#     var: ro_dir
+
+- name: If so, install /etc/tmpfiles.d/iiab.conf to create /var/log subdirs on each boot, so {Apache, MongoDB, Munin} run on Ubermix
+  copy:
+    src: roles/1-prep/files/iiab.conf
+    dest: /etc/tmpfiles.d/
+    owner: root
+    group: root
+    mode: 0644
+  when: ro_dir.stat.exists
+
 - name: SSHD
   include_role:
     name: sshd


### PR DESCRIPTION
Fixes #1371 thanks to @jvonau recommendations.