### PR TITLE
Warn implementers: kiwix_install: True is REQUIRED, if you install IIAB's Admin Console

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -370,6 +370,7 @@ kolibri_install: False
 kolibri_enabled: False
 kolibri_http_port: 8009
 
+# kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True
 kiwix_enabled: True
 kiwix_port: 3000

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -234,6 +234,7 @@ kalite_cron_enabled: True
 kolibri_install: True
 kolibri_enabled: True
 
+# kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True
 kiwix_enabled: True
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -234,6 +234,7 @@ kalite_cron_enabled: True
 kolibri_install: False
 kolibri_enabled: False
 
+# kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True
 kiwix_enabled: True
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -234,6 +234,7 @@ kalite_cron_enabled: True
 kolibri_install: False
 kolibri_enabled: False
 
+# kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True
 kiwix_enabled: True
 


### PR DESCRIPTION
Documentation to reduce the number of implementers who fall in this trap: #1822