### PR TITLE
Elgg 2.3.11 -> 2.3.12

### DIFF
--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -8,7 +8,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 elgg_xx: elgg
-elgg_version: 2.3.11
+elgg_version: 2.3.12
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg


### PR DESCRIPTION
Builds on PR #1592

This current PR downloads from http://d.iiab.io/packages/elgg-2.3.12.zip
Both branches' ChangeLogs:
https://github.com/Elgg/Elgg/blob/2.3.12/CHANGELOG.md
https://github.com/Elgg/Elgg/blob/3.0.2/CHANGELOG.md

Related:
#1597 Elgg 3.0.2+ is not LTS: is it ready for primetime?