### PR TITLE
Making IIAB's firewall (iptables) understandable to newbie implementers

### DIFF
--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -17,8 +17,8 @@
   # Where "2" means "ssh + http-or-https (for Admin Console's box.lan/admin too)"
   # SEE ~18 line explanation in box near:
   # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
-  # FOR NOW, $gui_port is used to open Admin Console port (http-or-https) here:
-  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L139-L145
+  # IF >= 2, Admin Console $gui_port from 0-init determines which port (http-or-https) is opened here:
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L128-L134
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -12,7 +12,10 @@
     owner: avahi
     group: avahi
     mode: 0640
-  when: 'gui_wan == True'
+  #when: 'gui_wan == True'
+  when: ports_externally_visible|int >= 2
+  # Where "2" means "ssh + Admin Console"
+  # SEE: https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L65
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -15,7 +15,7 @@
   #when: 'gui_wan == True'
   when: ports_externally_visible|int >= 2
   # Where "2" means "ssh + Admin Console"
-  # SEE: https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L65
+  # SEE: https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -18,7 +18,7 @@
   # SEE ~18 line explanation in box near:
   # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
   # IF >= 2, Admin Console $gui_port from 0-init determines which port (http-or-https) is opened here:
-  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L128-L134
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L129-L134
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -14,8 +14,11 @@
     mode: 0640
   #when: 'gui_wan == True'
   when: ports_externally_visible|int >= 2
-  # Where "2" means "ssh + Admin Console"
-  # SEE: https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
+  # Where "2" means "ssh + http-or-https (for Admin Console's box.lan/admin too)"
+  # SEE ~18 line explanation in box near:
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
+  # FOR NOW, $gui_port is used to open Admin Console port (http-or-https) here:
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L139-L145
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -16,9 +16,9 @@
   when: ports_externally_visible|int >= 2
   # Where "2" means "ssh + http-or-https (for Admin Console's box.lan/admin too)"
   # SEE ~18 line explanation in box near:
-  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L52-L69
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L53-L70
   # IF >= 2, Admin Console $gui_port from 0-init determines which port (http-or-https) is opened here:
-  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L129-L134
+  # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L130-L135
 
 - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -64,7 +64,7 @@ samba_tcp_mports={{ samba_tcp_mports }}
 #   4 = ssh + Admin Console + common IIAB services + Samba                     #
 #   5 = all but databases                                                      #
 #                                                                              #
-# Then enable it in iptables by running 'cd /opt/iiab/iiab; ./iiab-network'    #
+# Then enable it in iptables by running: cd /opt/iiab/iiab; ./iiab-network     #
 #                                                                              #
 ################################################################################
 

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+
 source {{ iiab_env_file }}
 {% if is_debuntu %}
 IPTABLES=/sbin/iptables
@@ -16,27 +17,27 @@ $IPTABLES -F
 $IPTABLES -t nat -F
 $IPTABLES -X
 
-# first match wins
+# First match wins
 # Always accept loopback traffic
 $IPTABLES -A INPUT -i lo -j ACCEPT
 
 # Always drop rpc
 $IPTABLES -A INPUT -p tcp --dport 111 -j DROP
 $IPTABLES -A INPUT -p udp --dport 111 -j DROP
-# mysql
+# MySQL
 $IPTABLES -A INPUT -p tcp --dport 3306 -j DROP
 $IPTABLES -A INPUT -p udp --dport 3306 -j DROP
-# postgres - not needed listens on lo only
+# PostgreSQL - not needed listens on lo only
 $IPTABLES -A INPUT -p tcp --dport 5432 -j DROP
 $IPTABLES -A INPUT -p udp --dport 5432 -j DROP
-# couchdb
+# CouchDB
 $IPTABLES -A INPUT -p tcp --dport 5984 -j DROP
 $IPTABLES -A INPUT -p udp --dport 5984 -j DROP
 }
 
-if [  "x$WANIF" == "xnone" ] || [ "$MODE" == "Appliance" ]; then
+if [ "x$WANIF" == "xnone" ] || [ "$MODE" == "Appliance" ]; then
     clear_fw
-    # save the rule set
+    # Save the rule set
 	{% if is_debuntu %}
 	netfilter-persistent save
 	{% else %}
@@ -47,7 +48,7 @@ fi
 lan=$LANIF
 wan=$WANIF
 
-# Good thing we replace this file should be treated like squid below
+# Good thing we replace this file; should be treated like Squid (that used to be?) below
 gw_block_https={{ gw_block_https }}
 ssh_port={{ ssh_port }}
 gui_wan={{ gui_wan }}
@@ -77,10 +78,8 @@ samba_tcp_mports={{ samba_tcp_mports }}
 block_DNS={{ block_DNS }}
 
 echo "LAN is $lan and WAN is $wan"
-#
-# delete all existing rules.
-#
 
