### PR TITLE
MediaWiki 1.32.3 -> 1.33.0

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: "1.32"
-mediawiki_minor_version: "2"
+mediawiki_major_version: "1.33"
+mediawiki_minor_version: "0"
 mediawiki_version: "{{ mediawiki_major_version  }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Hot on the heels of 1.32.3 @ PR #1808

Released here:
https://lists.wikimedia.org/pipermail/mediawiki-announce/2019-July/000235.html

Release notes still converging here:
https://www.mediawiki.org/wiki/Release_notes/1.33