### PR TITLE
Fix for MySQL timing out on boot: put TimeoutStartSec=180 in mariadb.service

### DIFF
--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,4 +1,4 @@
-# MySQL MANDATORY - VARIABLE 'mysql_install' HAS NO EFFECT - SEE roles/mysql/tasks/main.yml
+# MySQL MANDATORY - THESE 2 VARS HAVE NO EFFECT - SEE roles/0-init/tasks/main.yml & roles/mysql/tasks/main.yml
 # mysql_install: True
 # mysql_enabled: True
 

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,2 +1,9 @@
-mysql_install: True
-mysql_enabled: False
+# MySQL MANDATORY - VARIABLE 'mysql_install' HAS NO EFFECT - SEE roles/mysql/tasks/main.yml
+# mysql_install: True
+# mysql_enabled: True
+
+## mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0
+# mysql_root_password: fixmysql
+
+# All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -106,7 +106,7 @@
     path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
     regexp: "^TimeoutStartSec="
-    line: "\n# 2019-07-03: @jvonau @holta doubled MariaDB's default boot timeout 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180\n"
+    line: "\n# 2019-07-03: @jvonau @holta doubled MariaDB's default boot timeout, from\n# 90 seconds to 180 seconds, for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180\n"
     # If the line above were to be run repeatedly (never happens here!) Ansible
     # would pollute MariaDB's systemd unit file.  As multi-line regexp's are
     # not allowed (both regexp's should match, for idempotency).  If nec, use

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -72,6 +72,7 @@
 - name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized
   copy:
     force: yes
+    backup: yes
     src: /lib/systemd/system/mariadb.service
     dest: /etc/systemd/system/
   when: mariadb_unit_file.stat.exists
@@ -94,7 +95,6 @@
 
 - name: Set systemd boot timeout to 180 seconds for slow machines, in /etc/systemd/system/mariadb.service
   lineinfile:
-    backup: yes
     path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
     regexp: '^TimeoutStartSec='

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -69,7 +69,7 @@
     path: /lib/systemd/system/mariadb.service
   register: mariadb_unit_file
 
-- name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized
+- name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized (CREATES TIMETAMPED BACKUP OF /etc/systemd/system/mariadb.service e.g. IF OPERATOR CUSTOMIZED IT)
   copy:
     force: yes
     backup: yes

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -106,11 +106,13 @@
     path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
     regexp: "^TimeoutStartSec="
-    line: "TimeoutStartSec=180"
-    # LINE BELOW WOULD BE NICE...BUT ANSIBLE POLLUTES EACH TIME :(
-    # Hence Ansible's 'blockinfile', but this pollutes config files in its own
-    # way.  Still, it might be nec in future, so config files are *READABLE* !
-    #line: "\n# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180"
+    line: "\n# 2019-07-03: @jvonau @holta doubled MariaDB's default boot timeout 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180\n"
+    # If the line above were to be run repeatedly (never happens here!) Ansible
+    # would pollute MariaDB's systemd unit file.  As multi-line regexp's are
+    # not allowed (both regexp's should match, for idempotency).  If nec, use
+    # the 1-liner below, or Ansible's 'blockinfile' which pollutes config files
+    # in its own way...surrounding blocks with marker lines.
+    # line: "TimeoutStartSec=180"
   when: mariadb_unit_file.stat.exists
 
 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -59,8 +59,9 @@
   tags:
     - download
 
-# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s
-# for slow machines like this Ubuntu 18.04.2 VM:
+
+# 2019-07-03 @jvonau @holta: the next 50 lines (6 stanzas) double MariaDB's
+# default boot timeout (90s to 180s) for slow CPUs like this Ubuntu 18.04.2 VM:
 # https://github.com/iiab/iiab/issues/1802
 # https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd
 
@@ -69,7 +70,7 @@
     path: /lib/systemd/system/mariadb.service
   register: mariadb_unit_file
 
-- name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized (CREATES TIMETAMPED BACKUP OF /etc/systemd/system/mariadb.service e.g. IF OPERATOR CUSTOMIZED IT)
+- name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized (CREATES TIMETAMPED BACKUPS OF /etc/systemd/system/mariadb.service e.g. IF OPERATOR CUSTOMIZED IT, EVEN DESPITE WARNING BELOW!)
   copy:
     force: yes
     backup: yes
@@ -93,17 +94,25 @@
     path: /etc/systemd/system/mysqld.service
   when: mariadb_unit_file.stat.exists
 
+- name: "WARN OPERATOR: Changes made to /etc/systemd/system/mariadb.service WILL BE LOST whenever 'mysql' playbook is run"
+  lineinfile:
+    path: /etc/systemd/system/mariadb.service
+    insertbefore: BOF    # Beginning of file
+    line: "# WARNING: CHANGES TO THIS FILE WILL BE REGULARLY *OVERWRITTEN* BY:\n# /opt/iiab/iiab/roles/mysql/tasks/main.yml\n"
+  when: mariadb_unit_file.stat.exists
+
 - name: Set systemd boot timeout to 180 seconds for slow machines, in /etc/systemd/system/mariadb.service
   lineinfile:
     path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
