### PR TITLE
Fix #1747 | dnsmasq and systemd-resolved race issues

### DIFF
--- a/roles/network/templates/network/systemd-br0-network.j2
+++ b/roles/network/templates/network/systemd-br0-network.j2
@@ -5,7 +5,9 @@ Name=br0
 [Network]
 Address={{ lan_ip }}/19
 LinkLocalAddressing=no
-DNS={{ lan_ip }}
+# Commenting the below line as it has been causing race/looping issues between dnsmasq and systemd-resolved
+# IIAB ticket #1747
+#DNS={{ lan_ip }}
 Domains={{ iiab_domain }}
 
 


### PR DESCRIPTION
Thanks to @jvonau for coming up with the solution!

### Fixes Bug
#1747  

### Description of changes proposed in this pull request.
Comment out DNS line in /etc/systemd/network/IIAB-Bridge.network as it is causing race issues #1747

### Smoke-tested in operating system.
Ubuntu 18.04

### Mention a team member for further information or comment using @ name
Contact @jvonau @m-anish for more info.