### PR TITLE
Don't try to install usbmount 0.0.14-1 on Raspbian

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -18,7 +18,7 @@
   apt:
     deb: "{{ iiab_download_url }}/usbmount_0.0.14.1_all.deb"
     #timeout: "{{ download_timeout }}"    # Ansible's apt module doesn't support timeout parameter; that's ok as usbmount_0.0.14.1_all.deb is only 10KB
-  when: internet_available and is_debian_9
+  when: internet_available and is_debian_9 and not is_raspbian_9
 
 - name: "Install 7 deb/apt packages: avahi-daemon, avahi-discover, exfat-fuse, exfat-utils, inetutils-syslogd, libnss-mdns, wpasupplicant (debuntu)"
   package:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -486,7 +486,7 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # Platforms - turn all off and let /opt/iiab/iiab/vars/<OS>.yml turn on as appropriate
 
-# Wide to narrow
+# Wide to narrow (insofar as poss)
 is_debuntu: False
 is_ubuntu: False
 is_ubuntu_18: False
@@ -496,9 +496,9 @@ is_debian: False
 is_debian_10: False
 is_debian_9: False
 is_debian_8: False
-is_rpi: False
 is_raspbian_9: False
 is_raspbian_8: False
+is_rpi: False
 
 is_redhat: False
 is_centos: False


### PR DESCRIPTION
Fixes #1389

Which arose from the new vars/raspbian-9.yml which contains:
```
is_debuntu: True
is_debian: True
is_debian_9: True
is_raspbian_9: True
is_rpi: True
rtc_id: ds3231	rtc_id: ds3231
```
As a result of #1386