### PR TITLE
WiFi dnsmasq fix for #1519 - always create br0 on RPi

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -141,7 +141,7 @@
 - name: Set iiab_wired_lan_iface if present
   set_fact:
     iiab_wired_lan_iface: "{{ discovered_wired_iface }}"
-  when: discovered_wired_iface is defined and discovered_wired_iface != "none" and discovered_wired_iface != iiab_wan_iface
+  when: discovered_wired_iface is defined and discovered_wired_iface != "none" and discovered_wired_iface != iiab_wan_iface and not is_rpi
 
 #unused
 #- name: Get a list of ifcfg files to delete

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -74,5 +74,6 @@
   systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
-  when: (iiab_network_mode != "Appliance") and (not no_net_restart)
+  when: (iiab_network_mode != "Appliance")    # Sufficient b/c br0 exists thanks to /etc/network/interfaces.d/iiab
+  #when: (iiab_network_mode != "Appliance") and (not no_net_restart)
   #when: iiab_network_mode != "Appliance" and iiab_wan_iface != discovered_wireless_iface

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -60,4 +60,5 @@
     name: networking
     enabled: yes
     state: restarted
-  when: not nobridge is defined and not no_net_restart
+  when: not nobridge is defined    # less is better
+  #when: not nobridge is defined and not no_net_restart


### PR DESCRIPTION
Thanks to @jvonau

During WiFi install on RPi, Gateway is with no underlying slaves, until 'iiab-hotspot-on' is run.

A wired slave can be enabled to br0 (LAN stuff) in local_vars.yml by adding e.g. `iiab_wired_lan_iface: eth0`

Refs: #1519, PRs #1453 #1523