### PR TITLE
Revise boolean syntax for Ansible 2.8 e.g. 'when: X' -> 'when: X | bool' (eliminates most warnings)

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -109,7 +109,7 @@
 #  set_fact:
 #    mongodb_install: True
 #    mongodb_enabled: True
-#  when: sugarizer_enabled
+#  when: sugarizer_enabled | bool
 
 # There might be other db's
 - name: Turn on both vars for PostgreSQL if moodle_enabled or pathagar_enabled

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -9,7 +9,7 @@
       - uuid-runtime
       - sudo
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Does /etc/iiab/uuid file exist?
   stat:
@@ -77,7 +77,7 @@
 - name: OPENVPN
   include_role:
     name: openvpn
-  when: openvpn_install
+  when: openvpn_install | bool
   tags: openvpn
 
 # for rpi, without rtc, we need time as soon as possible
@@ -106,7 +106,7 @@
     name: apparmor
     enabled: False
     state: stopped
-  when: is_ubuntu
+  when: is_ubuntu | bool
   ignore_errors: true
 
 - name: Disable SELinux on next boot (OS's other than debuntu)

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -44,8 +44,8 @@
 - name: Does 'ubermix' exist in /etc/lsb-release?
   shell: grep -i ubermix /etc/lsb-release    # Pipe to cat to avoid red errors?
   register: grep_ubermix
-  failed_when: false    # Universal way to hide alarmist red errors!
-  #ignore_errors: true
+  failed_when: False    # Universal way to hide alarmist red errors!
+  #ignore_errors: True
   #check_mode: no
 
 #- debug:
@@ -107,7 +107,7 @@
     enabled: False
     state: stopped
   when: is_ubuntu | bool
-  ignore_errors: true
+  ignore_errors: True
 
 - name: Disable SELinux on next boot (OS's other than debuntu)
   selinux:
@@ -127,7 +127,7 @@
 - name: Check if the identifier for Intel's NUC6 built-in WiFi is present
   shell: "lsusb | grep 8087:0a2b | wc | awk '{print $1}'"
   register: usb_NUC6
-  ignore_errors: true
+  ignore_errors: True
 
 - name: Download {{ iiab_download_url }}/iwlwifi-8000C-13.ucode to /lib/firmware for built-in WiFi on NUC6    # iiab_download_url is http://download.iiab.io/packages
   get_url:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -37,14 +37,14 @@
     path: /etc/dphys-swapfile
     regexp: "^CONF_SWAPSIZE"
     line: CONF_SWAPSIZE=500
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Restart swap service "dphys-swapfile" (debuntu)
   #command: /etc/init.d/dphys-swapfile restart
   service:    # A rare/legacy service that is NOT systemd
     name: dphys-swapfile
     state: restarted
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install RPi rootfs resizing (iiab-rpi-max-rootfs.sh) and its systemd service (iiab-rpi-root-resize.service), from templates
   template:

--- a/roles/2-common/tasks/iptables.yml
+++ b/roles/2-common/tasks/iptables.yml
@@ -35,7 +35,7 @@
   package:
     name: iptables-persistent
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
@@ -60,4 +60,4 @@
     src: iptables
     dest: /etc/network/if-pre-up.d/iptables
     mode: 0755
-  when: is_debuntu
+  when: is_debuntu | bool

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -12,7 +12,7 @@
       - xml-common
       - yum-utils
     state: present
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Install {{ iiab_download_url }}/usbmount_0.0.14.1_all.deb, missing from Debian (debian-9 or debian-10, if NOT rpi)
   apt:
@@ -31,7 +31,7 @@
       - libnss-mdns
       - wpasupplicant
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: "Install 22 common packages: acpid, bridge-utils, bzip2, curl, gawk, hostapd, htop, i2c-tools, logrotate, make, mlocate, netmask, net-tools, ntfs-3g, pandoc, rsync, sudo, tar, unzip, usbmount, usbutils, wget"
   package:

--- a/roles/2-common/tasks/yum-historical.yml
+++ b/roles/2-common/tasks/yum-historical.yml
@@ -13,18 +13,18 @@
 - name: get the createrepo program
   package: name=createrepo
            state=present
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Create local repo
   shell: createrepo {{ yum_packages_dir }}
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Install local repo file.
   template: dest=/etc/yum.repos.d/iiab-local.repo
             src=local.repo
             owner=root
             mode=0644
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Install yum packages
   package: name={{ item }}
@@ -36,7 +36,7 @@
    - linux-firmware
    - syslog
    - xml-common
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Install yum packages for Debian
   package: name={{ item }}
@@ -44,7 +44,7 @@
   with_items:
     - inetutils-syslogd
     - wpasupplicant
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install common packages
   package: name={{ item }}
@@ -82,7 +82,7 @@
    - glibc # CVE-2015-7547
    - bash
    - iptables
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Update common packages  (debian)
   package: name={{ item }}
@@ -91,7 +91,7 @@
    - libc6
    - bash
    - iptables
-  when: is_debuntu
+  when: is_debuntu | bool
 
 
 # instuctions state to start with a fully updated system before starting, stop using

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -5,27 +5,27 @@
 
 - name: Install dnsmasq
   include_tasks: roles/network/tasks/dnsmasq.yml
-  when: dnsmasq_install
+  when: dnsmasq_install | bool
   tags: base, domain, dnsmasq, network
 
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
-  when: named_install
+  when: named_install | bool
   tags: base, named, network, domain
 
 - name: Installing captive portal
   include_tasks: roles/captive-portal/tasks/main.yml
-  when: captive_portal_install
+  when: captive_portal_install | bool
   tags: base, captive-portal, network, domain
 
 - name: Installing dhcpd
   include_tasks: roles/network/tasks/dhcpd.yml
-  when: dhcpd_install
+  when: dhcpd_install | bool
   tags: base, dhcpd, network, domain
 
 - name: Install Squid (and DansGuardian if dansguardian_install)
   include_tasks: roles/network/tasks/squid.yml
-  when: squid_install
+  when: squid_install | bool
   tags: base, squid, network, domain
 
 # NETWORK moved to the very end, after Stage 9 (9-LOCAL-ADDONS)
@@ -47,7 +47,7 @@
 - name: POSTGRESQL
   include_role:
     name: postgresql
-  when: postgresql_install
+  when: postgresql_install | bool
   tags: postgresql, pathagar, moodle
 
 # UNMAINTAINED
@@ -60,19 +60,19 @@
 - name: CUPS
   include_role:
     name: cups
-  when: cups_install
+  when: cups_install | bool
   tags: cups
 
 - name: SAMBA
   include_role:
     name: samba
-  when: samba_install
+  when: samba_install | bool
   tags: samba
 
 - name: USB-LIB
   include_role:
     name: usb-lib
-  when: usb_lib_install
+  when: usb_lib_install | bool
   tags: usb-lib
 
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed at the beginning of Stage 3 = roles/3-base-server/tasks/main.yml, which ran Apache playbook = roles/httpd/tasks/main.yml)

--- a/roles/5-xo-services/tasks/main.yml
+++ b/roles/5-xo-services/tasks/main.yml
@@ -6,19 +6,19 @@
 - name: ACTIVITY-SERVER
   include_role:
     name: activity-server
-  when: activity_server_install
+  when: activity_server_install | bool
   tags: olpc, activity-server
 
 - name: EJABBERD_XS
   include_role:
     name: ejabberd_xs
-  when: ejabberd_xs_install
+  when: ejabberd_xs_install | bool
   tags: olpc, ejabberd-xs
 
 - name: IDMGR
   include_role:
     name: idmgr
-  when: idmgr_install
+  when: idmgr_install | bool
   tags: olpc, idmgr
 
 - name: Recording STAGE 5 HAS COMPLETED =====================

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -6,73 +6,73 @@
 - name: DOKUWIKI
   include_role:
     name: dokuwiki
-  when: dokuwiki_install
+  when: dokuwiki_install | bool
   tags: dokuwiki
 
 - name: MEDIAWIKI
   include_role:
     name: mediawiki
-  when: mediawiki_install
+  when: mediawiki_install | bool
   tags: mediawiki
 
 - name: EJABBERD
   include_role:
     name: ejabberd
-  when: ejabberd_install
+  when: ejabberd_install | bool
   tags: ejabberd
 
 - name: ELGG
   include_role:
     name: elgg
-  when: elgg_install
+  when: elgg_install | bool
   tags: elgg
 
 - name: GITEA
   include_role:
     name: gitea
-  when: gitea_install
+  when: gitea_install | bool
   tags: gitea
 
 - name: LOKOLE
   include_role:
     name: lokole
-  when: lokole_install
+  when: lokole_install | bool
   tags: lokole
 
 - name: MOSQUITTO
   include_role:
     name: mosquitto
-  when: mosquitto_install
+  when: mosquitto_install | bool
   tags: mosquitto
 
 - name: NODE-RED
   include_role:
     name: nodered
-  when: nodered_install
+  when: nodered_install | bool
   tags: nodered
 
 - name: NEXTCLOUD
   include_role:
     name: nextcloud
-  when: nextcloud_install
+  when: nextcloud_install | bool
   tags: nextcloud
 
 #- name: OWNCLOUD
 #  include_role:
 #    name: owncloud
-#  when: owncloud_install
+#  when: owncloud_install | bool
 #  tags: owncloud
 
 - name: PBX
   include_role:
     name: pbx
-  when: pbx_install
+  when: pbx_install | bool
   tags: pbx  
 
 - name: WORDPRESS
   include_role:
     name: wordpress
-  when: wordpress_install
+  when: wordpress_install | bool
   tags: wordpress
 
 - name: Recording STAGE 6 HAS COMPLETED ====================

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -6,31 +6,31 @@
 - name: KALITE
   include_role:
     name: kalite
-  when: kalite_install
+  when: kalite_install | bool
   tags: kalite
 
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install
+  when: kolibri_install | bool
   tags: kolibri
 
 - name: KIWIX
   include_role:
     name: kiwix
-  when: kiwix_install
+  when: kiwix_install | bool
   tags: kiwix
 
 - name: MOODLE
   include_role:
     name: moodle
-  when: moodle_install
+  when: moodle_install | bool
   tags: olpc, moodle
 
 - name: OSM-VECTOR-MAPS
   include_role:
     name: osm-vector-maps
-  when: osm_vector_maps_install
+  when: osm_vector_maps_install | bool
   tags: osm, maps
 
 # UNMAINTAINED
@@ -50,7 +50,7 @@
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install
+  when: sugarizer_install | bool
   tags: sugarizer
 
 - name: Recording STAGE 7 HAS COMPLETED ========================

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -6,31 +6,31 @@
 - name: TRANSMISSION
   include_role:
     name: transmission
-  when: transmission_install
+  when: transmission_install | bool
   tags: transmission
 
 - name: AWSTATS
   include_role:
     name: awstats
-  when: awstats_install
+  when: awstats_install | bool
   tags: awstats
   
 - name: MONIT
   include_role:
     name: monit
-  when: monit_install
+  when: monit_install | bool
   tags: monit
 
 - name: MUNIN
   include_role:
     name: munin
-  when: munin_install
+  when: munin_install | bool
   tags: munin
 
 - name: PHPMYADMIN
   include_role:
     name: phpmyadmin
-  when: phpmyadmin_install
+  when: phpmyadmin_install | bool
   tags: phpmyadmin
 
 # UNMAINTAINED
@@ -50,7 +50,7 @@
 - name: VNSTAT
   include_role:
     name: vnstat
-  when: vnstat_install
+  when: vnstat_install | bool
   tags: vnstat
 
 # UNMAINTAINED

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -6,19 +6,19 @@
 - name: CALIBRE
   include_role:
     name: calibre
-  when: calibre_install
+  when: calibre_install | bool
   tags: calibre
 
 - name: CALIBRE-WEB
   include_role:
     name: calibre-web
-  when: calibreweb_install
+  when: calibreweb_install | bool
   tags: calibre-web
 
 - name: MINETEST
   include_role:
     name: minetest
-  when: minetest_install
+  when: minetest_install | bool
   tags: minetest
 
 - name: Recording STAGE 9 HAS COMPLETED ====================

--- a/roles/activity-server/tasks/main.yml
+++ b/roles/activity-server/tasks/main.yml
@@ -79,7 +79,7 @@
 
 - name: enable mod_expires for debian
   command: a2enmod expires
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: create the link which enables the site
   file: src=/etc/apache2/sites-available/xs-activity-server.conf

--- a/roles/ajenti/tasks/ajenti-wondershaper.yml
+++ b/roles/ajenti/tasks/ajenti-wondershaper.yml
@@ -1,3 +1,3 @@
 - name: Install wondershaper ajenti plugin
   pip: name="{{ iiab_download_url }}"/ajenti-plugin-wondershaper-0.3.tar.gz
-  when: internet_available
+  when: internet_available | bool

--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -45,7 +45,7 @@
   service: name=ajenti
            enabled=yes
            state=restarted
-  when: ajenti_enabled
+  when: ajenti_enabled | bool
 
 - name: Add 'ajenti' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/authserver/tasks/main.yml
+++ b/roles/authserver/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Install xs-authserver from pypi
   pip: name=xs-authserver
-  when: internet_available
+  when: internet_available | bool
 
 - name: install gunicorn
   package: name=python-gunicorn
@@ -48,7 +48,7 @@
   service: name=xs-authserver
            state=restarted
            enabled=yes
-  when: authserver_enabled
+  when: authserver_enabled | bool
 
 - name: Add 'authserver' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -29,8 +29,8 @@
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
     state: directory
-    recurse: true
-    force: true
+    recurse: yes
+    force: yes
   with_items:
     - "{{ awstats_data_dir }}"
     - "{{ apache_log_dir }}"

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -14,13 +14,13 @@
       - libapache2-mod-authnz-external
       - apache2-utils
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
 - name: Enable cgi execution (debuntu)
   command: a2enmod cgi
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: 'Mandate {{ apache_user }}:{{ apache_user }} perm 0750 dirs: {{ awstats_data_dir }} (intermediate summary storage) & {{ apache_log_dir }}'    # /library/awstats & /var/log/apache2 typically
   file:
@@ -57,7 +57,7 @@
   template:
     src: logrotate.d.apache2
     dest: /etc/logrotate.d/apache2
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Check if package installed /etc/awstats/awstats.conf
   stat:
@@ -94,14 +94,14 @@
     owner: root
     group: root
     mode: 0644
-  when: awstats_enabled
+  when: awstats_enabled | bool
 
 - name: Create a symlink /etc/awstats/awstats.conf for access by IP address
   file:
     src: /etc/awstats/awstats.schoolserver.conf
     path: /etc/awstats/awstats.conf
     state: link
-  when: awstats_enabled
+  when: awstats_enabled | bool
 
 - name: On first enabling of AWStats, summarize httpd logs up to now (OS's other than debuntu)
   shell: /bin/perl /usr/share/awstats/wwwroot/cgi-bin/awstats.pl -config=schoolserver -update

--- a/roles/awstats/tasks/main.yml
+++ b/roles/awstats/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Install AWStats if awstats_install
   include_tasks: install.yml
-  when: awstats_install
+  when: awstats_install | bool
 
 - name: Add 'awstats' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -3,7 +3,7 @@
     name:
       - imagemagick
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Allow ImageMagick to read PDFs (debuntu)
   lineinfile:
@@ -12,7 +12,7 @@
     backrefs: yes
     line: '  <policy domain="coder" rights="read" pattern="PDF" />'
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Create 3 Calibre-Web folders to store data and configuration files
   file:
@@ -35,7 +35,7 @@
     #update: yes
     depth: 1
     version: master
-  when: internet_available
+  when: internet_available | bool
 
 ## Ansible Pip Bug: Cannot use 'chdir' with 'env' https://github.com/ansible/ansible/issues/37912 (Patch landed)
 #- name: Download calibre-web dependencies into vendor subdirectory.
@@ -51,7 +51,7 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"
     virtualenv_site_packages: no
-  when: internet_available
+  when: internet_available | bool
 
 - name: Symlink {{ calibreweb_venv_path }}/vendor to {{ calibreweb_venv_path }}/lib/python2.7/site-packages to keep cps.py happy
   file:
@@ -87,7 +87,7 @@
     - roles/calibre-web/files/metadata.db
     - roles/calibre-web/files/metadata_db_prefs_backup.json
   when: not metadatadb.stat.exists
-  #when: calibreweb_provision
+  #when: calibreweb_provision | bool
 
 - name: Provision/Copy default admin settings to {{ calibreweb_config }}/app.db IF metadata.db did not exist    # {{ calibreweb_config }} is /library/calibre-web/config
   copy:
@@ -98,7 +98,7 @@
     mode: 0644
     backup: yes
   when: not metadatadb.stat.exists
-  #when: calibreweb_provision
+  #when: calibreweb_provision | bool
 
 - name: Enable & Restart 'calibre-web' systemd service
   systemd:
@@ -106,17 +106,17 @@
     daemon_reload: yes
     enabled: yes
     state: restarted
-  when: calibreweb_enabled
+  when: calibreweb_enabled | bool
 
 # Default: http://box/books
 # SEE ALSO: https://github.com/janeczku/calibre-web/wiki/Setup-Reverse-Proxy
 - name: Enable http://box{{ calibreweb_url }} with Apache
   command: a2ensite calibre-web.conf
-  when: calibreweb_enabled
+  when: calibreweb_enabled | bool
 
 #- name: Restart Apache after enabling calibre-web httpd2 site
 #  command: apachectl -k graceful
-#  when: calibreweb_enabled
+#  when: calibreweb_enabled | bool
 
 - name: Disable 'calibre-web' systemd service
   systemd:

--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -121,7 +121,7 @@
     name: calibre-serve
     enabled: yes
     state: started
-  when: calibre_enabled
+  when: calibre_enabled | bool
   #async: 900
   #poll: 5
 

--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -64,7 +64,7 @@
     state: stopped
     #enabled: no
   #register: command_result    # gist.github.com/tyrells/0a79681de339237cb04c
-  #failed_when: false          # Never Fail during "systemctl stop calibre-serve" (even if service doesn't exist!)
+  #failed_when: False          # Never Fail during "systemctl stop calibre-serve" (even if service doesn't exist!)
   #when: calibre_svc.stat.exists
 
 # 3. CREATE USER DATABASE

--- a/roles/calibre/tasks/py-installer.yml
+++ b/roles/calibre/tasks/py-installer.yml
@@ -12,7 +12,7 @@
     backup: yes
     timeout: "{{ download_timeout }}"
   register: calibre_download_output
-  when: internet_available
+  when: internet_available | bool
 
 # ALWAYS DEFINED, DESPITE get_url DOCUMENTATION CLAIM...
 # - debug:
@@ -53,4 +53,4 @@
   shell: "{{ downloads_dir }}/calibre-installer.py >> /dev/null"
   #args:
   #  creates: /usr/bin/calibre-uninstall
-  when: internet_available
+  when: internet_available | bool

--- a/roles/captive-portal/tasks/main.yml
+++ b/roles/captive-portal/tasks/main.yml
@@ -10,7 +10,7 @@
   package:
     name: libapache2-mod-wsgi
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install mod_wsgi (not debuntu)
   package:
@@ -70,7 +70,7 @@
     owner: root
     group: root
     mode: 0644
-  when: captive_portal_enabled
+  when: captive_portal_enabled | bool
 
 - name: Enable Apache's captive-portal.conf if captive_portal_enabled (debuntu)
   file:
@@ -92,7 +92,7 @@
 #    daemon-reload: yes
 #    enabled: yes
 #    state: started
-#  when: captive_portal_enabled
+#  when: captive_portal_enabled | bool
 
 #- name: Disable & Stop captive-portal.service if not captive_portal_enabled
 #  systemd:
@@ -128,7 +128,7 @@
 #  systemd:
 #    name: dnsmasq
 #    state: restarted
-#  when: dnsmasq_enabled
+#  when: dnsmasq_enabled | bool
 
 # ABOVE DOES NOT WORK ON UBUNTU 16.04 -- what follows is a crude hack (seems to work!)
 
@@ -136,11 +136,11 @@
   systemd:
     name: dnsmasq
     state: stopped
-  when: dnsmasq_enabled
+  when: dnsmasq_enabled | bool
 
 - name: Start dnsmasq
   systemd:
     name: dnsmasq
     state: started
-  when: dnsmasq_enabled
+  when: dnsmasq_enabled | bool
   

--- a/roles/cups/tasks/main.yml
+++ b/roles/cups/tasks/main.yml
@@ -3,7 +3,7 @@
   package:
     name: cups
     state: present
-  when: cups_install
+  when: cups_install | bool
   tags:
     - download
 
@@ -43,7 +43,7 @@
 
 - name: Permit headless admin of CUPS -- only works when CUPS daemon is running
   shell: "cupsctl --remote-admin"
-  when: cups_enabled
+  when: cups_enabled | bool
 
 - name: Disable both CUPS services (OS's other than Fedora 18)
   systemd:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -4,7 +4,7 @@
   with_items:
     - docker
     - python-docker-py
-  when: docker_install
+  when: docker_install | bool
   tags: download
 
 - name: put the systemd startup file in place
@@ -32,7 +32,7 @@
   service: name=docker
            state=started
            enabled=true
-  when: docker_enabled
+  when: docker_enabled | bool
 
 - name: Disable docker
   service: name=docker

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -3,7 +3,7 @@
     url: "{{ iiab_download_url }}/{{ dokuwiki_version }}.tgz"
     dest: "{{ downloads_dir }}/"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: Unarchive (unpack) it to /library/{{ dokuwiki_version }}
   unarchive:
@@ -25,7 +25,7 @@
   template:
     src: dokuwiki.conf.j2
     dest: "/etc/{{ apache_config_dir }}/dokuwiki.conf"
-  when: dokuwiki_enabled
+  when: dokuwiki_enabled | bool
 
 - name: Symlink /etc/apache2/sites-enabled/dokuwiki.conf to /etc/apache2/sites-available/dokuwiki.conf if dokuwiki_enabled (debuntu)
   file:

--- a/roles/dokuwiki/tasks/main.yml
+++ b/roles/dokuwiki/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Install DokuWiki
   include_tasks: install.yml
-  when: dokuwiki_install
+  when: dokuwiki_install | bool
 
 - name: Add 'dokuwiki' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -36,7 +36,7 @@
 #    src: ejabberd-iiab.init
 #    dest: /etc/init.d/ejabberd-iiab
 #    mode: 0755
-#  when: is_debuntu
+#  when: is_debuntu | bool
 
 #- name: Put the startup script in place - non debian
 #  template:
@@ -73,7 +73,7 @@
     #name: ejabberd-iiab
     state: restarted
     enabled: yes
-  when: ejabberd_enabled
+  when: ejabberd_enabled | bool
   #when: ejabberd_config.changed and ejabberd_enabled
 
 #- name: Wait for ejabberd service start

--- a/roles/elgg/tasks/main.yml
+++ b/roles/elgg/tasks/main.yml
@@ -9,7 +9,7 @@
     url: "{{ iiab_download_url }}/elgg-{{ elgg_version }}.zip"
     dest: "{{ downloads_dir }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: Check for existence of /opt/elgg-{{ elgg_version }}/index.php
   stat:

--- a/roles/elgg/tasks/main.yml
+++ b/roles/elgg/tasks/main.yml
@@ -34,7 +34,7 @@
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
     state: link
-    force: true
+    force: yes
 
 - name: 'Install /opt/elgg/elgg-config/settings.php from template (WARNING: overwrites manual settings!)'
   template:

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -54,4 +54,4 @@ gitea_log_root: "{{ gitea_root_directory }}/log"
 
 # Extra configuration
 gitea_display_name: Internet-in-a-Box Gitea
-skip_install_screen: true
+skip_install_screen: true    # lowercase for Gitea's own /etc/gitea/app.ini

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -59,7 +59,7 @@
     mode: 0775
   tags:
     - install
-  when: internet_available
+  when: internet_available | bool
 
 - name: Download Gitea GPG signature
   get_url:
@@ -68,7 +68,7 @@
   tags:
     - never
     - verify
-  when: internet_available
+  when: internet_available | bool
 
 - name: Verify Gitea binary with GPG signature
   shell: |
@@ -131,7 +131,7 @@
     name: gitea
     enabled: yes
     state: restarted
-  when: gitea_enabled
+  when: gitea_enabled | bool
 
 - name: Disable 'gitea' service
   systemd:

--- a/roles/gitea/tasks/main.yml
+++ b/roles/gitea/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: Install Gitea {{ gitea_version }} if gitea_install
   include_tasks: install.yml
-  when: gitea_install
+  when: gitea_install | bool

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -16,4 +16,4 @@
     src: "/etc/{{ apache_config_dir }}/iiab-homepage.conf"
     path: /etc/apache2/sites-enabled/iiab-homepage.conf
     state: link
-  when: is_debuntu
+  when: is_debuntu | bool

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -7,7 +7,7 @@
       - "php{{ php_version }}"
       - "php{{ php_version }}-curl"
     state: present
-  when: is_debian
+  when: is_debian | bool
   tags:
     - download
 
@@ -19,7 +19,7 @@
       - apache2
       - php
     state: present
-  when: is_ubuntu
+  when: is_ubuntu | bool
   tags:
     - download
 
@@ -44,7 +44,7 @@
       - php
       - php-curl
     state: present
-  when: is_redhat
+  when: is_redhat | bool
   tags:
     - download
 
@@ -68,7 +68,7 @@
     path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
-  when: apache_high_php_limits
+  when: apache_high_php_limits | bool
   with_items:
     - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
     - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
@@ -84,7 +84,7 @@
   with_items:
     - mpm_event.conf
     - mpm_event.load
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Create both mpm_prefork symlinks from /etc/apache2/mods-enabled to /etc/apache2/mods-available (debuntu)
   file:
@@ -94,7 +94,7 @@
   with_items:
     - mpm_prefork.conf
     - mpm_prefork.load
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: 'Turn on mod_proxy using a2enmod with: proxy, proxy_html, headers, rewrite (debuntu)'
   command: a2enmod {{ item }}
@@ -103,14 +103,14 @@
     - proxy_html
     - headers
     - rewrite
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Enable our site, creating 010-iiab.conf symlink from sites-enabled to sites-available (debuntu)
   file:
     src: "/etc/{{ apache_config_dir }}/010-iiab.conf"
     path: /etc/apache2/sites-enabled/010-iiab.conf
     state: link
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Remove 000-default.conf from /etc/apache2 and /etc/apache2/sites-enabled (debuntu)
   file:
@@ -119,7 +119,7 @@
   with_items:
     - /etc/apache2/000-default.conf    # Not nec on Raspbian.  Is this really still needed elsewhere?
     - /etc/apache2/sites-enabled/000-default.conf
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Create Apache's pid dir /var/run/{{ apache_user }}
   file:
@@ -178,7 +178,7 @@
     path: /etc/apache2/sites-enabled/osm.conf
     #path: "/etc/{{ apache_service }}/sites-enabled/osm.conf"
     state: link
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - include_tasks: html.yml
   tags:
@@ -200,7 +200,7 @@
     src: 020_apache_poweroff.j2
     dest: /etc/sudoers.d/020_apache_poweroff
     mode: 0755
-  when: apache_allow_sudo
+  when: apache_allow_sudo | bool
 
 - name: Remove {{ apache_user }} (per variable apache_user) permission to poweroff, removing /etc/sudoers.d/020_apache_poweroff
   file:

--- a/roles/httpd/tasks/php-stem.yml
+++ b/roles/httpd/tasks/php-stem.yml
@@ -5,7 +5,7 @@
 
 #- name: Download php-stem.rpi.tar
 #  command: cd /; wget http://download.iiab.io/packages/php-stem.rpi.tar
-#  when: is_rpi
+#  when: is_rpi | bool
 
 #- name: Download php-stem.x86.tar
 #  command: cd /; wget http://download.iiab.io/packages/php-stem.x64.tar
@@ -19,7 +19,7 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: is_rpi
+  when: is_rpi | bool
 
 - name: Unarchive http://download.iiab.io/packages/php-stem.x64.tar to / (debian-9 on x86_64 only)
   unarchive:

--- a/roles/idmgr/tasks/main.yml
+++ b/roles/idmgr/tasks/main.yml
@@ -44,7 +44,7 @@
   with_items:
     - idmgr
     - xinetd
-  when: xo_services_enabled
+  when: xo_services_enabled | bool
 
 - name: Disable idmgr service
   service: name={{ item }}

--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -14,7 +14,7 @@
   group:
     name: sudo
     state: present
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: 'Add user {{ iiab_admin_user }} to groups: wheel, sudo'
   user:

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: admin-user.yml
   tags:
     - base
-  when: iiab_admin_user_install
+  when: iiab_admin_user_install | bool
 
 - include_tasks: access.yml
   tags:

--- a/roles/kalite/tasks/install-f18.yml
+++ b/roles/kalite/tasks/install-f18.yml
@@ -7,7 +7,7 @@
   with_items:
     - python-psutil
     - expect
-  when: is_F18
+  when: is_F18 | bool
 
 - name: Install dependent pip packages (Fedora 18)
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -12,7 +12,7 @@
     url: "{{ kalite_requirements }}"
     dest: "{{ pip_packages_dir }}/kalite.txt"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 #- name: Install KA Lite non-static + reqs file with pip - (debuntu)
 #  pip: requirements={{ pip_packages_dir }}/kalite.txt

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Set KA Lite's SQLite filename (Fedora 18)
   set_fact:
     kalite_db_name: "{{ kalite_root }}/kalite/database/data.sqlite"
-  when: is_F18
+  when: is_F18 | bool
 
 - name: Set KA Lite's SQLite filename (OS's other than Fedora 18)
   set_fact:

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -47,7 +47,7 @@
     owner: root
     group: root
     force: no
-  when: kiwix_force_install
+  when: kiwix_force_install | bool
 
 - name: Create {{ kiwix_path }}/bin directory    # /opt/iiab/kiwix/bin
   file:
@@ -65,11 +65,11 @@
     dest: /tmp
     owner: root
     group: root
-  when: kiwix_force_install
+  when: kiwix_force_install | bool
 
 - name: Move /tmp/{{ kiwix_src_dir }}/* to permanent location /opt/iiab/kiwix/bin (armhf & linux64 & i686)
   shell: "mv /tmp/{{ kiwix_src_dir }}/* {{ kiwix_path }}/bin/"
-  when: kiwix_force_install
+  when: kiwix_force_install | bool
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU
 
@@ -81,7 +81,7 @@
   - proxy_html
   - proxy_http
   - rewrite
-  when: is_debuntu
+  when: is_debuntu | bool
 
 # 4. CREATE/ENABLE/RESTART (OR DISABLE) KIWIX SERVICE & ITS CRON JOB
 
@@ -106,14 +106,14 @@
     src: /etc/apache2/sites-available/kiwix.conf
     path: /etc/apache2/sites-enabled/kiwix.conf
     state: link
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Enable & Restart 'kiwix-serve' service
   service:
     name: kiwix-serve
     enabled: yes
     state: restarted
-  when: kiwix_enabled
+  when: kiwix_enabled | bool
 
 - name: Disable 'kiwix-serve' service
   service:

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -28,7 +28,7 @@
     url: "{{ iiab_download_url }}/{{ kiwix_src_file }}"
     dest: "{{ downloads_dir }}/{{ kiwix_src_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: Check for /opt/iiab/downloads/{{ kiwix_src_file }}
   stat:

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -27,17 +27,17 @@
     virtualenv_site_packages: no
     state: latest
     extra_args: --no-cache-dir
-  when: internet_available
+  when: internet_available | bool
 
 - name: Run Kolibri migrations
   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" manage migrate
   ignore_errors: yes
-  when: kolibri_provision
+  when: kolibri_provision | bool
 
 - name: Set Kolibri default language
   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
   ignore_errors: yes
-  when: kolibri_provision
+  when: kolibri_provision | bool
 
 - name: Create Kolibri default facility name, admin account and language
   shell: >
@@ -46,7 +46,7 @@
     --superusername "{{ kolibri_admin_user }}" --superuserpassword "{{ kolibri_admin_password }}"
     --preset "{{ kolibri_preset }}" --language_id "{{ kolibri_language }}" --verbosity 0 --noinput
   ignore_errors: yes
-  when: kolibri_provision
+  when: kolibri_provision | bool
 
 - name: chown -R {{ kolibri_user }}:{{ apache_user }} {{ kolibri_home }}
   file:
@@ -72,12 +72,12 @@
     enabled: yes
     state: restarted
     daemon_reload: yes
-  when: kolibri_enabled
+  when: kolibri_enabled | bool
 
 # Default: http://box/kolibri
 - name: Enable http://box{{ kolibri_url }} with Apache
   command: a2ensite kolibri.conf
-  when: kolibri_enabled
+  when: kolibri_enabled | bool
 
 - name: Disable kolibri service
   systemd:

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -20,7 +20,7 @@
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
   tags:
     - install
-  when: internet_available
+  when: internet_available | bool
 
 - name: Compile translations
   shell: |
@@ -73,7 +73,7 @@
     name: lokole
     enabled: yes
     state: restarted
-  when: lokole_enabled
+  when: lokole_enabled | bool
 
 - name: Disable 'lokole' service, if not lokole_enabled
   systemd:

--- a/roles/lokole/tasks/main.yml
+++ b/roles/lokole/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: Install Lokole {{ lokole_version }} if lokole_install
   include_tasks: install.yml
-  when: lokole_install
+  when: lokole_install | bool

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -14,7 +14,7 @@
     timeout: "{{ download_timeout }}"
     #force: yes
     #backup: yes
-  when: internet_available
+  when: internet_available | bool
 
 - name: Unpack it to permanent location {{ mediawiki_abs_path }}
   unarchive:

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: Install MediaWiki {{ mediawiki_version }} if mediawiki_install
   include_tasks: install.yml
-  when: mediawiki_install
+  when: mediawiki_install | bool

--- a/roles/minetest/tasks/calc_vars.yml
+++ b/roles/minetest/tasks/calc_vars.yml
@@ -7,7 +7,7 @@
 # only works if server run as root
     minetest_runas_user: root
     minetest_runas_group: root
-  when: is_rpi
+  when: is_rpi | bool
 
 # For other installs
 - name: Set some facts for other platforms

--- a/roles/minetest/tasks/main.yml
+++ b/roles/minetest/tasks/main.yml
@@ -78,7 +78,7 @@
     name: minetest-server
     enabled: yes
     state: restarted
-  when: minetest_enabled
+  when: minetest_enabled | bool
 
 - name: Disable 'minetest-server' service
   systemd:

--- a/roles/minetest/tasks/minetest_install.yml
+++ b/roles/minetest/tasks/minetest_install.yml
@@ -24,7 +24,7 @@
     line: "{{ item.line }}"
   with_items:
     - { regexp: '^mg_name = ', line: 'mg_name = flat' }
-  when: minetest_flat_world
+  when: minetest_flat_world | bool
 
 - name: Create /library/games/minetest/worlds/world
   file:

--- a/roles/minetest/tasks/rpi_minetest_install.yml
+++ b/roles/minetest/tasks/rpi_minetest_install.yml
@@ -49,4 +49,4 @@
   with_items:
     - { src: 'minetest.conf.j2', dest: '/etc/minetest/minetest.conf' }
     - { src: 'minetest-server.service.j2', dest: '/etc/systemd/system/minetest-server.service' }
-  when: minetest_install
+  when: minetest_install | bool

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -90,7 +90,7 @@
   group:
     name: mongodb
     state: present
-  when: is_rpi
+  when: is_rpi | bool
 
 - name: Create Linux user mongodb (rpi)
   user:
@@ -99,7 +99,7 @@
     groups: mongodb
     home: /var/lib/mongodb
     shell: /usr/sbin/nologin
-  when: is_rpi
+  when: is_rpi | bool
 
 
 # 2. CONFIGURE FOR IIAB
@@ -137,7 +137,7 @@
     daemon_reload: yes
     enabled: yes
     state: restarted
-  when: mongodb_enabled
+  when: mongodb_enabled | bool
 
 - name: Disable 'mongodb' service, if not mongodb_enabled
   systemd:

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -22,7 +22,7 @@
     group: root
     mode: 0600
 
-- name: Install config file /etc/monit.d/watchdog from template
+- name: Install config file /etc/monit.d/watchdog from template (NEVER RUNS, WHY?)
   template:
     src: watchdog
     dest: /etc/monit.d/watchdog
@@ -31,7 +31,7 @@
     force: yes
     mode: 0755
   register: monit_config
-  when: false | bool
+  when: False    # IS THIS A BUG ?
   until: monit_config | success
   retries: 5
   delay: 1

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -31,7 +31,7 @@
     force: yes
     mode: 0755
   register: monit_config
-  when: false
+  when: false | bool
   until: monit_config | success
   retries: 5
   delay: 1

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -18,7 +18,7 @@
       # mbstring is now included in php-cli
       - php{{ php_version }}-cli
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: "Install package: php{{ php_version }}-zip (ubuntu or debian-9+)"
   package:
@@ -28,7 +28,7 @@
 - name: "Install package: php-pclzip (debian-8)"
   package:
     name: php-pclzip
-  when: is_debian_8
+  when: is_debian_8 | bool
 
 - name: Determine if Moodle is already downloaded
   stat:
@@ -80,7 +80,7 @@
     owner: root
     group: root
     mode: 0644
-  when: moodle_enabled
+  when: moodle_enabled | bool
 
 - name: Create symlink 022-moodle.conf from sites-enabled to sites-available, if moodle_enabled (debuntu)
   file:
@@ -131,7 +131,7 @@
     name: postgresql-iiab
     state: restarted
     enabled: yes
-  when: moodle_enabled
+  when: moodle_enabled | bool
 
 - name: Restart Apache service ({{ apache_service }})
   service:

--- a/roles/mosquitto/tasks/main.yml
+++ b/roles/mosquitto/tasks/main.yml
@@ -5,7 +5,7 @@
   with_items:
     - mosquitto
     - mosquitto-clients
-  when: mosquitto_install
+  when: mosquitto_install | bool
   tags: download
 
 - name: Disable & Stop 'mosquitto' service
@@ -13,18 +13,18 @@
     name: mosquitto
     enabled: no
     state: stopped
-  when: mosquitto_install
+  when: mosquitto_install | bool
 
 - name: Create (touch) file /etc/mosquitto/passwd
   file:
     path: /etc/mosquitto/passwd
     state: touch
     mode: "u=rw,g=r,o=r"    # 0644
-  when: mosquitto_install
+  when: mosquitto_install | bool
 
 - name: Populate /etc/mosquitto/passwd with actual username/password
   shell: mosquitto_passwd -b /etc/mosquitto/passwd "{{ mosquitto_user }}" "{{ mosquitto_password  }}"
-  when: mosquitto_install
+  when: mosquitto_install | bool
 
 - name: Install /etc/mosquitto/conf.d/websockets.conf from template
   template:
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0755
-  when: mosquitto_install
+  when: mosquitto_install | bool
 
 - name: Enable & Start 'mosquitto' service
   systemd:
@@ -42,4 +42,4 @@
     name: mosquitto
     enabled: yes
     state: started
-  when: mosquitto_enabled
+  when: mosquitto_enabled | bool

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -9,7 +9,7 @@
     state: present
   tags:
     - download
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: "Install 2 packages: munin, munin-node (OS's other than debuntu)"
   package:
@@ -45,7 +45,7 @@
     name: munin-node
     enabled: yes
     state: started
-  when: munin_enabled
+  when: munin_enabled | bool
 
 - name: Create symlink munin24.conf from sites-enabled to sites-available (debuntu)
   file:
@@ -79,7 +79,7 @@
     - /usr/share/munin/plugins/mysql_queries
     - /usr/share/munin/plugins/mysql_slowqueries
     - /usr/share/munin/plugins/mysql_threads
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Add 'munin' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -14,7 +14,7 @@
       #- php{{ php_version }}-xml
       - php{{ php_version }}-xmlrpc
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
@@ -28,7 +28,7 @@
   package:
     name: php-xml-parser
     state: present
-  when: is_debian_8
+  when: is_debian_8 | bool
 
 - name: "Install packages: mysql, MySQL-python and 9 php packages (OS's other than debuntu)"
   package:
@@ -64,13 +64,13 @@
   systemd:
     name: "{{ mysql_service }}"
     state: started
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Enable MySQL systemd service (upon subsequent boots) if mysql_enabled
   systemd:
     name: "{{ mysql_service }}"
     enabled: yes
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 # 'localhost' needs to be the last item for idempotency, see
 # http://ansible.cc/docs/modules.html#mysql-user
@@ -81,7 +81,7 @@
     host: localhost
     password: "{{ mysql_root_password }}"
     priv: "*.*:ALL,GRANT"
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Install .my.cnf file from template, with root password credentials, if mysql_enabled
   template:
@@ -89,7 +89,7 @@
     dest: /root/.my.cnf
     owner: root
     mode: 0600
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Update MySQL root password for all remaining root accounts (127.0.0.1, ::1) if mysql_enabled
   mysql_user:
@@ -101,26 +101,26 @@
     #- "{{ iiab_hostname }}.{{ iiab_domain }}"
     - 127.0.0.1
     - ::1
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Delete anonymous MySQL server user for {{ ansible_hostname }}, if mysql_enabled
   mysql_user:
     user: ""
     host: "{{ ansible_hostname }}"
     state: absent
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Delete anonymous MySQL server user for localhost, if mysql_enabled
   mysql_user:
     user: ""
     state: absent
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 - name: Remove the MySQL 'test' database, if mysql_enabled
   mysql_db:
     db: test
     state: absent
-  when: mysql_enabled
+  when: mysql_enabled | bool
 
 # we had to start mysql in order to configure it, now turn if off if not enabled
 - name: Config is done but now DISABLE MySQL service, if not mysql_enabled

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -24,7 +24,7 @@
   shell: "ls /usr/share/doc/ | grep avahi | head -n1"
   register: avahi_ver
   ignore_errors: True
-  changed_when: false
+  changed_when: False
   # when: not is_debuntu    # would cause failures 6 lines below
 
 - name: Grab a clean copy of ssh.service (not debuntu)

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -33,7 +33,7 @@
     enabled: no
     state: stopped
   when: is_ubuntu and not is_ubuntu_16
-  #when: is_ubuntu_18
+  #when: is_ubuntu_18 | bool
 
 - name: Install systemd unit file to /etc/systemd/system/dhcpd.service
   template:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -107,7 +107,7 @@
 - name: Netplan in use on Ubuntu 18.04+
   include_tasks: netplan.yml
   when: is_ubuntu and not is_ubuntu_16
-  #when: is_ubuntu_18
+  #when: is_ubuntu_18 | bool
   #and not installing
   tags:
     - network

--- a/roles/nextcloud/tasks/F18.yml
+++ b/roles/nextcloud/tasks/F18.yml
@@ -9,7 +9,7 @@
     url: "{{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }}"
     dest: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: Copy it to permanent location /opt
   unarchive:

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -50,7 +50,7 @@
       - "php{{ php_version }}-mbstring"
       - "php{{ php_version }}-zip"
     state: present
-  when: is_debian
+  when: is_debian | bool
 
 # Ubuntu and Debian treat names differently
 - name: Install 4 php packages (ubuntu)
@@ -61,7 +61,7 @@
       - php-zip
       - php-mbstring
     state: present
-  when: is_ubuntu
+  when: is_ubuntu | bool
 
 - name: Install 5 more php packages (debuntu)
   package:
@@ -72,7 +72,7 @@
       - "php{{ php_version }}-curl"
       - "php{{ php_version }}-intl"
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: 'Install php{{ php_version }}-mcrypt IF this is a "pre-2018" distro in the debuntu family. NOTE: PHP 7.1 deprecated mcrypt 1-Dec-2016 and PHP 7.2 dropped it completely 30-Nov-2017, as it should no longer be nec.'
   package:
@@ -98,7 +98,7 @@
       # CentOS does not have a package for php-imagick
       #- php-imagick
     state: present
-  when: is_redhat
+  when: is_redhat | bool
 
 - name: Unarchive {{ nextcloud_src_file_old }} to permanent location {{ nextcloud_prefix }}/nextcloud on older OS's lacking PHP 7.1+    # e.g. unpack nextcloud_latest-15.tar.bz2 to /opt/nextcloud
   unarchive:
@@ -118,7 +118,7 @@
   file:
     path: /etc/nextcloud
     state: directory
-  when: is_centos
+  when: is_centos | bool
 
 - name: Install {{ nextcloud_prefix }}/nextcloud/config/autoconfig.php from template (centos)
   template:
@@ -127,7 +127,7 @@
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
     mode: 0640
-  when: is_centos
+  when: is_centos | bool
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ nextcloud_prefix }}/nextcloud
   file:

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -168,7 +168,7 @@
 #  service:
 #    name: "{{ apache_service }}"
 #    state: restarted
-## when: nextcloud_enabled     # taken care of by nextcloud_enabled.yml below
+## when: nextcloud_enabled | bool    # taken care of by nextcloud_enabled.yml below
 #  when: not nextcloud_enabled
 
 # Enables or disable Nextcloud!

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -21,12 +21,11 @@
     timeout: "{{ download_timeout }}"
     force: yes
     #validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
-  when: internet_available and nextcloud_force_install
   #async: 1800
   #poll: 10
   tags:
     - download
-  when: is_debian_9 or is_raspbian_9
+  when: internet_available and nextcloud_force_install and (is_debian_9 or is_raspbian_9)
 
 - name: Download {{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }} to {{ downloads_dir }}/{{ nextcloud_src_file }} on newer OS's that have PHP 7.1+
   get_url:
@@ -35,12 +34,11 @@
     timeout: "{{ download_timeout }}"
     force: yes
     #validate_certs: False    # TEMPORARY ON/AFTER 2018-07-22 AS download.nextcloud.com CERT EXPIRED: https://github.com/iiab/iiab/issues/954
-  when: internet_available and nextcloud_force_install
   #async: 1800
   #poll: 10
   tags:
     - download
-  when: not (is_debian_9 or is_raspbian_9)
+  when: internet_available and nextcloud_force_install and not (is_debian_9 or is_raspbian_9)
 
 # Ubuntu and Debian treat names differently
 - name: Install 3 php packages (debian)

--- a/roles/nextcloud/tasks/nextcloud_enabled.yml
+++ b/roles/nextcloud/tasks/nextcloud_enabled.yml
@@ -11,7 +11,7 @@
     owner: root
     group: root
     mode: 0644
-  when: nextcloud_enabled
+  when: nextcloud_enabled | bool
 
 - name: Create symlink nextcloud.conf from sites-enabled to sites-available for http://box/nextcloud (debuntu)
   file:

--- a/roles/nodered/meta/main.yml
+++ b/roles/nodered/meta/main.yml
@@ -1,3 +1,2 @@
  dependencies:
-     - { role: nodejs, tags: ['nodejs'], when: nodered_install }
-
+     - { role: nodejs, tags: ['nodejs'], when: nodered_install | bool }

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -14,7 +14,7 @@
   package:
     name: nodered
     state: absent
-  when: nodered_install
+  when: nodered_install | bool
 
 # 2012-02-13: the 6 RPi stanzas below recreate Raspbian Desktop's Node-RED
 # environment, inspired by:
@@ -159,7 +159,7 @@
     owner: root
     group: root
     mode: 0666
-  when: nodered_install
+  when: nodered_install | bool
 
 - name: Install Apache's sites-available/nodered.conf from template
   template:
@@ -169,7 +169,7 @@
     owner: root
     group: root
     mode: 0666
-  when: nodered_install
+  when: nodered_install | bool
 
 - name: Create symlink nodered.conf from sites-enabled to sites-available, for short URL http://box/nodered (if nodered_enabled)
   file:
@@ -178,7 +178,7 @@
     owner: root
     group: root
     state: link
-  when: nodered_enabled
+  when: nodered_enabled | bool
 
 - name: Remove symlink /etc/apache2/sites-enabled/nodered.conf (if not nodered_enabled)
   file:
@@ -190,14 +190,14 @@
   apache2_module:
     state: present
     name: proxy_wstunnel
-  when: nodered_install
+  when: nodered_install | bool
 
 - name: Restart Apache service ({{ apache_service }}) to enable/disable http://box/nodered (not just http://box:{{ nodered_port }}/nodered)
   systemd:
     #daemon_reload: yes
     name: "{{ apache_service }}"    # httpd or apache2
     state: restarted
-  when: nodered_install
+  when: nodered_install | bool
 
 - name: Enable & (Re)start 'nodered' systemd service (if nodered_enabled)
   systemd:
@@ -205,7 +205,7 @@
     name: nodered
     enabled: yes
     state: restarted
-  when: nodered_enabled
+  when: nodered_enabled | bool
 
 - name: Disable & Stop 'nodered' systemd service (if not nodered_enabled)
   systemd:

--- a/roles/nodogsplash/tasks/main.yml
+++ b/roles/nodogsplash/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: Install nodogsplash (Raspbian only)
   include_tasks: rpi.yml
-  when: is_rpi
+  when: is_rpi | bool

--- a/roles/nodogsplash/tasks/rpi.yml
+++ b/roles/nodogsplash/tasks/rpi.yml
@@ -8,7 +8,7 @@
      url: "{{ iiab_download_url }}/{{ nodogsplash_arm_deb }}"
      dest: "{{ downloads_dir }}/{{ nodogsplash_arm_deb }}"
      timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
   #async: 300
   #poll: 5
 
@@ -43,7 +43,7 @@
     name: nodogsplash
     enabled: yes
     state: started
-  when: nodogsplash_enabled
+  when: nodogsplash_enabled | bool
 
 - name: Disable 'nodogsplash' systemd service, if not nodogsplash_enabled
   systemd:

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -13,7 +13,7 @@
     regexp: "{{ item.regexp }}"
     path: /root/.ssh/authorized_keys
     #backup: yes
-  when: openvpn_install
+  when: openvpn_install | bool
   with_items:
     - regexp: "LvCSAAcfYIdZPR4ePVpVUZ/IbkGjpQSoRMa5HuVjMO3cZNR27ptqjNjq2husJOyhMFCOBTzo4thioGyTpBr4u3s=$" # Tim Moody
       pubkey: "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAhlQIh8ZPx4awdM0O6QNcPbx3qIZ39FHjF2YJ2SX3z7iLnYiz03Ek6Bux9P4HvaVAqlApiz2I68Vq8TfU2s/+LvCSAAcfYIdZPR4ePVpVUZ/IbkGjpQSoRMa5HuVjMO3cZNR27ptqjNjq2husJOyhMFCOBTzo4thioGyTpBr4u3s="
@@ -117,7 +117,7 @@
 #  template:
 #    src: up_wan
 #    dest: /usr/lib/iiab/up_wan
-#  when: is_debuntu
+#  when: is_debuntu | bool
 
 # Contained serious bug (15-openvpn called up-wan instead of up_wan in
 # /usr/lib/iiab/ as of August 2018) so evidently unused for ~2 years:
@@ -178,7 +178,7 @@
     daemon_reload: yes
     enabled: yes
     state: restarted    # 2018-09-02: Should we be concerned that "systemctl status openvpn" often shows "active (exited)" ?  If so we might consider "state: started" or "state: reloaded" instead?
-  when: openvpn_enabled
+  when: openvpn_enabled | bool
 
 - name: Enable hourly cron job for OpenVPN (starts CHILD service openvpn@xscenet, typically for CentOS only?)
   lineinfile:

--- a/roles/osm/tasks/main.yml
+++ b/roles/osm/tasks/main.yml
@@ -7,7 +7,7 @@
       - libapache2-mod-wsgi
       - libapache2-mod-xsendfile
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install 6 OSM required packages (not debuntu)
   package:
@@ -110,7 +110,7 @@
     group: root
     mode: 0644
     backup: no
-  when: osm_enabled
+  when: osm_enabled | bool
 
 - name: Create softlink osm.conf from sites-enabled to sites-available (debuntu)
   file:
@@ -144,7 +144,7 @@
     owner: root
     group: root
     state: link
-  when: osm_enabled
+  when: osm_enabled | bool
 
 - name: Create dir /library/knowledge/modules
   file:
@@ -165,7 +165,7 @@
     - { src: 'map.html', dest: "{{ osm_path }}/static/map.html" }
     - { src: 'l.control.geosearch.js', dest: "{{ osm_path }}/static/lib/leaflet/geosearch/l.control.geosearch.js" }
     - { src: "{{ osm_path }}/static/map.html", dest: "{{ osm_path }}/static/index.html" }
-  when: osm_enabled
+  when: osm_enabled | bool
 
 - name: Restart httpd service
   service:

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: add a repo def for ubuntu
   template: dest=/etc/apt/sources.list.d/
             src=owncloud.list
-  when: is_ubuntu
+  when: is_ubuntu | bool
 
 - name: See if the owncloud startup page exists
   stat: path={{ owncloud_prefix }}/owncloud/index.php
@@ -40,7 +40,7 @@
 
 - name: Get the owncloud software
   get_url: url={{ iiab_download_url }}/{{ owncloud_src_file }}  dest={{ downloads_dir }}/{{ owncloud_src_file }}
-  when: internet_available
+  when: internet_available | bool
   async: 300
   poll: 5
 
@@ -54,7 +54,7 @@
 - name: Copy it to permanent location /opt
   unarchive: src={{ downloads_dir }}/{{ owncloud_src_file }}
              dest={{ owncloud_prefix }}
-  when: is_F18
+  when: is_F18 | bool
 
 - name: in Centos, the following config dir is symlink to /etc/owncloud
   file: path=/etc/owncloud
@@ -103,7 +103,7 @@
 # Enable owncloud by copying template to httpd config
 
 - include_tasks: owncloud_enabled.yml
-  when: owncloud_enabled
+  when: owncloud_enabled | bool
 
 - name: Add 'owncloud' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -20,7 +20,7 @@
     - libapache2-mod-wsgi
     - libxml2-dev
     - libxslt-dev
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Install Pathagar prerequisites (not debuntu)
   package:
@@ -69,7 +69,7 @@
     - django-tagging==0.3.1
     - django-sendfile==0.3.6
     - lxml==3.4.4
-  when: internet_available
+  when: internet_available | bool
 
 - name: Install Pathagar requirements in a virtualenv
   pip:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -6,7 +6,7 @@
     url: "{{ asterisk_url }}/{{ asterisk_src_file }}"
     dest: "{{ downloads_dir }}/{{ asterisk_src_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: Asterisk - Check for /opt/iiab/downloads/{{ asterisk_src_file }}
   stat:

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -3,7 +3,7 @@
     url: "{{ chan_dongle_url }}/{{ chan_dongle_src_file }}"
     dest: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: chan_dongle - Check for /opt/iiab/downloads/{{ chan_dongle_src_file }}
   stat:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -6,7 +6,7 @@
     url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
     dest: "{{ downloads_dir }}/{{ freepbx_src_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
 
 - name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
   stat:
@@ -121,7 +121,7 @@
     src: /etc/apache2/sites-available/freepbx.conf
     dest: /etc/apache2/sites-enabled/freepbx.conf
     state: link
-  when: pbx_enabled
+  when: pbx_enabled | bool
 
 - name: FreePBX - Remove symlink /etc/apache2/sites-enabled/freepbx.conf (if not pbx_enabled)
   file: 

--- a/roles/pbx/tasks/freepbx_enable.yml
+++ b/roles/pbx/tasks/freepbx_enable.yml
@@ -4,7 +4,7 @@
     name: freepbx
     enabled: yes
     state: restarted
-  when: pbx_enabled
+  when: pbx_enabled | bool
 
 - name: FreePBX - Disable & Stop 'freepbx' systemd service (if not pbx_enabled)
   systemd:

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -44,4 +44,4 @@
 
 - name: Asterisk - Install chan_dongle
   include: chan_dongle.yml
-  when: asterisk_chan_dongle
+  when: asterisk_chan_dongle | bool

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -4,7 +4,7 @@
     dest: "{{ downloads_dir }}"
     timeout: "{{ download_timeout }}"
   #register: phpmyadmin_dl_output
-  when: internet_available
+  when: internet_available | bool
 
 - name: Does {{ downloads_dir }}/{{ phpmyadmin_name_zip }} exist?    # e.g. /opt/iiab/downloads/phpMyAdmin-4.8.3-all-languages.zip
   stat:
@@ -50,7 +50,7 @@
   template:
     src: phpmyadmin.j2
     dest: "/etc/{{ apache_config_dir }}/phpmyadmin.conf"
-  when: phpmyadmin_enabled
+  when: phpmyadmin_enabled | bool
 
 - name: Create symlink phpmyadmin.conf from sites-enabled to sites-available (debuntu)
   file:

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -9,7 +9,7 @@
   package:
     name: postgresql-client
     state: present
-  when: is_debuntu
+  when: is_debuntu | bool
   tags:
     - download
 
@@ -41,11 +41,11 @@
   lineinfile:
     dest: /etc/locale.gen
     line: "{{ postgresql_locale }} UTF-8"
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Generate locales (debuntu)
   command: /usr/sbin/locale-gen
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Initialize the PostgreSQL db, creating /library/pgsql-iiab/pg_hba.conf (debuntu)
   #command: su - postgres -c "/usr/lib/postgresql/{{ postgresql_version }}/bin/initdb -E 'UTF-8' --locale={{ postgresql_locale }} -D /library/pgsql-iiab"
@@ -54,7 +54,7 @@
     creates: /library/pgsql-iiab/pg_hba.conf
   become: yes
   become_user: postgres
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Initialize the PostgreSQL db, creating /library/pgsql-iiab/pg_hba.conf (OS's other than debuntu)
   #command: su - postgres -c "/usr/bin/initdb -E 'UTF-8' --lc-collate={{ postgresql_locale }} --lc-ctype={{ postgresql_locale }} -D /library/pgsql-iiab"
@@ -91,7 +91,7 @@
     name: postgresql-iiab
     state: started
     enabled: yes
-  when: postgresql_enabled
+  when: postgresql_enabled | bool
 
 - name: Disable postgresql-iiab service, if not postgresql_enabled
   systemd:

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -37,7 +37,7 @@
     enabled: yes
   tags:
     - samba
-  when: samba_enabled
+  when: samba_enabled | bool
 
 - name: Enable & Start NetBIOS name server ({{ nmb_service }})
   service:
@@ -46,7 +46,7 @@
     enabled: yes
   tags:
     - samba
-  when: samba_enabled
+  when: samba_enabled | bool
 
 - name: Disable Samba if not samba_enabled
   service:

--- a/roles/schooltool/tasks/main.yml
+++ b/roles/schooltool/tasks/main.yml
@@ -41,13 +41,13 @@
   service: name=docker
            state=restarted
            enabled=yes
-  when: schooltool_enabled
+  when: schooltool_enabled | bool
 
 - name: Enable schooltool
   service: name=schooltool
            state=started
            enabled=yes
-  when: schooltool_enabled
+  when: schooltool_enabled | bool
 
 - name: Disable schooltool
   service: name=schooltool

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -2,7 +2,7 @@
   package:
     name: "{{ sshd_package }}"
     state: present
-  when: sshd_enabled
+  when: sshd_enabled | bool
 
 - name: Disable root login with password
   lineinfile:
@@ -10,7 +10,7 @@
     regexp: '^PermitRootLogin'
     line: 'PermitRootLogin without-password'
     state: present
-  when: sshd_enabled
+  when: sshd_enabled | bool
 #TODO: use handler to reload ssh
 
 - name: Create root .ssh
@@ -20,7 +20,7 @@
     group: root
     mode: 0700
     state: directory
-  when: sshd_enabled
+  when: sshd_enabled | bool
 
 - name: Install dummy root keys as placeholder
   copy:
@@ -30,14 +30,14 @@
     group: root
     mode: 0600
     force: no
-  when: sshd_enabled
+  when: sshd_enabled | bool
 
 - name: Enable & start ssh daemon
   service:
     name: "{{ sshd_service }}"
     enabled: yes
     state: started
-  when: sshd_enabled
+  when: sshd_enabled | bool
 
 - name: Disable ssh daemon
   service:

--- a/roles/sugar-stats/tasks/main.yml
+++ b/roles/sugar-stats/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Enable sugar-stats service
   service: name=sugar-stats-server
            enabled=yes
-  when: sugar_stats_enabled
+  when: sugar_stats_enabled | bool
 
 - name: Disable sugar-stats service
   service: name=sugar-stats-server

--- a/roles/sugar-stats/tasks/statistics-consolidation.yml
+++ b/roles/sugar-stats/tasks/statistics-consolidation.yml
@@ -4,7 +4,7 @@
 
 - name: Install statistics-consolidation with pip
   pip: name=stats-consolidation version=2.1.2
-  when: internet_available
+  when: internet_available | bool
 
 - name: Install required libraries
   package: name={{ item }}

--- a/roles/sugarizer/meta/main.yml
+++ b/roles/sugarizer/meta/main.yml
@@ -1,3 +1,3 @@
 dependencies:
-    - { role: mongodb, tags: ['generic','mongodb'], when: sugarizer_install }
-    - { role: nodejs, tags: ['nodejs'], when: sugarizer_install }
+    - { role: mongodb, tags: ['generic','mongodb'], when: sugarizer_install | bool }
+    - { role: nodejs, tags: ['nodejs'], when: sugarizer_install | bool }

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -73,7 +73,7 @@
 #  stat:
 #    path: "{{ iiab_base }}/sugarizer-server/node_modules"
 #  register: nmtest
-#  ignore_errors: true
+#  ignore_errors: True
 #
 #- name: Set a flag to prevent re-running of "npm install"
 #  set_fact:

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -116,7 +116,7 @@
   args:
     chdir: "{{ iiab_base }}/sugarizer-server"
     #creates: "{{ iiab_base }}/sugarizer-server/node_modules"    # OLD WAY 2
-  when: internet_available    # "npm install" generally requires Internet access
+  when: internet_available | bool    # "npm install" generally requires Internet access
 # when: internet_available and git_sug_server_output.changed    # OLD WAY 3
 # when: internet_available and not is_F18 and not node_modules_exists    # OLD WAY 1
 

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -13,7 +13,7 @@
     version: "{{ sugarizer_git_version }}"
     force: yes
     depth: 1
-  when: internet_available
+  when: internet_available | bool
 
 - name: Create symlink /opt/iiab/sugarizer -> /opt/iiab/{{ sugarizer_dir_version }}
   file:
@@ -46,7 +46,7 @@
     version: "{{ sugarizer_server_git_version }}"
     force: yes
     depth: 1
-  when: internet_available
+  when: internet_available | bool
 
 - name: Create symlink /opt/iiab/sugarizer-server -> /opt/iiab/{{ sugarizer_server_dir_version }}
   file:
@@ -133,7 +133,7 @@
   command: npm install --allow-root --unsafe-perm=true path-prefix-proxy
   args:
     chdir: "{{ iiab_base }}/sugarizer-server"
-  when: internet_available
+  when: internet_available | bool
 
 
 # 5. CONFIG FILES
@@ -244,7 +244,7 @@
     daemon_reload: yes
     enabled: yes
     state: restarted
-  when: sugarizer_enabled
+  when: sugarizer_enabled | bool
   
 - name: Disable & Stop 'sugarizer' systemd service (if not sugarizer_enabled)
   systemd:
@@ -258,7 +258,7 @@
   systemd:
     name: "{{ apache_service }}"    # httpd or apache2
     state: restarted
-  #when: sugarizer_enabled
+  #when: sugarizer_enabled | bool
 
 #- name: Enable services (all OS's)
 #  service:
@@ -268,7 +268,7 @@
 #  with_items:
 ##   - { name: mongodb }    # 2018-07-14: NICE TRY, but still doesn't bring http://box:8089 to life reliably, as a reboot usually does!  (Is a "systemctl daemon-reload" or some such nec?)
 #    - { name: sugarizer }
-#  when: sugarizer_enabled
+#  when: sugarizer_enabled | bool
 
 #- name: Disable service (all OS's)
 #  service:

--- a/roles/teamviewer/tasks/install.yml
+++ b/roles/teamviewer/tasks/install.yml
@@ -28,7 +28,7 @@
     url: "{{ teamviewer_url }}/{{ teamviewer_rpm_file }}"
     dest: "{{ yum_packages_dir }}/{{ teamviewer_rpm_file }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
+  when: internet_available | bool
   tags:
     - download
 

--- a/roles/teamviewer/tasks/main.yml
+++ b/roles/teamviewer/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Install Teamviewer if intel
   include_tasks: install.yml
-  when: teamviewer_install
+  when: teamviewer_install | bool
 
 - name: Add 'teamviewer' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -33,7 +33,7 @@
     daemon_reload: yes
     enabled: yes
     state: restarted
-  when: transmission_enabled
+  when: transmission_enabled | bool
 
 - name: Add PAUSED KA Lite torrent(s) to transmission-daemon's queue
   shell: >

--- a/roles/usb-lib/tasks/main.yml
+++ b/roles/usb-lib/tasks/main.yml
@@ -13,7 +13,7 @@
     owner: root
     group: root
     mode: 0751
-  when: usb_lib_enabled
+  when: usb_lib_enabled | bool
 
 - name: 'Install from template: /etc/udev/rules.d/usbmount.rules, /etc/systemd/system/usbmount@.service, /usr/bin/iiab-usb-lib-show-all-on, /usr/bin/iiab-usb-lib-show-all-off'
   template:
@@ -39,7 +39,7 @@
     owner: root
     group: root
     mode: 0751
-  when: usb_lib_enabled
+  when: usb_lib_enabled | bool
 
 - name: Remove /etc/usbmount/mount.d/70-usb-library if not usb_lib_enabled
   file:
@@ -63,14 +63,14 @@
   template:
     src: content_dir.conf
     dest: "/etc/{{ apache_config_dir }}"
-  when: usb_lib_enabled
+  when: usb_lib_enabled | bool
 
 - name: Create symlink content_dir.conf from sites-enabled to sites-available (debuntu)
   file:
     src: "/etc/{{ apache_config_dir }}/content_dir.conf"
     dest: /etc/apache2/sites-enabled/content_dir.conf
     state: link
-  when: is_debuntu
+  when: is_debuntu | bool
 
 - name: Remove symlink content_dir.conf from /etc/apache2/sites-enabled (debuntu)
   file:

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -19,7 +19,7 @@
 #   force: yes
 #   backup: yes
   register: wp_download_output
-  when: internet_available
+  when: internet_available | bool
 
 - name: Create symlink from /opt/iiab/downloads/wordpress.tar.gz to {{ wp_download_output.dest }}
   file:

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -2,4 +2,4 @@
 
 - name: Install WordPress if wordpress_install
   include_tasks: install.yml
-  when: wordpress_install
+  when: wordpress_install | bool

--- a/roles/xovis/tasks/main.yml
+++ b/roles/xovis/tasks/main.yml
@@ -7,7 +7,7 @@
     - python-pip
     - nodejs
     - npm
-  when: internet_available
+  when: internet_available | bool
 
 - name: Determine if xovis is already downloaded
   stat: path={{ downloadds_dir }}/xovis/xxx
@@ -23,7 +23,7 @@
   npm: name=kanso
        global=yes
        path={{ downloads_dir }}
-  when: internet_available
+  when: internet_available | bool
 
 - name: move the xovis repo into place
   shell: "cp -rp {{ downloads_dir }}/xovis {{ xovis_root }}"
@@ -37,7 +37,7 @@
 
 - name: Install the xovis python dependencies
   pip: requirements={{ xovis_root }}/process_stats/requirements.txt
-  when: internet_available
+  when: internet_available | bool
 
 - name: Update xovis repo with Chart Heading
   lineinfile: dest="{{ xovis_root }}/index.html" regexp='(.+)<h1>(.*)</h1>' line='\1<h1>{{ xovis_chart_heading }}</h1>' backrefs=yes
@@ -49,17 +49,17 @@
   service: name=couchdb
            enabled=yes
            state=started
-  when: xovis_enabled
+  when: xovis_enabled | bool
 
 - name: Wait for CouchDB to become ready
   wait_for: port=5984
             delay=1
             timeout=5
-  when: xovis_enabled
+  when: xovis_enabled | bool
 
 - name: Add admin user
   command: curl -X PUT {{ xovis_target_host }}/_config/admins/{{ xovis_db_user }} -d "\"{{ xovis_db_password }}\""
-  when: xovis_enabled
+  when: xovis_enabled | bool
 
 - name: Check if db exists
   shell: "kanso listdb | grep {{ xovis_db_name }}"
@@ -79,7 +79,7 @@
   -d {{ xovis_backup_dir }}
   --deployment {{ xovis_deployment_name }}
   --server http://{{ xovis_db_login }}@{{ xovis_target_host }}"
-  when: xovis_enabled
+  when: xovis_enabled | bool
 
 - name: Add 'xovis' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -358,7 +358,7 @@ moodle_enabled: False
 # If using Moodle intensively, set apache_high_php_limits in 3-BASE-SERVER
 
 # MongoDB (/library/dbdata/mongodb) is used by Sugarizer:
-# Its 2 settings below are auto-set to True (in roles/0-init/tasks/main.yml) when: sugarizer_enabled
+# Its 2 settings below are auto-set to True (in roles/0-init/tasks/main.yml) when: sugarizer_enabled | bool
 # The mongodb playbook itself is later invoked by roles/sugarizer/meta/main.yml
 mongodb_install: False
 mongodb_enabled: False


### PR DESCRIPTION
The crux was converting 248 instances of 'when: X' -> 'when: X | bool' (i.e. Ansible 2.8's annoying new/safer syntax) by running:
```
cd /opt/iiab/iiab
find . -type f -exec sed -i 's/[#[:blank:]]when:[[:blank:]][0-Z_]*$/& | bool/' {} \;
```
Thereby resolving most of #1632

ALSO:
- I avoided 12 instances of `changed_when: False` by using `[#[:blank:]]` above
- I manually fixed 2 instances of `grep -r 'when:[[:blank:]][0-Z_]*[[:blank:]]*#'` (in roles/sugarizer/tasks/main.yml and roles/nextcloud/tasks/main.yml)
- I manually fixed 3 instances of `grep -r 'when:[[:blank:]][0-Z_]*[[:blank:]]*}'` (in roles/sugarizer/meta/main.yml and roles/nodered/meta/main.yml )
- I cleaned up 5 instances of `: false` to `: False` and 6 instances of `: true` (to either `: True` or `: yes`) after verifying each
- Duplicate when: clauses were fixed in nextcloud/tasks/main.yml, arising from PR #1667
- I ran `grep -r 'when:[0-Z_]'` and `grep -r 'when:[[:blank:]][[:blank:]]' | wc` to make sure none of those instances existed
- /opt/iiab/iiab-admin-console has about 17+ similar instances that trigger Ansible 2.8's bool warning, but it might be easier to fix those manually

PS this was smoke-tested with a BIG-sized IIAB on Ubuntu 18.04 using "./iiab-install --reinstall" but it should also be tested with a fresh/clean install on another OS ideally.