### PR TITLE
Clean roles/0-init & roles/network for Ansible 2.8 ('| bool'). Prep for Ubuntu 18/19+

### DIFF
--- a/roles/0-init/defaults/main.yml
+++ b/roles/0-init/defaults/main.yml
@@ -8,7 +8,7 @@ first_run: False
 rpi_model: none
 is_rpi: False
 xo_model: none
-gw_active: none
+gw_active: False
 internet_available: False
 discovered_wan_iface: none
 

--- a/roles/0-init/tasks/hostname.yml
+++ b/roles/0-init/tasks/hostname.yml
@@ -13,7 +13,7 @@
 
 - name: 'Turn the crank for systemd: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}" (debuntu)'
   shell: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install /etc/sysconfig/network from template (redhat)
   template:
@@ -22,7 +22,7 @@
     owner: root
     group: root
     mode: 0644
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Put hostnames "127.0.0.1 localhost.localdomain localhost box {{ iiab_hostname }}" in /etc/hosts
   lineinfile:

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -14,7 +14,7 @@
 # sections once and only once to preserve the install date and git hash.
 - name: Create IIAB directory structure and {{ iiab_ini_file }}, if first_run
   include_tasks: first_run.yml
-  when: first_run
+  when: first_run | bool
 
 #- name: Loading computed_vars
 #  include_tasks: roles/0-init/tasks/computed_vars.yml
@@ -92,7 +92,7 @@
 - name: Set port 443 for Admin Console if adm_cons_force_ssl
   set_fact:
     gui_port: 443
-  when: adm_cons_force_ssl
+  when: adm_cons_force_ssl | bool
 
 - name: Turn on both vars for MySQL (mandatory in Stage 3!)
   set_fact:
@@ -127,12 +127,12 @@
 - name: "Set python_path: /lib/python2.7/site-packages/ (redhat)"
   set_fact:
     python_path: /lib/python2.7/site-packages/
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: "Set python_path: /usr/local/lib/python2.7/dist-packages/ (debuntu)"
   set_fact:
     python_path: /usr/local/lib/python2.7/dist-packages/
-  when: is_debuntu
+  when: is_debuntu | bool
 
 # For various reasons the mysql service cannot be enabled on Fedora 20, but
 # 'mariadb', which is its real name can.  On Fedora 18 we need to use 'mysqld'.
@@ -154,7 +154,7 @@
 #- name: "Set mysql_service: mysql (debuntu)"
 #  set_fact:
 #    mysql_service: mysql
-#  when: is_debuntu
+#  when: is_debuntu | bool
 
 - name: "Set iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}"
   set_fact:
@@ -168,7 +168,7 @@
 
 - name: Set hostname if FQDN_changed
   include_tasks: hostname.yml
-  when: FQDN_changed
+  when: FQDN_changed | bool
 
 - name: Add 'runtime' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -202,21 +202,21 @@
     - option: product_id
       value: "{{ ansible_product_uuid }}"
     - option: gw_active
-      value:  "{{ gw_active }}"
+      value: "{{ gw_active }}"
     - option: internet_available
-      value:  "{{ internet_available }}"
+      value: "{{ internet_available }}"
     - option: is_rpi
-      value:  "{{ is_rpi }}"
+      value: "{{ is_rpi }}"
     - option: first_run
-      value:  "{{ first_run }}"
+      value: "{{ first_run }}"
     - option: local_tz
-      value:  "{{ local_tz }}"
+      value: "{{ local_tz }}"
     - option: no_NM_reload
       value: "{{ no_NM_reload }}"
     - option: is_F18
       value: "{{ is_F18 }}"
     - option: FQDN_changed
-      value:  "{{ FQDN_changed }}"
+      value: "{{ FQDN_changed }}"
 
 - name: Add 'runtime' variable 'is_VM' value if defined, to {{ iiab_ini_file }}
   ini_file:
@@ -226,7 +226,7 @@
     value: "{{ item.value }}"
   with_items:
     - option: is_VM
-      value:  "yes"
+      value: "yes"
   when: is_VM is defined
 
 - name: STAGE 0 HAS COMPLETED ======================================

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -3,7 +3,7 @@
     name: avahi
     createhome: no
     shell: /bin/false
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install avahi announce config file /etc/avahi/services/schoolserver.service
   template:
@@ -37,7 +37,7 @@
   copy:
     src: /usr/share/doc/avahi-daemon/examples/ssh.service
     dest: /etc/avahi/services/
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Set ssh port for avahi
   lineinfile:

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -61,6 +61,7 @@
   set_fact:
     user_wan_iface: "none"
   when: not iiab_wan_enabled
