### PR TITLE
Nextcloud 15 is required for older OS's that lack PHP 7.1 e.g. Ubuntu 16.04, Raspbian 9, Debian 9

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -15,7 +15,7 @@ nextcloud_dl_url: https://download.nextcloud.com/server/releases
 # 2019-05-11: latest-16.tar.bz2 finally published to https://download.nextcloud.com/server/releases/ (nextcloud/server#15502) e.g. for Ubuntu 18.04 & Debian 10
 nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-07-04: for legacy OS's {Debian 9, Raspbian 9, Ubuntu 16} where PHP 7.1+ isn't available
 nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
-nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-07-04: for all other OS's e.g. Debian 10 & Ubuntu 18.04+ where PHP 7.1+ is hopefully available!
+nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-07-04: for other/newer OS's e.g. Raspbian 10, Debian 10 & Ubuntu 18.04+ -- where PHP 7.1+ is hopefully available!
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -13,9 +13,9 @@ nextcloud_data_dir: "{{ content_base }}/nextcloud/data"
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
 
 # 2019-05-11: latest-16.tar.bz2 finally published to https://download.nextcloud.com/server/releases/ (nextcloud/server#15502) e.g. for Ubuntu 18.04 & Debian 10
-nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-05-16: for legacy OS's Debian 9 & Raspbian 9 where PHP 7.1+ isn't available
+nextcloud_orig_src_file_old: latest-15.tar.bz2    # 2019-07-04: for legacy OS's {Debian 9, Raspbian 9, Ubuntu 16} where PHP 7.1+ isn't available
 nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
-nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-05-16: for all other OS's e.g. Debian 10 & Ubuntu 18.04 where PHP 7.1+ is hopefully available!
+nextcloud_orig_src_file: latest-16.tar.bz2        # 2019-07-04: for all other OS's e.g. Debian 10 & Ubuntu 18.04+ where PHP 7.1+ is hopefully available!
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # we install on mysql with these setting or those from default_vars, etc.

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -25,7 +25,7 @@
   #poll: 10
   tags:
     - download
-  when: internet_available and nextcloud_force_install and (is_debian_9 or is_raspbian_9)
+  when: internet_available and nextcloud_force_install and (is_debian_9 or is_raspbian_9 or is_ubuntu_16)
 
 - name: Download {{ nextcloud_dl_url }}/{{ nextcloud_orig_src_file }} to {{ downloads_dir }}/{{ nextcloud_src_file }} on newer OS's that have PHP 7.1+
   get_url:
@@ -38,7 +38,7 @@
   #poll: 10
   tags:
     - download
-  when: internet_available and nextcloud_force_install and not (is_debian_9 or is_raspbian_9)
+  when: internet_available and nextcloud_force_install and not (is_debian_9 or is_raspbian_9 or is_ubuntu_16)
 
 # Ubuntu and Debian treat names differently
 - name: Install 3 php packages (debian)
@@ -103,14 +103,14 @@
     src: "{{ downloads_dir }}/{{ nextcloud_src_file_old }}"
     dest: "{{ nextcloud_prefix }}"
     #creates: "{{ nextcloud_prefix }}/nextcloud/version.php"
-  when: nextcloud_force_install and (is_debian_9 or is_raspbian_9)
+  when: nextcloud_force_install and (is_debian_9 or is_raspbian_9 or is_ubuntu_16)
 
 - name: Unarchive {{ nextcloud_src_file }} to permanent location {{ nextcloud_prefix }}/nextcloud on newer OS's that have PHP 7.1+    # e.g. unpack nextcloud_latest-16.tar.bz2 to /opt/nextcloud
   unarchive:
     src: "{{ downloads_dir }}/{{ nextcloud_src_file }}"
     dest: "{{ nextcloud_prefix }}"
     #creates: "{{ nextcloud_prefix }}/nextcloud/version.php"
-  when: nextcloud_force_install and not (is_debian_9 or is_raspbian_9)
+  when: nextcloud_force_install and not (is_debian_9 or is_raspbian_9 or is_ubuntu_16)
 
 - name: Create dir /etc/nextcloud (centos) for a subsequent config dir that's symlinked to /etc/nextcloud ?
   file:


### PR DESCRIPTION
Builds on PR #1667, as summarized @ #1615