### PR TITLE
Making IIAB (PRE-)release version number a bit more visible

### DIFF
--- a/roles/0-init/defaults/main.yml
+++ b/roles/0-init/defaults/main.yml
@@ -1,6 +1,7 @@
-# Use these to tag a release at a point in time, for {{ iiab_env_file }}
-iiab_base_ver: 7.0
-iiab_revision: 0
+# (PRE-)release version number, for {{ iiab_env_file }} = /etc/iiab/iiab.env
+# iiab_base_ver: 7.0
+# iiab_revision: 0
+# ABOVE MOVED TO /opt/iiab/iiab/vars/default_vars.yml
 
 # These entries should never be changed in this file.
 # These are defaults for boolean routines.

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -4,8 +4,14 @@
 
 # By convention we use True/False to indicate boolean values.
 
-# Configuration Files
+# (PRE-)release version number, for {{ iiab_env_file }}
+iiab_base_ver: 7.0
+iiab_revision: 0
+
+# Main configuration file
 iiab_local_vars_file: /etc/iiab/local_vars.yml
+
+# Installation status files
 iiab_env_file: /etc/iiab/iiab.env
 iiab_ini_file: /etc/iiab/iiab.ini
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -2,9 +2,9 @@
 # PUT YOUR CUSTOMIZATIONS HERE: /etc/iiab/local_vars.yml
 # READ "What is local_vars.yml and how do I customize it?" IN http://FAQ.IIAB.IO
 
-# By convention we use True/False to indicate boolean values.
+# Internet-in-a-Box (IIAB) uses True/False to indicate boolean values.
 
-# (PRE-)release version number, for {{ iiab_env_file }}
+# IIAB (PRE-)release version number, for {{ iiab_env_file }}
 iiab_base_ver: 7.0
 iiab_revision: 0
 


### PR DESCRIPTION
Smoke-tested on Ubuntu 18.04 with both ./iiab-install (runs iiab-stages.yml) and ./iiab-network (runs iiab-network.yml)