+# Delete all existing rules
 /sbin/modprobe ip_tables
 /sbin/modprobe iptable_filter
 /sbin/modprobe ip_conntrack
@@ -94,7 +93,7 @@ $IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
 # Allow mDNS
 $IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
-#when run as gateway
+# When run as gateway
 $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
 
 if [ "$gui_wan" == "True" ]; then
@@ -133,15 +132,15 @@ fi
 
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-#Block https traffic except if directed at server
-if [  "$gw_block_https" == "True" ]; then
+# Block https traffic except if directed at server
+if [ "$gw_block_https" == "True" ]; then
     $IPTABLES -A FORWARD -p tcp ! -d {{ lan_ip }} --dport 443 -j DROP
 fi
 
-# Allow outgoing connections from the LAN side.
+# Allow outgoing connections from the LAN side
 $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
 
-# Don't forward from the outside to the inside.
+# Don't forward from the outside to the inside
 $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
 $IPTABLES -A INPUT -i $wan -j DROP
 
@@ -154,9 +153,9 @@ if [ "$HTTPCACHE_ON" == "True" ]; then
     $IPTABLES  -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:3128
 fi
 
-# Enable routing.
+# Enable routing
 echo 1 > /proc/sys/net/ipv4/ip_forward
-# save the whole rule set now
+# Save the whole rule set now
 {% if is_debuntu %}
 netfilter-persistent save
 {% else %}

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -90,8 +90,9 @@ $IPTABLES -F
 $IPTABLES -t nat -F
 $IPTABLES -X
 
-# First Match Wins - establish iptable rules, starting at the top:
-# (you can verify the resulting rule set by running 'iptables -L -v')
+# FIRST MATCH WINS - establish iptable rules, starting at the top:
+# (verify the resulting rule set by running 'iptables -L -v')
+# New to iptables?  Run/read 'man iptables' & 'man iptables-extensions'
 
 # Always accept loopback traffic
 $IPTABLES -A INPUT -i lo -j ACCEPT

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -126,11 +126,10 @@ if [ "$wan" != "none" ]; then
         $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
     fi
 
-    # For now this is implemented using Admin Console variable "gui_port" from:
-    # https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/main.yml#L87-L95
-    #
     # 2 = ssh + http-or-https (for Admin Console's box.lan/admin too)
     if [ "$ports_externally_visible" -ge 2 ]; then
+        # For now this is implemented using Admin Console variable "gui_port" from:
+        # https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/main.yml#L87-L95
         $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
     fi
 

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -59,9 +59,9 @@ samba_tcp_mports={{ samba_tcp_mports }}
 #                                                                              #
 #   0 = none                                                                   #
 #   1 = ssh only                                                               #
-#   2 = ssh + Admin Console                                                    #
-#   3 = ssh + Admin Console + common IIAB services  <--  THIS IS THE DEFAULT   #
-#   4 = ssh + Admin Console + common IIAB services + Samba                     #
+#   2 = ssh + http-or-https (for Admin Console's box.lan/admin too)            #
+#   3 = ssh + http-or-https + common IIAB services  <--  THIS IS THE DEFAULT   #
+#   4 = ssh + http-or-https + common IIAB services + Samba                     #
 #   5 = all but databases                                                      #
 #                                                                              #
 # Then enable it with iptables by running: cd /opt/iiab/iiab; ./iiab-network   #
@@ -136,12 +136,15 @@ if [ "$ports_externally_visible" -ge 1 ]; then
     $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
 fi
 
-# 2 = ssh + Admin Console
+# For now this is implemented using Admin Console variable "gui_port" from:
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/main.yml#L87-L95
+#
+# 2 = ssh + http-or-https (for Admin Console's box.lan/admin too)
 if [ "$ports_externally_visible" -ge 2 ]; then
     $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
 fi
 
-# 3 = ssh + Admin Console + common IIAB services
+# 3 = ssh + http-or-https + common IIAB services
 if [ "$ports_externally_visible" -ge 3 ]; then
     $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
@@ -163,7 +166,7 @@ if [ "$ports_externally_visible" -ge 3 ]; then
     fi
 fi
 
-# 4 = ssh + Admin Console + common IIAB services + Samba
+# 4 = ssh + http-or-https + common IIAB services + Samba
 if [ "$ports_externally_visible" -ge 4 ]; then
     $IPTABLES -A INPUT -p udp --dport $samba_udp_ports -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp -m multiport --dports $samba_tcp_mports -m state --state NEW -i $wan -j ACCEPT

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+# To customize your iptables firewall, it's best to edit:
+# /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
+# And then run: cd /opt/iiab/iiab; ./iiab-network
+
 {% if is_debuntu %}
 IPTABLES=/sbin/iptables
 IPTABLES_DATA=/etc/iptables.up.rules

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -1,6 +1,5 @@
 #!/bin/bash -x
 
