### PR TITLE
1-prep: detect Ubermix (using grep) WITHOUT alarmist red errors

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -48,9 +48,10 @@
 #    var: ro_dir
 
 - name: Does 'ubermix' exist in /etc/lsb-release?
-  shell: grep -i ubermix /etc/lsb-release
+  shell: grep -i ubermix /etc/lsb-release    # Pipe to cat to avoid red errors?
   register: grep_ubermix
-  ignore_errors: true
+  failed_when: false    # Universal way to hide alarmist red errors!
+  #ignore_errors: true
   #check_mode: no
 
 #- debug:


### PR DESCRIPTION
Refines PR #1385 so implementers don't overeact to false alarms (Ansible's red errors) generated by grep's 3 different possible results (grep_ubermix.rc == 0 or 1 or 2) each of which are entirely expected and perfectly normal:

Excerpt from https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/main.yml#L68 below: (grep return code is 0 when it's indeed found the regular expression "ubermix" in file /etc/lsb-release)
```
  when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
```