### PR TITLE
Lokole 0.1.26 -> 0.1.35

### DIFF
--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -1,5 +1,5 @@
 # Info needed to install Lokole
-lokole_version: "0.1.26"
+lokole_version: "0.1.35"
 lokole_admin_user: admin    # lowercase seems nec here (even though uppercase Admin/changeme is IIAB's OOB recommendation!)
 lokole_admin_password: changeme
 lokole_install_path: "{{ content_base }}/lokole"    # /library/lokole


### PR DESCRIPTION
@c-w & @aidan-fitz I'm assuming 0.1.35 (2019-01-27) is more suitable than 0.1.26 (2018-12-02) for inclusion in [IIAB 6.7](https://github.com/iiab/iiab/wiki/IIAB-6.7-Release-Notes) in coming days?

Lokole 0.1.35 Release Notes / Changelog:
https://github.com/ascoderu/opwen-webapp/releases

Builds on PR #1305 etc.