### PR TITLE
Revert Gitea 1.8.1 to 1.7.6 b/c RPi, until Aidan clarifies next step

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -8,7 +8,7 @@
 # https://git.coolaj86.com/coolaj86/gitea-installer.sh
 
 # Information needed to install Gitea
-gitea_version: 1.8.1
+gitea_version: 1.7.6
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
As a result of https://github.com/iiab/iiab/issues/1673: Gitea 1.8.0+ installs on Raspbian but doesn't run.

Thanks @aidan-fitz if you can look into this in coming weeks, prior to IIAB 7.0's release sometime in June 2019!