### PR TITLE
Making network vars more findable via roles/network/defaults/main.yml

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -1,6 +1,50 @@
 # IIAB Networking Doc
 # https://github.com/iiab/iiab/wiki/IIAB-Networking
 
+# Firewall (iptables) can be tuned in /etc/iiab/local_vars.yml with this var:
+# ports_externally_visible: 3
+# https://github.com/iiab/iiab/wiki/IIAB-Networking#firewall-iptables
+
+# Wi-Fi
+# host_country_code: US
+# host_ssid: "Internet in a Box"
+# host_wifi_mode: g
+# host_channel: 6
+# hostapd_secure: False
+# hostapd_password: changeme
+# Above 6 vars set in /etc/iiab/local_vars.yml
+#
+# hostapd_enabled: True
+# Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
+# being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
+# and content is downloaded, to enable the internal WiFi Access Point / AP!)
+#
+# reboot_to_AP: False
+# For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
+# detection of WiFi-as-gateway, forcing "hostapd_enabled: True" regardless.
+#
+# Above 2 vars set in /opt/iiab/iiab/vars/default_vars.yml
+#
+hostapd_wait: 5
+host_wireless_n: False
+driver_name: nl80211
+
+# DNS / name resolution
+# dhcpd_install: False
+# dhcpd_enabled: False
+# named_install: False
+# named_enabled: False
+# dnsmasq_enabled: True
+# dnsmasq_install: True
+# dns_jail_enabled: False
+# Above 7 vars set in /etc/iiab/local_vars.yml
+#
+# dhcp_service: ????                 # Set in individual OS's /opt/iiab/iiab/vars/<OS>.yml for use in roles/network/tasks/dhcpd.yml
+# dhcp_service2: "dhcpd disabled"    # Moved to roles/network/tasks/computed_services.yml as community transitions from named/BIND to dnsmasq (PR #1202)
+
+# Dynamically calculated later
+# iiab_network_mode: "Gateway"
+
 # Defaults for network detection
 wireless_lan_present: False
 strict_networking: False
@@ -41,52 +85,8 @@ gui_desired_network_role: Gateway
 wondershaper_dspeed: "4096"
 wondershaper_upspeed: "1024"
 
-# Dynamically calculated later
-# iiab_network_mode: "Gateway"
-
-# ports_externally_visible: 3
-# Above var set in /etc/iiab/local_vars.yml
-# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Networking#firewall-iptables
-
-# Wi-Fi
-# host_country_code: US
-# host_ssid: "Internet in a Box"
-# host_wifi_mode: g
-# host_channel: 6
-# hostapd_secure: False
-# hostapd_password: changeme
-# Above 6 vars set in /etc/iiab/local_vars.yml: (so implementer sets them)
-#
-# hostapd_enabled: True
-# Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
-# being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
-# and content is downloaded, to enable the internal WiFi Access Point / AP!)
-#
-# reboot_to_AP: False
-# For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
-# detection of WiFi-as-gateway, forcing "hostapd_enabled: True" regardless.
-#
-# Above 2 vars set in /opt/iiab/iiab/vars/default_vars.yml
-#
-hostapd_wait: 5
-host_wireless_n: False
-driver_name: nl80211
-
 # Unused
 # network_config_dir: /etc/network/interfaces.d
-
-# DNS / name resolution
-# dhcpd_install: False
-# dhcpd_enabled: False
-# named_install: True
-# named_enabled: False
-# dnsmasq_enabled: True
-# dnsmasq_install: True
-# dns_jail_enabled: False
-# Above 7 vars set in /etc/iiab/local_vars.yml
-#
-# dhcp_service: ????                 # Set in individual OS's /opt/iiab/iiab/vars/<OS>.yml for use in roles/network/tasks/dhcpd.yml
-# dhcp_service2: "dhcpd disabled"    # Moved to roles/network/tasks/computed_services.yml as community transitions from named/BIND to dnsmasq (PR #1202)
 
 # Originally for @tim-moody's Nodogsplash approach to Captive Portal
 # Highly experimental as of June 2018: https://github.com/iiab/iiab/issues/608

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -92,8 +92,8 @@ wondershaper_upspeed: "1024"
 # Originally for @tim-moody's Nodogsplash approach to Captive Portal
 # Highly experimental as of June 2018: https://github.com/iiab/iiab/issues/608
 #
-# Python-based Captive Portal, that @m-anish & @jvonau experimented with in
-# July 2018 (https://github.com/iiab/iiab/pull/870) and that @georgejhunt
+# Newer: Python-based Captive Portal, that @m-anish & @jvonau experimented with
+# in July 2018 (https://github.com/iiab/iiab/pull/870) and that @georgejhunt
 # extensively refined in Sept 2018 (https://github.com/iiab/iiab/pull/1179)
 # captive_portal_install: False
 # captive_portal_enabled: False

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -1,5 +1,6 @@
-# IIAB Networking Doc
-# https://github.com/iiab/iiab/wiki/IIAB-Networking
+# IIAB Networking Doc: https://github.com/iiab/iiab/wiki/IIAB-Networking
+# Ansible README: https://github.com/iiab/iiab/tree/master/roles/network
+# http://FAQ.IIAB.IO -> click on "Any other networking tips?"
 
 # Firewall (iptables) can be tuned in /etc/iiab/local_vars.yml with this var:
 # ports_externally_visible: 3

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -1,3 +1,6 @@
+# IIAB Networking Doc
+# https://github.com/iiab/iiab/wiki/IIAB-Networking
+
 # Defaults for network detection
 wireless_lan_present: False
 strict_networking: False