-    regexp: '^TimeoutStartSec='
+    regexp: "^TimeoutStartSec="
     line: "TimeoutStartSec=180"
     # LINE BELOW WOULD BE NICE...BUT ANSIBLE POLLUTES EACH TIME :(
     # Hence Ansible's 'blockinfile', but this pollutes config files in its own
     # way.  Still, it might be nec in future, so config files are *READABLE* !
     #line: "\n# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180"
   when: mariadb_unit_file.stat.exists
+
 
 # Name of MySQL service varies by OS, so hardcoded in /opt/iiab/iiab/vars/<OS>.yml (formerly in roles/0-init/tasks/main.yml)
 - name: Enable & Start MySQL systemd service ({{ mysql_service }}) if mysql_enabled

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -86,7 +86,7 @@
   systemd:
     name: "{{ mysql_service }}"
     daemon_reload: yes
-    state: started
+    state: restarted
     enabled: yes
   when: mysql_enabled | bool
 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -59,10 +59,18 @@
   tags:
     - download
 
-### lineinfile to add 'TimeoutStartSec=180' to /lib/systemd/system/mariadb.service here
-# - if file exists!
-# - avoid adding it repeatedly!
-# - daemon_reload below...
+- name: Check if /lib/systemd/system/mariadb.service exists
+  stat:
+    path: /lib/systemd/system/mariadb.service
+  register: mariadb_unit_file
+
+- name: Set systemd boot timeout to 180 seconds for slow machines, if TimeoutStartSec not already set in /lib/systemd/system/mariadb.service
+  lineinfile:
+    path: /lib/systemd/system/mariadb.service
+    insertafter: '[Service]'
+    regexp: TimeoutStartSec
+    line: '\n# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180'
+  when: mariadb_unit_file.stat.exists
 
 # Name of MySQL service varies by OS, so hardcoded in /opt/iiab/iiab/vars/<OS>.yml (formerly in roles/0-init/tasks/main.yml)
 - name: Enable & Start MySQL systemd service ({{ mysql_service }}) if mysql_enabled

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -59,12 +59,16 @@
   tags:
     - download
 
-### lineinfile to add 'TimeoutStartSec=180' to /lib/systemd/system/mariadb.service here?
+### lineinfile to add 'TimeoutStartSec=180' to /lib/systemd/system/mariadb.service here
+# - if file exists!
+# - avoid adding it repeatedly!
+# - daemon_reload below...
 
-# Name of MySQL service varies by OS so softcoded in 1-prep
+# Name of MySQL service varies by OS, so hardcoded in /opt/iiab/iiab/vars/<OS>.yml (formerly in roles/0-init/tasks/main.yml)
 - name: Enable & Start MySQL systemd service ({{ mysql_service }}) if mysql_enabled
   systemd:
     name: "{{ mysql_service }}"
+    daemon_reload: yes
     state: started
     enabled: yes
   when: mysql_enabled | bool

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -59,19 +59,42 @@
   tags:
     - download
 
-- name: Check if /lib/systemd/system/mariadb.service exists
-  stat:
-    path: /lib/systemd/system/mariadb.service
-  register: mariadb_unit_file
-
 # 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s
 # for slow machines like this Ubuntu 18.04.2 VM:
 # https://github.com/iiab/iiab/issues/1802
 # https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd
 
-- name: Set systemd boot timeout to 180 seconds for slow machines, in /lib/systemd/system/mariadb.service
-  lineinfile:
+- name: Check if /lib/systemd/system/mariadb.service exists
+  stat:
     path: /lib/systemd/system/mariadb.service
+  register: mariadb_unit_file
+
+- name: Copy pkg's /lib/systemd/system/mariadb.service to /etc/systemd/system/ to be customized
+  copy:
+    force: yes
+    src: /lib/systemd/system/mariadb.service
+    dest: /etc/systemd/system/
+  when: mariadb_unit_file.stat.exists
+
+- name: Symlink /etc/systemd/system/mysql.service -> /etc/systemd/system/mariadb.service
+  file:
+    state: link
+    force: yes
+    src: /etc/systemd/system/mariadb.service
+    path: /etc/systemd/system/mysql.service
+  when: mariadb_unit_file.stat.exists
+
+- name: Symlink /etc/systemd/system/mysqld.service -> /etc/systemd/system/mariadb.service
+  file:
+    state: link
+    force: yes
+    src: /etc/systemd/system/mariadb.service
+    path: /etc/systemd/system/mysqld.service
+  when: mariadb_unit_file.stat.exists
+
+- name: Set systemd boot timeout to 180 seconds for slow machines, in /etc/systemd/system/mariadb.service
+  lineinfile:
+    path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
     regexp: '^TimeoutStartSec='
     line: "TimeoutStartSec=180"

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -64,12 +64,21 @@
     path: /lib/systemd/system/mariadb.service
   register: mariadb_unit_file
 
