### PR TITLE
Detect Ubermix using /etc/lsb-release; clean /etc/tmpfiles.d/iiab.conf; force 'apt -y remove "libgeos-*"' for KA Lite

### DIFF
--- a/roles/1-prep/files/iiab.conf
+++ b/roles/1-prep/files/iiab.conf
@@ -1,3 +1,3 @@
 d /var/log/apache2 1750 www-data www-data
-d /var/log/munin/ 1755 munin adm
+d /var/log/munin 1755 munin adm
 d /var/log/mongodb 1755 mongodb root

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -39,13 +39,22 @@
   set_fact:
     uuid: "{{ stored_uuid.stdout_lines[0] }}"
 
-- name: Does directory /ro exist? (indicating OS is Ubermix)
-  stat:
-    path: /ro
-  register: ro_dir
+#- name: Does directory /ro exist? (indicating OS is Ubermix)
+#  stat:
+#    path: /ro
+#  register: ro_dir
 
-# - debug:
-#     var: ro_dir
+#- debug:
+#    var: ro_dir
+
+- name: Does 'ubermix' exist in /etc/lsb-release?
+  shell: grep -i ubermix /etc/lsb-release
+  register: grep_ubermix
+  ignore_errors: true
+  #check_mode: no
+
+#- debug:
+#    var: grep_ubermix
 
 - name: If so, install /etc/tmpfiles.d/iiab.conf to create /var/log subdirs on each boot, so {Apache, MongoDB, Munin} run on Ubermix
   copy:
@@ -54,7 +63,9 @@
     owner: root
     group: root
     mode: 0644
-  when: ro_dir.stat.exists
+    force: yes
+  when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
+  #when: ro_dir.stat.exists
 
 - name: SSHD
   include_role:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -50,7 +50,11 @@
 #       extra_args="--disable-pip-version-check"
   when: internet_available and not is_debuntu
 
-- name: Remove libgeos-* pkgs, avoiding KA Lite Django failure on Ubermix #1382
+# This effectively does nothing at all on Ubuntu & Raspbian, where libgeos-*
+# pkgs are not installed FWIW.  But it's included to safeguard us across all
+# OS's, in case others OS's like Ubermix later appear.  See #1382 for details.
+# Removing pkgs libgeos-3.6.2 & libgeos-c1v5 fixed the situation on Ubermix!
+- name: Remove libgeos-* pkgs, avoiding KA Lite Django failure on Ubermix
   shell: apt -y remove "libgeos-*"
 
 - name: Default is to have cronserve started with KA Lite

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -50,6 +50,9 @@
 #       extra_args="--disable-pip-version-check"
   when: internet_available and not is_debuntu
 
+- name: Remove libgeos-* pkgs, avoiding KA Lite Django failure on Ubermix #1382
+  shell: apt -y remove "libgeos-*"
+
 - name: Default is to have cronserve started with KA Lite
   set_fact:
     job_scheduler_stanza: ""


### PR DESCRIPTION
Fixes #1380 #1382 #1383