-source {{ iiab_env_file }}
 {% if is_debuntu %}
 IPTABLES=/sbin/iptables
 IPTABLES_DATA=/etc/iptables.up.rules
@@ -8,53 +7,25 @@ IPTABLES_DATA=/etc/iptables.up.rules
 IPTABLES=/usr/sbin/iptables
 IPTABLES_DATA=/etc/sysconfig/iptables
 {% endif %}
-LANIF=$IIAB_LAN_DEVICE
-WANIF=$IIAB_WAN_DEVICE
-MODE=`grep iiab_network_mode_applied {{ iiab_ini_file }} | gawk '{print $3}'`
 
-clear_fw() {
-$IPTABLES -F
-$IPTABLES -t nat -F
-$IPTABLES -X
+source {{ iiab_env_file }}
+lan=$IIAB_LAN_DEVICE
+wan=$IIAB_WAN_DEVICE
+network_mode=`grep iiab_network_mode_applied {{ iiab_ini_file }} | gawk '{print $3}'`
+echo -e "\nLAN: $lan"
+echo -e "WAN: $wan"
+echo -e "Network Mode: $network_mode\n"
 
-# First match wins
-# Always accept loopback traffic
-$IPTABLES -A INPUT -i lo -j ACCEPT
-
-# Always drop rpc
-$IPTABLES -A INPUT -p tcp --dport 111 -j DROP
-$IPTABLES -A INPUT -p udp --dport 111 -j DROP
-# MySQL
-$IPTABLES -A INPUT -p tcp --dport 3306 -j DROP
-$IPTABLES -A INPUT -p udp --dport 3306 -j DROP
-# PostgreSQL - not needed listens on lo only
-$IPTABLES -A INPUT -p tcp --dport 5432 -j DROP
-$IPTABLES -A INPUT -p udp --dport 5432 -j DROP
-# CouchDB
-$IPTABLES -A INPUT -p tcp --dport 5984 -j DROP
-$IPTABLES -A INPUT -p udp --dport 5984 -j DROP
-}
-
-if [ "x$WANIF" == "xnone" ] || [ "$MODE" == "Appliance" ]; then
-    clear_fw
-    # Save the rule set
-	{% if is_debuntu %}
-	netfilter-persistent save
-	{% else %}
-	iptables-save > $IPTABLES_DATA
-	{% endif %}
-    exit 0
-fi
-lan=$LANIF
-wan=$WANIF
-
-# Good thing we replace this file; should be treated like Squid (that used to be?) below
+# "Good thing we replace this file; should be treated like Squid below" ?
+ports_externally_visible={{ ports_externally_visible }}
+#services_externally_visible={{ services_externally_visible }}
 gw_block_https={{ gw_block_https }}
 ssh_port={{ ssh_port }}
-gui_wan={{ gui_wan }}
+#gui_wan={{ gui_wan }}
 gui_port={{ gui_port }}
 iiab_gateway_enabled={{ iiab_gateway_enabled }}
-services_externally_visible={{ services_externally_visible }}
+block_DNS={{ block_DNS }}
+
 calibre_port={{ calibre_port }}
 calibreweb_port={{ calibreweb_port }}
 kiwix_port={{ kiwix_port }}
@@ -67,40 +38,107 @@ sugarizer_port={{ sugarizer_port }}
 nodered_port={{ nodered_port }}
 mosquitto_port={{ mosquitto_port }}
 minetest_port={{ minetest_port }}
+pbx_enabled={{ pbx_enabled }}
 pbx_signaling_ports_chan_sip={{ pbx_signaling_ports_chan_sip }}
 pbx_signaling_ports_chan_pjsip={{ pbx_signaling_ports_chan_pjsip }}
 pbx_data_ports={{ pbx_data_ports }}
-pbx_enabled={{ pbx_enabled }}
-samba_enabled={{ samba_enabled }}
 samba_udp_ports={{ samba_udp_ports }}
 samba_tcp_mports={{ samba_tcp_mports }}
 
-block_DNS={{ block_DNS }}
+################################################################################
+#                                                                              #
+# IF YOU NEED TO CHANGE ports_externally_visible DO THAT IN:                   #
+#                                                                              #
+#   /etc/iiab/local_vars.yml                                                   #
+#                                                                              #
+# It must be an integer {0...5} as follows:                                    #
+#                                                                              #
+#   0 = none                                                                   #
+#   1 = ssh only                                                               #
+#   2 = ssh + Admin Console                                                    #
+#   3 = ssh + Admin Console + common IIAB services  <--  THIS IS THE DEFAULT   #
+#   4 = ssh + Admin Console + common IIAB services + Samba                     #
+#   5 = all but databases                                                      #
+#                                                                              #
+# Then enable it in iptables by running 'cd /opt/iiab/iiab; ./iiab-network'    #
+#                                                                              #
+################################################################################
 
