### PR TITLE
Ugly workaround so that IIAB installs on Debian 10 Buster (which suddenly removed monit)

### DIFF
--- a/roles/monit/tasks/install.yml
+++ b/roles/monit/tasks/install.yml
@@ -22,19 +22,19 @@
     group: root
     mode: 0600
 
-- name: Install config file /etc/monit.d/watchdog from template (NEVER RUNS, WHY?)
-  template:
-    src: watchdog
-    dest: /etc/monit.d/watchdog
-    owner: root
-    group: root
-    force: yes
-    mode: 0755
-  register: monit_config
-  when: False    # IS THIS A BUG ?
-  until: monit_config | success
-  retries: 5
-  delay: 1
+# - name: Install config file /etc/monit.d/watchdog from template (NEVER RUNS, WHY?)
+#  template:
+#    src: watchdog
+#    dest: /etc/monit.d/watchdog
+#    owner: root
+#    group: root
+#    force: yes
+#    mode: 0755
+#  register: monit_config
+#  when: False    # IS THIS A BUG ?
+#  until: monit_config | success
+#  retries: 5
+#  delay: 1
 
 #TODO: create systemd script
 - name: Enable 'monit' service (chkconfig monit on)

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Install 'monit' if monit_install and not Debian 10+
+  include_tasks: install.yml
+  when: monit_install and not ((is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9))

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,3 +1,14 @@
+# 2019-07-06: The 'monit' package was suddenly removed from Debian 10.0.0
+# "Buster" during the very final days prior to release, as confirmed by the
+# sudden disappearance of these 2 pages:
+#
+#   https://packages.debian.org/buster/monit
+#   https://packages.debian.org/source/buster/monit
+#
+# And yet Raspbian Buster (is_raspbian_10, which confusingly IIAB declares to
+# be is_debian_10 in vars/raspbian-10.yml for now!) still provides 'monit' via
+# apt -- so eliminating "Debian 10+" requires this funky conditional:
+
 - name: Install 'monit' if monit_install and not Debian 10+
   include_tasks: install.yml
   when: monit_install and not ((is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9))


### PR DESCRIPTION
Bypasses installation of 'monit' on Debian 10+ for now.

Not our fault, that Debian 10 suddenly yanked `monit` during the very final days prior to its 2019-07-06 release.

Still, IIAB variables `is_debian` and `is_debian_*` really should "mean what they say and say what they mean" in future, e.g. for IIAB 7.1 [*] just as when spoken out loud / in plain English!  But let's leave it as is just for now, to get IIAB 7.0 out the door!

Documented @ https://github.com/iiab/iiab/blob/master/roles/monit/tasks/main.yml

[*] Much like #1406, `is_rpi` should likewise speak the truth about RPi hardware regardless of OS.  In that case, the separate variable `is_raspbian` is established for purposes of identifying the Raspbian OS &mdash; no matter whether the underlying HW is RPi, PC or Mac.