### PR TITLE
Not just is_ubuntu_18: make U19/U20 viable [Debian 10 already OK?] [extends use of php{{ php_version }}-sqlite3 to future OS's for now...somewhat controversially]

### DIFF
--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -46,7 +46,7 @@
 
 - name: Install/Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)
   command: scripts/calibre-install-latest.sh
-  when: not is_rpi and (is_ubuntu_16 or is_debian_9) and internet_available
+  when: (not is_rpi) and (is_ubuntu_16 or is_debian_9) and internet_available
   #when: not is_rpi and not is_ubuntu_18 and internet_available
 
 - name: Install/Upgrade to Calibre unstable .deb's IF calibre_unstable_debs

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -46,7 +46,8 @@
 
 - name: Install/Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)
   command: scripts/calibre-install-latest.sh
-  when: not is_rpi and not is_ubuntu_18 and internet_available
+  when: not is_rpi and (is_ubuntu_16 or is_debian_9) and internet_available
+  #when: not is_rpi and not is_ubuntu_18 and internet_available
 
 - name: Install/Upgrade to Calibre unstable .deb's IF calibre_unstable_debs
   command: scripts/calibre-install-unstable.sh

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -5,6 +5,8 @@
 # /opt/iiab/iiab/vars/raspbian-9.yml
 # /opt/iiab/iiab/vars/raspbian-10.yml
 # /opt/iiab/iiab/vars/debian-10.yml
+#
+# As viewable live @ https://github.com/iiab/iiab/tree/master/vars
 
 # If you want the latest Calibre, run the appropriate script below, standalone.
 # HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!) to

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -1,8 +1,9 @@
-# roles/calibre/tasks/main.yml REQUIRES calibre_via_debs (TO BE True) BEFORE
-# CALLING THIS SCRIPT.  As of 2018-10-23 this is set in only 3 places:
+# calibre_via_debs MUST BE TRUE IN ORDER FOR roles/calibre/tasks/main.yml TO
+# INVOKE THIS SCRIPT. As of 2019-05-30 calibre_via_debs is set by these 4 OS's:
 #
-# vars/raspbian-9.yml
 # vars/raspbian-8.yml
+# vars/raspbian-9.yml
+# vars/raspbian-10.yml
 # vars/debian-10.yml
 
 # If you want the latest Calibre, run the appropriate script below, standalone.

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -47,9 +47,10 @@
 #  command: scripts/calibre-install-pinned-rpi.sh    # Worked for Calibre 3.33.1 on 2018-10-23, e.g. so IIAB microSD bootable in RPi Zero W
 #  when: is_rpi and internet_available
 
-- name: Install/Upgrade to Calibre testing .deb's (debian-9 or ubuntu-16)
+- name: Install/Upgrade to Calibre testing .deb's (not rpi)
   command: scripts/calibre-install-latest.sh
-  when: (not is_rpi) and (is_debian_9 or is_ubuntu_16) and internet_available
+  when: (not is_rpi) and internet_available
+  #when: (not is_rpi) and (is_debian_9 or is_ubuntu_16) and internet_available
   #when: not is_rpi and not is_ubuntu_18 and internet_available
 
 - name: Install/Upgrade to Calibre unstable .deb's IF calibre_unstable_debs

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -1,10 +1,10 @@
 # calibre_via_debs MUST BE TRUE IN ORDER FOR roles/calibre/tasks/main.yml TO
-# INVOKE THIS SCRIPT. As of 2019-05-30 calibre_via_debs is set by these 4 OS's:
+# INVOKE THIS SCRIPT.  As of 2019-05-30, that means these 4 OS's:
 #
-# vars/raspbian-8.yml
-# vars/raspbian-9.yml
-# vars/raspbian-10.yml
-# vars/debian-10.yml
+# /opt/iiab/iiab/vars/raspbian-8.yml
+# /opt/iiab/iiab/vars/raspbian-9.yml
+# /opt/iiab/iiab/vars/raspbian-10.yml
+# /opt/iiab/iiab/vars/debian-10.yml
 
 # If you want the latest Calibre, run the appropriate script below, standalone.
 # HOWEVER: it's strongly suggested you wait for apt (blessed by your OS!) to

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -1,5 +1,5 @@
-# roles/calibre/tasks/main.yml requires calibre_via_debs (to be True) before
-# calling this script.  As of 2018-10-23 this is set in only 3 places:
+# roles/calibre/tasks/main.yml REQUIRES calibre_via_debs (TO BE True) BEFORE
+# CALLING THIS SCRIPT.  As of 2018-10-23 this is set in only 3 places:
 #
 # vars/raspbian-9.yml
 # vars/raspbian-8.yml
