### PR TITLE
Gitea: configure clone URLs

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -8,7 +8,7 @@
 # https://git.coolaj86.com/coolaj86/gitea-installer.sh
 
 # Information needed to install Gitea
-gitea_version: "1.7.3"
+gitea_version: "1.7.4"
 iset_suffixes:
   i386: "386"
   x86_64: "amd64"

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -42,8 +42,6 @@ gitea_home: "/home/{{ gitea_user }}" # SSH credentials stored here
 gitea_run_directory: "{{ gitea_root_directory }}"
 
 gitea_url: /gitea
-gitea_full_url: "http://{{ iiab_hostname }}.{{ iiab_domain }}{{ gitea_url }}"
-
 gitea_port: 61734 # leet for GITEA
 
 # Data locations

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -184,7 +184,5 @@
       value: "{{ gitea_run_directory }}"
     - option: gitea_url
       value: "{{ gitea_url }}"
-    - option: gitea_full_url
-      value: "{{ gitea_full_url }}"
     - option: gitea_enabled
       value: "{{ gitea_enabled }}"

--- a/roles/gitea/templates/app.ini.j2
+++ b/roles/gitea/templates/app.ini.j2
@@ -118,8 +118,8 @@ FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
 [server]
 ; The protocol the server listens on. One of 'http', 'https', 'unix' or 'fcgi'.
 PROTOCOL = http
-DOMAIN = localhost
-ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s{{ gitea_url }}/
+DOMAIN = box
+ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s{{ gitea_url }}/
 ; The address to listen on. Either a IPv4/IPv6 address or the path to a unix socket.
 HTTP_ADDR = 0.0.0.0
 HTTP_PORT = {{ gitea_port }}

--- a/roles/gitea/templates/app.ini.j2
+++ b/roles/gitea/templates/app.ini.j2
@@ -118,7 +118,7 @@ FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
 [server]
 ; The protocol the server listens on. One of 'http', 'https', 'unix' or 'fcgi'.
 PROTOCOL = http
-DOMAIN = box
+DOMAIN = {{ iiab_hostname }}.{{ iiab_domain }}
 ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s{{ gitea_url }}/
 ; The address to listen on. Either a IPv4/IPv6 address or the path to a unix socket.
 HTTP_ADDR = 0.0.0.0


### PR DESCRIPTION
### Fixes Bug

### Description of changes proposed in this pull request.

* Set `DOMAIN = box` (used in HTTP and SSH clone URLs)
* Hide port number in `ROOT_URL` (used in HTTP clone URLs)

Confirmed that this does not affect page resource URLs.

* Upgrade to Gitea 1.7.4

### Smoke-tested in operating system.

Ubuntu 18.04 LTS Azure

### Mention a team member for further information or comment using @ name

@holta 