+  #when: 'not iiab_wan_enabled'
 
 # gui wants LanController # keeps ifcfg-WAN but onboot=no
 # the change over might be a little bumpy ATM.

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -60,7 +60,7 @@
 - name: Checking iiab_wan_enabled
   set_fact:
     user_wan_iface: "none"
-  when: 'not iiab_wan_enabled'
+  when: not iiab_wan_enabled
 
 # gui wants LanController # keeps ifcfg-WAN but onboot=no
 # the change over might be a little bumpy ATM.
@@ -141,7 +141,7 @@
   set_fact:
     iiab_lan_iface: "br0"
     iiab_wireless_lan_iface: "wlan0"
-  when: is_rpi
+  when: is_rpi | bool
 
 - name: Enable hostapd if discovered_wireless_iface is not WAN
   set_fact:

--- a/roles/network/tasks/dansguardian.yml
+++ b/roles/network/tasks/dansguardian.yml
@@ -21,7 +21,7 @@
     owner: dansguardian
     group: dansguardian
     mode: 0640
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install /etc/dansguardian/dansguardian.conf from template (CentOS)
   template:

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -73,13 +73,13 @@
   service:
     name: dhcpd
     state: stopped
-  when: dhcpd_install
+  when: dhcpd_install | bool
 
 - name: dhcpd_server may be affected - stopping dnsmasq
   service:
     name: dnsmasq
     state: stopped
-  when: dnsmasq_install
+  when: dnsmasq_install | bool
 
 - name: Reload systemd
   systemd:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -17,7 +17,7 @@
 
 - name: Red Hat network detection (redhat)
   include_tasks: detected_redhat.yml
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Setting dhcpcd_test results
   set_fact:
@@ -40,7 +40,7 @@
 
 - name: Check /etc/network/interfaces for gateway
   shell: grep {{ device_gw }} /etc/network/interfaces | wc -l
-  when: is_debuntu
+  when: is_debuntu | bool
   register: wan_file
 
 - name: Setting wan_in_interfaces

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -33,6 +33,7 @@
     enabled: no
     state: stopped
   when: is_ubuntu and not is_ubuntu_16
+  #when: is_ubuntu_18
 
 - name: Install systemd unit file to /etc/systemd/system/dhcpd.service
   template:

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -2,7 +2,7 @@
   package:
     name: isc-dhcp-server
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
@@ -18,21 +18,21 @@
   user:
     name: dhcpd
     createhome: no
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Disable stock dhcp_service (debuntu)
   service:
     name: "{{ dhcp_service }}"
     enabled: no
     state: stopped
-  when: is_debuntu
+  when: is_debuntu | bool
 
-- name: Disable stock dhcp_service ipv6 (ubuntu-18)
+- name: Disable stock dhcp_service ipv6 (ubuntu-18 and higher)
   service:
     name: "{{ dhcp_service }}6"
     enabled: no
     state: stopped
-  when: is_ubuntu_18
+  when: is_ubuntu and not is_ubuntu_16
 
 - name: Install systemd unit file to /etc/systemd/system/dhcpd.service
   template:
@@ -48,7 +48,7 @@
   command: touch /var/lib/dhcpd/dhcpd.leases
   args:
     creates: /var/lib/dhcpd/dhcpd.leases
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Set dhcpd.leases permissions/ownership (redhat)
   file:
@@ -57,4 +57,4 @@
     group: dhcpd
     mode: 0644
     state: file
-  when: is_redhat
+  when: is_redhat | bool

--- a/roles/network/tasks/down-debian.yml
+++ b/roles/network/tasks/down-debian.yml
@@ -16,10 +16,10 @@
   service:
     name: dhcpd
     state: stopped
-  when: dhcpd_install
+  when: dhcpd_install | bool
 
 - name: dhcpd_server may be affected - stopping dnsmasq
   service:
     name: dnsmasq
     state: stopped
-  when: dnsmasq_install
+  when: dnsmasq_install | bool

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -31,7 +31,7 @@
     owner: root
     group: root
     mode: 0755
-  when: is_rpi
+  when: is_rpi | bool
 
 - name: Create /usr/bin/iiab-hotspot-off from template
   template:
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0755
-  when: is_rpi
+  when: is_rpi | bool
 
 - name: Disable the Access Point 'hostapd' service
   systemd:

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -36,13 +36,13 @@
   service:
     name: dhcpd
     state: stopped
