### PR TITLE
Dnsmasq fixes

### DIFF
--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -157,7 +157,7 @@
 
 # so this works
 - name: Interface count
-  shell: ls /sys/class/net | grep -v -e lo -e bridge0 -e veth | wc | awk '{print $1}'
+  shell: ls /sys/class/net | grep -v -e lo -e bridge0 -e veth -e "br-*" -e docker| wc | awk '{print $1}'
   register: adapter_count
 
 # well if there ever was a point to tell the user things are FUBAR this is it.

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -157,7 +157,7 @@
 
 # so this works
 - name: Interface count
-  shell: ls /sys/class/net | grep -v -e lo | wc | awk '{print $1}'
+  shell: ls /sys/class/net | grep -v -e lo -e bridge0 -e veth | wc | awk '{print $1}'
   register: adapter_count
 
 # well if there ever was a point to tell the user things are FUBAR this is it.

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -112,7 +112,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
-  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e {{ device_gw }} -e {{ ap_device }}
+  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }}
   when: num_lan_interfaces != "0"
   register: lan_list_result
 

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -112,7 +112,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
-  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }}
+  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e "br-*" -e docker -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }}
   when: num_lan_interfaces != "0"
   register: lan_list_result
 

--- a/roles/network/tasks/dnsmasq.yml
+++ b/roles/network/tasks/dnsmasq.yml
@@ -14,6 +14,14 @@
    - { src: 'roles/network/templates/network/dnsmasq.service.u18', dest: '/etc/systemd/system/iiab-dnsmasq.service', mode: '0644' }
    - { src: 'roles/network/templates/network/dnsmasq-iiab', dest: '/etc/dnsmasq.d/dnsmasq-iiab', mode: '644' }
 
+- name: Copy script to restart dnsmasq whenever br0 comes up
+  template: 
+    src: "roles/network/templates/network/dnsmasq.sh.j2"
+    dest: "/etc/networkd-dispatcher/routable.d/dnsmasq.sh"
+    mode: "0755"
+    owner: root
+    group: root
+
 - name: Don't use stock dnsmasq systemd unit file during boot
   systemd:
     name: dnsmasq

--- a/roles/network/tasks/dnsmasq.yml
+++ b/roles/network/tasks/dnsmasq.yml
@@ -14,14 +14,6 @@
    - { src: 'roles/network/templates/network/dnsmasq.service.u18', dest: '/etc/systemd/system/iiab-dnsmasq.service', mode: '0644' }
    - { src: 'roles/network/templates/network/dnsmasq-iiab', dest: '/etc/dnsmasq.d/dnsmasq-iiab', mode: '644' }
 
-- name: Copy script to restart dnsmasq whenever br0 comes up
-  template: 
-    src: "roles/network/templates/network/dnsmasq.sh.j2"
-    dest: "/etc/networkd-dispatcher/routable.d/dnsmasq.sh"
-    mode: "0755"
-    owner: root
-    group: root
-
 - name: Don't use stock dnsmasq systemd unit file during boot
   systemd:
     name: dnsmasq

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -54,6 +54,15 @@
     dest: /etc/dnsmasq.d/iiab.conf
   when: dnsmasq_enabled and dnsmasq_install and (iiab_network_mode != "Appliance")
 
+- name: Copy script to restart dnsmasq whenever br0 comes up
+  template: 
+    src: "roles/network/templates/network/dnsmasq.sh.j2"
+    dest: "/etc/networkd-dispatcher/routable.d/dnsmasq.sh"
+    mode: "0755"
+    owner: root
+    group: root
+  when: dnsmasq_enabled and dnsmasq_install and (iiab_network_mode != "Appliance")
+
 - name: Remove /etc/dnsmasq.d/iiab.conf, when not dnsmasq_enabled or is Appliance
   file:
     path: /etc/dnsmasq.d/iiab.conf

--- a/roles/network/templates/network/dnsmasq.sh.j2
+++ b/roles/network/templates/network/dnsmasq.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "$IFACE" == "{{ iiab_lan_iface }}" ];
+then
+	/bin/systemctl restart dnsmasq.service
+fi


### PR DESCRIPTION
This includes Jerry's PR #1753 PLUS
  *  Changing the network iface list in Jerry's PR to include more docker-created interfaces
  *  Restarting dnsmasq whenever br0 comes up. This can allow hotplugging of the wired LAN later after the server has booted, and still dnsmasq will come up.
