### PR TITLE
apt-key fails within scripts/ansible when br0 present, so: keyserver.ubuntu.com -> hkp://keyserver.ubuntu.com:80

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -71,8 +71,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
-    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367"\n'
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
     echo -e "\napt update; apt install ansible\n"
     apt update

--- a/scripts/ansible-2.6.x
+++ b/scripts/ansible-2.6.x
@@ -71,8 +71,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo "deb http://ppa.launchpad.net/ansible/ansible-2.6/ubuntu xenial main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
-    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367"\n'
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
     echo -e "\napt update; apt install ansible\n"
     apt update

--- a/scripts/ansible-2.7.x
+++ b/scripts/ansible-2.7.x
@@ -71,8 +71,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo "deb http://ppa.launchpad.net/ansible/ansible-2.7/ubuntu xenial main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
-    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367"\n'
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
     echo -e "\napt update; apt install ansible\n"
     apt update


### PR DESCRIPTION
Many thanks to Tony Anderson & @jvonau for this valuable fix, that will broadly help many IIAB implementers...

i.e. folks who attempt to re-run "sudo iiab" when br0 (i.e. the bridge for [LAN-side](https://github.com/iiab/iiab/wiki/IIAB-Networking) of IIAB, i.e. Wi-Fi, hostapd etc) is present...

...which triggered an obscure bug/issue in the `apt-key` command, that we've now worked around thanks to:
https://unix.stackexchange.com/questions/399027/gpg-keyserver-receive-failed-server-indicated-a-failure

Tangentially Related to: #1306, PR #1636