### PR TITLE
Sugarizer Server 1.1.0 in /opt/iiab/sugarizer-server-1.1.0

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -13,10 +13,7 @@ sugarizer_dir_version: sugarizer-1.1.0    # WAS: sugarizer-1.0, sugarizer-master
 sugarizer_git_version: v1.1.0             # WAS: v1.0.1, master
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
-sugarizer_server_dir_version: sugarizer-server-dev                        # WAS: sugarizer-server-1.0, sugarizer-server-master
-sugarizer_server_git_version: f27bf6acd56aba6d99116ef471ca713b0f0dfed3    # WAS: v1.0.1, master, dev
-# Above commit (githash f27bf6a... for iiab/iiab PR #1430 from 'dev' branch of
-# https://github.com/llaske/sugarizer-server) well-tested Jan 29 - Feb 12 2019.
-#
+sugarizer_server_dir_version: sugarizer-server-1.1.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev
+sugarizer_server_git_version: v1.1.0                    # WAS: v1.0.1, master, dev, f27bf6acd56aba6d99116ef471ca713b0f0dfed3
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer-server/commits/dev
 #                 AND https://github.com/llaske/sugarizer-server/releases

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -3,14 +3,6 @@
     msg: "Sugarizer install cannot proceeed, as it currently requires Node.js 10.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
   when: sugarizer_install and (nodejs_version != "10.x")
 
-# 0. CLEAN UP PRIOR VERSIONS OF SUGARIZER (NEEDS WORK!)
-
-# - name: Wipe /library/www/html/sugarizer* if installing sugarizer-1.0
-#   shell: "rm -rf {{ doc_root }}/sugarizer*"
-#   args:
-#     warn: no
-#   when: sugarizer_dir_version == "sugarizer-1.0"
-
 
 # 1. DOWNLOAD+LINK /opt/iiab/sugarizer
 


### PR DESCRIPTION
Sugarizer 1.1.0 is a quite significant upgrade, see details off of #1449

- `./runrole sugarizer` and http://box/sugarizer tested on Ubuntu 18.04
- Testing is also needed on Raspbian & Debian 9.9
- Debian 10 which will be released in coming months (if not weeks?) poses a deeper conundrum, as MongoDB will no longer be supported there, and on an increasing number of OS's/distros apparently...

Related:

#1437 [Debian 10] MongoDB not installable due to missing packages