@@ -31,59 +34,72 @@ wan_in_interfaces: False
 network_manager_active: False
 systemd_networkd_active: False
 
-# The values here are default local variables.
+# The values here are default local variables
 gui_wan_iface: "unset"
 gui_static_wan_ip: "unset"
 gui_desired_network_role: Gateway
 wondershaper_dspeed: "4096"
 wondershaper_upspeed: "1024"
 
+# Dynamically calculated later
+# iiab_network_mode: "Gateway"
+
+# ports_externally_visible: 3
+# Above var set in /etc/iiab/local_vars.yml
+# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Networking#firewall-iptables
+
 # Wi-Fi
-host_ssid: IIAB
-hostapd_wait: 5
-host_wifi_mode: g
-host_channel: 6
-host_wireless_n: False
-# Below moved to /etc/iiab/local_vars.yml: (so implementer sets this)
-#host_country_code: US
-hostapd_secure: True
-hostapd_password: "iiab2017"
-driver_name: nl80211
-hostapd_enabled: True
+# host_country_code: US
+# host_ssid: "Internet in a Box"
+# host_wifi_mode: g
+# host_channel: 6
+# hostapd_secure: False
+# hostapd_password: changeme
+# Above 6 vars set in /etc/iiab/local_vars.yml: (so implementer sets them)
+#
+# hostapd_enabled: True
 # Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
 # being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
 # and content is downloaded, to enable the internal WiFi Access Point / AP!)
-reboot_to_AP: False
+#
+# reboot_to_AP: False
 # For those installing IIAB over WiFi: "reboot_to_AP: True" overrides the above
 # detection of WiFi-as-gateway, forcing "hostapd_enabled: True" regardless.
+#
+# Above 2 vars set in /opt/iiab/iiab/vars/default_vars.yml
+#
+hostapd_wait: 5
+host_wireless_n: False
+driver_name: nl80211
 
-network_config_dir: /etc/network/interfaces.d
-#iiab_network_mode: "Gateway"
-dns_jail_enabled: False
-services_externally_visible: False
+# Unused
+# network_config_dir: /etc/network/interfaces.d
 
 # DNS / name resolution
-dhcpd_install: True
-dhcpd_enabled: False
-#dhcp_service: ????                 # Set in individual OS's /opt/iiab/iiab/vars/<OS>.yml for use in roles/network/tasks/dhcpd.yml
-#dhcp_service2: "dhcpd disabled"    # Moved to roles/network/tasks/computed_services.yml as community transitions from named/BIND to dnsmasq (PR #1202)
-named_install: True
-named_enabled: False
-dnsmasq_enabled: True
-dnsmasq_install: True
+# dhcpd_install: False
+# dhcpd_enabled: False
+# named_install: True
+# named_enabled: False
+# dnsmasq_enabled: True
+# dnsmasq_install: True
+# dns_jail_enabled: False
+# Above 7 vars set in /etc/iiab/local_vars.yml
+#
+# dhcp_service: ????                 # Set in individual OS's /opt/iiab/iiab/vars/<OS>.yml for use in roles/network/tasks/dhcpd.yml
+# dhcp_service2: "dhcpd disabled"    # Moved to roles/network/tasks/computed_services.yml as community transitions from named/BIND to dnsmasq (PR #1202)
 
+# Originally for @tim-moody's Nodogsplash approach to Captive Portal
+# Highly experimental as of June 2018: https://github.com/iiab/iiab/issues/608
+#
 # Python-based Captive Portal, that @m-anish & @jvonau experimented with in
 # July 2018 (https://github.com/iiab/iiab/pull/870) and that @georgejhunt
 # extensively refined in Sept 2018 (https://github.com/iiab/iiab/pull/1179)
-captive_portal_install: True
-captive_portal_enabled: True
-captive_portal_port: "9090"
+# captive_portal_install: False
+# captive_portal_enabled: False
+# Above 2 vars set in /etc/iiab/local_vars.yml
+# captive_portal_port: "9090"
+# Above var set in /opt/iiab/iiab/vars/default_vars.yml
 py_captive_portal_port: "9090"
 py_captive_portal_username: "Admin"
 py_captive_portal_password: "changeme"
 # In a pinch, disable it by running: systemctl disable captive-portal
-
-# For @tim-moody's Nodogsplash approach to Captive Portal?
-# Highly experimental as of June 2018: https://github.com/iiab/iiab/issues/608
-# captive_portal_install: False
-# captive_portal_enabled: False

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -44,10 +44,10 @@ echo -e "WAN: $wan\n"
 
 # "Good thing we replace this file; should be treated like Squid below" ?
 ports_externally_visible={{ ports_externally_visible }}
-#services_externally_visible={{ services_externally_visible }}
+#services_externally_visible= [deprecated]
 gw_block_https={{ gw_block_https }}
 ssh_port={{ ssh_port }}
-#gui_wan={{ gui_wan }}
+#gui_wan= [no longer needed]
 gui_port={{ gui_port }}
 iiab_gateway_enabled={{ iiab_gateway_enabled }}
 block_DNS={{ block_DNS }}


### PR DESCRIPTION
There are a very large number of IIAB network variables, defined in many different places.

This PR annotates where the main ones are defined &mdash; so roles/network/defaults/main.yml can become more readable as a manifest/inventory facilitating understanding of their rough scope.