### PR TITLE
Asterisk (with chan_dongle) and FreePBX

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -57,6 +57,12 @@
 #  when: owncloud_install
 #  tags: owncloud
 
+- name: PBX
+  include_role:
+    name: pbx
+  when: pbx_install
+  tags: pbx  
+
 - name: WORDPRESS
   include_role:
     name: wordpress

--- a/roles/network/tasks/hosts.yml
+++ b/roles/network/tasks/hosts.yml
@@ -10,7 +10,7 @@
   lineinfile:
     path: /etc/hosts
     regexp: '^172\.18\.96\.1'
-    line: '172.18.96.1     {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box box.lan'
+    line: '172.18.96.1     {{ iiab_hostname }}.{{ iiab_domain }} {{ iiab_hostname }} box box.lan pbx pbx.lan'
     state: present
   when: iiab_lan_iface != "none" and not installing
 

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -1,10 +1,10 @@
-===============
+==========
 PBX README
-===============
+==========
 
-Adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality.
+This 'pbx' playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality.
 
-Asterisk is a software implementation of a private branch exchange (PBX). In conjunction with suitable telephony hardware interfaces and network applications, Asterisk is used to establish and control telephone calls between telecommunication endpoints, such as customary telephone sets, destinations on the public switched telephone network (PSTN), and devices or services on voice over Internet Protocol (VoIP) networks. Its name comes from the asterisk (*) symbol for a signal used in dual-tone multi-frequency (DTMF) dialing. 
+Asterisk is a software implementation of a private branch exchange (PBX).  In conjunction with suitable telephony hardware interfaces and network applications, Asterisk is used to establish and control telephone calls between telecommunication endpoints, such as customary telephone sets, destinations on the public switched telephone network (PSTN), and devices or services on Voice over Internet Protocol (VoIP) networks.  Its name comes from the asterisk (*) symbol for a signal used in dual-tone multi-frequency (DTMF) dialing. 
 
 FreePBX is a web-based open source GUI (graphical user interface) that controls and manages Asterisk (PBX), an open source communication server.
 
@@ -16,11 +16,11 @@ Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.
   pbx_install: True
   pbx_enabled: True
 
-Optionally, you may want to enable `chan_dongle <https://github.com/wdoekes/asterisk-chan-dongle>`_, which is a channel driver for Huawei UMTS cards allowing regular voice calls over GSM. You will need to configure a dongle post install for it to be recognized properly::
+Optionally, you may want to enable `chan_dongle <https://github.com/wdoekes/asterisk-chan-dongle>`_, which is a channel driver for Huawei UMTS cards allowing regular voice calls over GSM.  You will need to configure a dongle post-install, for it to be recognized properly::
 
   asterisk_chan_dongle: True
 
-After installing PBX as part IIAB, please log in to http://pbx.lan and proceed with inital configuration.
+After installing PBX as part of IIAB, please visit http://pbx.lan/freepbx and proceed with initial configuration — which asks you to create a login/password.
 
 You can monitor the PBX service with command::
 
@@ -29,8 +29,4 @@ You can monitor the PBX service with command::
 Attribution
 -----------
 
-The asterisk and freepbx playbooks have been heavily inspired by the work `here <https://github.com/Yannik/ansible-role-asterisk>`_ and `here <https://github.com/Yannik/ansible-role-freepbx>`_. 
-Dependencies
-------------
-
-1. This playbooks compiles and installs asterisk and freepbx from source, so running this feature involves significant bandwidth and compute time.
+This 'pbx' playbook was heavily inspired by Yannik Sembritzki's `Asterisk <https://github.com/Yannik/ansible-role-asterisk>`_ and `FreePBX <https://github.com/Yannik/ansible-role-freepbx>`_ Ansible work.

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -1,0 +1,40 @@
+===============
+PBX README
+===============
+
+Adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality.
+
+Asterisk is a software implementation of a private branch exchange (PBX). In conjunction with suitable telephony hardware interfaces and network applications, Asterisk is used to establish and control telephone calls between telecommunication endpoints, such as customary telephone sets, destinations on the public switched telephone network (PSTN), and devices or services on voice over Internet Protocol (VoIP) networks. Its name comes from the asterisk (*) symbol for a signal used in dual-tone multi-frequency (DTMF) dialing. 
+
+FreePBX is a web-based open source GUI (graphical user interface) that controls and manages Asterisk (PBX), an open source communication server.
+
+Using It
+--------
+
+Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ contains::
+
+  pbx_install: True
+  pbx_enabled: True
+  nodejs_version: 10.x
+
+As a dependency the following must be set::
+  
+  sugarizer_install: False
+  sugarizer_enabled: False
+
+
+After installing PBX as part IIAB, please log in to http://pbx.lan and proceed with inital configuration.
+
+You can monitor the PBX service with command::
+
+  systemctl status freepbx
+
+Attribution
+-----------
+
+The asterisk and freepbx playbooks have been heavily inspired by the work `here <https://github.com/Yannik/ansible-role-asterisk>`_ and `here <https://github.com/Yannik/ansible-role-freepbx>`_. 
+Dependencies
+------------
+
+1. This playbooks compiles and installs asterisk and freepbx from source, so running this feature involves significant bandwidth and compute time.
+2. This playbook is also incompatible with sugarizer, and nodejs-8.x. Therefore if either of those are set to be install, this playbook will gracefully fail with a message requesting the user to fix those incompatibilites. 

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -15,16 +15,10 @@ Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.
 
   pbx_install: True
   pbx_enabled: True
-  nodejs_version: 10.x
 
 Optionally, you may want to enable `chan_dongle <https://github.com/wdoekes/asterisk-chan-dongle>`_, which is a channel driver for Huawei UMTS cards allowing regular voice calls over GSM. You will need to configure a dongle post install for it to be recognized properly::
 
   asterisk_chan_dongle: True
-
-As a dependency the following *must* be set::
-  
-  sugarizer_install: False
-  sugarizer_enabled: False
 
 After installing PBX as part IIAB, please log in to http://pbx.lan and proceed with inital configuration.
 
@@ -40,4 +34,3 @@ Dependencies
 ------------
 
 1. This playbooks compiles and installs asterisk and freepbx from source, so running this feature involves significant bandwidth and compute time.
-2. This playbook is also incompatible with sugarizer, and nodejs-8.x. Therefore if either of those are set to be install, this playbook will gracefully fail with a message requesting the user to fix those incompatibilites. 

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -17,11 +17,14 @@ Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.
   pbx_enabled: True
   nodejs_version: 10.x
 
-As a dependency the following must be set::
+Optionally, you may want to enable `chan_dongle <https://github.com/wdoekes/asterisk-chan-dongle>`_, which is a channel driver for Huawei UMTS cards allowing regular voice calls over GSM. You will need to configure a dongle post install for it to be recognized properly::
+
+  asterisk_chan_dongle: True
+
+As a dependency the following *must* be set::
   
   sugarizer_install: False
   sugarizer_enabled: False
-
 
 After installing PBX as part IIAB, please log in to http://pbx.lan and proceed with inital configuration.
 

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -10,4 +10,7 @@ freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
 freepbx_src_file: freepbx-15.0-latest.tgz
 freepbx_src_dir: /opt/iiab/freepbx
 freepbx_install_dir: /var/www/html/freepbx
-libodbc_path: ""
+
+chan_dongle_url: https://github.com/wdoekes/asterisk-chan-dongle/archive/
+chan_dongle_src_file: master.zip
+chan_dongle_src_dir: /opt/iiab/chan_dongle

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -15,3 +15,4 @@ asterisk_db_cdrdbname: asteriskcdrdb
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
 freepbx_src_file: freepbx-15.0-latest.tgz
 freepbx_src_dir: /opt/iiab/freepbx
+libodbc_path: ""

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -6,12 +6,6 @@ asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
 asterisk_src_file: asterisk-16-current.tar.gz
 asterisk_src_dir: /opt/iiab/asterisk
 
-#asterisk_db_host: localhost
-#asterisk_db_user: asterisk
-#asterisk_db_dbname: asterisk
-#asterisk_db_password: changeme
-#asterisk_db_cdrdbname: asteriskcdrdb
-
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
 freepbx_src_file: freepbx-15.0-latest.tgz
 freepbx_src_dir: /opt/iiab/freepbx

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -15,4 +15,5 @@ asterisk_src_dir: /opt/iiab/asterisk
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
 freepbx_src_file: freepbx-15.0-latest.tgz
 freepbx_src_dir: /opt/iiab/freepbx
+freepbx_install_dir: /var/www/html/freepbx
 libodbc_path: ""

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -1,0 +1,7 @@
+pbx_install: False
+pbx_enabled: False
+pbx_installed: False
+
+asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
+asterisk_src_file: asterisk-16-current.tar.gz
+asterisk_src_dir: /opt/iiab/asterisk

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -12,6 +12,12 @@ freepbx_src_file: freepbx-15.0-latest.tgz
 freepbx_src_dir: /opt/iiab/freepbx
 freepbx_install_dir: /var/www/html/freepbx
 
+asterisk_db_host: localhost
+asterisk_db_user: asterisk
+asterisk_db_dbname: asterisk
+asterisk_db_password: asterisk
+asterisk_db_cdrdbname: asteriskcdrdb
+
 chan_dongle_url: https://github.com/wdoekes/asterisk-chan-dongle/archive/
 chan_dongle_src_file: master.zip
 chan_dongle_src_dir: /opt/iiab/chan_dongle

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -1,6 +1,7 @@
 pbx_install: False
 pbx_enabled: False
 pbx_installed: False
+asterisk_chan_dongle: False
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
 asterisk_src_file: asterisk-16-current.tar.gz

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -5,3 +5,13 @@ pbx_installed: False
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
 asterisk_src_file: asterisk-16-current.tar.gz
 asterisk_src_dir: /opt/iiab/asterisk