-- name: Set systemd boot timeout to 180 seconds for slow machines, if TimeoutStartSec not already set in /lib/systemd/system/mariadb.service
+# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s
+# for slow machines like this Ubuntu 18.04.2 VM:
+# https://github.com/iiab/iiab/issues/1802
+# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd
+
+- name: Set systemd boot timeout to 180 seconds for slow machines, in /lib/systemd/system/mariadb.service
   lineinfile:
     path: /lib/systemd/system/mariadb.service
-    insertafter: '[Service]'
-    regexp: TimeoutStartSec
-    line: '\n# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180'
+    insertafter: '^\[Service\]$'
+    regexp: '^TimeoutStartSec='
+    line: "TimeoutStartSec=180"
+    # LINE BELOW WOULD BE NICE...BUT ANSIBLE POLLUTES EACH TIME :(
+    # Hence Ansible's 'blockinfile', but this pollutes config files in its own
+    # way.  Still, it might be nec in future, so config files are *READABLE* !
+    #line: "\n# 2019-07-03: @jvonau @holta doubled the default boot timeout from 90s to 180s\n# for slow machines like this Ubuntu 18.04.2 VM:\n# https://github.com/iiab/iiab/issues/1802\n# https://mariadb.com/kb/en/library/what-to-do-if-mariadb-doesnt-start/#systemd\nTimeoutStartSec=180"
   when: mariadb_unit_file.stat.exists
 
 # Name of MySQL service varies by OS, so hardcoded in /opt/iiab/iiab/vars/<OS>.yml (formerly in roles/0-init/tasks/main.yml)

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -94,6 +94,7 @@
 
 - name: Set systemd boot timeout to 180 seconds for slow machines, in /etc/systemd/system/mariadb.service
   lineinfile:
+    backup: yes
     path: /etc/systemd/system/mariadb.service
     insertafter: '^\[Service\]$'
     regexp: '^TimeoutStartSec='

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -18,11 +18,11 @@
   tags:
     - download
 
-- name: Install php{{ php_version }}-xml (ubuntu or debian-9)
+- name: Install php{{ php_version }}-xml (ubuntu or debian 9+)
   package:
     name: "php{{ php_version }}-xml"
     state: present
-  when: is_ubuntu or is_debian_9
+  when: is_ubuntu or (is_debian and not is_debian_8)
 
 - name: Install php-xml-parser (debian-8)
   package:
@@ -59,16 +59,13 @@
   tags:
     - download
 
+### lineinfile to add 'TimeoutStartSec=180' to /lib/systemd/system/mariadb.service here?
+
 # Name of MySQL service varies by OS so softcoded in 1-prep
-- name: 'Start MySQL systemd service: {{ mysql_service }}'
+- name: Enable & Start MySQL systemd service ({{ mysql_service }}) if mysql_enabled
   systemd:
     name: "{{ mysql_service }}"
     state: started
-  when: mysql_enabled | bool
-
-- name: Enable MySQL systemd service (upon subsequent boots) if mysql_enabled
-  systemd:
-    name: "{{ mysql_service }}"
     enabled: yes
   when: mysql_enabled | bool
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -218,7 +218,7 @@ apache_allow_sudo: True
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 
-# MySQL MANDATORY - THESE SETTINGS HAVE NO EFFECT - SEE roles/1-prep/tasks/computed_vars.yml, roles/mysql/tasks/main.yml
+# MySQL MANDATORY - VARIABLE 'mysql_install' HAS NO EFFECT - SEE roles/mysql/tasks/main.yml
 mysql_install: True
 mysql_enabled: True
 # mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -218,7 +218,7 @@ apache_allow_sudo: True
 apache_high_php_limits: False
 # SEE ALSO VARIABLES NEAR TOP OF THIS FILE: default_language, language_priority
 
-# MySQL MANDATORY - VARIABLE 'mysql_install' HAS NO EFFECT - SEE roles/mysql/tasks/main.yml
+# MySQL MANDATORY - THESE 2 VARS HAVE NO EFFECT - SEE roles/0-init/tasks/main.yml & roles/mysql/tasks/main.yml
 mysql_install: True
 mysql_enabled: True
 # mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0


### PR DESCRIPTION
Fixes #1802 "MySQL (MariaDB 10.1.40) fails on every boot, Ubuntu Server 18.04 VM, fresh IIAB BIG-sized install [so http://box/mediawiki "Cannot access the database" etc]"