### PR TITLE
Gitea 1.7.6 -> 1.8.2 once again works on Raspberry Pi?!

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -13,7 +13,7 @@ iset_suffixes:
   i386: 386
   x86_64: amd64
   armv6l: arm-6
-  armv7l: arm-7   # IS THIS LINE OK, GIVEN GITEA 1.8.0 & 1.8.1 HAD ARM7 PROBLEMS IN MAY 2019 https://github.com/iiab/iiab/issues/1673 ?
+  armv7l: arm-6   # "arm-7" used to work, but no longer since 2019-04-20's Gitea 1.8.0: https://github.com/iiab/iiab/issues/1673 https://github.com/iiab/iiab/pull/1713
 
 gitea_iset_suffix: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
 

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -8,12 +8,12 @@
 # https://git.coolaj86.com/coolaj86/gitea-installer.sh
 
 # Information needed to install Gitea
-gitea_version: 1.7.6
+gitea_version: 1.8.2
 iset_suffixes:
   i386: 386
   x86_64: amd64
   armv6l: arm-6
-  armv7l: arm-7
+  armv7l: arm-7   # IS THIS LINE OK, GIVEN GITEA 1.8.0 & 1.8.1 HAD ARM7 PROBLEMS IN MAY 2019 https://github.com/iiab/iiab/issues/1673 ?
 
 gitea_iset_suffix: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
 


### PR DESCRIPTION
@aidan-fitz are all 4 lines of your code below still applicable / best?
```
iset_suffixes:
  i386: 386	  i386: 386
  x86_64: amd64	  x86_64: amd64
  armv6l: arm-6	  armv6l: arm-6
  armv7l: arm-7	  armv7l: arm-7
```
Thanks!

Towards fixing #1673, we hope-

Ref: PR #1242