+
+asterisk_db_host: localhost
+asterisk_db_user: asterisk
+asterisk_db_dbname: asterisk
+asterisk_db_password: changeme
+asterisk_db_cdrdbname: asteriskcdrdb
+
+freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
+freepbx_src_file: freepbx-15.0-latest.tgz
+freepbx_src_dir: /opt/iiab/freepbx

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -1,7 +1,11 @@
-pbx_install: False
-pbx_enabled: False
+# pbx_install: False
+# pbx_enabled: False
+# asterisk_chan_dongle: False
+
+# All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
+
 pbx_installed: False
-asterisk_chan_dongle: False
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
 asterisk_src_file: asterisk-16-current.tar.gz

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -6,11 +6,11 @@ asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
 asterisk_src_file: asterisk-16-current.tar.gz
 asterisk_src_dir: /opt/iiab/asterisk
 
-asterisk_db_host: localhost
-asterisk_db_user: asterisk
-asterisk_db_dbname: asterisk
-asterisk_db_password: changeme
-asterisk_db_cdrdbname: asteriskcdrdb
+#asterisk_db_host: localhost
+#asterisk_db_user: asterisk
+#asterisk_db_dbname: asterisk
+#asterisk_db_password: changeme
+#asterisk_db_cdrdbname: asteriskcdrdb
 
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/
 freepbx_src_file: freepbx-15.0-latest.tgz

--- a/roles/pbx/meta/main.yml
+++ b/roles/pbx/meta/main.yml
@@ -1,0 +1,3 @@
+ dependencies:
+     - { role: nodejs, tags: ['nodejs'], when: pbx_install }
+

--- a/roles/pbx/meta/main.yml
+++ b/roles/pbx/meta/main.yml
@@ -1,3 +1,3 @@
  dependencies:
-     - { role: nodejs, tags: ['nodejs'], when: pbx_install and (nodejs_version == "10.x") and (not sugarizer_install)}
+     - { role: nodejs, tags: ['nodejs'], when: pbx_install and (nodejs_version == "10.x")}
 

--- a/roles/pbx/meta/main.yml
+++ b/roles/pbx/meta/main.yml
@@ -1,3 +1,3 @@
  dependencies:
-     - { role: nodejs, tags: ['nodejs'], when: pbx_install }
+     - { role: nodejs, tags: ['nodejs'], when: pbx_install and (nodejs_version == "10.x")}
 

--- a/roles/pbx/meta/main.yml
+++ b/roles/pbx/meta/main.yml
@@ -1,3 +1,3 @@
  dependencies:
-     - { role: nodejs, tags: ['nodejs'], when: pbx_install and (nodejs_version == "10.x")}
+     - { role: nodejs, tags: ['nodejs'], when: pbx_install and (nodejs_version == "10.x") and (not sugarizer_install)}
 

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -30,6 +30,7 @@
     owner: root
     group: root
     extra_opts: [--strip-components=1]
+    creates: "{{ asterisk_src_dir }}/Makefile"
 
 - name: Asterisk - Download mp3 decoder library into source tree
   command: "./contrib/scripts/get_mp3_source.sh"
@@ -50,12 +51,14 @@
 - name: Asterisk - Run the configure script
   command: "./configure"
   args:
-    chdir: "{{ asterisk_src_dir }}"  
+    chdir: "{{ asterisk_src_dir }}"
+    creates: "config.log"  
 
 - name: Asterisk - Run make menuselect.makeopts
   command: "make menuselect.makeopts"
   args:
     chdir: "{{ asterisk_src_dir }}"
+    creates: "menuselect.makeopts"  
 
 - name: Asterisk - Do a bit of menuselect configuration
   command: >
@@ -70,21 +73,13 @@
   command: make 
   args:
     chdir: "{{ asterisk_src_dir }}"
+    creates: "defaults.h"
 
 - name: Asterisk - install
   command: make install
   args:
     chdir: "{{ asterisk_src_dir }}"
-
-- name: Asterisk - install config
-  command: make config
-  args:
-    chdir: "{{ asterisk_src_dir }}"
-
-- name: Asterisk - install samples
-  command: make samples
-  args:
-    chdir: "{{ asterisk_src_dir }}"
+    creates: "/usr/sbin/asterisk"
 
 - name: Asterisk - ldconfig
   command: ldconfig

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,0 +1,136 @@
+- name: Asterisk - Install dependencies
+  include: asterisk_dependencies.yml
+
+- name: Asterisk - Download software to /opt/iiab/downloads
+  get_url:
+    url: "{{ asterisk_url }}/{{ asterisk_src_file }}"
+    dest: "{{ downloads_dir }}/{{ asterisk_src_file }}"
+    timeout: "{{ download_timeout }}"
+  when: internet_available
+
+- name: Asterisk - Check for /opt/iiab/downloads/{{ asterisk_src_file }}
+  stat:
+    path: "{{ downloads_dir }}/{{ asterisk_src_file }}"
+  register: asterisk_src
+
+- name: Asterisk - FAIL (force Ansible to exit) IF /opt/iiab/downloads/{{ asterisk_src_file }} doesn't exist
+  fail:
+    msg: "{ downloads_dir }}/{{ asterisk_src_file }} is REQUIRED in order to install."
+  when: not asterisk_src.stat.exists
+
+- name: Asterisk - Create install source directory
+  file: 
+    path: "{{ asterisk_src_dir }}"
+    state: directory
+
+- name: Asterisk - Extract source
+  unarchive: 
+    src: "{{ downloads_dir }}/{{ asterisk_src_file }}"
+    dest: "{{ asterisk_src_dir }}"
+    owner: root
+    group: root
+
+- name: Asterisk - Download mp3 decoder library into source tree
+  command: "./contrib/scripts/get_mp3_source.sh"
+  args:
+    chdir: {{ asterisk_src_dir }}
+    creates: addons/mp3/mpg123.h
+
+- name: Asterisk - Ensure all dependencies are resolved
+  shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install 
+  args:
+    chdir: {{ asterisk_src_dir }}
+
+- name: Asterisk - Run the configure script
+  command: "./configure"
+  args:
+    chdir:{{ asterisk_src_dir }}  
+
+- name: Asterisk - Run make menuselect.makeopts
+  command: "make menuselect.makeopts"
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - Do a bit of menuselect configuration
+  command: >
+    menuselect/menuselect --enable app_macro --enable format_mp3
+    --enable CORE-SOUNDS-EN-WAV --enable CORE-SOUNDS-EN-G722
+    --enable EXTRA-SOUNDS-EN-WAV --enable EXTRA-SOUNDS-EN-G722 --enable EXTRA-SOUNDS-EN-GSM
+    --disable-category MENUSELECT_MOH        
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - Run 'make'
+  command: make 
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - install
+  command: make install
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - install config
+  command: make config
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - install samples
+  command: make samples
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - ldconfig
+  command: ldconfig
+  args:
+    chdir:{{ asterisk_src_dir }}
+
+- name: Asterisk - Create the necessary user/group config and set permissions
+  command: "{{ item }} chdir={{ asterisk_src_dir }}"
+  with_items:
+    - groupadd asterisk
+    - useradd -r -d /var/lib/asterisk -g asterisk asterisk
+    - usermod -aG audio,dialout asterisk
+    - chown -R asterisk.asterisk /etc/asterisk
+    - chown -R asterisk.asterisk /var/{lib,log,spool}/asterisk
+    - chown -R asterisk.asterisk /usr/lib/asterisk
+
+- name: Asterisk - Set default user to asterisk in /etc/default/asterisk
+  lineinfile:
+      path: /etc/default/asterisk
+      regexp: 'AST_USER='
+      line: 'AST_USER="asterisk"'
+
+- name: Asterisk - Set default group to asterisk in /etc/default/asterisk
+  lineinfile:
+      path: /etc/default/asterisk
+      regexp: 'AST_GROUP='
+      line: 'AST_GROUP="asterisk"'
+
+- name: Asterisk - Set default user to asterisk in /etc/asterisk/asterisk.conf
+  lineinfile:
+      path: /etc/asterisk/asterisk.conf
+      regexp: 'runuser ='
+      line: 'runuser = asterisk'
+
+- name: Asterisk - Set default group to asterisk in /etc/asterisk/asterisk.conf
+  lineinfile:
+      path: /etc/asterisk/asterisk.conf
+      regexp: 'rungroup ='
+      line: 'rungroup = asterisk'
+
+- name: Enable & Start asterisk service
+  systemd:
+    daemon_reload: yes
+    name: asterisk
+    enabled: yes
+    state: started
+  when: asterisk_enabled
+
+- name: Disable & Stop asterisk service
+  systemd:
+    daemon_reload: yes
+    name: asterisk
+    enabled: no
+    state: stopped
+  when: (not asterisk_enabled)

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -38,9 +38,9 @@
     chdir: "{{ asterisk_src_dir }}"
     creates: "addons/mp3/mpg123.h"
 
-- name: Install aptitude (otherwise install_prereq fails)
+- name: Asterisk - Install aptitude (otherwise install_prereq fails?)
   package: 
-    name: aptitude 
+    name: aptitude
     state: latest
 
 - name: Asterisk - Ensure all dependencies are resolved
@@ -68,29 +68,29 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - Run 'make'
+- name: Asterisk - Run 'make' - CAN TAKE 10 MIN OR LONGER!
   command: make 
   args:
     chdir: "{{ asterisk_src_dir }}"
     creates: "defaults.h"
 
-- name: Asterisk - install
+- name: Asterisk - Run 'make install' - CAN TAKE 3 MIN OR LONGER!
   command: make install
   args:
     chdir: "{{ asterisk_src_dir }}"
     creates: "/usr/sbin/asterisk"
 
-- name: Asterisk - config
+- name: Asterisk - Run 'make config'
   command: make config
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - samples
+- name: Asterisk - Run 'make samples'
   command: make samples
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - ldconfig
+- name: Asterisk - Run 'ldconfig'
   shell: ldconfig
   args:
     chdir: "{{ asterisk_src_dir }}"
