### PR TITLE
Sugarizer should fail the install if nodejs version is incorrect

### DIFF
--- a/roles/sugarizer/meta/main.yml
+++ b/roles/sugarizer/meta/main.yml
@@ -1,3 +1,3 @@
 dependencies:
     - { role: mongodb, tags: ['generic','mongodb'], when: sugarizer_install }
-    - { role: nodejs, tags: ['nodejs'], when: sugarizer_install }
+    - { role: nodejs, tags: ['nodejs'], when: sugarizer_install and (nodejs_version == "8.x") }

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Fail if nodejs_version is incorrect
   fail: 
-    msg: sugarizer: Refusing to install as nodejs_version is not 8.x. Fix that and rerun.
+    msg: "Sugarizer install cannot proceeed, as it requires Nodejs 8.x, and your nodejs_version is set to {{ nodejs_version }}.  Please fix that (typically in /etc/iiab/local_vars.yml) and rerun."
   when: sugarizer_install and (nodejs_version != "8.x")
 
 # 0. CLEAN UP PRIOR VERSIONS OF SUGARIZER (NEEDS WORK!)

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Fail if nodejs_version is incorrect
+  fail: 
+    msg: sugarizer: Refusing to install as nodejs_version is not 8.x. Fix that and rerun.
+  when: sugarizer_install and (nodejs_version != "8.x")
+
 # 0. CLEAN UP PRIOR VERSIONS OF SUGARIZER (NEEDS WORK!)
 
 - name: Wipe /library/www/html/sugarizer* if installing sugarizer-1.0


### PR DESCRIPTION
As the title says, and as we discussed on skype (between me and @holta ) sugarizer should fail the install process if the nodejs version is incorrect. 

Merge after #1411 
