### PR TITLE
Revert to Kolibri 0.12.3, due to Kolibri 0.12.4 bug

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -6,6 +6,9 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
+# Just comment out this pinning line if you want Kolibri's "latest" version, after 0.12.4's bug is resolved: https://github.com/iiab/iiab/issues/1675 https://github.com/learningequality/kolibri/issues/5664
+kolibri_version: 0.12.3
+
 # Kolibri folder to store its data and configuration files.
 kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
 

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -27,7 +27,16 @@
     virtualenv_site_packages: no
     state: latest
     extra_args: --no-cache-dir
-  when: internet_available | bool
+  when: internet_available and not (kolibri_version is defined)
+
+- name: Install kolibri {{ kolibri_version }} using pip
+  pip:
+    name: kolibri
+    virtualenv: "{{ kolibri_venv_path }}"
+    virtualenv_site_packages: no
+    version: "{{ kolibri_version }}"
+    extra_args: --no-cache-dir
+  when: internet_available and kolibri_version is defined
 
 - name: Run Kolibri migrations
   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" manage migrate


### PR DESCRIPTION
Tested to support both options in future:

1) A specific Kolibri version number hard-coded into [roles/kolibri/defaults/main.yml](https://github.com/iiab/iiab/blob/master/roles/kolibri/defaults/main.yml#L9-L10) (as variable kolibri_version)

or

2) Comment out that [line that defines kolibri_version](https://github.com/iiab/iiab/blob/master/roles/kolibri/defaults/main.yml#L9-L10), if you instead want to attempt the installation of the very latest Kolibri version

Refs: #1675 and https://github.com/learningequality/kolibri/issues/5664