### PR TITLE
Elgg 2.3.12 -> 2.3.13 (pending d.iiab.io/packages)

### DIFF
--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -8,7 +8,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 elgg_xx: elgg
-elgg_version: 2.3.12
+elgg_version: 2.3.13
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg


### PR DESCRIPTION
When package is published imminently, to:
https://elgg.org/about/download

And then to:
http://download.iiab.io/packages

Changelog: https://github.com/Elgg/Elgg/releases/tag/2.3.13

Refs: #1607