@@ -109,7 +109,7 @@
     system: yes
     append: yes
 
-- name: Asterisk - Set directory ownership
+- name: 'Asterisk - Set ownership of 5 directories: /etc/asterisk, /var/lib/asterisk, /var/log/asterisk, /var/spool/asterisk, /usr/lib/asterisk'
   file: 
     dest: "{{ item }}" 
     owner: asterisk 

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -37,6 +37,11 @@
     chdir: "{{ asterisk_src_dir }}"
     creates: "addons/mp3/mpg123.h"
 
+- name: Install aptitude (otherwise install_prereq fails)
+  package: 
+    name: aptitude 
+    state: latest
+
 - name: Asterisk - Ensure all dependencies are resolved
   shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install 
   args:
@@ -93,7 +98,9 @@
     - useradd -r -d /var/lib/asterisk -g asterisk asterisk
     - usermod -aG audio,dialout asterisk
     - chown -R asterisk.asterisk /etc/asterisk
-    - chown -R asterisk.asterisk /var/{lib,log,spool}/asterisk
+    - chown -R asterisk.asterisk /var/lib/asterisk
+    - chown -R asterisk.asterisk /var/log/asterisk
+    - chown -R asterisk.asterisk /var/spool/asterisk
     - chown -R asterisk.asterisk /usr/lib/asterisk
 
 - name: Asterisk - Set default user to asterisk in /etc/default/asterisk

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -136,3 +136,7 @@
     path: /etc/asterisk/asterisk.conf
     regexp: 'rungroup ='
     line: 'rungroup = asterisk'
+
+- name: Asterisk - Install chan_dongle
+  include: chan_dongle.yml
+  when: asterisk_chan_dongle

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -29,6 +29,7 @@
     dest: "{{ asterisk_src_dir }}"
     owner: root
     group: root
+    extra_opts: [--strip-components=1]
 
 - name: Asterisk - Download mp3 decoder library into source tree
   command: "./contrib/scripts/get_mp3_source.sh"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -85,7 +85,11 @@
   command: make samples
   args:
     chdir: "{{ asterisk_src_dir }}"
-    creates: "/etc/default/asterisk"
+
+- name: Asterisk - basic pbx
+  command: make basic-pbx
+  args:
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - ldconfig
   command: ldconfig

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -142,7 +142,7 @@
       regexp: 'rungroup ='
       line: 'rungroup = asterisk'
 
-- name: Enable & Start asterisk service
+- name: Asterisk - Enable & Start asterisk service
   systemd:
     daemon_reload: yes
     name: asterisk
@@ -150,7 +150,7 @@
     state: started
   when: pbx_enabled
 
-- name: Disable & Stop asterisk service
+- name: Asterisk - Disable & Stop asterisk service
   systemd:
     daemon_reload: yes
     name: asterisk

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -91,17 +91,32 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - Create the necessary user/group config and set permissions
-  command: "{{ item }} chdir={{ asterisk_src_dir }}"
+- name: Asterisk - Ensure group "asterisk" exists
+  group:
+    name: asterisk
+    state: present
+
+- name: Asterisk - Ensure user "asterisk" exists, and belongs to the required groups
+  user:
+    name: asterisk
+    group: asterisk
+    groups: audio,dialout
+    home: "/var/lib/asterisk"
+    system: yes
+    append: yes
+
+- name: Asterisk - Set directory ownership
+  file: 
+    dest: "{{ item }}" 
+    owner: asterisk 
+    group: asterisk
+    recurse: yes
   with_items:
-    - groupadd asterisk
-    - useradd -r -d /var/lib/asterisk -g asterisk asterisk
-    - usermod -aG audio,dialout asterisk
-    - chown -R asterisk.asterisk /etc/asterisk
-    - chown -R asterisk.asterisk /var/lib/asterisk
-    - chown -R asterisk.asterisk /var/log/asterisk
-    - chown -R asterisk.asterisk /var/spool/asterisk
-    - chown -R asterisk.asterisk /usr/lib/asterisk
+    - /etc/asterisk
+    - /var/lib/asterisk
+    - /var/log/asterisk
+    - /var/spool/asterisk
+    - /usr/lib/asterisk
 
 - name: Asterisk - Set default user to asterisk in /etc/default/asterisk
   lineinfile:
@@ -133,7 +148,7 @@
     name: asterisk
     enabled: yes
     state: started
-  when: asterisk_enabled
+  when: pbx_enabled
 
 - name: Disable & Stop asterisk service
   systemd:
@@ -141,4 +156,4 @@
     name: asterisk
     enabled: no
     state: stopped
-  when: (not asterisk_enabled)
+  when: (not pbx_enabled)

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -81,6 +81,12 @@
     chdir: "{{ asterisk_src_dir }}"
     creates: "/usr/sbin/asterisk"
 
+- name: Asterisk - sample config
+  command: make samples
+  args:
+    chdir: "{{ asterisk_src_dir }}"
+    creates: "/etc/default/asterisk"
+
 - name: Asterisk - ldconfig
   command: ldconfig
   args:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -120,24 +120,24 @@
 
 - name: Asterisk - Set default user to asterisk in /etc/default/asterisk
   lineinfile:
-      path: /etc/default/asterisk
-      regexp: 'AST_USER='
-      line: 'AST_USER="asterisk"'
+    path: /etc/default/asterisk
+    regexp: 'AST_USER='
+    line: 'AST_USER="asterisk"'
 
 - name: Asterisk - Set default group to asterisk in /etc/default/asterisk
   lineinfile:
-      path: /etc/default/asterisk
-      regexp: 'AST_GROUP='
-      line: 'AST_GROUP="asterisk"'
+    path: /etc/default/asterisk
+    regexp: 'AST_GROUP='
+    line: 'AST_GROUP="asterisk"'
 
 - name: Asterisk - Set default user to asterisk in /etc/asterisk/asterisk.conf
   lineinfile:
-      path: /etc/asterisk/asterisk.conf
-      regexp: 'runuser ='
-      line: 'runuser = asterisk'
+    path: /etc/asterisk/asterisk.conf
+    regexp: 'runuser ='
+    line: 'runuser = asterisk'
 
 - name: Asterisk - Set default group to asterisk in /etc/asterisk/asterisk.conf
   lineinfile:
-      path: /etc/asterisk/asterisk.conf
-      regexp: 'rungroup ='
-      line: 'rungroup = asterisk'
+    path: /etc/asterisk/asterisk.conf
+    regexp: 'rungroup ='
+    line: 'rungroup = asterisk'

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -92,7 +92,7 @@
     chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - ldconfig
-  command: ldconfig
+  shell: ldconfig
   args:
     chdir: "{{ asterisk_src_dir }}"
 

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -43,7 +43,7 @@
     name: aptitude
     state: latest
 
-- name: Asterisk - Ensure all dependencies are resolved
+- name: Asterisk - Ensure all dependencies are resolved - CAN TAKE 2 MIN OR LONGER!
   shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install 
   args:
     chdir: "{{ asterisk_src_dir }}"
@@ -95,12 +95,12 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - Ensure group "asterisk" exists
+- name: Asterisk - Ensure group 'asterisk' exists
   group:
     name: asterisk
     state: present
 
-- name: Asterisk - Ensure user "asterisk" exists, and belongs to the required groups
+- name: Asterisk - Ensure user 'asterisk' exists, and belongs to the required groups
   user:
     name: asterisk
     group: asterisk
@@ -122,25 +122,25 @@
     - /var/spool/asterisk
     - /usr/lib/asterisk
 
-- name: Asterisk - Set default user to asterisk in /etc/default/asterisk
+- name: Asterisk - Set default user to 'asterisk' in /etc/default/asterisk
   lineinfile:
     path: /etc/default/asterisk
     regexp: 'AST_USER='
     line: 'AST_USER="asterisk"'
 
-- name: Asterisk - Set default group to asterisk in /etc/default/asterisk
+- name: Asterisk - Set default group to 'asterisk' in /etc/default/asterisk
   lineinfile:
     path: /etc/default/asterisk
     regexp: 'AST_GROUP='
     line: 'AST_GROUP="asterisk"'
 
-- name: Asterisk - Set default user to asterisk in /etc/asterisk/asterisk.conf
+- name: Asterisk - Set default user to 'asterisk' in /etc/asterisk/asterisk.conf
   lineinfile:
     path: /etc/asterisk/asterisk.conf
     regexp: 'runuser ='
     line: 'runuser = asterisk'
 
-- name: Asterisk - Set default group to asterisk in /etc/asterisk/asterisk.conf
+- name: Asterisk - Set default group to 'asterisk' in /etc/asterisk/asterisk.conf
   lineinfile:
     path: /etc/asterisk/asterisk.conf
     regexp: 'rungroup ='

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -141,19 +141,3 @@
       path: /etc/asterisk/asterisk.conf
       regexp: 'rungroup ='
       line: 'rungroup = asterisk'
-
-- name: Asterisk - Enable & Start asterisk service
-  systemd:
-    daemon_reload: yes
-    name: asterisk
-    enabled: yes
-    state: started
-  when: pbx_enabled
-
-- name: Asterisk - Disable & Stop asterisk service
-  systemd:
-    daemon_reload: yes
-    name: asterisk
-    enabled: no
-    state: stopped
-  when: (not pbx_enabled)

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -49,10 +49,9 @@
     chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Run the configure script
-  command: "./configure"
+  command: "./configure --with-jansson-bundled"
   args:
     chdir: "{{ asterisk_src_dir }}"
-    creates: "config.log"  
 
 - name: Asterisk - Run make menuselect.makeopts
   command: "make menuselect.makeopts"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -81,7 +81,12 @@
     chdir: "{{ asterisk_src_dir }}"
     creates: "/usr/sbin/asterisk"
 
-- name: Asterisk - sample config
+- name: Asterisk - config
+  command: make config
+  args:
+    chdir: "{{ asterisk_src_dir }}"
+
+- name: Asterisk - samples
   command: make samples
   args:
     chdir: "{{ asterisk_src_dir }}"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -44,12 +44,12 @@
 - name: Asterisk - Run the configure script
   command: "./configure"
   args:
