### PR TITLE
Elgg 2.3.10 -> 2.3.11 LTS (defer 3.0.1 for now??)

### DIFF
--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -8,7 +8,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 elgg_xx: elgg
-elgg_version: "2.3.10"
+elgg_version: "2.3.11"
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg

--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -8,7 +8,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 elgg_xx: elgg
-elgg_version: "2.3.11"
+elgg_version: 2.3.11
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg


### PR DESCRIPTION
- This current PR downloads from http://d.iiab.io/packages/elgg-2.3.11.zip
- Both branches' ChangeLogs:
  - https://github.com/Elgg/Elgg/blob/2.3.11/CHANGELOG.md
  - https://github.com/Elgg/Elgg/blob/3.0.1/CHANGELOG.md
- If T.K. Kang or others prefer that IIAB transition to non-LTS Elgg 3.x (e.g. 3.0.1 for now) they should let us know!