### PR TITLE
Enable http://box/map too, per #1496 + osm-vector-maps/README.md

### DIFF
--- a/roles/osm-vector-maps/README.md
+++ b/roles/osm-vector-maps/README.md
@@ -1,0 +1,6 @@
+# OSM Vector Maps README
+
+### Documentation
+
+- Please see [IIAB Maps](https://github.com/iiab/iiab/wiki/IIAB-Maps) for the latest implementer-focused instructions!
+- Also: ["How do I add zoomable maps for my region?"](http://FAQ.IIAB.IO#How_do_I_add_zoomable_maps_for_my_region.3F) in [FAQ.IIAB.IO](http://FAQ.IIAB.IO)

--- a/roles/osm-vector-maps/templates/osm-vector-maps.conf
+++ b/roles/osm-vector-maps/templates/osm-vector-maps.conf
@@ -1,4 +1,4 @@
-# For downloadable regional vector tilesets
+# For downloadable regional vector tilesets, see https://github.com/iiab/iiab/wiki/IIAB-Maps
 Alias /map {{ vector_map_path }}
 Alias /maps {{ vector_map_path }}
 Alias /osm-vector-maps {{ vector_map_path }}

--- a/roles/osm-vector-maps/templates/osm-vector-maps.conf
+++ b/roles/osm-vector-maps/templates/osm-vector-maps.conf
@@ -1,4 +1,5 @@
 # For downloadable regional vector tilesets
+Alias /map {{ vector_map_path }}
 Alias /maps {{ vector_map_path }}
 Alias /osm-vector-maps {{ vector_map_path }}
 <Directory {{ vector_map_path }}>


### PR DESCRIPTION
Implements #1496 "Make http://box/maps & http://box/map work with whatever maps the implementer has...most recently installed? [OSM]"