### PR TITLE
Use --no-cache-dir during pip install of Lokole

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -18,7 +18,7 @@
     version: "{{ lokole_version }}"
     virtualenv: "{{ lokole_venv }}"
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
-    extra_args: --no-cache-dir    # To avoid caching issues e.g. when new releases hit https://pypi.org/project/opwen-email-client/
+    extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
   tags:
     - install
   when: internet_available | bool

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -18,6 +18,7 @@
     version: "{{ lokole_version }}"
     virtualenv: "{{ lokole_venv }}"
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
+    extra_args: --no-cache-dir    # To avoid caching issues e.g. when new releases hit https://pypi.org/project/opwen-email-client/
   tags:
     - install
   when: internet_available | bool


### PR DESCRIPTION
To avoid caching issues e.g. when new releases hit https://pypi.org/project/opwen-email-client/

Refs:

PR #1803 Lokole 0.4.2 -> 0.4.3
https://github.com/ascoderu/opwen-webapp/issues/192 When is pip install of Lokole 0.4.3 likely expected?