### PR TITLE
Nextcloud 15.0.x on Debian 9 & Raspbian 9 (PHP 7.1+ is missing) -- but Nextcloud 16.0.y on all others distros

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -13,10 +13,10 @@ nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
 
 # 2019-05-11: latest-16.tar.bz2 finally published to https://download.nextcloud.com/server/releases/ (nextcloud/server#15502) e.g. for Ubuntu 18.04 & Debian 10
-nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-05-16: for Debian 10 & Ubuntu 18.04 where PHP 7.1+ is available
-nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
-nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-05-16: for Debian 9 & Raspbian 9 where PHP 7.1+ isn't available
+nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-05-16: for legacy OS's Debian 9 & Raspbian 9 where PHP 7.1+ isn't available
 nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
+nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-05-16: for all other OS's e.g. Debian 10 & Ubuntu 18.04 where PHP 7.1+ is hopefully available!
+nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.
 nextcloud_dbname: nextcloud

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -16,7 +16,7 @@ nextcloud_dl_url: https://download.nextcloud.com/server/releases
 nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-05-16: for Debian 10 & Ubuntu 18.04 where PHP 7.1+ is available
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-05-16: for Debian 9 & Raspbian 9 where PHP 7.1+ isn't available
-nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file }}
+nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
 
 # we install on mysql with these setting or those from default_vars, etc.
 nextcloud_dbname: nextcloud

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -11,8 +11,12 @@ nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
-nextcloud_orig_src_file: latest-15.tar.bz2    # 2019-04-24: nextcloud-16.0.0.tar.bz2 requires PHP 7.1+ and so fails on current Raspbian 9 and Debian 9 "Stretch".  2019-05-11: latest-16.tar.bz2 finally published to https://download.nextcloud.com/server/releases/ (nextcloud/server#15502) e.g. for Ubuntu 18.04+
+
+# 2019-05-11: latest-16.tar.bz2 finally published to https://download.nextcloud.com/server/releases/ (nextcloud/server#15502) e.g. for Ubuntu 18.04 & Debian 10
+nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-05-16: for Debian 10 & Ubuntu 18.04 where PHP 7.1+ is available
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
+nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-05-16: for Debian 9 & Raspbian 9 where PHP 7.1+ isn't available
+nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.
 nextcloud_dbname: nextcloud

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -14,7 +14,21 @@
 # - debug:
 #     msg: "nextcloud_force_install: {{ nextcloud_force_install }}"
 
-- name: Download {{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }} to {{ downloads_dir }}/{{ nextcloud_src_file }}
+- name: Download {{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file_old }} to {{ downloads_dir }}/{{ nextcloud_src_file_old }} on older OS's lacking PHP 7.1+
+  get_url:
+    url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file_old }}"
+    dest: "{{ downloads_dir }}/{{ nextcloud_src_file_old }}"
+    timeout: "{{ download_timeout }}"
+    force: yes
+    #validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
+  when: internet_available and nextcloud_force_install
+  #async: 1800
+  #poll: 10
+  tags:
+    - download
+  when: is_debian_9 or is_raspbian_9
+
+- name: Download {{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }} to {{ downloads_dir }}/{{ nextcloud_src_file }} on newer OS's that have PHP 7.1+
   get_url:
     url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }}"
     dest: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
@@ -26,6 +40,7 @@
   #poll: 10
   tags:
     - download
+  when: not (is_debian_9 or is_raspbian_9)
 
 # Ubuntu and Debian treat names differently
 - name: Install 3 php packages (debian)
@@ -85,12 +100,19 @@
     state: present
   when: is_redhat
 
-- name: Unarchive {{ nextcloud_src_file }} to permanent location {{ nextcloud_prefix }}/nextcloud    # e.g. unpack nextcloud_latest-14.tar.bz2 to /opt/nextcloud
+- name: Unarchive {{ nextcloud_src_file_old }} to permanent location {{ nextcloud_prefix }}/nextcloud on older OS's lacking PHP 7.1+    # e.g. unpack nextcloud_latest-15.tar.bz2 to /opt/nextcloud
+  unarchive:
+    src: "{{ downloads_dir }}/{{ nextcloud_src_file_old }}"
+    dest: "{{ nextcloud_prefix }}"
+    #creates: "{{ nextcloud_prefix }}/nextcloud/version.php"
+  when: nextcloud_force_install and (is_debian_9 or is_raspbian_9)
+
+- name: Unarchive {{ nextcloud_src_file }} to permanent location {{ nextcloud_prefix }}/nextcloud on newer OS's that have PHP 7.1+    # e.g. unpack nextcloud_latest-16.tar.bz2 to /opt/nextcloud
   unarchive:
     src: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     dest: "{{ nextcloud_prefix }}"
     #creates: "{{ nextcloud_prefix }}/nextcloud/version.php"
-  when: nextcloud_force_install
+  when: nextcloud_force_install and not (is_debian_9 or is_raspbian_9)
 
 - name: Create dir /etc/nextcloud (centos) for a subsequent config dir that's symlinked to /etc/nextcloud ?
   file:


### PR DESCRIPTION
Needs testing to be sure!

Refs:  #1324, PR #1614, #1615, #1649