### PR TITLE
Update sugarizer-server (dev branch) for new docs & small improvements

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -13,8 +13,8 @@ sugarizer_git_version: v1.1.0             # WAS: v1.0.1, master
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
 sugarizer_server_dir_version: sugarizer-server-dev                        # WAS: sugarizer-server-1.0, sugarizer-server-master
-sugarizer_server_git_version: 46c4822bc7801ff8d621c22988aa4418359e7e19    # WAS: v1.0.1, master, dev
-# Above commit (githash 46c4822... for iiab/iiab PR #1430 from 'dev' branch of
-# https://github.com/llaske/sugarizer-server) well tested Jan 29 - Feb 2 2019.
+sugarizer_server_git_version: f27bf6acd56aba6d99116ef471ca713b0f0dfed3    # WAS: v1.0.1, master, dev
+# Above commit (githash f27bf6a... for iiab/iiab PR #1430 from 'dev' branch of
+# https://github.com/llaske/sugarizer-server) well-tested Jan 29 - Feb 2 2019.
 #
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer-server/releases


### PR DESCRIPTION
Builds on PRs #1430 #1475

Future Ref: #1449 Upgrade to / Validate sugarizer-server v1.1.0 on release "March 2019"