### PR TITLE
Revert "Disable Calibre-Web in MEDIUM-sized & BIG-sized IIAB installs, until #1624 is fixed"

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -296,8 +296,8 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # program, so we recommend you also install Calibre (above!)
 
 # Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
+calibreweb_install: True
+calibreweb_enabled: True
 calibreweb_port: 8083    # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -296,8 +296,8 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # program, so we recommend you also install Calibre (above!)
 
 # Calibre-Web alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
+calibreweb_install: True
+calibreweb_enabled: True
 calibreweb_port: 8083    # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url: /books


### PR DESCRIPTION
Reverts iiab/iiab#1628 as #1624 now appears to be fixed, Thanks everyone who can test on Raspberry Pi especially!

Smoke-tested an existing BIG-sized Raspbian Desktop on RPi 3B+.