@@ -44,9 +44,9 @@
 #  command: scripts/calibre-install-pinned-rpi.sh    # Worked for Calibre 3.33.1 on 2018-10-23, e.g. so IIAB microSD bootable in RPi Zero W
 #  when: is_rpi and internet_available
 
-- name: Install/Upgrade to Calibre testing .deb's - target Ubuntu 16.04 (not rpi and not ubuntu_18)
+- name: Install/Upgrade to Calibre testing .deb's (debian-9 or ubuntu-16)
   command: scripts/calibre-install-latest.sh
-  when: (not is_rpi) and (is_ubuntu_16 or is_debian_9) and internet_available
+  when: (not is_rpi) and (is_debian_9 or is_ubuntu_16) and internet_available
   #when: not is_rpi and not is_ubuntu_18 and internet_available
 
 - name: Install/Upgrade to Calibre unstable .deb's IF calibre_unstable_debs

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -24,11 +24,11 @@
     - download
 
 # 2019-05-26: Irrelevant (never invoked)
-- name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
-  package:
-    name: "php{{ php_version }}-sqlite"
-  when: is_raspbian_8 or is_debian_8
-  #when: is_debian and ansible_distribution_major_version == "8"
+#- name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
+#  package:
+#    name: "php{{ php_version }}-sqlite"
+#  when: is_raspbian_8 or is_debian_8
+#  #when: is_debian and ansible_distribution_major_version == "8"
 
 # 2019-05-29: It's interesting that http://box.lan/admin and everything seems
 # to work even without php{{ php_version }}-sqlite3 as confirmed on Ubuntu

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -36,7 +36,8 @@
 # we decided that because sqlite3 and php are part of the base install the
 # connector should be too."
 # We might *try* deprecating this as we transition beyond {raspbian-9,
-# debian-9, ubuntu-18} in coming months to verify...
+# debian-9, ubuntu-18} in coming months to verify that roles/osm-vector-maps
+# is the only role that needs this?
 #
 # SQLite3 no longer included in another package
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -23,23 +23,23 @@
   tags:
     - download
 
-# 2019-05-26: Irrelevant (never invoked)
+# 2019-05-30: Irrelevant (never invoked)
 #- name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
 #  package:
 #    name: "php{{ php_version }}-sqlite"
 #  when: is_raspbian_8 or is_debian_8
 #  #when: is_debian and ansible_distribution_major_version == "8"
 
-# 2019-05-29: It's interesting that http://box.lan/admin and everything seems
+# 2019-05-30: It's interesting that http://box.lan/admin and everything seems
 # to work even without php{{ php_version }}-sqlite3 as confirmed on Ubuntu
 # 16.04 (SEE PR #1697).  And likely all others?  @tim-moody writes "I think
 # we decided that because sqlite3 and php are part of the base install the
 # connector should be too."
-# We might *try* deprecating this as we transition beyond {raspbian-9,
+# We might *try* deprecating this here as we transition beyond {raspbian-9,
 # debian-9, ubuntu-18} in coming months to verify that roles/osm-vector-maps
-# is the only role that needs this?
+# is the only role that needs it?
 #
-# SQLite3 no longer included in another package
+# Legacy Comment: SQLite3 no longer included in another package
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)
   package:
     name: "php{{ php_version }}-sqlite3"

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -23,12 +23,19 @@
   tags:
     - download
 
+# 2019-05-26: Irrelevant (never invoked)
 - name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
   package:
     name: "php{{ php_version }}-sqlite"
   when: is_raspbian_8 or is_debian_8
   #when: is_debian and ansible_distribution_major_version == "8"
 
+# 2019-05-26: It's interesting that http://box.lan/admin and everything seems
+# to work even without php{{ php_version }}-sqlite3.  As confirmed on Ubuntu
+# 16.04 (SEE PR #1697).  And likely all others?  @tim-moody writes "I think
+# we decided that because sqlite3 and php are part of the base install the
+# connector should be too."
+#
 # SQLite3 no longer included in another package
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)
   package:

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -39,7 +39,7 @@
 # debian-9, ubuntu-18} in coming months to verify...
 #
 # SQLite3 no longer included in another package
