### PR TITLE
hostapd fails to start if wifi connected to wan

### DIFF
--- a/roles/network/templates/network/iiab-hotspot-on
+++ b/roles/network/templates/network/iiab-hotspot-on
@@ -1,6 +1,8 @@
 #!/bin/bash
 cp -f /etc/hostapd/hostapd.conf.iiab /etc/hostapd/hostapd.conf
 sed -i -e "s/^#denyinterfaces/denyinterfaces/" /etc/dhcpcd.conf
+# shut down wlan0 in case connected to network
+ip link set wlan0 down
 systemctl enable hostapd
 #systemctl enable dnsmasq
 systemctl daemon-reload


### PR DESCRIPTION
### Fixes Bug

hostapd fails to start if wifi connected to wan