-  when: dhcpd_install
+  when: dhcpd_install | bool
 
 - name: dhcpd_server may be affected - stopping dnsmasq
   service:
     name: dnsmasq
     state: stopped
-  when: dnsmasq_install
+  when: dnsmasq_install | bool
 
 - name: Stop the LAN/Bridge deleting iiab-LAN
   shell: nmcli con delete id iiab-LAN

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -57,7 +57,7 @@
 
 - name: Configure wondershaper
   include_tasks: wondershaper.yml
-  when: wondershaper_install
+  when: wondershaper_install | bool
   tags:
     - network
     - wondershaper
@@ -99,7 +99,7 @@
 #### Start network layout
 - name: Redhat networking
   include_tasks: ifcfg_mods.yml
-  when: is_redhat
+  when: is_redhat | bool
   #and not installing
   tags:
     - network

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -4,7 +4,7 @@
       - bind9
       - bind9utils
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
@@ -79,7 +79,7 @@
   template:
     src: roles/network/templates/named/dns-jail.conf
     dest: "/etc/{{ apache_config_dir }}/"
-  when: dns_jail_enabled
+  when: dns_jail_enabled | bool
 
 - name: Create symlink dns-jail.conf from sites-enabled to sites-available (if debuntu and dns_jail_enabled)
   file:

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -27,7 +27,7 @@
     enabled: yes
   with_items:
     - systemd-networkd-wait-online
-  when: systemd_networkd_active
+  when: systemd_networkd_active | bool
 
 # ICO will always set gui_static_wan_ip away from the default of 'unset' while
 # gui_static_wan turns dhcp on/off through wan_ip in computed_network and

--- a/roles/network/tasks/redetect.yml
+++ b/roles/network/tasks/redetect.yml
@@ -57,7 +57,7 @@
   shell: nmcli conn up id iiab-WAN
   register: dhcp_WAN
   ignore_errors: yes
-  when: has_WAN
+  when: has_WAN | bool
 
 - name: BAD ifcfg-WAN
   debug:
@@ -117,7 +117,7 @@
   register: ifcfg_dhcp_device
   ignore_errors: True
   changed_when: False
-  when: dhcp_good
+  when: dhcp_good | bool
 
 - name: Setting has ifcfg gw based on device if found
   set_fact:

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -15,13 +15,13 @@
     name: "{{ proxy }}"
     state: stopped
   async: 120
-  when: squid_install
+  when: squid_install | bool
 
 - name: Stop DansGuardian
   systemd:
     name: dansguardian
     state: stopped
-  when: dansguardian_install
+  when: dansguardian_install | bool
 
 - name: Restart DansGuardian service (dansguardian) except Ubuntu which needs reboot to activate
   systemd:
@@ -40,7 +40,7 @@
   systemd:
     name: wondershaper
     state: restarted
-  when: wondershaper_enabled
+  when: wondershaper_enabled | bool
 
 - name: Restart Avahi service (avahi-daemon)
   systemd:

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -9,7 +9,7 @@
 
 - name: "Bigger hammer for Ubuntu, run: /etc/init.d/squid stop"
   command: /etc/init.d/squid stop
-  when: is_ubuntu
+  when: is_ubuntu | bool
 
 - name: Stop Squid
   service:
@@ -79,7 +79,7 @@
     state: directory
 
 - include_tasks: roles/network/tasks/dansguardian.yml
-  when: dansguardian_install
+  when: dansguardian_install | bool
 
 # {{ proxy }} is normally "squid", but is "squid3" on raspbian-8 & debian-8
 - name: Add '{{ proxy }}' variable values to {{ iiab_ini_file }}

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -33,11 +33,12 @@
     wan_cidr: "{{ CIDR.stdout }}"
   when: wan_ip != "dhcp"
 
-- name: Supply static WAN template
+- name: Supply static WAN template (ubuntu-16)
   template:
     dest: /etc/systemd/network/IIAB-Static.network
     src: network/systemd-static-net.j2
-  when: wan_ip != "dhcp" and not is_ubuntu_18
+  when: wan_ip != "dhcp" and is_ubuntu_16
+  #when: wan_ip != "dhcp" and not is_ubuntu_18
 
 - name: Stopping services
   include_tasks: down-debian.yml


### PR DESCRIPTION
Partially deals with:

#1632 Ansible 2.8 is part of IIAB, and throws many new/purple warnings!