### PR TITLE
Make vars/<OS>.yml files less confusing (with dnsmasq, we can generally ignore "dns_service: named" & "dns_service: bind9")

### DIFF
--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -2,8 +2,11 @@ is_redhat: True
 is_centos: True
 is_centos_7: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: named
 dns_user: named
+
 proxy: squid
 proxy_user: squid
 apache_service: httpd

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -2,9 +2,12 @@ is_debuntu: True
 is_debian: True
 is_debian_10: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dhcp_service: isc-dhcp-server
 dns_user: bind
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -2,8 +2,11 @@ is_debuntu: True
 is_debian: True
 is_debian_8: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
+
 proxy: squid3
 proxy_user: proxy
 apache_service: apache2

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -2,9 +2,12 @@ is_debuntu: True
 is_debian: True
 is_debian_9: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dhcp_service: isc-dhcp-server
 dns_user: bind
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -2,8 +2,11 @@ is_redhat: True
 is_fedora: True
 is_fedora_18: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: named
 dns_user: named
+
 proxy: squid
 proxy_user: squid
 apache_service: httpd

--- a/vars/fedora-22.yml
+++ b/vars/fedora-22.yml
@@ -2,8 +2,11 @@ is_redhat: True
 is_fedora: True
 is_fedora_22: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: named
 dns_user: named
+
 proxy: squid
 proxy_user: squid
 apache_service: httpd

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -5,8 +5,11 @@ is_raspbian_8: True
 is_rpi: True
 rtc_id: ds3231
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
+
 proxy: squid3
 proxy_user: proxy
 apache_service: apache2

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -5,9 +5,12 @@ is_raspbian_9: True
 is_rpi: True
 rtc_id: ds3231
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -2,9 +2,12 @@ is_debuntu: True
 is_ubuntu: True
 is_ubuntu_16: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2

--- a/vars/ubuntu-17.yml
+++ b/vars/ubuntu-17.yml
@@ -2,9 +2,12 @@ is_debuntu: True
 is_ubuntu: True
 is_ubuntu_17: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -2,9 +2,12 @@ is_debuntu: True
 is_ubuntu: True
 is_ubuntu_18: True
 
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
 dns_service: bind9
 dns_user: bind
 dhcp_service: isc-dhcp-server
+
 proxy: squid
 proxy_user: proxy
 apache_service: apache2


### PR DESCRIPTION
Fixes #1436 sufficiently for now?