-- name: Install php{{ php_version }}-sqlite3 (raspbian-9 or debian-9 or ubuntu-18)
+- name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)
   package:
     name: "php{{ php_version }}-sqlite3"
   #when: is_raspbian_9 or is_debian_9 or is_ubuntu_18

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -29,10 +29,10 @@
   when: is_debian and ansible_distribution_major_version == "8"
 
 # SQLite3 no longer included in another package
-- name: Install php{{ php_version }}-sqlite3 (debian-9+ or ubuntu-18+)
+- name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)
   package:
     name: "php{{ php_version }}-sqlite3"
-  when: (is_debian and not is_debian_8) or (is_ubuntu and not is_ubuntu_16)
+  when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
   #when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
 
 - name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -26,7 +26,8 @@
 - name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
   package:
     name: "php{{ php_version }}-sqlite"
-  when: is_debian and ansible_distribution_major_version == "8"
+  when: is_raspbian_8 or is_debian_8
+  #when: is_debian and ansible_distribution_major_version == "8"
 
 # SQLite3 no longer included in another package
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -30,14 +30,13 @@
   when: is_raspbian_8 or is_debian_8
   #when: is_debian and ansible_distribution_major_version == "8"
 
-# 2019-05-26: It's interesting that http://box.lan/admin and everything seems
-# to work even without php{{ php_version }}-sqlite3.  As confirmed on Ubuntu
+# 2019-05-29: It's interesting that http://box.lan/admin and everything seems
+# to work even without php{{ php_version }}-sqlite3 as confirmed on Ubuntu
 # 16.04 (SEE PR #1697).  And likely all others?  @tim-moody writes "I think
 # we decided that because sqlite3 and php are part of the base install the
 # connector should be too."
-#
-# So let's *try* deprecating this as we transition beyond {raspbian-9,
-# debian-9, ubuntu-18} in coming months.
+# We might *try* deprecating this as we transition beyond {raspbian-9,
+# debian-9, ubuntu-18} in coming months to verify...
 #
 # SQLite3 no longer included in another package
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9 or debian-9 or ubuntu-18)

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -43,8 +43,8 @@
 - name: Install php{{ php_version }}-sqlite3 (raspbian-9 or debian-9 or ubuntu-18)
   package:
     name: "php{{ php_version }}-sqlite3"
-  when: is_raspbian_9 or is_debian_9 or is_ubuntu_18
-  #when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
+  #when: is_raspbian_9 or is_debian_9 or is_ubuntu_18
+  when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
   #when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
 
 - name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -36,11 +36,15 @@
 # we decided that because sqlite3 and php are part of the base install the
 # connector should be too."
 #
+# So let's *try* deprecating this as we transition beyond {raspbian-9,
+# debian-9, ubuntu-18} in coming months.
+#
 # SQLite3 no longer included in another package
-- name: Install php{{ php_version }}-sqlite3 (raspbian-9+ or debian-9+ or ubuntu-18+)
+- name: Install php{{ php_version }}-sqlite3 (raspbian-9 or debian-9 or ubuntu-18)
   package:
     name: "php{{ php_version }}-sqlite3"
-  when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
+  when: is_raspbian_9 or is_debian_9 or is_ubuntu_18
+  #when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
   #when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
 
 - name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -23,7 +23,7 @@
   tags:
     - download
 
-- name: Install php{{ php_version }}-sqlite (debian-8)
+- name: Install php{{ php_version }}-sqlite (raspbian-8 or debian-8)
   package:
     name: "php{{ php_version }}-sqlite"
   when: is_debian and ansible_distribution_major_version == "8"

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -29,10 +29,11 @@
   when: is_debian and ansible_distribution_major_version == "8"
 
 # SQLite3 no longer included in another package
-- name: Install php{{ php_version }}-sqlite3 (debian-9 or ubuntu-18)
+- name: Install php{{ php_version }}-sqlite3 (debian-9+ or ubuntu-18+)
   package:
     name: "php{{ php_version }}-sqlite3"
-  when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
+  when: (is_debian and not is_debian_8) or (is_ubuntu and not is_ubuntu_16)
+  #when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
 
 - name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'
   package:


### PR DESCRIPTION
Building off PR #1696

Should be evaluated/tested in context with:

#1387 Debian 10 Buster: 3 outstanding issues w/ workarounds + 2 bugs (Kolibri & MongoDB)