### PR TITLE
Announce kiwix over avahi when enabled

### DIFF
--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -176,7 +176,7 @@
 
 - name: Install avahi announce config file /etc/avahi/services/kiwix.service
   template:
-    src: kiwix.service
+    src: kiwix.service.j2
     dest: /etc/avahi/services/kiwix.service
     owner: avahi
     group: avahi

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -172,3 +172,26 @@
     value: "{{ kiwix_library_xml }}"
   - option: kiwix_enabled
     value: "{{ kiwix_enabled }}"
+
+
+- name: Install avahi announce config file /etc/avahi/services/kiwix.service
+  template:
+    src: kiwix.service
+    dest: /etc/avahi/services/kiwix.service
+    owner: avahi
+    group: avahi
+    mode: 0640
+  when: kiwix_enabled
+
+- name: Remove avahi announce config file /etc/avahi/services/kiwix.service if kiwix not enabled
+  file:
+    state: absent
+    path: /etc/avahi/services/kiwix.service
+  when: not kiwix_enabled
+
+- name: Enable & (Re)start 'avahi-daemon' systemd service
+  systemd:
+    daemon_reload: yes
+    name: avahi-daemon
+    enabled: yes
+    state: restarted

--- a/roles/kiwix/templates/kiwix.service
+++ b/roles/kiwix/templates/kiwix.service
@@ -6,5 +6,7 @@
 <type>_http._tcp</type>
 <port>80</port>
 <txt-record>path=/kiwix</txt-record>
+<txt-record>iiab-type=kiwix</txt-record>
+<txt-record>iiab-json-path=/common/assets/zim_version_idx.json</txt-record>
 </service>
 </service-group>

--- a/roles/kiwix/templates/kiwix.service
+++ b/roles/kiwix/templates/kiwix.service
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+<name replace-wildcards="yes">Kiwix server at %h </name>
+<service>
+<type>_http._tcp</type>
+<port>80</port>
+<txt-record>path=/kiwix</txt-record>
+</service>
+</service-group>

--- a/roles/kiwix/templates/kiwix.service.j2
+++ b/roles/kiwix/templates/kiwix.service.j2
@@ -5,8 +5,9 @@
 <service>
 <type>_http._tcp</type>
 <port>80</port>
-<txt-record>path=/kiwix</txt-record>
-<txt-record>iiab-type=kiwix</txt-record>
-<txt-record>iiab-json-path=/common/assets/zim_version_idx.json</txt-record>
+<txt-record>path={{ kiwix_alias_url }}</txt-record>
+<txt-record>type=kiwix</txt-record>
+<txt-record>iiab-media-type=kiwix</txt-record>
+<txt-record>iiab-kiwix-assets=/common/assets/zim_version_idx.json</txt-record>
 </service>
 </service-group>

--- a/roles/kiwix/templates/kiwix.service.j2
+++ b/roles/kiwix/templates/kiwix.service.j2
@@ -6,7 +6,7 @@
 <type>_http._tcp</type>
 <port>80</port>
 <txt-record>path={{ kiwix_alias_url }}</txt-record>
-<txt-record>type=kiwix</txt-record>
+<txt-record>type=iiab</txt-record>
 <txt-record>iiab-media-type=kiwix</txt-record>
 <txt-record>iiab-kiwix-assets=/common/assets/zim_version_idx.json</txt-record>
 </service>


### PR DESCRIPTION
This PR will announce the kiwix service over avahi when `kiwix_enabled: True`
On top of the URL, it will also announce a `TXT` record `path` set to the value `/kiwix`