### PR TITLE
Ncat [for OpenVPN on Debian 10 Buster]

### DIFF
--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -7,6 +7,15 @@
   tags:
     - download
 
+- name: Install Ncat package
+  package:
+    name:
+      - ncat
+    state: present
+  when: need_ncat is defined and need_ncat
+  tags:
+    - download
+
 - name: Install ssh public keys for remote support (if openvpn_install)
   lineinfile:
     line: "{{ item.pubkey }}"

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -12,7 +12,7 @@
     name:
       - ncat
     state: present
-  when: need_ncat is defined and need_ncat
+  when:  need_ncat | bool
   tags:
     - download
 

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -27,3 +27,4 @@ systemd_location: /lib/systemd/system
 # Upgrade OS's own Calibre to very latest:
 calibre_via_debs: True
 calibre_via_python: False
+need_ncat: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -188,6 +188,9 @@ openvpn_cron_enabled: False
 openvpn_server: xscenet.net
 openvpn_server_virtual_ip: 10.8.0.1
 openvpn_server_port: 1194
+# Newer versions of NMap do not include NCat which is used to announce handle
+# need_ncat is turned true by os-#.yml files that don't have ncat in nmap
+need_ncat: False
 
 
 # 2-COMMON

--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -40,3 +40,4 @@ minetest_working_dir: /library/games/minetest
 minetest_game_dir: /library/games/minetest/games/minetest_game
 minetest_rpi_src_url: http://www.nathansalapat.com/downloads/0.4.17.1.tar.gz
 minetest_rpi_src: minetest-0.4.17.1.tar.gz
+need_ncat: True

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -29,3 +29,4 @@ systemd_location: /lib/systemd/system
 # Upgrade Ubuntu 19.x's Calibre 3.39.1+ to very latest
 calibre_via_debs: False
 calibre_via_python: True
+need_ncat: True


### PR DESCRIPTION
Maybe this "need_ncat" is better than having to add is_debian-10 ... as a new release comes out-- but only a little better.