### PR TITLE
Increase hostapd_wait from 1 to 5 sec (?) at end of roles/network (restart.yml) for dnsmasq

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -40,7 +40,7 @@ wondershaper_upspeed: "1024"
 
 # Wi-Fi
 host_ssid: IIAB
-hostapd_wait: 1
+hostapd_wait: 5
 host_wifi_mode: g
 host_channel: 6
 host_wireless_n: False


### PR DESCRIPTION
Thanks to @jvonau and Tony Anderson, this fix is essential for IIAB's initial install when the network role (after Stage 0-9) is running on certain hardware.

Note the problem ocurred during network role near the very end &mdash; as you can see if you're running IIAB's roles/network manually:
```
cd /opt/iiab/iiab
./iiab-network
```
Ref: #1306