### PR TITLE
1m & 1km details are often visible, don't sell us short!  [OSM]

### DIFF
--- a/roles/osm-vector-maps/templates/iiab-update-map
+++ b/roles/osm-vector-maps/templates/iiab-update-map
@@ -180,7 +180,7 @@ def create_menu_def(region,default_name,intended_use='map'):
    menuDef["map_name"] = item['perma_ref']
    # the following is in the idx json
    #menuDef["file_name"] = lang + '-osm-omt_' + region + '_' + os.path.basename(item['url'])[:-4]
-   menuDef["description"] = '18 levels of zoom (5 m resolution) for ' + fancyTitle + ', illustrating human geography.<p>10 levels of zoom (5 km resolution) for satellite photos, covering the whole world.'
+   menuDef["description"] = '18 levels of zoom (~1 m details) for ' + fancyTitle + ', illustrating human geography.<p>10 levels of zoom (~1 km details) for satellite photos, covering the whole world.'
    menuDef["extra_description"] = 'Search for cities/towns with more than 1000 people.  There are about 127,654 worldwide.'
    menuDef["extra_html"] = ""
    #menuDef["automatically_generated"] = "true"


### PR DESCRIPTION
Builds on PRs #1823, #1824 and the revised documentation @ https://github.com/iiab/iiab/wiki/IIAB-Maps

Our prior docs & description mentioned 5m & 5km, which is really selling us badly short, as to what is often possible with IIAB's new OSM vector maps & satellite imagery.

Example 1: OSM within IIAB's new Map Packs show many buildings worldwide to 1m accuracy or better.

Example 2: Central Park is may not gorgeous in postcard glory, but it's very clearly visible via IIAB/Sentinel's new satellite imagery, even despite the fact that it (Central Park) is less than 1 km wide in actual fact.

Ref: https://github.com/iiab/iiab/issues/1739