### PR TITLE
fix for usbmount 0.0.14 condition (Debian 10 logic accidentally broke Raspbian)

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -18,7 +18,7 @@
   apt:
     deb: "{{ iiab_download_url }}/usbmount_0.0.14.1_all.deb"
     #timeout: "{{ download_timeout }}"    # Ansible's apt module doesn't support timeout parameter; that's ok as usbmount_0.0.14.1_all.deb is only 10KB
-  when: internet_available and is_debian_9 or is_debian_10 and not is_raspbian_9
+  when: internet_available and (is_debian_9 or is_debian_10) and not is_rpi
 
 - name: "Install 7 deb/apt packages: avahi-daemon, avahi-discover, exfat-fuse, exfat-utils, inetutils-syslogd, libnss-mdns, wpasupplicant (debuntu)"
   package:


### PR DESCRIPTION
Fixes #1438

Accidentally introduced by lack of parens in PR #1435