### PR TITLE
osm-vector-maps playbook: reload Apache at end

### DIFF
--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -90,3 +90,8 @@
     src: test-index.redirect
     dest: "{{ vector_map_path }}/index.html"
   #when: not osm_redirect.stat.exists
+
+- name: Reload Apache service ({{ apache_service }})    # e.g. apache2
+  systemd:
+    name: "{{ apache_service }}"
+    state: reloaded


### PR DESCRIPTION
Allows `cd /opt/iiab/iiab ; ./runrole osm-vector-maps` to complete the job properly.

Builds on PRs #1834 #1835 #1836 

Ref: #877