### PR TITLE
MediaWiki 1.32.1 -> MediaWiki 1.32.2

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: "1.32"
-mediawiki_minor_version: "1"
+mediawiki_minor_version: "2"
 mediawiki_version: "{{ mediawiki_major_version  }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Originally from 2019-06-06:
https://releases.wikimedia.org/mediawiki/1.32/