### PR TITLE
./install-support prompts for openvpn_handle & confirms resulting 10.8.0.* IP address

### DIFF
--- a/iiab-support.yml
+++ b/iiab-support.yml
@@ -1,4 +1,3 @@
----
 - hosts: all
   become: yes
 
@@ -10,5 +9,5 @@
   roles:
     - { role: 0-init, tags: ['0-init'] }
     #- { role: 1-prep, tags: ['1-prep', 'platform', 'base'] }
-    - { role: 1-prep, tags: ['1-prep'] }
-    #- { role: openvpn, tags: ['openvpn'] }    # no longer nec, as 1-prep calls role openvpn (2018-09-19)
+    #- { role: 1-prep, tags: ['1-prep'] }
+    - { role: openvpn, tags: ['openvpn'] }

--- a/install-support
+++ b/install-support
@@ -12,7 +12,16 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-sed -i -e "s/openvpn_install: False/openvpn_install: True/" /etc/iiab/local_vars.yml
-sed -i -e "s/openvpn_enabled: False/openvpn_enabled: True/" /etc/iiab/local_vars.yml
+echo -en "\nWhat OpenVPN machine name do you want? "
+read ans < /dev/tty
+if [ "$ans" != "" ]; then
+    sed -i -e "s/^openvpn_handle:.*/openvpn_handle: $ans/" /etc/iiab/local_vars.yml
+    echo -e "\nYour machine's openvpn_handle will now be set... \n"
+else
+    echo -e "\nWARNING: your machine's openvpn_handle will remain unchanged...\n"
+fi
+
+sed -i -e "s/^openvpn_install:.*/openvpn_install: True/" /etc/iiab/local_vars.yml
+sed -i -e "s/^openvpn_enabled:.*/openvpn_enabled: True/" /etc/iiab/local_vars.yml
 
 ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local

--- a/install-support
+++ b/install-support
@@ -12,16 +12,22 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-echo -en "\nWhat OpenVPN machine name do you want? "
+echo -en "\n\nWhat OpenVPN machine name (openvpn_handle) do you want? "
 read ans < /dev/tty
 if [ "$ans" != "" ]; then
     sed -i -e "s/^openvpn_handle:.*/openvpn_handle: $ans/" /etc/iiab/local_vars.yml
-    echo -e "\nYour machine's openvpn_handle will now be set... \n"
+    echo -e "\nYour machine's openvpn_handle is now set, in /etc/iiab/local_vars.yml\n"
 else
-    echo -e "\nWARNING: your machine's openvpn_handle will remain unchanged...\n"
+    echo -e "\nWARNING: openvpn_handle remains unchanged in /etc/iiab/local_vars.yml\n"
 fi
 
 sed -i -e "s/^openvpn_install:.*/openvpn_install: True/" /etc/iiab/local_vars.yml
 sed -i -e "s/^openvpn_enabled:.*/openvpn_enabled: True/" /etc/iiab/local_vars.yml
 
+echo -e "Now let's (re)install and activate OpenVPN...\n"
+
 ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local
+
+echo -en "\nYour OpenVPN handle is....... "
+cat /etc/iiab/openvpn_handle
+echo -e "\nYour OpenVPN IP address is... $(ip a | grep tun0$ | awk '{print $2}')\n\n"

--- a/roles/openvpn/templates/iiab-handle.j2
+++ b/roles/openvpn/templates/iiab-handle.j2
@@ -1,20 +1,45 @@
 #!/bin/bash
-# DEPRECATED interactive script (over)writes /etc/iiab/openvpn_handle file, identifying client to server
 
-echo -e '\nCORRECT METHOD: CHANGE VARIABLE openvpn_handle IN /etc/iiab/local_vars.yml'
-echo -e 'THEN RUN "cd /opt/iiab/iiab" THEN "./runrole openvpn"\n'
 
-echo -e "Or, for a temporary solution until the next time Ansible is run,"
-read -p "what OpenVPN handle do you want to use? " ans
+echo -e '\n\nDEPRECATED:\n'
+
+echo -e 'This interactive script TEMPORARILY (over)writes /etc/iiab/openvpn_handle'
+echo -e 'to identifying client to server, until the next time Ansible runs.\n\n'
+
+
+echo -e 'PLEASE USE THIS NEW METHOD INSTEAD:\n'
+
+echo -e 'cd /opt/iiab/iiab'
+echo -e 'sudo ./install-support\n\n'
+
+
+#echo -e 'CORRECT METHOD: CHANGE VARIABLE openvpn_handle IN /etc/iiab/local_vars.yml'
+#echo -e 'THEN RUN "cd /opt/iiab/iiab" THEN "./runrole openvpn"\n'
+
+echo -e 'PLEASE NOW TYPE CTRL-C TO QUIT.  Or, if you really want it temporary until the'
+read -p 'next time Ansible is run, what OpenVPN handle do you want? ' ans
 echo
 
-if [ "$ans" == "" ]; then
-    if [ -f /etc/iiab/openvpn_handle ]; then
-        rm -f /etc/iiab/openvpn_handle
-    fi
-else
+
+if [ "$ans" != "" ]; then
     echo $ans > /etc/iiab/openvpn_handle
+    echo -e "\nYour machine's openvpn_handle is TEMPORARILY now set... \n"
+else
+    echo -e "\nWARNING: your machine's openvpn_handle remains unchanged...\n"
 fi
+
+echo -e "Restarting OpenVPN daemon...\n\n"
+
+# 2019-05-09: removing /etc/iiab/openvpn_handle (or setting it to "") are both very bad practices
+#if [ "$ans" == "" ]; then
+#    if [ -f /etc/iiab/openvpn_handle ]; then
+#        rm -f /etc/iiab/openvpn_handle
+#    fi
+#else
+#    echo $ans > /etc/iiab/openvpn_handle
+#fi
+
+
 {{ systemctl_program }} restart openvpn@xscenet
 # This would also work: (but would bounce all VPN connections, if others exist, causing unnec disruption if so)
 #{{ systemctl_program }} restart openvpn


### PR DESCRIPTION
Also toughens up the deprecated command /usr/bin/iiab-handle &mdash; for those who insist on a temporary /etc/iiab/openvpn_handle (that will be wiped during the next Ansible run!)

Tangentially related to: #1575, PR #1596