### PR TITLE
Recommend 2.7.11 if running scripts/ansible-2.7.x

### DIFF
--- a/scripts/ansible-2.7.x
+++ b/scripts/ansible-2.7.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.10"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.7.11"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Ansible 2.7.11 just released.

Changelog:
https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst#v2-7-11

To be used if any developer wants to roll back from 2.8.0 temporarily for testing etc.

Builds on PR #1669