### PR TITLE
Node-RED service fix for Ubuntu Server 18.04 & other OS's too?

### DIFF
--- a/roles/nodered/templates/node-red.service.j2
+++ b/roles/nodered/templates/node-red.service.j2
@@ -3,11 +3,12 @@ Description=Node-RED
 After=syslog.target network.target
 
 [Service]
-{% if is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17 %}
+# {% if is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17 %} FAILS ON UBUNTU SERVER 18.04
+# {% if is_debuntu %}
 ExecStart=/usr/bin/node-red-pi --max-old-space-size=128 -v
-{% else %}
-ExecStart=/usr/local/bin/node-red-pi --max-old-space-size=128 -v
-{% endif %}
+# {% else %}
+# ExecStart=/usr/local/bin/node-red-pi --max-old-space-size=128 -v
+# {% endif %}
 Restart=on-failure
 KillSignal=SIGINT
 
@@ -22,4 +23,3 @@ Group=nodered
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
@m-anish please review this as a possible fix for #1431 ?

This approach would deprecate /usr/**local**/bin/node-red-pi (in favor of /usr/bin/node-red-pi) across all OS's.

(Or...do you know of any OS's/distros that still require /usr/**local**/bin/node-red-pi ?)