-echo "LAN is $lan and WAN is $wan"
+echo -e "\nports_externally_visible: "$ports_externally_visible"\n"
+if ! [ "$ports_externally_visible" -eq "$ports_externally_visible" ] 2> /dev/null; then
+    echo "EXITING: an integer is required"
+    exit 1
+elif [ "$ports_externally_visible" -lt 0 ] || [ "$ports_externally_visible" -gt 5 ]; then
+    echo "EXITING: it must be in the range {0...5}"
+    exit 1
+fi
 
-# Delete all existing rules
-/sbin/modprobe ip_tables
-/sbin/modprobe iptable_filter
-/sbin/modprobe ip_conntrack
-/sbin/modprobe iptable_nat
-clear_fw
+if [ "$wan" != "none" ] && [ "$network_mode" != "Appliance" ]; then
+    # Load iptables kernel modules
+    /sbin/modprobe ip_tables
+    /sbin/modprobe iptable_filter
+    /sbin/modprobe ip_conntrack
+    /sbin/modprobe iptable_nat
+fi
+
+# Delete all existing firewall rules
+$IPTABLES -F
+$IPTABLES -t nat -F
+$IPTABLES -X
+
+# First Match Wins - establish iptable rules, starting at the top:
+# (you can verify the resulting rule set by running 'iptables -L -v')
+
+# Always accept loopback traffic
+$IPTABLES -A INPUT -i lo -j ACCEPT
+
+# Disable access to databases, on LAN-side and WAN-side
+# SunRPC
+$IPTABLES -A INPUT -p tcp --dport 111 -j DROP
+$IPTABLES -A INPUT -p udp --dport 111 -j DROP
+# MySQL
+$IPTABLES -A INPUT -p tcp --dport 3306 -j DROP
+$IPTABLES -A INPUT -p udp --dport 3306 -j DROP
+# PostgreSQL - not needed listens on lo only
+$IPTABLES -A INPUT -p tcp --dport 5432 -j DROP
+$IPTABLES -A INPUT -p udp --dport 5432 -j DROP
+# CouchDB
+$IPTABLES -A INPUT -p tcp --dport 5984 -j DROP
+$IPTABLES -A INPUT -p udp --dport 5984 -j DROP
+
+save_rules_and_exit() {
+{% if is_debuntu %}
+    netfilter-persistent save
+{% else %}
+    iptables-save > $IPTABLES_DATA
+{% endif %}
+
+    exit 0
+}
+
+if [ "$wan" == "none" ] || [ "$network_mode" == "Appliance" ]; then
+    save_rules_and_exit
+fi
 
 # Allow established connections, and those not coming from the outside
 $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
+$IPTABLES -A INPUT -m state --state NEW -i $lan -j ACCEPT
 
-# Allow mDNS
+# Allow mDNS from WAN-side too (WHY OUT OF CURIOSITY?)
 $IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
-# When run as gateway
-$IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
+# 1 = ssh only
+if [ "$ports_externally_visible" -ge 1 ]; then
+    $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
+fi
 
-if [ "$gui_wan" == "True" ]; then
+# 2 = ssh + Admin Console
+if [ "$ports_externally_visible" -ge 2 ]; then
     $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
 fi
 
-if [ "$services_externally_visible" == "True" ]; then
+# 3 = ssh + Admin Console + common IIAB services
+if [ "$ports_externally_visible" -ge 3 ]; then
     $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
     $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
@@ -119,46 +157,48 @@ if [ "$services_externally_visible" == "True" ]; then
         $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_pjsip -m state --state NEW -i $wan -j ACCEPT
         $IPTABLES -A INPUT -p udp --dport $pbx_data_ports -m state --state NEW -i $wan -j ACCEPT
     fi
-
-    if [ "$samba_enabled" == "True" ]; then
-        $IPTABLES -A INPUT -p udp --dport $samba_udp_ports -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp -m multiport --dports $samba_tcp_mports -m state --state NEW -i $wan -j ACCEPT
-    fi
 fi
 
+# 4 = ssh + Admin Console + common IIAB services + Samba
+if [ "$ports_externally_visible" -ge 4 ]; then
+    $IPTABLES -A INPUT -p udp --dport $samba_udp_ports -m state --state NEW -i $wan -j ACCEPT
+    $IPTABLES -A INPUT -p tcp -m multiport --dports $samba_tcp_mports -m state --state NEW -i $wan -j ACCEPT
+fi
+
+# Typically False, to keep students off the Internet
 if [ "$iiab_gateway_enabled" == "True" ]; then
     $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
 fi
 
+# 3 or 4 IP forwarding rules
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
-
 # Block https traffic except if directed at server
 if [ "$gw_block_https" == "True" ]; then
     $IPTABLES -A FORWARD -p tcp ! -d {{ lan_ip }} --dport 443 -j DROP
 fi
-
 # Allow outgoing connections from the LAN side
 $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
-
 # Don't forward from the outside to the inside
 $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
