### PR TITLE
Recommend Ansible 2.7.10

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.6.15
+MIN_ANSIBLE_VER=2.6.16
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.9"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.10"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.9"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.10"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.7.x
+++ b/scripts/ansible-2.7.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.9"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.10"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Changelogs:

Ansible 2.7.10
https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst
Ansible 2.6.16
https://github.com/ansible/ansible/blob/stable-2.6/changelogs/CHANGELOG-v2.6.rst

Hasn't yet appeared in Ubuntu & Raspbian's official apt repos e.g.
https://launchpad.net/~ansible/+archive/ubuntu/ansible
So mainline testing will need to wait a few hours/days?

Or, for those who want to try it immediately:
https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.7
https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.6

Ref #1571