### PR TITLE
Captive Portal: works on Windows 7,8,10, with no network wire

### DIFF
--- a/roles/captive-portal/templates/capture-wsgi.py
+++ b/roles/captive-portal/templates/capture-wsgi.py
@@ -177,27 +177,7 @@ def set_lasttimestamp(ip):
     conn.commit()
 
 #  ###################  Action routines based on OS  ################3
-def microsoft_splash(environ,start_response):
-    en_txt={ 'message':"Click on the button to go to the IIAB home page",\
-            "FQDN": fully_qualified_domain_name, \
-            'btn1':"GO TO IIAB HOME PAGE",'doc_root':get_iiab_env("WWWROOT")}
-    es_txt={ 'message':"Haga clic en el botón para ir a la página de inicio de IIAB",\
-            "FQDN": fully_qualified_domain_name, \
-            'btn1':"IIAB",'doc_root':get_iiab_env("WWWROOT")}
-    txt = en_txt
-    if lang == "en":
-        txt = en_txt
-    elif lang == "es":
-        txt = es_txt
-    response_body = str(j2_env.get_template("simple.template").render(**txt))
-    status = '200 OK'
-    response_headers = [('Content-type','text/html'),
-            ('Content-Length',str(len(response_body)))]
-    start_response(status, response_headers)
-    return [response_body]
-
 def microsoft(environ,start_response):
-    global MICROSOFT_TRIGGERED
     # firefox -- seems both mac and Windows use it
     agent = environ.get('HTTP_USER_AGENT','default_agent')
     if agent.startswith('Mozilla'):
@@ -205,7 +185,7 @@ def microsoft(environ,start_response):
     logger.debug("sending microsoft redirect")
     response_body = ""
     status = '302 Moved Temporarily'
-    response_headers = [('Location','/microsoft_splash'),
+    response_headers = [('Location','http://box.lan/home'),
             ('Content-type','text/html'),
             ('Content-Length',str(len(response_body)))]
     start_response(status, response_headers)
@@ -542,10 +522,6 @@ def application (environ, start_response):
       return android(environ, start_response) 
 
    # microsoft
-   if  environ['PATH_INFO'] == "/microsoft_splash":
-     return microsoft_splash(environ, start_response) 
-   if  environ['PATH_INFO'] == "/connecttest.txt" and not is_inactive(ip):
-     return microsoft_connect(environ, start_response) 
    if environ['HTTP_HOST'] == "ipv6.msftncsi.com" or\
      environ['HTTP_HOST'] == "detectportal.firefox.com" or\
      environ['HTTP_HOST'] == "ipv6.msftncsi.com.edgesuite.net" or\
@@ -557,7 +533,7 @@ def application (environ, start_response):
      environ['HTTP_HOST'] == "teredo.ipv6.microsoft.com.nsatc.net": 
      return microsoft(environ, start_response) 
 
-   logger.debug("executing the default 204 response. [%s"%data)
+   logger.debug("executing the default 302 response. [%s"%data)
    return put_302(environ,start_response)
 
 # Instantiate the server


### PR DESCRIPTION
- Tested on Windows10 internet explorer
- then downloaded chrome on windows10, and installed as default browser--worked
- Tested on Win7,8,10, with no network wire, and rpi repowered, and client caches deleted.
- retested on iphone, macbook, android 5,7 with no network wire, rpi3 repowered
- Not tested on android 8,9
- With network wire, windows10,default set to internet explorer, pasted a unsuccesful fetch of microsoft.com, on top of box.lan.home's tab, whereas when the default browser was set to edge, the captive portal worked properly --not hidden by another tab
