### PR TITLE
iiab_base_ver: 6.7 to 7.0 in roles/0-init/defaults/main.yml 

### DIFF
--- a/roles/0-init/defaults/main.yml
+++ b/roles/0-init/defaults/main.yml
@@ -1,5 +1,5 @@
 # Use these to tag a release at a point in time, for {{ iiab_env_file }}
-iiab_base_ver: 6.7
+iiab_base_ver: 7.0
 iiab_revision: 0
 
 # These entries should never be changed in this file.


### PR DESCRIPTION
As usual after a new release of IIAB.

We could find a better place to set variable `iiab_base_ver:` (than roles/0-init/defaults/main.yml) but it'll do for now...