### PR TITLE
9-local-addons/tasks/main.yml playbooks in alphabetical order

### DIFF
--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -15,17 +15,17 @@
   when: calibreweb_install | bool
   tags: calibre-web
 
-- name: MINETEST
-  include_role:
-    name: minetest
-  when: minetest_install | bool
-  tags: minetest
-
 - name: INTERNETARCHIVE
   include_role:
     name: internetarchive
   when: internetarchive_install | bool
   tags: internetarchive
+
+- name: MINETEST
+  include_role:
+    name: minetest
+  when: minetest_install | bool
+  tags: minetest
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:


### PR DESCRIPTION
In keeping with IIAB's other stages (1 to 9 anyway) we try to run the playbooks in alphabetical order, within each of these 9 stages, where possible anyway.