-    chdir:{{ asterisk_src_dir }}  
+    chdir: {{ asterisk_src_dir }}  
 
 - name: Asterisk - Run make menuselect.makeopts
   command: "make menuselect.makeopts"
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - Do a bit of menuselect configuration
   command: >
@@ -58,32 +58,32 @@
     --enable EXTRA-SOUNDS-EN-WAV --enable EXTRA-SOUNDS-EN-G722 --enable EXTRA-SOUNDS-EN-GSM
     --disable-category MENUSELECT_MOH        
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - Run 'make'
   command: make 
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - install
   command: make install
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - install config
   command: make config
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - install samples
   command: make samples
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - ldconfig
   command: ldconfig
   args:
-    chdir:{{ asterisk_src_dir }}
+    chdir: {{ asterisk_src_dir }}
 
 - name: Asterisk - Create the necessary user/group config and set permissions
   command: "{{ item }} chdir={{ asterisk_src_dir }}"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -86,11 +86,6 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - basic pbx
-  command: make basic-pbx
-  args:
-    chdir: "{{ asterisk_src_dir }}"
-
 - name: Asterisk - ldconfig
   shell: ldconfig
   args:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -33,23 +33,23 @@
 - name: Asterisk - Download mp3 decoder library into source tree
   command: "./contrib/scripts/get_mp3_source.sh"
   args:
-    chdir: {{ asterisk_src_dir }}
-    creates: addons/mp3/mpg123.h
+    chdir: "{{ asterisk_src_dir }}"
+    creates: "addons/mp3/mpg123.h"
 
 - name: Asterisk - Ensure all dependencies are resolved
   shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install 
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Run the configure script
   command: "./configure"
   args:
-    chdir: {{ asterisk_src_dir }}  
+    chdir: "{{ asterisk_src_dir }}"  
 
 - name: Asterisk - Run make menuselect.makeopts
   command: "make menuselect.makeopts"
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Do a bit of menuselect configuration
   command: >
@@ -58,32 +58,32 @@
     --enable EXTRA-SOUNDS-EN-WAV --enable EXTRA-SOUNDS-EN-G722 --enable EXTRA-SOUNDS-EN-GSM
     --disable-category MENUSELECT_MOH        
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Run 'make'
   command: make 
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - install
   command: make install
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - install config
   command: make config
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - install samples
   command: make samples
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - ldconfig
   command: ldconfig
   args:
-    chdir: {{ asterisk_src_dir }}
+    chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Create the necessary user/group config and set permissions
   command: "{{ item }} chdir={{ asterisk_src_dir }}"

--- a/roles/pbx/tasks/asterisk_dependencies.yml
+++ b/roles/pbx/tasks/asterisk_dependencies.yml
@@ -1,0 +1,16 @@
+- name: Install asterisk dependencies
+  package:
+    name:
+      - git
+      - curl
+      - wget
+      - libnewt-dev
+      - libssl-dev
+      - libncurses5-dev
+      - subversion
+      - libsqlite3-dev
+      - build-essential
+      - libjansson-dev
+      - libxml2-dev
+      - uuid-dev
+    state: latest

--- a/roles/pbx/tasks/asterisk_dependencies.yml
+++ b/roles/pbx/tasks/asterisk_dependencies.yml
@@ -1,4 +1,4 @@
-- name: Install asterisk dependencies
+- name: Asterisk - Install dependencies
   package:
     name:
       - git

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -23,11 +23,14 @@
 - name: chan_dongle - Extract source
   unarchive: 
     src: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"
-    dest: "{{ chan_dongle_src_dir }}"
+    dest: "{{ downloads_dir }}"
     owner: root
     group: root
-    extra_opts: [--strip-components=1]
-    creates: "{{ chan_dongle_src_dir }}/Makefile.in"
+
+- name: chan_dongle - move to {{ chan_dongle_src_dir }}
+  command: mv {{ downloads_dir }}/chan_dongle* {{ chan_dongle_src_dir }}
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"
 
 - name: chan_dongle - Run the bootstrap script
   command: "./bootstrap"

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -39,7 +39,7 @@
     creates: "{{ chan_dongle_src_dir }}/configure"
 
 - name: chan_dongle - Find out asterisk version
-  command: "asterisk -V |cut -d ' ' -f 2"
+  shell: asterisk -V |cut -d " " -f 2
   register: asterisk_ver
 
 - name: chan_dongle - Run the configure script

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -28,7 +28,7 @@
     group: root
 
 - name: chan_dongle - move to {{ chan_dongle_src_dir }}
-  command: mv {{ downloads_dir }}/asterisk-chan-dongle-master/ {{ chan_dongle_src_dir }}
+  command: rsync -av {{ downloads_dir }}/asterisk-chan-dongle-master/ {{ chan_dongle_src_dir }}
   args:
     chdir: "{{ downloads_dir }}"
 

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -33,13 +33,26 @@
   command: "./bootstrap"
   args:
     chdir: "{{ chan_dongle_src_dir }}"
+    creates: "{{ chan_dongle_src_dir }}/configure"
+
+- name: chan_dongle - Find out asterisk version
+  command: "asterisk -V |cut -d ' ' -f 2"
+  register: asterisk_ver
 
 - name: chan_dongle - Run the configure script
-  command: "./configure"
+  command: "./configure --with-astversion={{asterisk_ver.stdout}}"
   args:
     chdir: "{{ chan_dongle_src_dir }}"
+    creates: "{{ chan_dongle_src_dir }}/Makefile"
 
 - name: chan_dongle - Run 'make'
   command: make 
   args:
     chdir: "{{ chan_dongle_src_dir }}"
+    creates: "{{ chan_dongle_src_dir }}/chan_dongle.o"
+
+- name: chan_dongle - Run 'make install'
+  command: make install
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"
+    creates: "/usr/lib/asterisk/modules/chan_dongle.so"

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -28,7 +28,7 @@
     group: root
 
 - name: chan_dongle - move to {{ chan_dongle_src_dir }}
-  command: mv {{ downloads_dir }}/asterisk-chan-dongle-master {{ chan_dongle_src_dir }}
+  command: mv {{ downloads_dir }}/asterisk-chan-dongle-master/ {{ chan_dongle_src_dir }}
   args:
     chdir: "{{ downloads_dir }}"
 

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -59,3 +59,10 @@
   args:
     chdir: "{{ chan_dongle_src_dir }}"
     creates: "/usr/lib/asterisk/modules/chan_dongle.so"
+
+- name: chan_dongle - Copy dongle.conf over
+  command: cp {{ chan_dongle_src_dir }}/etc/dongle.conf /etc/asterisk/
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"
+    creates: "/etc/asterisk/dongle.conf"
+

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -28,7 +28,7 @@
     group: root
 
 - name: chan_dongle - move to {{ chan_dongle_src_dir }}
-  command: mv {{ downloads_dir }}/asterisk-chan-dongle* {{ chan_dongle_src_dir }}
+  command: mv {{ downloads_dir }}/asterisk-chan-dongle-master {{ chan_dongle_src_dir }}
   args:
     chdir: "{{ downloads_dir }}"
 

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -28,9 +28,9 @@
     group: root
 
 - name: chan_dongle - move to {{ chan_dongle_src_dir }}
-  command: mv {{ downloads_dir }}/chan_dongle* {{ chan_dongle_src_dir }}
+  command: mv {{ downloads_dir }}/asterisk-chan-dongle* {{ chan_dongle_src_dir }}
   args:
-    chdir: "{{ chan_dongle_src_dir }}"
+    chdir: "{{ downloads_dir }}"
 
 - name: chan_dongle - Run the bootstrap script
   command: "./bootstrap"

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -1,0 +1,45 @@
+- name: chan_dongle - Download software to /opt/iiab/downloads
+  get_url:
+    url: "{{ chan_dongle_url }}/{{ chan_dongle_src_file }}"
+    dest: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"
+    timeout: "{{ download_timeout }}"
+  when: internet_available
+
+- name: chan_dongle - Check for /opt/iiab/downloads/{{ chan_dongle_src_file }}
+  stat:
+    path: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"
+  register: chan_dongle_src
+
+- name: chan_dongle - FAIL (force Ansible to exit) IF /opt/iiab/downloads/{{ chan_dongle_src_file }} doesn't exist
+  fail:
+    msg: "{ downloads_dir }}/{{ chan_dongle_src_file }} is REQUIRED in order to install."
+  when: not chan_dongle_src.stat.exists
+
+- name: chan_dongle - Create install source directory
+  file: 
+    path: "{{ chan_dongle_src_dir }}"
+    state: directory
+
+- name: chan_dongle - Extract source
+  unarchive: 
+    src: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"
+    dest: "{{ chan_dongle_src_dir }}"
+    owner: root
+    group: root
+    extra_opts: [--strip-components=1]
+    creates: "{{ chan_dongle_src_dir }}/Makefile.in"
+
+- name: chan_dongle - Run the bootstrap script
+  command: "./bootstrap"
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"
+
+- name: chan_dongle - Run the configure script
+  command: "./configure"
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"
+
+- name: chan_dongle - Run 'make'
+  command: make 
+  args:
+    chdir: "{{ chan_dongle_src_dir }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -29,6 +29,7 @@
     owner: root
     group: root
     extra_opts: [--strip-components=1]
+    creates: "{{ freepbx_src_dir }}/install"
 
 - name: FreePBX - Disable & Stop asterisk service
   systemd:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -38,7 +38,7 @@
     priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
     login_host: "{{ asterisk_db_host }}"
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
-  state: present
+    state: present
 
 - name: FreePBX - Add mysql db
   mysql_db:
@@ -46,7 +46,7 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-  state: present
+    state: present
 
 - name: FreePBX - Add cdr mysql db
   mysql_db:
