### PR TITLE
Tweaks to get BIG-sized IIAB (almost!) working on Ubuntu Server 19.04 Beta

### DIFF
--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -71,6 +71,10 @@
   # NOT NEC TO TEST FOR is_raspbian_8 OR is_raspbian_9 AS /opt/iiab/iiab/vars/<OS>.yml
   # DEFINES THESE AS SUBSETS OF is_debian_8 OR is_debian_9 (FOR NOW!)
 
+# 2019-03-29: Above works on Debian 10 Buster pre-releases, but fails on Ubuntu
+# 19.04 Beta.  Comment it out for now, and manually run: "apt install npm" then
+# "npm install -g npm@latest" (all *SHOULD* be magically fixed by 2019-04-18 ?)
+
 - name: Install latest Node.js {{ nodejs_version }} which includes /usr/bin/npm (debuntu)
   package:
   #   name: nodejs={{ nodejs_version }}
@@ -127,3 +131,6 @@
 # This May Change: thanks all for running "apt -a list nodejs" on Buster's
 # daily builds @ www.debian.org/devel/debian-installer/ and Disco Dingo (Ubuntu
 # 19.04) https://launchpad.net/ubuntu/+source/nodejs to keep us informed!
+
+# 2019-03-29: Debian 10 Buster & Ubuntu 19.04 pre-releases made the jump
+# thankfully; currently both offer Node.js 10.15.2

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -24,7 +24,7 @@ sshd_package: openssh-server
 sshd_service: ssh
 php_version: 7.2
 # "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
-postgresql_version: 10
+postgresql_version: 11
 systemd_location: /lib/systemd/system
 # Upgrade Ubuntu 19.x's Calibre 3.39.1+ to very latest
 calibre_via_debs: False

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -23,7 +23,7 @@ apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
 php_version: 7.2
-# "postgresql_version: 10.3" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 18.04)
+# "postgresql_version: 11.2" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 19.04)
 postgresql_version: 11
 systemd_location: /lib/systemd/system
 # Upgrade Ubuntu 19.x's Calibre 3.39.1+ to very latest


### PR DESCRIPTION
@jvonau "A start job is running for Wait for Network to be Configured" holds up boot (for more than 2 min) every time, on BIG-sized IIAB install on Ubuntu Server 19.04 Beta, in a VM.

What are the best ways to diagnose this?

@m-anish "systemctl start nodered" fails every time on Ubuntu 19.04 Beta:

> root@box:~# systemctl status nodered
● nodered.service - Node-RED
   Loaded: loaded (/etc/systemd/system/nodered.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Fri 2019-03-29 00:49:53 PDT; 29min ago
  Process: 1986 ExecStart=/usr/bin/node-red-pi -v (code=exited, status=203/EXEC)
 Main PID: 1986 (code=exited, status=203/EXEC)
>
> Mar 29 00:49:53 box.lan systemd[1]: nodered.service: Service RestartSec=100ms expired, scheduling restart.
Mar 29 00:49:53 box.lan systemd[1]: nodered.service: Scheduled restart job, restart counter is at 5.
Mar 29 00:49:53 box.lan systemd[1]: Stopped Node-RED.
Mar 29 00:49:53 box.lan systemd[1]: nodered.service: Start request repeated too quickly.
Mar 29 00:49:53 box.lan systemd[1]: nodered.service: Failed with result 'exit-code'.
Mar 29 00:49:53 box.lan systemd[1]: Failed to start Node-RED.

Ref: PR #1580