### PR TITLE
Fix iiab-admin published password warnings for Raspbian Desktop 2018-11-13 especially

### DIFF
--- a/roles/iiab-admin/defaults/main.yml
+++ b/roles/iiab-admin/defaults/main.yml
@@ -3,19 +3,22 @@
 # Set iiab_admin_user_install: False if you don't want iiab_admin_user & wheel
 # group auto-created in roles/iiab-admin/tasks/main.yml (hence disabling sudo-
 # checks/warnings of published passwds like pi/raspberry & iiab-admin/g0adm1n).
-iiab_admin_user_install: True
+# iiab_admin_user_install: True
 # If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
 # Linux user that has sudo access, for login to Admin Console http://box/admin
 
 # ODDLY THIS IS ALSO USED BY roles/usb-lib/tasks/main.yml TO SET GROUP PERM FOR /library/www/html/local_content (ISN'T {{ apache_user }} MORE APPROPRIATE?)
-iiab_admin_user: iiab-admin
+# iiab_admin_user: iiab-admin
 
 # For live checks/alerts of published pwds
-iiab_admin_published_pwd: g0adm1n
+# iiab_admin_published_pwd: g0adm1n
 
 # Password hash to override above, if Ansible creates above user:
-iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
+# iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:
 #    python3 -c 'import crypt; print(crypt.crypt("<plaintext>", crypt.mksalt(crypt.METHOD_SHA512)))'
 # Obtain a password hash - OLD WAY:
 #    python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
+
+# All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -21,24 +21,32 @@
     - option: iiab_admin_user
       value: "{{ iiab_admin_user }}"
 
-- name: Install /etc/profile.d/profile_ssh_warn.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is still default
+- name: Install /etc/profile.d/sshpwd-profile-iiab.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
   template:
-    src: profile_ssh_warn.sh
+    src: sshpwd-profile-iiab.sh
     dest: /etc/profile.d/
+    mode: 0644
 
-- name: Is this LXDE?
+- name: Is this LXDE-pi?
   stat:
-    path: /home/pi/.config/lxsession
+    path: /etc/xdg/lxsession/LXDE-pi
   register: lx
 
-- name: "Likewise for Raspbian, installing: /home/pi/.config/lxsession/LXDE-pi/lxde_ssh_warn.sh"
+- name: "Likewise for Raspbian, installing: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
   template:
-    src: lxde_ssh_warn.sh
-    dest: /home/pi/.config/lxsession/LXDE-pi/
+    src: sshpwd-lxde-iiab.sh
+    dest: /etc/xdg/lxsession/LXDE-pi/
+    mode: 0755
   when: lx.stat.isdir is defined and lx.stat.isdir and is_rpi and is_debuntu
 
-- name: Put line in /home/pi/.config/lxsession/LXDE-pi/autostart to run the above (raspbian)
+# 2019-03-07: This popup (/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh) does
+# not actually appear when triggered by /etc/xdg/autostart/pprompt-iiab.desktop
+# (or pprompt.desktop as Raspbian has working since 2018-11-13!)  Too bad as it
+# would be really nice to standardize this popup across Ubermix & all distros..
+# Is this a permissions/security issue presumably?
+
+- name: Put line in /etc/xdg/lxsession/LXDE-pi/autostart to run the above (raspbian)
   lineinfile:
-    path: /home/pi/.config/lxsession/LXDE-pi/autostart
-    line: "@/home/pi/.config/lxsession/LXDE-pi/lxde_ssh_warn.sh"
+    path: /etc/xdg/lxsession/LXDE-pi/autostart
+    line: "@/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
   when: lx.stat.isdir is defined and lx.stat.isdir and is_rpi and is_debuntu

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+export TEXTDOMAIN=pprompt-iiab
+
+. gettext.sh
+
+# bash syntax "function check_user_pwd() {" was removed, as it prevented all
+# lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
 check_user_pwd() {
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
@@ -9,24 +15,14 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-# credit to the folks at raspberry pi foundatioon
+# Credit to the folks at the Raspberry Pi Foundation
 check_hash() {
    if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
    if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
-   #test -x /usr/bin/mkpasswd || return 0
-   #SHADOW="$(sudo -n grep -E '^iiab-admin:' /etc/shadow 2>/dev/null)"
-   #test -n "${SHADOW}" || return 0
-   #if echo $SHADOW | grep -q "iiab-admin:!" ; then return 0 ; fi
-   #SHADOW_PW=$(echo $SHADOW | cut -d: -f2)
-   #if [ "$SHADOW_PW" != "\$6\$iiab51\$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop." ]; then return 0 ; fi
-   #if echo "${SHADOW}" | grep -q "${HASH}"; then
    if check_user_pwd "iiab-admin" "{{ iiab_admin_published_pwd }}"; then
-       zenity --warning --text="SSH is enabled and the published password for user 'iiab-admin' is in use.\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box/admin) -> Utilities -> Change Password."
+       zenity --warning --width=600 --text="SSH is enabled and the default password for user 'iiab-admin' is in use.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
    fi
 }
 
-#if service ssh status | grep -q running; then
-#    check_hash
-#fi
 systemctl is-active {{ sshd_service }} > /dev/null && check_hash
 unset check_hash

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+export TEXTDOMAIN=Linux-PAM
+
+. gettext.sh
+
 # bash syntax "function check_user_pwd() {" was removed, as it prevented all
 # lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
 check_user_pwd() {
@@ -11,20 +15,16 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-# credit to the folks at raspberry pi foundatioon
+# Credit to the folks at the Raspberry Pi Foundation
 check_hash() {
     if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
     if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
-    #SHADOW="$(sudo -n grep -E '^iiab-admin:' /etc/shadow 2>/dev/null)"
-    #test -n "${SHADOW}" || return 0
-    #if echo $SHADOW | grep -q "iiab-admin:!" ; then return 0 ; fi
-    #SHADOW_PW=$(echo $SHADOW | cut -d: -f2)
-    #if [ "$SHADOW_PW" != '{{ iiab_admin_pwd_hash }}' ]; then return 0 ; fi
     if check_user_pwd "iiab-admin" "{{ iiab_admin_published_pwd }}"; then
-        echo -e "\nSSH is enabled and the published password for user 'iiab-admin' is in use."
-        echo -e "THIS IS A SECURITY RISK - please log in as user 'iiab-admin' and run 'passwd'"
-        echo -e "to change its password.\n"
-    fi
+        echo
+        echo $(/usr/bin/gettext "SSH is enabled and the published password for user 'iiab-admin' is in use.")
+        echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd iiab-admin' to change it.")
+        echo
+     fi
 }
 
 systemctl is-active {{ sshd_service }} > /dev/null && check_hash

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -33,6 +33,7 @@ language_priority: en es fr
 iiab_admin_user_install: True
 # If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
 # Linux user that has sudo access, for login to Admin Console http://box/admin
+# ODDLY THIS IS ALSO USED BY roles/usb-lib/tasks/main.yml TO SET GROUP PERM FOR /library/www/html/local_content (ISN'T {{ apache_user }} MORE APPROPRIATE?)
 iiab_admin_user: iiab-admin
 iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to override above, if Ansible creates above user:


### PR DESCRIPTION
Fixes #1537, the visual warning (popup) especially.

Also cleans up the text warning on shell and ssh login.

Testing ongoing.