### PR TITLE
Revise template for /etc/netplan to mitigate 2+ min stall during Ubuntu 19.04 boot

### DIFF
--- a/roles/network/templates/network/netplan.j2
+++ b/roles/network/templates/network/netplan.j2
@@ -16,7 +16,9 @@ network:
         search: [{{ iiab_domain }}]
 {% else %}
       dhcp4: yes
+      optional: true
 {% endif %}
+
 #{% if iiab_lan_iface == "br0" %}
 #    bridges:
 #      # the key name is the name for virtual (created) interfaces


### PR DESCRIPTION
Fixes #1586's more-than-2-minute delay ("A start job is running for Wait for Network to be Configured") on every boot of IIAB on Ubuntu 19.04

Thanks to @jvonau who agrees with this change suggested by @floydianslips [*] while hoping others test this across Ubuntu 18.04, 19.04 and others (with many different network conditions, internal AP and external AP, etc) in coming months!

[*] originally suggested by https://askubuntu.com/questions/972215/a-start-job-is-running-for-wait-for-network-to-be-configured-ubuntu-server-17-1/1110474#1110474 ?

Related to: #1586, PR #1633