@@ -54,7 +54,7 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-  state: present
+    state: present
 
 - name: FreePBX - Disable & Stop asterisk service
   systemd:
@@ -63,12 +63,12 @@
     enabled: no
     state: stopped
 
-# using named groups due to this: http://www.handverdrahtet.org/2016/01/ansible-using-numbered-backreference.html
-- name: FreePBX - Enable freepbx installation with remote mysql db
-  replace:
-    dest: "{{ freepbx_src_dir }}/installlib/installcommand.class.php"
-    regexp: "(?P<firstpart>\$amp_conf\[.AMPDBHOST.\] = .)localhost(.;)"
-    replace: "\g<firstpart>{{ asterisk_db_host }}\2"
+## using named groups due to this: http://www.handverdrahtet.org/2016/01/ansible-using-numbered-backreference.html
+#- name: Enable freepbx installation with remote mysql db
+#  replace:
+#    dest: '{{ freepbx_src_dir }}/installlib/installcommand.class.php'
+#    regexp: '(?P<firstpart>\$amp_conf\[.AMPDBHOST.\] = .)localhost(.;)'
+#    replace: '\g<firstpart>{{ asterisk_db_host }}\2'
 
 - name: Don't let freepbx take over the php sessions dir
   blockinfile:
@@ -84,15 +84,20 @@
 - name: Install freepbx (just ran once)
   command: "{{ item }}"
   args:
-    chdir: "{{ freepbx_src_dir }}/freepbx"
+    chdir: "{{ freepbx_src_dir }}"
     creates: /var/www/freepbx
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot /var/www/freepbx --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
   register: freepbx_installation
 
-- name: Install systemd freepbx service
-  copy: src=freepbx.service.j2 dest=/etc/systemd/system/freepbx.service mode=755
+- name: Install unit file /etc/systemd/system/freepbx.service from templates
+  template:
+    src: "freepbx.service.j2"
+    dest: "/etc/systemd/system/freepbx.service"
+    owner: root
+    group: root
+    mode: 0644
 
 # http://community.freepbx.org/t/fixing-cdr-cel-on-ubuntu-debian-installation/30836
 # Test using `isql -v MySQL-asteriskcdrdb`
@@ -106,14 +111,12 @@
       Description = ODBC for MySQL
       Driver      = {{ libodbc_path }}
       FileUsage   = 1
-  notify: Reload asterisk modules
 
 - name: Fix asterisk cdr odbc connection (2)
   replace:
     dest: /etc/odbc.ini
     regexp: /var/lib/mysql/mysql.sock
     replace: /var/run/mysqld/mysqld.sock
-  notify: Reload asterisk modules
 
 - name: Install freepbx modules
   command: "fwconsole ma downloadinstall {{ item }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -39,6 +39,31 @@
     enabled: no
     state: stopped
 
+- name: Add mysql user
+  mysql_user:
+    name: "{{ asterisk_db_user }}"
+    password: "{{ asterisk_db_password }}"
+    priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
+    login_host: "{{ asterisk_db_host }}"
+    host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
+    state: present
+
+- name: Add mysql db
+  mysql_db:
+    name: "{{ asterisk_db_dbname }}"
+    encoding: utf8
+    collation: utf8_general_ci
+    login_host: "{{ asterisk_db_host }}"
+    state: present
+
+- name: Add cdr mysql db
+  mysql_db:
+    name: "{{ asterisk_db_cdrdbname }}"
+    encoding: utf8
+    collation: utf8_general_ci
+    login_host: "{{ asterisk_db_host }}"
+    state: present
+
 - name: FreePBX - Install (just run once)
   command: "{{ item }}"
   args:
@@ -46,7 +71,7 @@
     creates: "{{ freepbx_install_dir }}"
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser root --dbpass {{ mysql_root_password }} 
+    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
 - name: FreePBX - Create /etc/odbc.ini
   template:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -45,6 +45,8 @@
     password: "{{ asterisk_db_password }}"
     priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
     login_host: "{{ asterisk_db_host }}"
+    login_user: "root"
+    login_password: "{{ mysql_root_password }}"
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
     state: present
 
@@ -54,6 +56,8 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
+    login_user: "root"
+    login_password: "{{ mysql_root_password }}"
     state: present
 
 - name: FreePBX - Add cdr mysql db

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -11,7 +11,6 @@
 - name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
   stat:
     path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
-  register: freepbx_src
 
 - name: FreePBX - FAIL (force Ansible to exit) IF {{ downloads_dir }}/{{ freepbx_src_file }} doesn't exist
   fail:
@@ -46,7 +45,6 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser root --dbpass {{ mysql_root_password }} 
-  register: freepbx_installation
 
 - name: FreePBX - Create /etc/odbc.ini
   template:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -11,6 +11,7 @@
 - name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
   stat:
     path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+  register: freepbx_src
 
 - name: FreePBX - FAIL (force Ansible to exit) IF {{ downloads_dir }}/{{ freepbx_src_file }} doesn't exist
   fail:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -31,55 +31,12 @@
     group: root
     extra_opts: [--strip-components=1]
 
-- name: FreePBX - Add mysql user
-  mysql_user:
-    name: "{{ asterisk_db_user }}"
-    password: "{{ asterisk_db_password }}"
-    priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
-    login_host: "{{ asterisk_db_host }}"
-    host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
-    state: present
-
-- name: FreePBX - Add mysql db
-  mysql_db:
-    name: "{{ asterisk_db_dbname }}"
-    encoding: utf8
-    collation: utf8_general_ci
-    login_host: "{{ asterisk_db_host }}"
-    state: present
-
-- name: FreePBX - Add cdr mysql db
-  mysql_db:
-    name: "{{ asterisk_db_cdrdbname }}"
-    encoding: utf8
-    collation: utf8_general_ci
-    login_host: "{{ asterisk_db_host }}"
-    state: present
-
 - name: FreePBX - Disable & Stop asterisk service
   systemd:
     daemon_reload: yes
     name: asterisk
     enabled: no
     state: stopped
-
-## using named groups due to this: http://www.handverdrahtet.org/2016/01/ansible-using-numbered-backreference.html
-#- name: Enable freepbx installation with remote mysql db
-#  replace:
-#    dest: '{{ freepbx_src_dir }}/installlib/installcommand.class.php'
-#    regexp: '(?P<firstpart>\$amp_conf\[.AMPDBHOST.\] = .)localhost(.;)'
-#    replace: '\g<firstpart>{{ asterisk_db_host }}\2'
-
-- name: Don't let freepbx take over the php sessions dir
-  blockinfile:
-    content: |
-      [blacklist]
-      directory = /var/lib/php/sessions
-    marker: "; {mark} ANSIBLE MANAGED BLOCK"
-    dest: /etc/asterisk/freepbx_chown.conf
-    owner: asterisk
-    group: asterisk
-    create: yes
 
 - name: Install freepbx (just ran once)
   command: "{{ item }}"
@@ -88,58 +45,13 @@
     creates: /var/www/html/freepbx
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot /var/www/html/freepbx --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - ./install -n --webroot /var/www/html/freepbx --dbuser root --dbpass {{ mysql_root_password }} 
   register: freepbx_installation
 
-- name: Install unit file /etc/systemd/system/freepbx.service from templates
+- name: Create /etc/odbc.ini
   template:
-    src: "freepbx.service.j2"
-    dest: "/etc/systemd/system/freepbx.service"
+    src: odbc.ini.j2
+    dest: /etc/odbc.ini
     owner: root
     group: root
     mode: 0644
-
-# http://community.freepbx.org/t/fixing-cdr-cel-on-ubuntu-debian-installation/30836
-# Test using `isql -v MySQL-asteriskcdrdb`
-- name: Fix asterisk cdr odbc connection (1)
-  blockinfile:
-    dest: /etc/odbcinst.ini
-    create: yes
-    marker: "; {mark} ANSIBLE MANAGED BLOCK"
-    content: |
-      [MySQL]
-      Description = ODBC for MySQL
-      Driver      = {{ libodbc_path }}
-      FileUsage   = 1
-
-- name: Fix asterisk cdr odbc connection (2)
-  replace:
-    dest: /etc/odbc.ini
-    regexp: /var/lib/mysql/mysql.sock
-    replace: /var/run/mysqld/mysqld.sock
-
-- name: Install freepbx modules
-  command: "fwconsole ma downloadinstall {{ item }}"
-  args:
-    creates: /var/www/html/freepbx/admin/modules/{{ item }}
-  with_items:
-    - userman
-    - asteriskinfo
-    - backup
-    - outroutemsg
-
-- name: FreePBX - Enable and start FreePBX service
-  systemd:
-    daemon_reload: yes
-    name: freepbx
-    enabled: yes
-    state: started
-  when: pbx_enabled
-
-- name: FreePBX - Disable and Stop FreePBX service
-  systemd:
-    daemon_reload: yes
-    name: freepbx
-    enabled: no
-    state: stopped
-  when: pbx_enabled

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -91,7 +91,7 @@
     group: asterisk
     recurse: yes
  
-- name: FreePBX - Install (just run once)
+- name: FreePBX - Install (just run once) - CAN TAKE 2 MIN OR LONGER!
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -79,6 +79,18 @@
     group: asterisk
     create: yes
 
+- name: FreePBX - Create php sessions directory
+  file: 
+    path: "/var/lib/php/asterisk_sessions/"
+    state: directory
+
+- name: FreePBX - Set ownership for php sessions directory
+  file: 
+    dest: "/var/lib/php/asterisk_sessions/" 
+    owner: asterisk 
+    group: asterisk
+    recurse: yes
+ 
 - name: FreePBX - Install (just run once)
   command: "{{ item }}"
   args:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -39,7 +39,7 @@
     enabled: no
     state: stopped
 
-- name: Add mysql user
+- name: FreePBX - Add mysql user
   mysql_user:
     name: "{{ asterisk_db_user }}"
     password: "{{ asterisk_db_password }}"
@@ -48,7 +48,7 @@
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
     state: present
 
