### PR TITLE
Move dnsmasq config file to /etc/dnsmasq.d/

### DIFF
--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -34,6 +34,7 @@
    - { src: 'named/named-iiab.conf.j2', dest: '/etc/named-iiab.conf', mode: '0644' }
    - { src: 'named/school.local.zone.db', dest: '/var/named-iiab/', mode: '0644' }
    - { src: 'named/school.internal.zone.db', dest: '/var/named-iiab/', mode: '0644' }
+  when: named_enabled and named_install
 
 - name: Enable named service ({{ dns_service }}) if named_enabled
   systemd:
@@ -50,8 +51,14 @@
 - name: Install /etc/dnsmasq.conf from template, if dnsmasq_enabled
   template:
     src: network/dnsmasq.conf.j2
-    dest: /etc/dnsmasq.conf
+    dest: /etc/dnsmasq.d/iiab.conf
   when: dnsmasq_enabled and dnsmasq_install
+
+- name: Remove /etc/dnsmasq.d/iiab.conf when not dnsmasq_enabled or is Appliance
+  file:
+    path: /etc/dnsmasq.d/iiab.conf
+    state: absent
+  when: (not dnsmasq_enabled) or (iiab_network_mode == "Appliance")
 
 - name: Enable iiab-dnsmasq systemd service, if dnsmasq_enabled
   systemd:

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -48,13 +48,13 @@
     enabled: no
   when: not named_enabled and named_install
 
-- name: Install /etc/dnsmasq.conf from template, if dnsmasq_enabled
+- name: Install /etc/dnsmasq.d/iiab.conf from template, when dnsmasq_enabled and isn't Appliance
   template:
     src: network/dnsmasq.conf.j2
     dest: /etc/dnsmasq.d/iiab.conf
   when: dnsmasq_enabled and dnsmasq_install and (iiab_network_mode != "Appliance")
 
-- name: Remove /etc/dnsmasq.d/iiab.conf when not dnsmasq_enabled or is Appliance
+- name: Remove /etc/dnsmasq.d/iiab.conf, when not dnsmasq_enabled or is Appliance
   file:
     path: /etc/dnsmasq.d/iiab.conf
     state: absent

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -52,7 +52,7 @@
   template:
     src: network/dnsmasq.conf.j2
     dest: /etc/dnsmasq.d/iiab.conf
-  when: dnsmasq_enabled and dnsmasq_install
+  when: dnsmasq_enabled and dnsmasq_install and (iiab_network_mode != "Appliance")
 
 - name: Remove /etc/dnsmasq.d/iiab.conf when not dnsmasq_enabled or is Appliance
   file:


### PR DESCRIPTION
### Fixes Bug
Bugfix don't supply named/bind files when not enabled.
### Description of changes proposed in this pull request.
move dnsmasq config file to /etc/dnsmasq.d/
### Smoke-tested in operating system.
not yet
### Mention a team member for further information or comment using @ name
