### PR TITLE
ejabberd flaky so don't install it by default, even in BIG-sized local_vars.yml

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -177,7 +177,7 @@ mediawiki_enabled: True
 elgg_install: True
 elgg_enabled: True
 
-ejabberd_install: True
+ejabberd_install: False
 ejabberd_enabled: False
 
 # Lokole (email for rural communities) from https://ascoderu.ca


### PR DESCRIPTION
Why?  The installation of ejabberd has been intermittently very flaky in recent weeks, as reconfirmed by @m-anish as well.