-- name: Add mysql db
+- name: FreePBX - Add mysql db
   mysql_db:
     name: "{{ asterisk_db_dbname }}"
     encoding: utf8
@@ -56,13 +56,24 @@
     login_host: "{{ asterisk_db_host }}"
     state: present
 
-- name: Add cdr mysql db
+- name: FreePBX - Add cdr mysql db
   mysql_db:
     name: "{{ asterisk_db_cdrdbname }}"
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
     state: present
+
+- name: FreePBX - Don't let freepbx take over the php sessions dir
+  blockinfile:
+    content: |
+      [blacklist]
+      directory = /var/lib/php/sessions
+    marker: "; {mark} ANSIBLE MANAGED BLOCK"
+    dest: /etc/asterisk/freepbx_chown.conf
+    owner: asterisk
+    group: asterisk
+    create: yes
 
 - name: FreePBX - Install (just run once)
   command: "{{ item }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -1,0 +1,142 @@
+- name: FreePBX - Install dependencies
+  include: freepbx_dependencies.yml
+
+- name: FreePBX - Download software to /opt/iiab/downloads
+  get_url:
+    url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
+    dest: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+    timeout: "{{ download_timeout }}"
+  when: internet_available
+
+- name: FreePBX - Check for /opt/iiab/downloads/{{ freepbx_src_file }}
+  stat:
+    path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+  register: freepbx_src
+
+- name: FreePBX - FAIL (force Ansible to exit) IF /opt/iiab/downloads/{{ freepbx_src_file }} doesn't exist
+  fail:
+    msg: "{ downloads_dir }}/{{ freepbx_src_file }} is REQUIRED in order to install."
+  when: not freepbx_src.stat.exists
+
+- name: FreePBX - Create install source directory
+  file: 
+    path: "{{ freepbx_src_dir }}"
+    state: directory
+
+- name: FreePBX - Extract source
+  unarchive: 
+    src: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+    dest: "{{ freepbx_src_dir }}"
+    owner: root
+    group: root
+    extra_opts: [--strip-components=1]
+
+- name: FreePBX - Add mysql user
+  mysql_user:
+    name: "{{ asterisk_db_user }}"
+    password: "{{ asterisk_db_password }}"
+    priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
+    login_host: "{{ asterisk_db_host }}"
+    host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
+  state: present
+
+- name: FreePBX - Add mysql db
+  mysql_db:
+    name: "{{ asterisk_db_dbname }}"
+    encoding: utf8
+    collation: utf8_general_ci
+    login_host: "{{ asterisk_db_host }}"
+  state: present
+
+- name: FreePBX - Add cdr mysql db
+  mysql_db:
+    name: "{{ asterisk_db_cdrdbname }}"
+    encoding: utf8
+    collation: utf8_general_ci
+    login_host: "{{ asterisk_db_host }}"
+  state: present
+
+- name: FreePBX - Disable & Stop asterisk service
+  systemd:
+    daemon_reload: yes
+    name: asterisk
+    enabled: no
+    state: stopped
+
+# using named groups due to this: http://www.handverdrahtet.org/2016/01/ansible-using-numbered-backreference.html
+- name: FreePBX - Enable freepbx installation with remote mysql db
+  replace:
+    dest: "{{ freepbx_src_dir }}/installlib/installcommand.class.php"
+    regexp: "(?P<firstpart>\$amp_conf\[.AMPDBHOST.\] = .)localhost(.;)"
+    replace: "\g<firstpart>{{ asterisk_db_host }}\2"
+
+- name: Don't let freepbx take over the php sessions dir
+  blockinfile:
+    content: |
+      [blacklist]
+      directory = /var/lib/php/sessions
+    marker: "; {mark} ANSIBLE MANAGED BLOCK"
+    dest: /etc/asterisk/freepbx_chown.conf
+    owner: asterisk
+    group: asterisk
+    create: yes
+
+- name: Install freepbx (just ran once)
+  command: "{{ item }}"
+  args:
+    chdir: "{{ freepbx_src_dir }}/freepbx"
+    creates: /var/www/freepbx
+  with_items:
+    - ./start_asterisk start
+    - ./install -n --webroot /var/www/freepbx --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+  register: freepbx_installation
+
+- name: Install systemd freepbx service
+  copy: src=freepbx.service.j2 dest=/etc/systemd/system/freepbx.service mode=755
+
+# http://community.freepbx.org/t/fixing-cdr-cel-on-ubuntu-debian-installation/30836
+# Test using `isql -v MySQL-asteriskcdrdb`
+- name: Fix asterisk cdr odbc connection (1)
+  blockinfile:
+    dest: /etc/odbcinst.ini
+    create: yes
+    marker: "; {mark} ANSIBLE MANAGED BLOCK"
+    content: |
+      [MySQL]
+      Description = ODBC for MySQL
+      Driver      = {{ libodbc_path }}
+      FileUsage   = 1
+  notify: Reload asterisk modules
+
+- name: Fix asterisk cdr odbc connection (2)
+  replace:
+    dest: /etc/odbc.ini
+    regexp: /var/lib/mysql/mysql.sock
+    replace: /var/run/mysqld/mysqld.sock
+  notify: Reload asterisk modules
+
+- name: Install freepbx modules
+  command: "fwconsole ma downloadinstall {{ item }}"
+  args:
+    creates: /var/www/freepbx/admin/modules/{{ item }}
+  with_items:
+    - userman
+    - asteriskinfo
+    - backup
+    - outroutemsg
+
+- name: FreePBX - Enable and start FreePBX service
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: yes
+    state: started
+  when: pbx_enabled
+
+- name: FreePBX - Disable and Stop FreePBX service
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: no
+    state: stopped
+  when: pbx_enabled

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -8,12 +8,12 @@
     timeout: "{{ download_timeout }}"
   when: internet_available
 
-- name: FreePBX - Check for /opt/iiab/downloads/{{ freepbx_src_file }}
+- name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
   stat:
     path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
   register: freepbx_src
 
-- name: FreePBX - FAIL (force Ansible to exit) IF /opt/iiab/downloads/{{ freepbx_src_file }} doesn't exist
+- name: FreePBX - FAIL (force Ansible to exit) IF {{ downloads_dir }}/{{ freepbx_src_file }} doesn't exist
   fail:
     msg: "{ downloads_dir }}/{{ freepbx_src_file }} is REQUIRED in order to install."
   when: not freepbx_src.stat.exists
@@ -38,20 +38,41 @@
     enabled: no
     state: stopped
 
-- name: Install freepbx (just ran once)
+- name: FreePBX - Install (just run once)
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
-    creates: /var/www/html/freepbx
+    creates: "{{ freepbx_install_dir }}"
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot /var/www/html/freepbx --dbuser root --dbpass {{ mysql_root_password }} 
+    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser root --dbpass {{ mysql_root_password }} 
   register: freepbx_installation
 
-- name: Create /etc/odbc.ini
+- name: FreePBX - Create /etc/odbc.ini
   template:
     src: odbc.ini.j2
     dest: /etc/odbc.ini
     owner: root
     group: root
     mode: 0644
+
+- name: FreePBX - Copy freepbx.conf
+  template:
+    src: freepbx.conf.j2
+    dest: /etc/apache2/sites-available/freepbx.conf
+    owner: www-data
+    group: www-data
+    mode: 0644
+
+- name: FreePBX - Enable freepbx
+  file: 
+    src: /etc/apache2/sites-available/freepbx.conf
+    dest: /etc/apache2/sites-enabled/freepbx.conf
+    state: link
+  when: pbx_enabled
+
+- name: FreePBX - Disable freepbx
+  file: 
+    path: /etc/apache2/sites-enabled/freepbx.conf
+    state: absent
+  when: (not pbx_enabled)

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -64,15 +64,37 @@
     group: www-data
     mode: 0644
 
-- name: FreePBX - Enable freepbx
+- name: FreePBX - Link freepbx.conf apache file to sites-enabled
   file: 
     src: /etc/apache2/sites-available/freepbx.conf
     dest: /etc/apache2/sites-enabled/freepbx.conf
     state: link
   when: pbx_enabled
 
-- name: FreePBX - Disable freepbx
+- name: FreePBX - Unlink freepbx.conf apachefile from sites-enabled
   file: 
     path: /etc/apache2/sites-enabled/freepbx.conf
     state: absent
+  when: (not pbx_enabled)
+
+- name: FreePBX - Copy systemd unit file
+  template:
+    src: freepbx.service.j2
+    dest: /etc/systemd/system/freepbx.service
+    mode: 755
+
+- name: FreePBX - Enable and Start freepbx service
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: yes
+    state: started
+  when: pbx_enabled
+
+- name: FreePBX - Disable & Stop freepbx service
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: no
+    state: stopped
   when: (not pbx_enabled)

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -85,10 +85,10 @@
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
-    creates: /var/www/freepbx
+    creates: /var/www/html/freepbx
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot /var/www/freepbx --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - ./install -n --webroot /var/www/html/freepbx --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
   register: freepbx_installation
 
 - name: Install unit file /etc/systemd/system/freepbx.service from templates
@@ -121,7 +121,7 @@
 - name: Install freepbx modules
   command: "fwconsole ma downloadinstall {{ item }}"
   args:
-    creates: /var/www/freepbx/admin/modules/{{ item }}
+    creates: /var/www/html/freepbx/admin/modules/{{ item }}
   with_items:
     - userman
     - asteriskinfo

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -26,4 +26,5 @@
     - php-fpm
     - libapache2-mod-php
     - python-mysqldb # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
+    - libapache2-mpm-itk # To serve FreePBX through a VirtualHost as asterisk user
     state: latest

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -1,30 +1,30 @@
 - name: FreePBX - Install dependencies
   package:
     name:
