### PR TITLE
is_ubuntu_19 for Ubuntu Disco Dingo 19.04 & 19.10; is_raspbian_10 for upcoming Raspbian Buster

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -19,18 +19,19 @@ DHCPCD_PATH=`which dhcpcd`
 NM_PATH=`which NetworkManager`
 
 case $OS_VER in
-    "fedora-18" | \
-    "fedora-22" | \
-    "debian-8"  | \
-    "debian-9"  | \
-    "debian-10" | \
-    "ubuntu-16" | \
-    "ubuntu-17" | \
-    "ubuntu-18" | \
-    "ubuntu-19" | \
-    "centos-7"  | \
-    "raspbian-8"| \
-    "raspbian-9")
+    "fedora-18"  | \
+    "fedora-22"  | \
+    "debian-8"   | \
+    "debian-9"   | \
+    "debian-10"  | \
+    "ubuntu-16"  | \
+    "ubuntu-17"  | \
+    "ubuntu-18"  | \
+    "ubuntu-19"  | \
+    "centos-7"   | \
+    "raspbian-8" | \
+    "raspbian-9" | \
+    "raspbian-10")
         ;;
     *)	OS_VER="OS_not_supported"
         ;;

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -27,6 +27,7 @@ case $OS_VER in
     "ubuntu-16" | \
     "ubuntu-17" | \
     "ubuntu-18" | \
+    "ubuntu-19" | \
     "centos-7"  | \
     "raspbian-8"| \
     "raspbian-9")

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -551,7 +551,7 @@ is_raspbian_9: False
 is_raspbian_8: False
 is_rpi: False
 
-is_redhat: False
+is_redhat: False    # https://github.com/iiab/iiab/issues/1434
 is_centos: False
 is_centos_7: False
 is_fedora: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -532,15 +532,21 @@ minetest_flat_world: False
 # Platforms - turn all off and let /opt/iiab/iiab/vars/<OS>.yml turn on as appropriate
 
 # Wide to narrow (insofar as poss)
-is_debuntu: False
+is_debuntu: False    # covers all 3: Ubuntu, Debian, Raspbian
+
 is_ubuntu: False
+is_ubuntu_19: False
 is_ubuntu_18: False
 is_ubuntu_17: False
 is_ubuntu_16: False
-is_debian: False
+
+is_debian: False    # covers both: Debian, Raspbian
 is_debian_10: False
 is_debian_9: False
 is_debian_8: False
+
+is_raspbian: False    # covers RPi HW and non-RPi HW versions of Raspbian
+is_raspbian_10: False
 is_raspbian_9: False
 is_raspbian_8: False
 is_rpi: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -549,9 +549,9 @@ is_raspbian: False    # covers RPi HW and non-RPi HW versions of Raspbian
 is_raspbian_10: False
 is_raspbian_9: False
 is_raspbian_8: False
-is_rpi: False
+is_rpi: False    # 2019-03-23 - doesn't yet test for RPi HW, but hopefully soon: https://github.com/iiab/iiab/issues/1406
 
-is_redhat: False    # https://github.com/iiab/iiab/issues/1434
+is_redhat: False    # not well supported as of 2019, see: https://github.com/iiab/iiab/issues/1434
 is_centos: False
 is_centos_7: False
 is_fedora: False

--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -1,0 +1,42 @@
+is_debuntu: True
+is_debian: True
+is_debian_10: True
+is_raspbian: True
+is_raspbian_10: True
+is_rpi: True
+rtc_id: ds3231
+
+# 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dns_user: bind
+dhcp_service: isc-dhcp-server
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_config_dir: apache2/sites-available
+apache_user: www-data
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: ssh
+sshd_service: ssh
+php_version: 7.3
+postgresql_version: 11
+systemd_location: /lib/systemd/system
+# Upgrade Raspbian Buster's Calibre 3.x: (via role/calibre/tasks/debs.yml,
+# with .deb's released about 5-10 days after Calibre's quasi-monthly releases)
+calibre_via_debs: True
+# roles/calibre/tasks/py-installer.yml FAILS on ARM as of 2018-05-10:
+calibre_via_python: False
+
+# minetest for rpi
+minetest_server_bin: /library/games/minetest/bin/minetestserver
+minetest_working_dir: /library/games/minetest
+minetest_game_dir: /library/games/minetest/games/minetest_game
+minetest_rpi_src_url: http://www.nathansalapat.com/downloads/0.4.17.1.tar.gz
+minetest_rpi_src: minetest-0.4.17.1.tar.gz

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_debian: True
 is_debian_8: True
+is_raspbian: True
 is_raspbian_8: True
 is_rpi: True
 rtc_id: ds3231

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -1,6 +1,7 @@
 is_debuntu: True
 is_debian: True
 is_debian_9: True
+is_raspbian: True
 is_raspbian_9: True
 is_rpi: True
 rtc_id: ds3231

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -1,0 +1,31 @@
+is_debuntu: True
+is_ubuntu: True
+is_ubuntu_19: True
+
+# 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dns_user: bind
+dhcp_service: isc-dhcp-server
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_user: www-data
+apache_config_dir: apache2/sites-available
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+# issue raised 
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: 7.2
+# "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
+postgresql_version: 10
+systemd_location: /lib/systemd/system
+# Upgrade Ubuntu 19.x's Calibre 3.39.1+ to very latest
+calibre_via_debs: False
+calibre_via_python: True


### PR DESCRIPTION
Fixes #1577 and partially implements #1406 so is_raspbian may be used independently from is_rpi, for those experimenting with the Raspbian OS on non RPi hardware.

Caveat: #1406 is not fully implementeed yet, so is_rpi is not in fact yet a promise that the underlying hardware is in fact RPi.  In future, testing for actual RPi hardware should run something like:
`grep -qi raspberry /proc/device-tree/model`
...as is done in https://github.com/iiab/iiab-factory/blob/master/iiab#L167-L171