### PR TITLE
Add client config that works when DNS does not [OpenVPN]

### DIFF
--- a/roles/openvpn/templates/xscenet.conf.j2
+++ b/roles/openvpn/templates/xscenet.conf.j2
@@ -7,6 +7,7 @@
 port {{ openvpn_server_port }}
 dev tun
 remote {{ openvpn_server }}
+remote {{ openvpn_server_real_ip }}
 
 # TLS parameters
 tls-client

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -191,6 +191,7 @@ openvpn_handle:
 openvpn_cron_enabled: False
 # General OpenVPN settings
 openvpn_server: xscenet.net
+openvpn_server_real_ip: 3.89.148.185
 openvpn_server_virtual_ip: 10.8.0.1
 openvpn_server_port: 1194
 # Newer versions of NMap do not include NCat which is used to announce handle


### PR DESCRIPTION
Creeping feature
Add an ip address as well as a url address for the Amazon openvpn server
Not Smoke-tested in clean install -- but changed in default vars, runrole, change handle, restart openvpn