-    - wget
-    - git 
-    - unixodbc # for asterisk cdr
-    - sudo # required by freepbx install script
-    - net-tools # fwconsole requirement
-    - cron # required by freepbx ucp package
-    - sox # required for CDR web-playback
-    - php 
-    - php-pear
-    - php-cgi
-    - php-common
-    - php-curl
-    - php-mbstring
-    - php-gd
-    - php-mysql
-    - php-gettext
-    - php-bcmath
-    - php-zip
-    - php-xml
-    - php-imap
-    - php-json
-    - php-snmp 
-    - php-fpm
-    - libapache2-mod-php
-    - python-mysqldb # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
-    - libapache2-mpm-itk # To serve FreePBX through a VirtualHost as asterisk user
+      - wget
+      - git 
+      - unixodbc     # for Asterisk CDR (Call Detail Records)
+      - sudo         # required by FreePBX install script
+      - net-tools    # required by FWConsole (command-line utility, that controls FreePBX)
+      - cron         # required by FreePBX UCP package (User Control Panel)
+      - sox          # required for CDR web-playback
+      - php 
+      - php-pear
+      - php-cgi
+      - php-common
+      - php-curl
+      - php-mbstring
+      - php-gd
+      - php-mysql
+      - php-gettext
+      - php-bcmath
+      - php-zip
+      - php-xml
+      - php-imap
+      - php-json
+      - php-snmp 
+      - php-fpm
+      - libapache2-mod-php
+      - python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
+      - libapache2-mpm-itk    # To serve FreePBX through a VirtualHost as asterisk user
     state: latest

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -26,4 +26,4 @@
     - php-fpm
     - libapache2-mod-php
     - python-mysqldb # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
-  state: latest
+    state: latest

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -1,0 +1,29 @@
+- name: FreePBX - Install dependencies
+  package:
+    name:
+    - wget
+    - git 
+    - unixodbc # for asterisk cdr
+    - sudo # required by freepbx install script
+    - net-tools # fwconsole requirement
+    - cron # required by freepbx ucp package
+    - sox # required for CDR web-playback
+    - php 
+    - php-pear
+    - php-cgi
+    - php-common
+    - php-curl
+    - php-mbstring
+    - php-gd
+    - php-mysql
+    - php-gettext
+    - php-bcmath
+    - php-zip
+    - php-xml
+    - php-imap
+    - php-json
+    - php-snmp 
+    - php-fpm
+    - libapache2-mod-php
+    - python-mysqldb # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
+  state: latest

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -8,12 +8,13 @@
 
 #- name: TODO: Check if asterisk and freepbx are already installed
 
-- debug:
+- debug:    # Crazy spacing below is tuned for 80-column screens
     msg: >-
+      ###################################################################
       WARNING: ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.
       Please assist Internet-in-a-Box communities worldwide if you can make
       Asterisk and FreePBX work on other OS's / distros, Thank You!
-      http://FAQ.IIAB.IO
+      http://FAQ.IIAB.IO               ###############################################################################
 
 - name: Install Asterisk (debuntu)
   include_tasks: asterisk.yml

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,0 +1,9 @@
+#- name: TODO: Check if asterisk and freepbx are already installed
+
+- name: Install asterisk
+  include_tasks: asterisk.yml
+  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed)
+
+- name: Install freepbx
+  include_tasks: freepbx.yml
+  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed)

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Throw warning if nodejs_version is incorrect
+- name: Fail if nodejs_version is incorrect
   fail: 
     msg: PBX: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
   when: pbx_install and (nodejs_version != "10.x")

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -19,7 +19,7 @@
   when: internet_available and pbx_install and (not pbx_installed) and is_debuntu
   #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)
 
-- name: Install FreePBX
-  include_tasks: freepbx.yml (debuntu)
+- name: Install FreePBX (debuntu)
+  include_tasks: freepbx.yml
   when: internet_available and pbx_install and (not pbx_installed) and is_debuntu
   #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Fail if nodejs_version is incorrect
   fail:
-    msg: |
+    msg: >
       PBX: Refusing to install as nodejs_version is not 10.x.  Please fix that
       (looking into /etc/iiab/local_vars.yml and
       /opt/iiab/iiab/vars/default_vars.yml) and then rerun.
@@ -9,7 +9,7 @@
 #- name: TODO: Check if asterisk and freepbx are already installed
 
 - debug:
-    msg: |
+    msg: >
       WARNING: ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.
       Please assist Internet-in-a-Box communities worldwide if you can improve
       our coverage on other OS's/distros, Thank You!  http://FAQ.IIAB.IO

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -10,11 +10,10 @@
 
 - debug:    # Crazy spacing below is tuned for 80-column screens
     msg: >-
-      ###################################################################
-      WARNING: ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.
-      Please assist Internet-in-a-Box communities worldwide if you can make
-      Asterisk and FreePBX work on other OS's / distros, Thank You!
-      http://FAQ.IIAB.IO               ###############################################################################
+      ####################################################################WARNING:
+      ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.      Please
+      assist Internet-in-a-Box communities worldwide if you can make Asterisk
+      and FreePBX work on other OS's / distros, Thank You!  http://FAQ.IIAB.IO             ###############################################################################
 
 - name: Install Asterisk (debuntu)
   include_tasks: asterisk.yml

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,9 +1,17 @@
+- name: Throw warning if sugarizer_install is true
+  debug: Refusing to install as sugarizer_install is true. Fix that and rerun.
+  when: pbx_install and sugarizer_install
+
+- name: Throw warning if sugarizer_install is true
+  debug: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
+  when: pbx_install and (nodejs_version != "10.x")
+
 #- name: TODO: Check if asterisk and freepbx are already installed
 
 - name: Install asterisk
   include_tasks: asterisk.yml
-  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed)
+  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed) and (not sugarizer_install) and (nodejs_version == "10.x")
 
 - name: Install freepbx
   include_tasks: freepbx.yml
-  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed)
+  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed) and (not sugarizer_install) and (nodejs_version == "10.x")

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,11 +1,6 @@
-- name: Throw warning if sugarizer_install is true
-  debug: 
-    msg: Refusing to install as sugarizer_install is true. Fix that and rerun.
-  when: pbx_install and sugarizer_install
-
 - name: Throw warning if nodejs_version is incorrect
-  debug: 
-    msg: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
+  fail: 
+    msg: PBX: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
   when: pbx_install and (nodejs_version != "10.x")
 
 #- name: TODO: Check if asterisk and freepbx are already installed

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -13,7 +13,8 @@
       ####################################################################WARNING:
       ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.      Please
       assist Internet-in-a-Box communities worldwide if you can make Asterisk
-      and FreePBX work on other OS's / distros, Thank You!  http://FAQ.IIAB.IO             ###############################################################################
+      and FreePBX work on other OS's / distros, Thank
+      You!  http://FAQ.IIAB.IO         ###############################################################################
 
 - name: Install Asterisk (debuntu)
   include_tasks: asterisk.yml

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Fail if nodejs_version is incorrect
   fail: 
-    msg: PBX: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
+    msg: "PBX: Refusing to install as nodejs_version is not 10.x. Fix that and rerun."
   when: pbx_install and (nodejs_version != "10.x")
 
 #- name: TODO: Check if asterisk and freepbx are already installed

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -12,8 +12,8 @@
     msg: >-
       ####################################################################WARNING:
       ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.      Please
-      assist Internet-in-a-Box communities worldwide if you can make Asterisk
-      and FreePBX work on other OS's / distros, Thank
+      assist Internet-in-a-Box communities worldwide if you can make
+      Asterisk  and FreePBX work on other OS's / distros, Thank
       You!  http://FAQ.IIAB.IO         ###############################################################################
 
 - name: Install Asterisk (debuntu)

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -14,7 +14,7 @@
       ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.      Please
       assist Internet-in-a-Box communities worldwide if you can make
       Asterisk  and FreePBX work on other OS's / distros, Thank
-      You!  http://FAQ.IIAB.IO         ###############################################################################
+      You!  http://FAQ.IIAB.IO        ###############################################################################
 
 - name: Install Asterisk (debuntu)
   include_tasks: asterisk.yml

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,14 +1,25 @@
 - name: Fail if nodejs_version is incorrect
-  fail: 
-    msg: "PBX: Refusing to install as nodejs_version is not 10.x. Fix that and rerun."
+  fail:
+    msg: |
+      PBX: Refusing to install as nodejs_version is not 10.x.  Please fix that
+      (looking into /etc/iiab/local_vars.yml and
+      /opt/iiab/iiab/vars/default_vars.yml) and then rerun.
   when: pbx_install and (nodejs_version != "10.x")
 
 #- name: TODO: Check if asterisk and freepbx are already installed
 
-- name: Install asterisk
-  include_tasks: asterisk.yml
-  when: internet_available and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18) and pbx_install and (not pbx_installed) and (nodejs_version == "10.x")
+- debug:
+    msg: |
+      WARNING: ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.
+      Please assist Internet-in-a-Box communities worldwide if you can improve
+      our coverage on other OS's/distros, Thank You!  http://FAQ.IIAB.IO
 
-- name: Install freepbx
-  include_tasks: freepbx.yml
-  when: internet_available and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18) and pbx_install and (not pbx_installed) and (nodejs_version == "10.x")
+- name: Install Asterisk (debuntu)
+  include_tasks: asterisk.yml
+  when: internet_available and pbx_install and (not pbx_installed) and is_debuntu
+  #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)
+
+- name: Install FreePBX
+  include_tasks: freepbx.yml (debuntu)
+  when: internet_available and pbx_install and (not pbx_installed) and is_debuntu
+  #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -7,8 +7,8 @@
 
 - name: Install asterisk
   include_tasks: asterisk.yml
-  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed) and (not sugarizer_install) and (nodejs_version == "10.x")
+  when: internet_available and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18) and pbx_install and (not pbx_installed) and (nodejs_version == "10.x")
 
 - name: Install freepbx
   include_tasks: freepbx.yml
