### PR TITLE
default_vars.yml fell out of sync with local_vars_min.yml's iiab_usb_lib_show_all: True

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -233,7 +233,7 @@ samba_enabled: False
 usb_lib_install: True
 usb_lib_enabled: True
 # Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: False
+iiab_usb_lib_show_all: True
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False


### PR DESCRIPTION
Back in sync with common community practices now, as the default in all vars/default_vars.yml + 3 {MIN, MEDIUM, BIG} vars files:
```
iiab_usb_lib_show_all: True
```