### PR TITLE
Fixes for 2019's Debian 10 "Buster" + 2 outstanding issues incl workarounds

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -65,7 +65,7 @@
     state: present
   when: is_debuntu and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
   # NOT NEC TO TEST FOR is_raspbian_8 OR is_raspbian_9 AS /opt/iiab/iiab/vars/<OS>.yml
-  # DEFINES THESE AS SUBSETS OF is_debian_8 OR is_debian_9
+  # DEFINES THESE AS SUBSETS OF is_debian_8 OR is_debian_9 (FOR NOW!)
 
 # we need to install the rpm in order to get the dependencies
 # but we only need to do this the first time

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -59,7 +59,7 @@
     state: present
   when: is_debuntu
 
-- name: 'Install php{{ php_version }}-mcrypt -- on "debuntu" distros released prior to 2018. NOTE: php7.1 deprecated mcrypt 1-Dec-2016 and php7.2 dropped it completely 30-Nov-2017, as it should no longer be nec.'
+- name: 'Install php{{ php_version }}-mcrypt IF this is a "pre-2018" distro in the debuntu family. NOTE: PHP 7.1 deprecated mcrypt 1-Dec-2016 and PHP 7.2 dropped it completely 30-Nov-2017, as it should no longer be nec.'
   package:
     name: "php{{ php_version }}-mcrypt"
     state: present

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -59,11 +59,11 @@
     state: present
   when: is_debuntu
 
-- name: 'Install php{{ php_version }}-mcrypt (debuntu but not ubuntu-18) NOTE: php7.2 dropped mcrypt'
+- name: 'Install php{{ php_version }}-mcrypt (debuntu prior to 2018) NOTE: php7.2 dropped mcrypt'
   package:
     name: "php{{ php_version }}-mcrypt"
     state: present
-  when: is_debuntu and not is_ubuntu_18
+  when: is_debuntu and (is_raspbian_8 or is_raspbian_9 or is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17) 
 
 # we need to install the rpm in order to get the dependencies
 # but we only need to do this the first time

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -59,11 +59,13 @@
     state: present
   when: is_debuntu
 
-- name: 'Install php{{ php_version }}-mcrypt (debuntu prior to 2018) NOTE: php7.2 dropped mcrypt'
+- name: 'Install php{{ php_version }}-mcrypt (debuntu prior to 2018) NOTE: php7.2 dropped mcrypt as this should no longer be nec'
   package:
     name: "php{{ php_version }}-mcrypt"
     state: present
-  when: is_debuntu and (is_raspbian_8 or is_raspbian_9 or is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17) 
+  when: is_debuntu and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
+  # NOT NEC TO TEST FOR is_raspbian_8 OR is_raspbian_9 AS /opt/iiab/iiab/vars/<OS>.yml
+  # DEFINES THESE AS SUBSETS OF is_debian_8 OR is_debian_9
 
 # we need to install the rpm in order to get the dependencies
 # but we only need to do this the first time

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -59,7 +59,7 @@
     state: present
   when: is_debuntu
 
-- name: 'Install php{{ php_version }}-mcrypt (debuntu prior to 2018) NOTE: php7.2 dropped mcrypt as this should no longer be nec'
+- name: 'Install php{{ php_version }}-mcrypt -- on "debuntu" distros released prior to 2018. NOTE: php7.1 deprecated mcrypt 1-Dec-2016 and php7.2 dropped it completely 30-Nov-2017, as it should no longer be nec.'
   package:
     name: "php{{ php_version }}-mcrypt"
     state: present

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -1,5 +1,7 @@
-is_centos: True
 is_redhat: True
+is_centos: True
+is_centos7: True
+
 dns_service: named
 dns_user: named
 proxy: squid

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -1,6 +1,6 @@
 is_redhat: True
 is_centos: True
-is_centos7: True
+is_centos_7: True
 
 dns_service: named
 dns_user: named

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -17,8 +17,8 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.1
-postgresql_version: 10
+php_version: 7.3
+postgresql_version: 11
 systemd_location: /lib/systemd/system
 # Upgrade OS's own Calibre to very latest:
 calibre_via_debs: True

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_debian: True
 is_debian_10: True
+
 dns_service: bind9
 dhcp_service: isc-dhcp-server
 dns_user: bind

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_debian: True
 is_debian_8: True
+
 dns_service: bind9
 dns_user: bind
 proxy: squid3

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_debian: True
 is_debian_9: True
+
 dns_service: bind9
 dhcp_service: isc-dhcp-server
 dns_user: bind

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -490,16 +490,22 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 is_debuntu: False
 is_ubuntu: False
 is_ubuntu_18: False
+is_ubuntu_17: False
 is_ubuntu_16: False
 is_debian: False
 is_debian_10: False
 is_debian_9: False
 is_debian_8: False
 is_rpi: False
+is_raspbian_9: False
+is_raspbian_8: False
 
 is_redhat: False
-is_fedora: False
 is_centos: False
