### PR TITLE
Moodle 3.5.x -> 3.7.x, for new OS's that contain PHP 7.3, for #1658

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -7,7 +7,7 @@
 # If using Moodle intensively, consider setting apache_high_php_limits in:
 # /etc/iiab/local_vars.yml
 
-moodle_version: 35
+moodle_version: 37
 #moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_repo_url: "git://git.moodle.org/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"    # /opt/iiab


### PR DESCRIPTION
See #1658 PHP 7.x / 7.3 issue.