### PR TITLE
Ansible output fixed for internetarchive & Minetest

### DIFF
--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -18,7 +18,7 @@
     state: directory
     owner: "root"
 
-- name: Run yarn install to get needed modules (CAN TAKE ~5 MINUTES)
+- name: Run yarn install to get needed modules (CAN TAKE ~15 MINUTES)
   command: sudo yarn add @internetarchive/dweb-archive @internetarchive/dweb-mirror
   args:
     chdir: "{{ internetarchive_dir }}"

--- a/roles/minetest/tasks/rpi_minetest_install.yml
+++ b/roles/minetest/tasks/rpi_minetest_install.yml
@@ -23,7 +23,7 @@
     - /etc/minetest
     - /var/log/minetest
 
-- name: Extract {{ downloads_dir }}/{{ rpi_src }} into /library/games
+- name: Extract {{ downloads_dir }}/{{ minetest_rpi_src }} into /library/games
   unarchive:
     src: "{{ downloads_dir }}/{{ minetest_rpi_src }}"
     dest: /library/games


### PR DESCRIPTION
@mitra42 do you know why "yarn install to get needed modules" is taking so much longer than it used to?

https://github.com/iiab/iiab/blob/master/roles/internetarchive/tasks/main.yml#L21-L25

FWIW this is running on a much faster machine than in the past (RPi 4) and yet it still took 3X longer here!

(Not the end of the world of course, but several people have asked us to keep IIAB's mainline installs to less than an hour, so please help us keep an eye on it ;-)