### PR TITLE
Force Node.js 10.x & 'npm install' Node-RED (0.19.5 for now).  On RPi, emulate Raspbian Desktop approach (install Node-RED start menu icon, install 8 examples, run as user 'pi', etc)

### DIFF
--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -38,6 +38,7 @@
 #      /etc/iiab/local_vars.yml -- then re-run this IIAB installer.
 #  when: nodejs_version_installed is defined and nodejs_version_installed.stdout != nodejs_version and nodejs_version_installed.stderr == ""
 
+# BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop & Ubermix that often include an older version of Node.js
 - name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node.js {{ nodejs_version_installed.stdout }} (IF IT'S NOT {{ nodejs_version }})
   package:
     name: nodejs

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -53,8 +53,10 @@
 
 # 2. INSTALL Node.js USING nodesource.com
 
-# SHOULD NOT BE NEC, AS STANZA BELOW SHOULD OVERWRITE /etc/apt/sources.list.d/nodesource.list REGARDLESS
-#- name: Clear prior /etc/apt/sources.list.d/nodesource.list (permitting downgrade if nec)
+# 2019-02-12: Should not be nec, as stanza below it should overwrite
+# /etc/apt/sources.list.d/nodesource.list regardless!
+#
+#- name: Clear prior /etc/apt/sources.list.d/nodesource.list (permitting Node.js downgrade if nec)
 #  file:
 #    path: /etc/apt/sources.list.d/nodesource.list
 #    state: absent

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -29,14 +29,20 @@
 # nodejs_version_installed.stderr == "/bin/sh: 1: nodejs: not found"
 # BOTH ABOVE (incl non-null stderr) are USED BELOW to confirm install is nec!
 
-- name: "ENFORCE PRECONDITION: Stop installing (intentionally fail) IF an installed 'nodejs' version isn't {{ nodejs_version }}"
-  fail:
-    msg: >
-      PLEASE REMOVE 'nodejs' VERSION {{ nodejs_version_installed.stdout }} AS
-      IT DOES NOT MATCH THE REQUIRED nodejs_version: {{ nodejs_version }} --
-      as set in /opt/iiab/iiab/vars/default_vars.yml and/or
-      /etc/iiab/local_vars.yml -- then re-run this IIAB installer.
-  when: nodejs_version_installed is defined and nodejs_version_installed.stdout != nodejs_version and nodejs_version_installed.stderr == ""
+#- name: "ENFORCE PRECONDITION: Stop installing (intentionally fail) IF an installed 'nodejs' version isn't {{ nodejs_version }}"
+#  fail:
+#    msg: >
+#      PLEASE REMOVE 'nodejs' VERSION {{ nodejs_version_installed.stdout }} AS
+#      IT DOES NOT MATCH THE REQUIRED nodejs_version: {{ nodejs_version }} --
+#      as set in /opt/iiab/iiab/vars/default_vars.yml and/or
+#      /etc/iiab/local_vars.yml -- then re-run this IIAB installer.
+#  when: nodejs_version_installed is defined and nodejs_version_installed.stdout != nodejs_version and nodejs_version_installed.stderr == ""
+
+- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node.js {{ nodejs_version_installed.stdout }} (IF IT'S NOT {{ nodejs_version }})
+  package:
+    name: nodejs
+    state: absent
+  when: nodejs_version_installed is defined and nodejs_version_installed.stdout != nodejs_version and nodejs_version_installed.stdout != ""
 
 - name: Warn if Node.js {{ nodejs_version}} already installed & might be updated
   debug:
@@ -45,6 +51,13 @@
 
 
 # 2. INSTALL Node.js USING nodesource.com
+
+# SHOULD NOT BE NEC, AS STANZA BELOW SHOULD OVERWRITE /etc/apt/sources.list.d/nodesource.list REGARDLESS
+#- name: Clear prior /etc/apt/sources.list.d/nodesource.list (permitting downgrade if nec)
+#  file:
+#    path: /etc/apt/sources.list.d/nodesource.list
+#    state: absent
+#  when: internet_available and is_debuntu
 
 - name: Set up Node.js {{ nodejs_version }} apt sources (debuntu)
   shell: curl -sL https://deb.nodesource.com/setup_{{ nodejs_version }} | bash -

--- a/roles/nodered/defaults/main.yml
+++ b/roles/nodered/defaults/main.yml
@@ -13,3 +13,4 @@ nodered_password_hash: $2b$08$oxgvoU9et3deSbXY8UNVTOWHSTQAyEASIal86RHVMqYQJhpPMN
 # To generate a new password hash, run 'node-red-admin hash-pw' and enter the
 # new password.  Paste the resulting hash above.  After Ansible runs, username
 # and password hash will be placed in: /home/nodered/.node-red/settings.js
+# Or...on Raspberry Pi it's placed in: /home/pi/.node-red/settings.js

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -1,15 +1,53 @@
 # 2019-01-16: @jvonau's PR #1403 moved installation of Node.js (8.x for now) &
 # npm to roles/nodejs/tasks/main.yml, triggered by roles/nodered/meta/main.yml
 
-# BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop & Ubermix that often include an older version of Node-RED
-- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node-RED (IF IT WAS INSTALLED BY OS PKG MANAGER)
-  package:
-    name: nodered
-    state: absent
+# Too brutal, as this removed customizations on graphical desktop OS's e.g.
+# Raspbian Desktop's:
+#   1. Node-RED's icon (Raspberry Menu in top-left -> Programming -> Node-RED)
+#   2. scripts like {node-red-start, node-red-stop, node-red-log} in /usr/bin
+#   3. other changes per /usr/bin/update-nodejs-and-nodered summarized at
+#      https://nodered.org/docs/hardware/raspberrypi for example low-memory
+#      flag --max_old_space_size=256 for unit file (any reason we use 128?)
+## BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop & Ubermix that often include an older version of Node-RED
+#- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node-RED (IF IT WAS INSTALLED BY OS PKG MANAGER)
+#  package:
+#    name: nodered
+#    state: absent
+#  when: nodered_install
+
+#- name: 'npm install node-red packages globally: node-red, node-red-admin, node-red-dashboard'
+#  shell: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
+#  when: nodered_install
+
+# To protect pre-installed packages within /usr/lib/node_modules in graphical
+# desktop OS's like Raspbian Desktop & Ubermix, we now only install those that
+# are missing -- among the 3 below.  WARNING: THIS COULD POTENTIALLY LEAD TO
+# INCOMPATIBILITIES, IF OS'S /usr/lib/node_modules/node-red GETS OUT OF DATE!
+
+# /usr/lib/node_modules/node-red is PRE-INSTALLED by Raspbian Desktop, even if
+# their package (42MB, 0.19.4) is a bit out of date compared to npm's (55MB,
+# 0.19.5) as of 2019-02-12.  Among others in /usr/lib/node_modules, pre-placed
+# by Raspbian Desktop's apt package 'nodered':
+#   node-red-contrib-ibm-watson-iot, node-red-contrib-play-audio,
+#   node-red-node-ledborg, node-red-node-ping, node-red-node-pi-sense-hat
+#   node-red-node-random, node-red-node-serialport, node-red-node-smooth
+- name: Globally 'npm install' pkg 'node-red' if /usr/lib/node_modules/node-red missing (most OS's except for Raspbian Desktop)
+  command: npm install -g --unsafe-perm node-red
+  creates: /usr/lib/node_modules/node-red
   when: nodered_install
 
-- name: 'npm install node-red packages globally: node-red, node-red-admin, node-red-dashboard'
-  shell: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
+# NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
+# on most all OS's:
+- name: Globally 'npm install' pkg 'node-red-admin' if /usr/lib/node_modules/node-red-admin missing (most OS's)
+  command: npm install -g --unsafe-perm node-red-admin
+  creates: /usr/lib/node_modules/node-red-admin
+  when: nodered_install
+
+# NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
+# on most all OS's:
+- name: Globally 'npm install' pkg 'node-red-dashboard' if /usr/lib/node_modules/node-red-dashboard missing (most OS's)
+  command: npm install -g --unsafe-perm node-red-dashboard
+  creates: /usr/lib/node_modules/node-red-dashboard
   when: nodered_install
 
 - name: Ensure Linux group 'nodered' exists
@@ -117,7 +155,7 @@
     - option: name
       value: Node-RED
     - option: description
-      value: '"Node-RED is a flow-based development tool for visual programming developed originally by IBM for wiring together hardware devices, APIs and online services as part of the Internet of Things. Node-RED provides a web browser-based flow editor, which can be used to create JavaScript functions."'
+      value: '"Node-RED is a flow-based development tool for visual programming developed originally by IBM for wiring together hardware devices, APIs and online services as part of the Internet of Things.  Node-RED provides a web browser-based flow editor, which can be used to create JavaScript functions."'
     - option: nodered_install
       value: "{{ nodered_install }}"
     - option: nodered_enabled

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -33,21 +33,24 @@
 #   node-red-node-random, node-red-node-serialport, node-red-node-smooth
 - name: Globally 'npm install' pkg 'node-red' if /usr/lib/node_modules/node-red missing (most OS's except for Raspbian Desktop)
   command: npm install -g --unsafe-perm node-red
-  creates: /usr/lib/node_modules/node-red
+  args:
+    creates: /usr/lib/node_modules/node-red
   when: nodered_install
 
 # NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
 # on most all OS's:
 - name: Globally 'npm install' pkg 'node-red-admin' if /usr/lib/node_modules/node-red-admin missing (most OS's)
   command: npm install -g --unsafe-perm node-red-admin
-  creates: /usr/lib/node_modules/node-red-admin
+  args:
+    creates: /usr/lib/node_modules/node-red-admin
   when: nodered_install
 
 # NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
 # on most all OS's:
 - name: Globally 'npm install' pkg 'node-red-dashboard' if /usr/lib/node_modules/node-red-dashboard missing (most OS's)
   command: npm install -g --unsafe-perm node-red-dashboard
-  creates: /usr/lib/node_modules/node-red-dashboard
+  args:
+    creates: /usr/lib/node_modules/node-red-dashboard
   when: nodered_install
 
 - name: Ensure Linux group 'nodered' exists

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -1,80 +1,138 @@
 # 2019-01-16: @jvonau's PR #1403 moved installation of Node.js (8.x for now) &
 # npm to roles/nodejs/tasks/main.yml, triggered by roles/nodered/meta/main.yml
 
-# Too brutal, as this removed customizations on graphical desktop OS's e.g.
-# Raspbian Desktop's:
+# BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop &
+# Ubermix that often include an older version of Node-RED.  Brutal, as this
+# removes customizations on graphical desktop OS's e.g. Raspbian Desktop's:
 #   1. Node-RED's icon (Raspberry Menu in top-left -> Programming -> Node-RED)
 #   2. scripts like {node-red-start, node-red-stop, node-red-log} in /usr/bin
 #   3. other changes per /usr/bin/update-nodejs-and-nodered summarized at
 #      https://nodered.org/docs/hardware/raspberrypi for example low-memory
-#      flag --max_old_space_size=256 for unit file (any reason we use 128?)
-## BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop & Ubermix that often include an older version of Node-RED
-#- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node-RED (IF IT WAS INSTALLED BY OS PKG MANAGER)
-#  package:
-#    name: nodered
-#    state: absent
-#  when: nodered_install
-
-#- name: 'npm install node-red packages globally: node-red, node-red-admin, node-red-dashboard'
-#  shell: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
-#  when: nodered_install
-
-# To protect pre-installed packages within /usr/lib/node_modules in graphical
-# desktop OS's like Raspbian Desktop & Ubermix, we now only install those that
-# are missing -- among the 3 below.  WARNING: THIS COULD POTENTIALLY LEAD TO
-# INCOMPATIBILITIES, IF OS'S /usr/lib/node_modules/node-red GETS OUT OF DATE!
-
-# /usr/lib/node_modules/node-red is PRE-INSTALLED by Raspbian Desktop, even if
-# their package (42MB, 0.19.4) is a bit out of date compared to npm's (55MB,
-# 0.19.5) as of 2019-02-12.  Among others in /usr/lib/node_modules, pre-placed
-# by Raspbian Desktop's apt package 'nodered':
-#   node-red-contrib-ibm-watson-iot, node-red-contrib-play-audio,
-#   node-red-node-ledborg, node-red-node-ping, node-red-node-pi-sense-hat
-#   node-red-node-random, node-red-node-serialport, node-red-node-smooth
-- name: Globally 'npm install' pkg 'node-red' if /usr/lib/node_modules/node-red missing (most OS's except for Raspbian Desktop)
-  command: npm install -g --unsafe-perm node-red
-  args:
-    creates: /usr/lib/node_modules/node-red
+#      flag --max_old_space_size=256 for unit file (we're using 128 on RPi)
+# That we'll reconstitute below!
+- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING 'nodered' (IF PREVIOUSLY INSTALLED BY OS PKG MANAGER)
+  package:
+    name: nodered
+    state: absent
   when: nodered_install
 
-# NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
-# on most all OS's:
-- name: Globally 'npm install' pkg 'node-red-admin' if /usr/lib/node_modules/node-red-admin missing (most OS's)
-  command: npm install -g --unsafe-perm node-red-admin
-  args:
-    creates: /usr/lib/node_modules/node-red-admin
-  when: nodered_install
+- name: "Globally 'npm install' 3 Node-RED packages: node-red, node-red-admin, node-red-dashboard"
+  command: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
+  when: nodered_install and internet_available
 
-# NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
-# on most all OS's:
-- name: Globally 'npm install' pkg 'node-red-dashboard' if /usr/lib/node_modules/node-red-dashboard missing (most OS's)
-  command: npm install -g --unsafe-perm node-red-dashboard
-  args:
-    creates: /usr/lib/node_modules/node-red-dashboard
-  when: nodered_install
+- name: "Globally 'npm install' 8 Node-RED learning examples for RPi: node-red-contrib-ibm-watson-iot, node-red-contrib-play-audio, node-red-node-ledborg, node-red-node-ping, node-red-node-pi-sense-hat, node-red-node-random, node-red-node-serialport, node-red-node-smooth"
+  command: npm install -g --unsafe-perm node-red-contrib-ibm-watson-iot node-red-contrib-play-audio node-red-node-ledborg node-red-node-ping node-red-node-pi-sense-hat node-red-node-random node-red-node-serialport node-red-node-smooth
+  when: nodered_install and internet_available and is_rpi
 
-- name: Ensure Linux group 'nodered' exists
+# TEST UNNEC ICON/MENU FILE PLACEMENT ON RASPIAN LITE TOO !
+- name: 'Download/Install 4 useful items for RPi: Node-RED icon, start menu item, /etc/logrotate.d/nodered, tweaked "Pi cpu temperature.json"'
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - url: https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-icon.svg
+      dest: /usr/share/icons/hicolor/scalable/apps/node-red-icon.svg
+    - url: https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/Node-RED.desktop
+      dest: /usr/share/applications/Node-RED.desktop
+    - url: https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/nodered.rotate
+      dest: /etc/logrotate.d/nodered
+    - url: 'https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/Pi%20cpu%20temperature.json'
+      dest: '/usr/lib/node_modules/node-red-contrib-ibm-watson-iot/examples/Pi cpu temperature.json'
+  when: nodered_install and internet_available and is_rpi
+
+#- name: Replace/Tweak "node-red-contrib-ibm-watson-iot/examples/Pi cpu temperature.json" (rpi)
+#  command: 'curl -sL -o /usr/lib/node_modules/node-red-contrib-ibm-watson-iot/examples/Pi\ cpu\ temperature.json https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/Pi%20cpu%20temperature.json'
+#  when: nodered_install and internet_available and is_rpi
+
+- name: 'Download/Install 4 RPi executables to /usr/bin: node-red-start, node-red-stop, node-red-restart, node-red-log'
+  get_url:
+    url: "{{ item }}"
+    dest: /usr/bin
+    mode: a+x
+  with:
+    - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-start
+    - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-stop
+    - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-restart
+    - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-log
+  when: nodered_install and internet_available and is_rpi
+
+## To protect pre-installed packages within /usr/lib/node_modules in graphical
+## desktop OS's like Raspbian Desktop & Ubermix, we now only install those that
+## are missing -- among the 3+8 below.  WARNING: THIS COULD POTENTIALLY LEAD TO
+## INCOMPATIBILITIES, IF OS'S /usr/lib/node_modules/node-red GETS OUT OF DATE!
+#
+## /usr/lib/node_modules/node-red is PRE-INSTALLED by Raspbian Desktop, even if
+## their package (42MB, 0.19.4) is a bit out of date compared to npm's (55MB,
+## 0.19.5) as of 2019-02-12.  Among others in /usr/lib/node_modules, pre-placed
+## by Raspbian Desktop's apt package 'nodered':
+##   node-red-contrib-ibm-watson-iot, node-red-contrib-play-audio,
+##   node-red-node-ledborg, node-red-node-ping, node-red-node-pi-sense-hat
+##   node-red-node-random, node-red-node-serialport, node-red-node-smooth
+#- name: Globally 'npm install' pkg 'node-red' if /usr/lib/node_modules/node-red missing (most OS's except for Raspbian Desktop)
+#  #command: npm install -g --unsafe-perm node-red
+#  command: npm install -g --unsafe-perm node-red@latest
+#  args:
+#    creates: /usr/lib/node_modules/node-red
+#  when: nodered_install and internet_available
+#
+## NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
+## on most all OS's:
+#- name: Globally 'npm install' pkg 'node-red-admin' if /usr/lib/node_modules/node-red-admin missing (most OS's)
+#  command: npm install -g --unsafe-perm node-red-admin
+#  args:
+#    creates: /usr/lib/node_modules/node-red-admin
+#  when: nodered_install and internet_available
+#
+## NOT pre-installed by Raspbian Desktop as of 2019-02-12...so we install this
+## on most all OS's:
+#- name: Globally 'npm install' pkg 'node-red-dashboard' if /usr/lib/node_modules/node-red-dashboard missing (most OS's)
+#  command: npm install -g --unsafe-perm node-red-dashboard
+#  args:
+#    creates: /usr/lib/node_modules/node-red-dashboard
+#  when: nodered_install and internet_available
+
+
+- name: Create /home/pi/.node-red/ directory (rpi)
+  file:
+    path: /home/pi/.node-red
+    state: directory
+    owner: pi
+    group: pi
+    mode: 0775
+  when: nodered_install and is_rpi
+
+- name: Install /home/pi/.node-red/settings.js from template, with authentication (rpi)
+  template:
+    backup: yes
+    src: settings.js.j2
+    dest: /home/pi/.node-red/settings.js
+    owner: pi
+    group: pi
+    mode: 0755
+  when: nodered_install and is_rpi
+
+- name: Ensure Linux group 'nodered' exists (if not rpi)
   group:
     name: nodered
     state: present
-  when: nodered_install
+  when: nodered_install and not is_rpi
 
-- name: Ensure Linux user 'nodered' exists and is added to group 'nodered'
+- name: Ensure Linux user 'nodered' exists and is added to group 'nodered' (if not rpi)
   user:
     name: nodered
     group: nodered
-  when: nodered_install
+  when: nodered_install and not is_rpi
 
-- name: Create /home/nodered/.node-red/ directory
+- name: Ensure directory /home/nodered/.node-red/ exists (if not rpi)
   file:
     path: /home/nodered/.node-red
     state: directory
     owner: nodered
     group: nodered
     mode: 0775
-  when: nodered_install
+  when: nodered_install and not is_rpi
 
-- name: Install /home/nodered/.node-red/settings.js from template, with authentication
+- name: Install /home/nodered/.node-red/settings.js from template, with authentication (if not rpi)
   template:
     backup: yes
     src: settings.js.j2
@@ -82,13 +140,14 @@
     owner: nodered
     group: nodered
     mode: 0755
-  when: nodered_install
+  when: nodered_install and not is_rpi
 
-- name: Install /etc/systemd/system/node-red.service systemd unit file from template
+
+- name: Install /etc/systemd/system/nodered.service systemd unit file from template
   template:
     backup: yes
-    src: node-red.service.j2
-    dest: /etc/systemd/system/node-red.service
+    src: nodered.service.j2
+    dest: /etc/systemd/system/nodered.service
     owner: root
     group: root
     mode: 0666
@@ -132,21 +191,22 @@
     state: restarted
   when: nodered_install
 
-- name: Enable & (Re)start 'node-red' systemd service (if nodered_enabled)
+- name: Enable & (Re)start 'nodered' systemd service (if nodered_enabled)
   systemd:
     daemon_reload: yes
-    name: node-red
+    name: nodered
     enabled: yes
     state: restarted
   when: nodered_enabled
 
-- name: Disable & Stop 'node-red' systemd service (if not nodered_enabled)
+- name: Disable & Stop 'nodered' systemd service (if not nodered_enabled)
   systemd:
     daemon_reload: yes
-    name: node-red
+    name: nodered
     enabled: no
     state: stopped
   when: not nodered_enabled
+
 
 - name: Add 'nodered' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -16,6 +16,12 @@
     state: absent
   when: nodered_install
 
+# 2012-02-13: the 6 RPi stanzas below recreate Raspbian Desktop's Node-RED
+# environment, inspired by:
+# https://nodered.org/docs/hardware/raspberrypi
+# https://github.com/node-red/raspbian-deb-package/blob/master/resources/update-nodejs-and-nodered
+# https://github.com/iiab/iiab/pull/1497
+
 - name: "Globally 'npm install' 3 Node-RED packages: node-red, node-red-admin, node-red-dashboard"
   command: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
   when: nodered_install and internet_available

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -49,7 +49,7 @@
     url: "{{ item }}"
     dest: /usr/bin
     mode: a+x
-  with:
+  with_items:
     - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-start
     - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-stop
     - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-restart

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -1,6 +1,13 @@
 # 2019-01-16: @jvonau's PR #1403 moved installation of Node.js (8.x for now) &
 # npm to roles/nodejs/tasks/main.yml, triggered by roles/nodered/meta/main.yml
 
+# BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop & Ubermix that often include an older version of Node-RED
+- name: ASK apt/yum/dnf TO REMOVE PRE-EXISTING Node-RED (IF IT WAS INSTALLED BY OS PKG MANAGER)
+  package:
+    name: nodered
+    state: absent
+  when: nodered_install
+
 - name: 'npm install node-red packages globally: node-red, node-red-admin, node-red-dashboard'
   shell: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
   when: nodered_install

--- a/roles/nodered/templates/node-red.service.j2
+++ b/roles/nodered/templates/node-red.service.j2
@@ -5,10 +5,12 @@ After=syslog.target network.target
 [Service]
 # Ansible template HAD: if is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17
 # Ansible template HAD: if is_debuntu
+{% if is_rpi %}
 ExecStart=/usr/bin/node-red-pi --max-old-space-size=128 -v
-# Ansible template HAD: else
+{% else %}
 # ExecStart=/usr/local/bin/node-red-pi --max-old-space-size=128 -v
-# Ansible template HAD: endif
+ExecStart=/usr/bin/node-red-pi -v
+{% endif %}
 Restart=on-failure
 KillSignal=SIGINT
 

--- a/roles/nodered/templates/nodered.service.j2
+++ b/roles/nodered/templates/nodered.service.j2
@@ -19,9 +19,15 @@ SyslogIdentifier=node-red
 StandardOutput=syslog
 
 # non-root user to run as
+{% if is_rpi %}
+WorkingDirectory=/home/pi/
+User=pi
+Group=pi
+{% else %}
 WorkingDirectory=/home/nodered/
 User=nodered
 Group=nodered
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
WIP that will hopefully be complete & tested by end of day.

Needed as a result of distros like Raspbian Desktop &mdash; which out-of-the-box currently includes its own Node.js 8.x (IIAB & Asterisk require 10.x) AND Node-RED 0.19.4 (IIAB requests 0.19.5 for now):
```
root@raspberrypi:~# apt -a list nodejs nodered
Listing... Done
nodejs/stable,now 8.11.1~dfsg-2~bpo9+1 armhf [installed,automatic]
nodejs/stable 4.8.2~dfsg-1 armhf

nodered/stable,now 0.19.4 armhf [installed]
```

Ref: #1495