### PR TITLE
Revert to Nextcloud 16 to 15 (i.e. 15.0.7 for now)

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -11,7 +11,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
-nextcloud_orig_src_file: nextcloud-15.tar.bz2    # 2019-04-25: latest-16.0.0.tar.bz2 requires PHP 7.1+ and so fails on current Raspbian and Debian 9 "Buster". Aside: latest-16.tar.bz2 not yet published at https://download.nextcloud.com/server/releases/
+nextcloud_orig_src_file: nextcloud-15.tar.bz2    # 2019-04-25: latest-16.0.0.tar.bz2 requires PHP 7.1+ and so fails on current Raspbian and Debian 9 "Stretch". Aside: latest-16.tar.bz2 oddly not yet published at https://download.nextcloud.com/server/releases/
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -11,7 +11,7 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
-nextcloud_orig_src_file: nextcloud-16.0.0.tar.bz2    # latest-16.tar.bz2 is not yet ready as of 2019-04-25 :(
+nextcloud_orig_src_file: nextcloud-15.tar.bz2    # 2019-04-25: latest-16.0.0.tar.bz2 requires PHP 7.1+ and so fails on current Raspbian and Debian 9 "Buster". Aside: latest-16.tar.bz2 not yet published at https://download.nextcloud.com/server/releases/
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.


### PR DESCRIPTION
Raspbian 10 built on Debian 10 "Buster" might be released as soon as July 2019 possibly?

Refs: #1613 #1614