-  when: internet_available and is_ubuntu_18 and pbx_install and (not pbx_installed) and (not sugarizer_install) and (nodejs_version == "10.x")
+  when: internet_available and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18) and pbx_install and (not pbx_installed) and (nodejs_version == "10.x")

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -3,7 +3,7 @@
     msg: Refusing to install as sugarizer_install is true. Fix that and rerun.
   when: pbx_install and sugarizer_install
 
-- name: Throw warning if sugarizer_install is true
+- name: Throw warning if nodejs_version is incorrect
   debug: 
     msg: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
   when: pbx_install and (nodejs_version != "10.x")

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Fail if nodejs_version is incorrect
   fail:
-    msg: >
+    msg: >-
       PBX: Refusing to install as nodejs_version is not 10.x.  Please fix that
       (looking into /etc/iiab/local_vars.yml and
       /opt/iiab/iiab/vars/default_vars.yml) and then rerun.
@@ -9,10 +9,11 @@
 #- name: TODO: Check if asterisk and freepbx are already installed
 
 - debug:
-    msg: >
+    msg: >-
       WARNING: ONLY UBUNTU 18.04 AND DEBIAN 9 ARE SUPPORTED AS OF FEBRUARY 2019.
-      Please assist Internet-in-a-Box communities worldwide if you can improve
-      our coverage on other OS's/distros, Thank You!  http://FAQ.IIAB.IO
+      Please assist Internet-in-a-Box communities worldwide if you can make
+      Asterisk and FreePBX work on other OS's / distros, Thank You!
+      http://FAQ.IIAB.IO
 
 - name: Install Asterisk (debuntu)
   include_tasks: asterisk.yml

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: Throw warning if sugarizer_install is true
-  debug: Refusing to install as sugarizer_install is true. Fix that and rerun.
+  debug: 
+    msg: Refusing to install as sugarizer_install is true. Fix that and rerun.
   when: pbx_install and sugarizer_install
 
 - name: Throw warning if sugarizer_install is true
-  debug: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
+  debug: 
+    msg: Refusing to install as nodejs_version is not 10.x. Fix that and rerun.
   when: pbx_install and (nodejs_version != "10.x")
 
 #- name: TODO: Check if asterisk and freepbx are already installed

--- a/roles/pbx/templates/freepbx.conf.j2
+++ b/roles/pbx/templates/freepbx.conf.j2
@@ -1,0 +1,19 @@
+<VirtualHost *:80>
+
+ServerName pbx.lan
+
+ServerAdmin anishmg@umich.edu
+DocumentRoot /var/www/html/
+
+<Directory /var/www/html/freepbx>
+        Require all granted
+</Directory>
+
+<IfModule mpm_itk_module>
+AssignUserId asterisk asterisk
+</IfModule>
+
+ErrorLog ${APACHE_LOG_DIR}/pbx-error.log
+CustomLog ${APACHE_LOG_DIR}/pbx-access.log combined
+
+</VirtualHost>

--- a/roles/pbx/templates/freepbx.conf.j2
+++ b/roles/pbx/templates/freepbx.conf.j2
@@ -15,6 +15,8 @@ DocumentRoot /var/www/html/
 AssignUserId asterisk asterisk
 </IfModule>
 
+php_value session.save_path /var/lib/php/asterisk_sessions/
+
 ErrorLog ${APACHE_LOG_DIR}/pbx-error.log
 CustomLog ${APACHE_LOG_DIR}/pbx-access.log combined
 

--- a/roles/pbx/templates/freepbx.conf.j2
+++ b/roles/pbx/templates/freepbx.conf.j2
@@ -6,6 +6,8 @@ ServerAdmin admin@box.lan
 DocumentRoot /var/www/html/
 
 <Directory {{ freepbx_install_dir }}>
+        AllowOverride All
+        Options Indexes FollowSymLinks
         Require all granted
 </Directory>
 

--- a/roles/pbx/templates/freepbx.conf.j2
+++ b/roles/pbx/templates/freepbx.conf.j2
@@ -2,10 +2,10 @@
 
 ServerName pbx.lan
 
-ServerAdmin anishmg@umich.edu
+ServerAdmin admin@box.lan
 DocumentRoot /var/www/html/
 
-<Directory /var/www/html/freepbx>
+<Directory {{ freepbx_install_dir }}>
         Require all granted
 </Directory>
 

--- a/roles/pbx/templates/freepbx.service.j2
+++ b/roles/pbx/templates/freepbx.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=FreePBX VoIP Server
+After=mysql.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/fwconsole start
+ExecStop=/usr/sbin/fwconsole stop
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/pbx/templates/odbc.ini.j2
+++ b/roles/pbx/templates/odbc.ini.j2
@@ -1,0 +1,8 @@
+[MySQL-asteriskcdrdb]
+Description=MySQL connection to 'asteriskcdrdb' database
+driver=MySQL
+server=localhost
+database=asteriskcdrdb
+Port=3306
+Socket=/var/run/mysqld/mysqld.sock
+option=3

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -296,15 +296,11 @@ nodered_port: 1880
 nextcloud_install: False
 nextcloud_enabled: False
 
-# A full featured PBX based on Asterisk and FreePBX
-#
-# Caution!
-# This is a LARGE install that will compile from source and take lots of time. Handle with care!
-# So far, supported on Ubuntu 18.x ONLY.
+# A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
+# So far, supported on Ubuntu 18.x and Debian 9 ONLY.  Uses Node.js 10.x
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False
-#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -303,6 +303,7 @@ nextcloud_enabled: False
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -303,6 +303,7 @@ nextcloud_enabled: False
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+asterisk_chan_dongle: False
 #nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -296,6 +296,14 @@ nodered_port: 1880
 nextcloud_install: False
 nextcloud_enabled: False
 
+# A full featured PBX based on Asterisk and FreePBX
+#
+# Caution!
+# This is a LARGE install that will compile from source and take lots of time. Handle with care!
+# So far, supported on Ubuntu 18.x ONLY.
+pbx_install: False
+pbx_enabled: False
+
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False
 wordpress_enabled: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -195,15 +195,11 @@ nodered_enabled: True
 nextcloud_install: True
 nextcloud_enabled: True
 
-# A full featured PBX based on Asterisk and FreePBX
-#
-# Caution!
-# This is a LARGE install that will compile from source and take lots of time. Handle with care!
-# So far, supported on Ubuntu 18.x ONLY.
+# A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
+# So far, supported on Ubuntu 18.x and Debian 9 ONLY.  Uses Node.js 10.x
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False
-#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: True
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: True
 pbx_enabled: True
+asterisk_chan_dongle: True
 #nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: True
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: True
 pbx_enabled: True
+#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -195,6 +195,14 @@ nodered_enabled: True
 nextcloud_install: True
 nextcloud_enabled: True
 
+# A full featured PBX based on Asterisk and FreePBX
+#
+# Caution!
+# This is a LARGE install that will compile from source and take lots of time. Handle with care!
+# So far, supported on Ubuntu 18.x ONLY.
+pbx_install: True
+pbx_enabled: True
+
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True
 wordpress_enabled: True

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -200,9 +200,9 @@ nextcloud_enabled: True
 # Caution!
 # This is a LARGE install that will compile from source and take lots of time. Handle with care!
 # So far, supported on Ubuntu 18.x ONLY.
-pbx_install: True
-pbx_enabled: True
-asterisk_chan_dongle: True
+pbx_install: False
+pbx_enabled: False
+asterisk_chan_dongle: False
 #nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: True
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+asterisk_chan_dongle: False
 #nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -195,15 +195,11 @@ nodered_enabled: False
 nextcloud_install: True
 nextcloud_enabled: True
 
-# A full featured PBX based on Asterisk and FreePBX
-#
-# Caution!
-# This is a LARGE install that will compile from source and take lots of time. Handle with care!
-# So far, supported on Ubuntu 18.x ONLY.
+# A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
+# So far, supported on Ubuntu 18.x and Debian 9 ONLY.  Uses Node.js 10.x
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False
-#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: True
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -195,6 +195,14 @@ nodered_enabled: False
 nextcloud_install: True
 nextcloud_enabled: True
 
+# A full featured PBX based on Asterisk and FreePBX
+#
+# Caution!
+# This is a LARGE install that will compile from source and take lots of time. Handle with care!
+# So far, supported on Ubuntu 18.x ONLY.
+pbx_install: False
+pbx_enabled: False
+
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: True
 wordpress_enabled: True

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: False
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+asterisk_chan_dongle: False
 #nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -202,6 +202,7 @@ nextcloud_enabled: False
 # So far, supported on Ubuntu 18.x ONLY.
 pbx_install: False
 pbx_enabled: False
+#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -195,15 +195,11 @@ nodered_enabled: False
 nextcloud_install: False
 nextcloud_enabled: False
 
-# A full featured PBX based on Asterisk and FreePBX
-#
-# Caution!
-# This is a LARGE install that will compile from source and take lots of time. Handle with care!
-# So far, supported on Ubuntu 18.x ONLY.
+# A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
+# So far, supported on Ubuntu 18.x and Debian 9 ONLY.  Uses Node.js 10.x
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False
-#nodejs_version: 10.x
 
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -195,6 +195,14 @@ nodered_enabled: False
 nextcloud_install: False
 nextcloud_enabled: False
 
+# A full featured PBX based on Asterisk and FreePBX
+#
+# Caution!
+# This is a LARGE install that will compile from source and take lots of time. Handle with care!
+# So far, supported on Ubuntu 18.x ONLY.
+pbx_install: False
+pbx_enabled: False
+
 # If using WordPress intensively, set apache_high_php_limits in 3-BASE-SERVER
 wordpress_install: False
 wordpress_enabled: False


### PR DESCRIPTION
This PR introduces the Asterisk and FreePBX applications for IIAB installs on top of Ubuntu 18.x based setups. 

~~Note: This is for testing only at this point. **Do not merge!**~~

You will have to atleast set pbx_install to True to have both apps install. And optionally set the enabled flag to enable them as well. 

Eagerly looking forwards to test results and polishing this further. We could potentially experiment with running this on debian 9.6 as well.
