### PR TITLE
kiwix-tools 0.9.0 -> 1.1.0

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -10,9 +10,9 @@
 # Which kiwix-tools to download from http://download.iiab.io/packages/
 # As obtained from http://download.kiwix.org/release/kiwix-tools/ or http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: "kiwix-tools_linux-armhf-0.9.0"
-kiwix_version_linux64: "kiwix-tools_linux-x86_64-0.9.0"
-kiwix_version_i686: "kiwix-tools_linux-i586-0.9.0"
+kiwix_version_armhf: "kiwix-tools_linux-armhf-1.1.0"
+kiwix_version_linux64: "kiwix-tools_linux-x86_64-1.1.0"
+kiwix_version_i686: "kiwix-tools_linux-i586-1.1.0"
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")
 # v0.10 for i686 published Oct 2016 ("experimental") REPLACED IN EARLY 2018, thx to Matthieu Gautier:


### PR DESCRIPTION
Plz test on RPi & x86_64 as it's rather concerning that:
- http://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-armhf-1.1.0.tar.gz is 67% smaller than 0.9.0 from 6 weeks ago
- http://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-x86_64-1.1.0.tar.gz is 23% smaller than 0.9.0 from 6 weeks ago

Fixes: #1522