### PR TITLE
Add logic to install a given commit from the Lokole repository

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -21,7 +21,25 @@
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
   tags:
     - install
-  when: internet_available | bool
+  when:
+    - internet_available | bool
+    - lokole_commit is undefined
+
+# For development purposes -- To install Lokole from a given commit, add the
+# following line to roles/lokole/defaults/main.yml:
+# 
+# lokole_commit: <git_commit_id>
+- name: pip install opwen_email_client (Lokole) from git commit {{ lokole_commit }} (for development purposes)
+  pip:
+    name: "git+https://github.com/ascoderu/opwen-webapp.git@{{ lokole_commit }}#egg=opwen_email_client"
+    virtualenv: "{{ lokole_venv }}"
+    virtualenv_command: python3 -m venv "{{ lokole_venv }}"
+    extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
+  tags:
+    - install
+  when:
+    - internet_available | bool
+    - lokole_commit is defined
 
 - name: Compile translations
   shell: |


### PR DESCRIPTION
### Fixes Bug
N/A

### Description of changes proposed in this pull request.
To make testing Lokole on IIAB easier, I've added an alternative play that installs an unreleased version of Lokole from [ascoderu/opwen-webapp](https://github.com/ascoderu/opwen-webapp) instead of a released version from PyPI. This play is activated by setting `lokole_commit` to the ID of the commit you want to install from. If `lokole_commit` is unset, the standard play to install a released version will run instead.

I anticipate that this will streamline addressing #1830 and future integration testing of Lokole &times; IIAB.

### Smoke-tested in operating system.
N/A, although I have used this hack on my development server, which runs Ubuntu 18.04.2 LTS.

### Mention a team member for further information or comment using @ name
@holta
