### PR TITLE
Move osm-vector-maps install from 4-server-options to 7-edu-apps stage

### DIFF
--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -13,12 +13,6 @@
   when: named_install
   tags: base, named, network, domain
 
-- name: Installing vector map test page
-  include_role: 
-      name: osm-vector-maps
-  when: osm_vector_maps_install
-  tags: base, map
-
 - name: Installing captive portal
   include_tasks: roles/captive-portal/tasks/main.yml
   when: captive_portal_install

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -31,14 +31,14 @@
   include_role:
     name: osm-vector-maps
   when: osm_vector_maps_install
-  tags: osm
+  tags: osm, maps
 
 # UNMAINTAINED
 - name: OSM
   include_role:
     name: osm
   when: osm_install is defined and osm_install
-  tags: osm
+  tags: osm, maps
 
 # UNMAINTAINED
 - name: PATHAGAR

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -27,7 +27,7 @@
   when: moodle_install
   tags: olpc, moodle
 
-- name: OSM_VECTOR_MAPS
+- name: OSM-VECTOR-MAPS
   include_role:
     name: osm-vector-maps
   when: osm_vector_maps_install


### PR DESCRIPTION
Thanks to @georgejhunt who confirms this is ok, and to @tim-moody who initiated this change at PR https://github.com/iiab/iiab/pull/1678