### PR TITLE
Fix Typo: enable masquerade only when "$lan" != "none" (typo fixed, iptables firewall)

### DIFF
--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -164,7 +164,7 @@ if [ "$wan" != "none" ]; then
     fi
 
     # Typically False, to keep client machines (e.g. students) off the Internet
-    if [ "$iiab_gateway_enabled" == "True" ]  && [ "$lan" == "none" ]; then
+    if [ "$iiab_gateway_enabled" == "True" ] && [ "$lan" != "none" ]; then
         $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
     fi
 


### PR DESCRIPTION
Builds on PR #1677

Thanks to @jvonau for earlier today suggesting this.