+is_centos_7: False
+is_fedora: False
+is_fedora_22: False
+is_fedora_18: False
 
 # How This Works:
 # 1. /opt/iiab/iiab/iiab-install copies scripts/local_facts.fact to /etc/ansible/facts.d/local_facts.fact

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -1,4 +1,5 @@
 is_redhat: True
+is_fedora: True
 is_fedora_18: True
 
 dns_service: named

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -1,4 +1,6 @@
 is_redhat: True
+is_fedora_18: True
+
 dns_service: named
 dns_user: named
 proxy: squid

--- a/vars/fedora-22.yml
+++ b/vars/fedora-22.yml
@@ -1,4 +1,6 @@
 is_redhat: True
+is_fedora_22: True
+
 dns_service: named
 dns_user: named
 proxy: squid

--- a/vars/fedora-22.yml
+++ b/vars/fedora-22.yml
@@ -1,4 +1,5 @@
 is_redhat: True
+is_fedora: True
 is_fedora_22: True
 
 dns_service: named

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_debian_8: True
 is_raspbian_8: True
 is_rpi: True
 rtc_id: ds3231

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -1,6 +1,7 @@
-is_rpi: True
-is_debian: True
 is_debuntu: True
+is_debian: True
+is_raspbian_8: True
+is_rpi: True
 rtc_id: ds3231
 
 dns_service: bind9

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_debian_9: True
 is_raspbian_9: True
 is_rpi: True
 rtc_id: ds3231

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -1,6 +1,7 @@
-is_rpi: True
-is_debian: True
 is_debuntu: True
+is_debian: True
+is_raspbian_9: True
+is_rpi: True
 rtc_id: ds3231
 
 dns_service: bind9

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_ubuntu: True
 is_ubuntu_16: True
+
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server

--- a/vars/ubuntu-17.yml
+++ b/vars/ubuntu-17.yml
@@ -1,5 +1,7 @@
 is_debuntu: True
 is_ubuntu: True
+is_ubuntu_17: True
+
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_ubuntu: True
 is_ubuntu_18: True
+
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server


### PR DESCRIPTION
BIG-sized http://d.iiab.io/6.7 installed to completion on the [testing branch of Debian 10 "Buster", daily build 2019-01-13](https://www.debian.org/devel/debian-installer/) after forcing the following line into `/etc/os-release` :
```
VERSION_ID="10"
```
(The above allows [iiab-install](https://github.com/iiab/iiab/blob/master/iiab-install) to run [/opt/iiab/iiab/scripts/local_facts.fact](https://github.com/iiab/iiab/blob/master/scripts/local_facts.fact) -> `/etc/ansible/facts.d/local_facts.fact` properly, setting OS_VER to "debian-10" so we're ready for Debian 10's beta releases in coming months and final release by/around mid-2019.)

THIS PR FIXES:
- #928 PHP 7.3 & PostgreSQL 11 go into [vars/debian-10.yml ](https://github.com/iiab/iiab/blob/master/vars/debian-10.yml)
- Nextcloud install is fixed by ending the installation of `php{{ php_version }}-mcrypt` on all OS's released after 2017.  This is accomplished by better self-identifying all OS's within [/opt/iiab/iiab/vars](https://github.com/iiab/iiab/tree/master/vars).  @jvonau can hopefully confirm that mcrypt is completely unnec going forward?

OUTSTANDING ISSUES &mdash; INCL WORKAROUNDS:
- The [3 lines](https://github.com/iiab/iiab/blob/master/roles/httpd/templates/refresh-wiki-docs.sh#L36-L38) in /usr/bin/iiab-refresh-wiki-docs that use lynx to d/l from github.com need to be commented out for now (mysteriously GitHub is blocking all connections from lynx on Debian 10, even when lynx issues exactly the same headers as from Ubuntu/Raspbian or Debian 9!)  Possibly this is a subtle SSL/TLS problem, even when lynx claims to be using the same SSL as on the other distros?!
- ["Stop ejabberd service"](https://github.com/iiab/iiab/blob/master/roles/ejabberd/tasks/main.yml#L62-L68) froze during ejabberd's install, so `systemctl stop ejabberd` had to be run manually.  Installation then continued on its own: relaunching IIAB's install with `sudo iiab` was not even nec this time!

https://github.com/iiab/iiab-admin-console/pull/116 FIXED:

- [Admin Console will now install](https://github.com/iiab/iiab-factory/blob/master/iiab#L203-L205) as obsolete `pip install --download <dir> SomePackage` syntax was removed and replaced with `pip download --dest <dir> SomePackage` in 2 sections of [roles/cmdsrv/tasks/main.yml](https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml).  Specifically `--download` was deprecated after pip 9.x as documented at https://het.as.utexas.edu/HET/Software/Pip/reference/pip_download.html &mdash; and currently Debian 10 uses pip 18.1.  _Errors had been: pip has "no such option: --download"_ in both "TASK [cmdsrv : Download zeromq and python binding]" and "TASK [cmdsrv : Download speedtest-cli]".  PR116 fixed pip syntax and was tested across 3 distros.

Others Refs: #878 #899 #928 #935