### PR TITLE
Possible fix for dnsmasq during WiFi installs for #1519

### DIFF
--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -74,4 +74,4 @@
   systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
-  when: iiab_network_mode != "Appliance" and iiab_wan_iface != discovered_wireless_iface
+  when: (iiab_network_mode != "Appliance") and (iiab_wan_iface != discovered_wireless_iface) and (not no_net_restart)

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -74,4 +74,5 @@
   systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
-  when: (iiab_network_mode != "Appliance") and (iiab_wan_iface != discovered_wireless_iface) and (not no_net_restart)
+  when: (iiab_network_mode != "Appliance") and (not no_net_restart)
+  #when: iiab_network_mode != "Appliance" and iiab_wan_iface != discovered_wireless_iface


### PR DESCRIPTION
Thanks to @jvonau, towards resolving @mitra42's DNS problem in #1519.

Background: dnsmasq was failing to restart due to br0 not being created, due to the suppression of networking restart during WiFi installs.