-$IPTABLES -A INPUT -i $wan -j DROP
+# Enable routing (kernel IP forwarding)
+echo 1 > /proc/sys/net/ipv4/ip_forward
 
+# 5 = "all but databases"
+if [ "$ports_externally_visible" -lt 5 ]; then
+    # Drop everything else arriving via WAN
+    $IPTABLES -A INPUT -i $wan -j DROP
+fi
+
+# TCP & UDP block of DNS port 53 if truly nec
 if [ "$block_DNS" == "True" ]; then
     $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
     $IPTABLES -t nat -A PREROUTING -i $lan -p udp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
 fi
 
+# If Squid enabled, indicated by /etc/iiab/iiab.env
 if [ "$HTTPCACHE_ON" == "True" ]; then
-    $IPTABLES  -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:3128
+    $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:3128
 fi
 
-# Enable routing
-echo 1 > /proc/sys/net/ipv4/ip_forward
-# Save the whole rule set now
-{% if is_debuntu %}
-netfilter-persistent save
-{% else %}
-iptables-save > $IPTABLES_DATA
-{% endif %}
-exit 0
+# Save the whole rule set
+save_rules_and_exit

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -15,10 +15,10 @@ IPTABLES_DATA=/etc/sysconfig/iptables
 source {{ iiab_env_file }}
 lan=$IIAB_LAN_DEVICE
 wan=$IIAB_WAN_DEVICE
-network_mode=`grep iiab_network_mode_applied {{ iiab_ini_file }} | gawk '{print $3}'`
 echo -e "\nLAN: $lan"
 echo -e "WAN: $wan"
-echo -e "Network Mode: $network_mode\n"
+#network_mode=`grep iiab_network_mode_applied {{ iiab_ini_file }} | gawk '{print $3}'`
+#echo -e "Network Mode: $network_mode\n"
 
 # "Good thing we replace this file; should be treated like Squid below" ?
 ports_externally_visible={{ ports_externally_visible }}
@@ -164,7 +164,7 @@ if [ "$wan" != "none" ]; then
     fi
 
     # Typically False, to keep client machines (e.g. students) off the Internet
-    if [ "$iiab_gateway_enabled" == "True" ]; then
+    if [ "$iiab_gateway_enabled" == "True" ]  && [ "$lan" == "none" ]; then
         $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
     fi
 

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -55,7 +55,7 @@ samba_tcp_mports={{ samba_tcp_mports }}
 #                                                                              #
 #   /etc/iiab/local_vars.yml                                                   #
 #                                                                              #
-# It must be an integer {0...5} as follows:                                    #
+# This firewall variable must be an integer {0...5} as follows:                #
 #                                                                              #
 #   0 = none                                                                   #
 #   1 = ssh only                                                               #
@@ -64,7 +64,7 @@ samba_tcp_mports={{ samba_tcp_mports }}
 #   4 = ssh + Admin Console + common IIAB services + Samba                     #
 #   5 = all but databases                                                      #
 #                                                                              #
