### PR TITLE
Simplify node-js installation from nodesource and a variable for version

### DIFF
--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,0 +1,1 @@
+nodejs_version: 8.x

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,54 +1,12 @@
-# 2019-01-16: duplicate Node.js code unified thanks to @jvonau. It's used by:
-#   roles/sugarizer/tasks/main.yml with roles/sugarizer/meta/main.yml
-#   roles/nodered/tasks/main.yml   with roles/nodered/meta/main.yml
-
-# 2019-01-16: fyi Node.js 10.x became "LTS" on 2018-10-30 but distros are
-# holding back for now: certainly Ubuntu 18.04 and even Debian 10/Buster
-# ("testing" branch) both install Node.js 8.x (instead of 10.x).  While the
-# more bleeding-edge Debian Sid ("unstable" branch) does install Node.js 10.x
-#
-# This May Change: thanks all for running "apt -a list nodejs" on Buster's
-# daily builds @ www.debian.org/devel/debian-installer/ to keep us informed!
-
-- name: Set up Node.js 8.x apt sources (debuntu distros UP TO 2017)
-  shell: curl -sL https://deb.nodesource.com/setup_8.x | bash -
+- name: Set up Node.js {{ nodejs_version }} apt sources 
+  shell: curl -sL https://deb.nodesource.com/setup_{{ nodejs_version }} | bash -
   args:
     warn: no
-  when: internet_available and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
-  # NOT NEC TO TEST FOR is_raspbian_8 OR is_raspbian_9 AS /opt/iiab/iiab/vars/<OS>.yml
-  # DEFINES THESE AS SUBSETS OF is_debian_8 OR is_debian_9 (FOR NOW!)
+  when: internet_available
 
-- name: Install latest Node.js which includes /usr/bin/npm (debuntu distros UP TO 2017)
+- name: Install latest Node.js which includes /usr/bin/npm
   package:
     name: nodejs
-    # name: nodejs=8.x
     state: latest
-    # state: present
-  when: internet_available and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
+  when: internet_available
 
-# 2018-07-14: BOTH STEPS ABOVE TAKE TIME, but Raspbian (apt offers npm
-# 1.4.21) & Debian 9 (apt offers no npm!) STILL NEED the above
-# nodesource.com approach to get a version of npm that works with Sugarizer:
-# https://github.com/iiab/iiab/issues/798#issuecomment-404324530
-#
-# MORE POSITIVELY: this nodesource.com approach (brings in npm 5.6.0 with
-# nodejs 8.11.3 for now, to any OS) would also work on Ubuntu 18.04, and
-# might even bring about a sane consistency across mainline OS's?
-#
-# BUT FOR NOW: Ubuntu 18.04's apt (approach below) brings in npm 3.5.2,
-# which appears suffic "SO FAR"?  18.04's nodejs 8.10.0 is more reassuring!
-
-# CRAZY IDEA: most versions of npm can upgrade themselves to the latest
-# (6.2.0 for now) using command "npm install -g npm", if that helps us in
-# future, e.g. TK's memory issue etc?  If so, be CAREFUL this puts npm
-# in /usr/local/bin on Ubuntu 18.04 -- unlike Ubuntu 16.04 and Raspbian
-# where it upgrades /usr/bin/npm in place:
-# https://askubuntu.com/questions/1036278/npm-is-incorrect-version-on-latest-ubuntu-18-04-installation
-
-- name: Install latest packages nodejs and npm (debuntu distros AFTER 2017, or other distros)
-  package:
-    name:
-      - nodejs
-      - npm
-    state: latest
-  when: internet_available and not (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -109,6 +109,9 @@ gw_block_https: False
 dhcpd_install: False
 dhcpd_enabled: False
 
+# node-js version
+nodejs_version: 8.x
+
 # named (BIND)
 named_install: False
 named_enabled: False


### PR DESCRIPTION
For 7.0, we should think about simplifying the way nodejs is installed. This PR does that:

1. Introduces a variable to set nodejs version
2. Installs from nodesource regardless of platform
