### PR TITLE
nextcloud-16.0.0.tar.bz2 needed for now: latest-16.tar.bz2 ain't ready :(

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -11,7 +11,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
-nextcloud_orig_src_file: latest-16.tar.bz2
+nextcloud_orig_src_file: nextcloud-16.0.0.tar.bz2    # latest-16.tar.bz2 is not yet ready as of 2019-04-25 :(
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.


### PR DESCRIPTION
Unfortunately Nextcloud has so far neglected to publish their "dynamic" image latest-16.tar.bz2 at https://download.nextcloud.com/server/releases/

So we'll use their "static" image nextcloud-16.0.0.tar.bz2 for now.

Builds on PR #1613