-# Then enable it in iptables by running: cd /opt/iiab/iiab; ./iiab-network     #
+# Then enable it with iptables by running: cd /opt/iiab/iiab; ./iiab-network   #
 #                                                                              #
 ################################################################################
 

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -77,13 +77,13 @@ elif [ "$ports_externally_visible" -lt 0 ] || [ "$ports_externally_visible" -gt 
     exit 1
 fi
 
-if [ "$wan" != "none" ] && [ "$network_mode" != "Appliance" ]; then
-    # Load iptables kernel modules
-    /sbin/modprobe ip_tables
-    /sbin/modprobe iptable_filter
-    /sbin/modprobe ip_conntrack
-    /sbin/modprobe iptable_nat
-fi
+#if [ "$wan" != "none" ] && [ "$network_mode" != "Appliance" ]; then
+# Load iptables kernel modules
+/sbin/modprobe ip_tables
+/sbin/modprobe iptable_filter
+/sbin/modprobe ip_conntrack
+/sbin/modprobe iptable_nat
+#fi
 
 # Delete all existing firewall rules
 $IPTABLES -F
@@ -110,90 +110,81 @@ $IPTABLES -A INPUT -p udp --dport 5432 -j DROP
 $IPTABLES -A INPUT -p tcp --dport 5984 -j DROP
 $IPTABLES -A INPUT -p udp --dport 5984 -j DROP
 
-save_rules_and_exit() {
-{% if is_debuntu %}
-    netfilter-persistent save
-{% else %}
-    iptables-save > $IPTABLES_DATA
-{% endif %}
-
-    exit 0
-}
-
-if [ "$wan" == "none" ] || [ "$network_mode" == "Appliance" ]; then
-    save_rules_and_exit
-fi
-
 # Allow established connections, and those not coming from the outside
 $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 $IPTABLES -A INPUT -m state --state NEW -i $lan -j ACCEPT
 
-# Allow mDNS from WAN-side too (WHY OUT OF CURIOSITY?)
+# Allow mDNS from WAN-side too (ON PURPOSE? WHY OUT OF CURIOSITY?)
 $IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
-# 1 = ssh only
-if [ "$ports_externally_visible" -ge 1 ]; then
-    $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
-fi
+#if [ "$wan" != "none" ] && [ "$network_mode" != "Appliance" ]; then
+if [ "$wan" != "none" ]; then
 
-# For now this is implemented using Admin Console variable "gui_port" from:
-# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/main.yml#L87-L95
-#
-# 2 = ssh + http-or-https (for Admin Console's box.lan/admin too)
-if [ "$ports_externally_visible" -ge 2 ]; then
-    $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
-fi
-
-# 3 = ssh + http-or-https + common IIAB services
-if [ "$ports_externally_visible" -ge 3 ]; then
-    $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $calibreweb_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $cups_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $nodered_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $mosquitto_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $transmission_http_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp --dport $transmission_peer_port -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p udp --dport $minetest_port -m state --state NEW -i $wan -j ACCEPT
-
-    if [ "$pbx_enabled" == "True" ]; then
-        $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_sip -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_pjsip -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p udp --dport $pbx_data_ports -m state --state NEW -i $wan -j ACCEPT
+    # 1 = ssh only
+    if [ "$ports_externally_visible" -ge 1 ]; then
+        $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
     fi
-fi
 
-# 4 = ssh + http-or-https + common IIAB services + Samba
-if [ "$ports_externally_visible" -ge 4 ]; then
-    $IPTABLES -A INPUT -p udp --dport $samba_udp_ports -m state --state NEW -i $wan -j ACCEPT
-    $IPTABLES -A INPUT -p tcp -m multiport --dports $samba_tcp_mports -m state --state NEW -i $wan -j ACCEPT
-fi
+    # For now this is implemented using Admin Console variable "gui_port" from:
+    # https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/main.yml#L87-L95
+    #
+    # 2 = ssh + http-or-https (for Admin Console's box.lan/admin too)
+    if [ "$ports_externally_visible" -ge 2 ]; then
+        $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
+    fi
 
-# Typically False, to keep students off the Internet
-if [ "$iiab_gateway_enabled" == "True" ]; then
-    $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
-fi
+    # 3 = ssh + http-or-https + common IIAB services
+    if [ "$ports_externally_visible" -ge 3 ]; then
+        $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $calibreweb_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $cups_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $nodered_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $mosquitto_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $transmission_http_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $transmission_peer_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p udp --dport $minetest_port -m state --state NEW -i $wan -j ACCEPT
 
-# 3 or 4 IP forwarding rules
-$IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
-# Block https traffic except if directed at server
-if [ "$gw_block_https" == "True" ]; then
-    $IPTABLES -A FORWARD -p tcp ! -d {{ lan_ip }} --dport 443 -j DROP
-fi
-# Allow outgoing connections from the LAN side
-$IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
-# Don't forward from the outside to the inside
-$IPTABLES -A FORWARD -i $wan -o $lan -j DROP
-# Enable routing (kernel IP forwarding)
-echo 1 > /proc/sys/net/ipv4/ip_forward
+        if [ "$pbx_enabled" == "True" ]; then
+            $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_sip -m state --state NEW -i $wan -j ACCEPT
+            $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_pjsip -m state --state NEW -i $wan -j ACCEPT
+            $IPTABLES -A INPUT -p udp --dport $pbx_data_ports -m state --state NEW -i $wan -j ACCEPT
+        fi
+    fi
 
-# 5 = "all but databases"
-if [ "$ports_externally_visible" -lt 5 ]; then
-    # Drop everything else arriving via WAN
-    $IPTABLES -A INPUT -i $wan -j DROP
+    # 4 = ssh + http-or-https + common IIAB services + Samba
+    if [ "$ports_externally_visible" -ge 4 ]; then
+        $IPTABLES -A INPUT -p udp --dport $samba_udp_ports -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp -m multiport --dports $samba_tcp_mports -m state --state NEW -i $wan -j ACCEPT
+    fi
+
+    # Typically False, to keep client machines (e.g. students) off the Internet
+    if [ "$iiab_gateway_enabled" == "True" ]; then
+        $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
+    fi
+
+    # 3 or 4 IP forwarding rules
+    $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
+    # Block https traffic except if directed at server
+    if [ "$gw_block_https" == "True" ]; then
+        $IPTABLES -A FORWARD -p tcp ! -d {{ lan_ip }} --dport 443 -j DROP
+    fi
+    # Allow outgoing connections from the LAN side
+    $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
+    # Don't forward from the outside to the inside
+    $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
+    # Enable routing (kernel IP forwarding)
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+
+    # 5 = "all but databases"
+    if [ "$ports_externally_visible" -lt 5 ]; then
+        # Drop everything else arriving via WAN
+        $IPTABLES -A INPUT -i $wan -j DROP
+    fi
+
 fi
 
 # TCP & UDP block of DNS port 53 if truly nec
@@ -202,10 +193,16 @@ if [ "$block_DNS" == "True" ]; then
     $IPTABLES -t nat -A PREROUTING -i $lan -p udp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
 fi
 
-# If Squid enabled, indicated by /etc/iiab/iiab.env
+# If Squid enabled, as indicated by "HTTPCACHE_ON=True" in /etc/iiab/iiab.env
 if [ "$HTTPCACHE_ON" == "True" ]; then
     $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:3128
 fi
 
 # Save the whole rule set
-save_rules_and_exit
+{% if is_debuntu %}
+netfilter-persistent save
+{% else %}
+iptables-save > $IPTABLES_DATA
+{% endif %}
+
+exit 0

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -32,20 +32,21 @@ block_DNS={{ block_DNS }}
 
 calibre_port={{ calibre_port }}
 calibreweb_port={{ calibreweb_port }}
-kiwix_port={{ kiwix_port }}
-kalite_server_port={{ kalite_server_port }}
-kolibri_http_port={{ kolibri_http_port }}
 cups_port={{ cups_port }}
-transmission_http_port={{ transmission_http_port }}
-transmission_peer_port={{ transmission_peer_port }}
-sugarizer_port={{ sugarizer_port }}
-nodered_port={{ nodered_port }}
-mosquitto_port={{ mosquitto_port }}
+kalite_server_port={{ kalite_server_port }}
+kiwix_port={{ kiwix_port }}
+kolibri_http_port={{ kolibri_http_port }}
 minetest_port={{ minetest_port }}
+mosquitto_port={{ mosquitto_port }}
+nodered_port={{ nodered_port }}
 pbx_enabled={{ pbx_enabled }}
 pbx_signaling_ports_chan_sip={{ pbx_signaling_ports_chan_sip }}
 pbx_signaling_ports_chan_pjsip={{ pbx_signaling_ports_chan_pjsip }}
 pbx_data_ports={{ pbx_data_ports }}
+sugarizer_port={{ sugarizer_port }}
+transmission_http_port={{ transmission_http_port }}
+transmission_peer_port={{ transmission_peer_port }}
+
 samba_udp_ports={{ samba_udp_ports }}
 samba_tcp_mports={{ samba_tcp_mports }}
 
@@ -135,24 +136,25 @@ if [ "$wan" != "none" ]; then
 
     # 3 = ssh + http-or-https + common IIAB services
     if [ "$ports_externally_visible" -ge 3 ]; then
-        $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
         $IPTABLES -A INPUT -p tcp --dport $calibre_port -m state --state NEW -i $wan -j ACCEPT
         $IPTABLES -A INPUT -p tcp --dport $calibreweb_port -m state --state NEW -i $wan -j ACCEPT
         $IPTABLES -A INPUT -p tcp --dport $cups_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $nodered_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $mosquitto_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $transmission_http_port -m state --state NEW -i $wan -j ACCEPT
-        $IPTABLES -A INPUT -p tcp --dport $transmission_peer_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $kalite_server_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $kiwix_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $kolibri_http_port -m state --state NEW -i $wan -j ACCEPT
         $IPTABLES -A INPUT -p udp --dport $minetest_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $mosquitto_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $nodered_port -m state --state NEW -i $wan -j ACCEPT
 
         if [ "$pbx_enabled" == "True" ]; then
             $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_sip -m state --state NEW -i $wan -j ACCEPT
             $IPTABLES -A INPUT -p udp --dport $pbx_signaling_ports_chan_pjsip -m state --state NEW -i $wan -j ACCEPT
             $IPTABLES -A INPUT -p udp --dport $pbx_data_ports -m state --state NEW -i $wan -j ACCEPT
         fi
+
+        $IPTABLES -A INPUT -p tcp --dport $sugarizer_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $transmission_http_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $transmission_peer_port -m state --state NEW -i $wan -j ACCEPT
     fi
 
     # 4 = ssh + http-or-https + common IIAB services + Samba

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -91,10 +91,20 @@ gui_wan: True
 adm_cons_force_ssl: False
 adm_cons_allow_downloads: False
 
-# Enables "campus access" to kiwix (3000), kalite (8008) & calibre (8010 or
-# 8080) on WAN side of server. See network/templates/gateway/iiab-gen-iptables
-# within github.com/iiab/iiab/blob/master/roles/
-services_externally_visible: True
+# Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite
+# (8008) and Calibre (8010 or 8080) etc, on the WAN side of your IIAB server.
+# Only 1 of the 6 lines below should be uncommented:
+#
+#ports_externally_visible: 0    # none
+#ports_externally_visible: 1    # ssh only
+#ports_externally_visible: 2    # ssh + Admin Console
+ports_externally_visible: 3     # ssh + Admin Console + common IIAB services
+#ports_externally_visible: 4    # ssh + Admin Console + common IIAB services + Samba
+#ports_externally_visible: 5    # all but databases
+#
+# Or further customize your iptables firewall by editing:
+# /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
+# And then run: cd /opt/iiab/iiab; ./iiab-network
 
 # Gateway and Filters
 # Most all implementations use "iiab_gateway_enabled: False" within

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -40,10 +40,20 @@ host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
 
-# Enables "campus access" to kiwix (3000), kalite (8008) & calibre (8010 or
-# 8080) on WAN side of server. See network/templates/gateway/iiab-gen-iptables
-# within github.com/iiab/iiab/blob/master/roles/
-services_externally_visible: True
+# Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite
+# (8008) and Calibre (8010 or 8080) etc, on the WAN side of your IIAB server.
+# Only 1 of the 6 lines below should be uncommented:
+#
+#ports_externally_visible: 0    # none
+#ports_externally_visible: 1    # ssh only
+#ports_externally_visible: 2    # ssh + Admin Console
+ports_externally_visible: 3     # ssh + Admin Console + common IIAB services
+#ports_externally_visible: 4    # ssh + Admin Console + common IIAB services + Samba
+#ports_externally_visible: 5    # all but databases
+#
+# Or further customize your iptables firewall by editing:
+# /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
+# And then run: cd /opt/iiab/iiab; ./iiab-network
 
 # Make this True if client machines should have access to WAN/Internet:
 iiab_gateway_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -40,10 +40,20 @@ host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
 
-# Enables "campus access" to kiwix (3000), kalite (8008) & calibre (8010 or
-# 8080) on WAN side of server. See network/templates/gateway/iiab-gen-iptables
-# within github.com/iiab/iiab/blob/master/roles/
-services_externally_visible: True
+# Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite
+# (8008) and Calibre (8010 or 8080) etc, on the WAN side of your IIAB server.
+# Only 1 of the 6 lines below should be uncommented:
+#
+#ports_externally_visible: 0    # none
+#ports_externally_visible: 1    # ssh only
+#ports_externally_visible: 2    # ssh + Admin Console
+ports_externally_visible: 3     # ssh + Admin Console + common IIAB services
+#ports_externally_visible: 4    # ssh + Admin Console + common IIAB services + Samba
+#ports_externally_visible: 5    # all but databases
+#
+# Or further customize your iptables firewall by editing:
+# /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
+# And then run: cd /opt/iiab/iiab; ./iiab-network
 
 # Make this True if client machines should have access to WAN/Internet:
 iiab_gateway_enabled: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -40,10 +40,20 @@ host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
 
-# Enables "campus access" to kiwix (3000), kalite (8008) & calibre (8010 or
-# 8080) on WAN side of server. See network/templates/gateway/iiab-gen-iptables
-# within github.com/iiab/iiab/blob/master/roles/
-services_externally_visible: True
+# Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite
+# (8008) and Calibre (8010 or 8080) etc, on the WAN side of your IIAB server.
+# Only 1 of the 6 lines below should be uncommented:
+#
+#ports_externally_visible: 0    # none
+#ports_externally_visible: 1    # ssh only
+#ports_externally_visible: 2    # ssh + Admin Console
+ports_externally_visible: 3     # ssh + Admin Console + common IIAB services
+#ports_externally_visible: 4    # ssh + Admin Console + common IIAB services + Samba
+#ports_externally_visible: 5    # all but databases
+#
+# Or further customize your iptables firewall by editing:
+# /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
+# And then run: cd /opt/iiab/iiab; ./iiab-network
 
 # Make this True if client machines should have access to WAN/Internet:
 iiab_gateway_enabled: False


### PR DESCRIPTION
```
IF YOU NEED TO CHANGE ports_externally_visible DO THAT IN:

  /etc/iiab/local_vars.yml

This firewall variable must be an integer {0...5} as follows:

  0 = none
  1 = ssh only
  2 = ssh + http-or-https (for Admin Console's box.lan/admin too)
  3 = ssh + http-or-https + common IIAB services  <--  THIS IS THE DEFAULT
  4 = ssh + http-or-https + common IIAB services + Samba
  5 = all but databases

Then enable it with iptables by running: cd /opt/iiab/iiab; ./iiab-network
```
(above pasted in from this PR's iiab/roles/network/templates/gateway/iiab-gen-iptables)
```
Or further customize your iptables firewall by editing:
/opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
And then run: cd /opt/iiab/iiab; ./iiab-network
```
(above pasted in from this PR's local_vars files & default_vars.yml)

To be documented in https://github.com/iiab/iiab/wiki/IIAB-Networking and http://FAQ.IIAB.IO

FYI Ansible variables `services_externally_visible` and `gui_wan` are intentionally deprecated, in order to make possible this big improvement in usability for new IIAB implementers.

Builds on #1664, PR #1665