### PR TITLE
Download Raspberry Pi resources and make available offline

### DIFF
--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -37,11 +37,11 @@ lynx -reload -source https://github.com/XSCE/xsce/wiki/IIAB-6.2-Release-Notes > 
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.0.md > $DESTPATH/ReleaseNotes6.0.html
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.1.md > $DESTPATH/ReleaseNotes6.1.html
 
-# Get raspberry pi resources
-wget -P $DESTPATH https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf 
-wget -P $DESTPATH https://dn.odroid.com/IoT/other_doc.pdf 
+# Download Raspberry Pi guides
+wget -nc -P $DESTPATH https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf
+wget -nc -P $DESTPATH https://dn.odroid.com/IoT/other_doc.pdf
 
-# update the link to pi resources on the info splash page
+# Update Raspberry Pi guide links on main page (http://box/info)
 sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
 sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|other_doc.pdf|g" $DESTPATH/index.html
 

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -37,6 +37,14 @@ lynx -reload -source https://github.com/XSCE/xsce/wiki/IIAB-6.2-Release-Notes > 
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.0.md > $DESTPATH/ReleaseNotes6.0.html
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.1.md > $DESTPATH/ReleaseNotes6.1.html
 
+# Get raspberry pi resources
+wget -P $DESTPATH https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf 
+wget -P $DESTPATH https://dn.odroid.com/IoT/other_doc.pdf 
+
+# update the link to pi resources on the info splash page
+sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
+sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|other_doc.pdf|g" $DESTPATH/index.html
+
 # Make links refer to local items
 for f in $DESTPATH/*.html; do
     sed -i -r "s|https://github.com/iiab/iiab/wiki/([-.A-Za-z0-9]*)|\1.html|g" $f


### PR DESCRIPTION

This has been tested on rpi4. 

It is coupled with a change to the iiab main wiki page (already done).

The main wiki page has two bullets for the two pi resources. The bullets are not translated by lynx correctly -- they are rendered inline.

But the links to the web are correctly changed to refer to /info/<rpi pdfs>

The update procedure for an already initialized pi involves:
```
./runrole httpd
iiab-refresh-wiki-docs
```