### PR TITLE
Add Lokole PDF (User's Guide) to http://box/info offline docs

### DIFF
--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -3,15 +3,17 @@
 # Pull down repo's entire wiki (and similar) to create offline docs
 
 set -e
-source {{ iiab_env_file }}
+source {{ iiab_env_file }}       # /etc/iiab/iiab.env
 INPUT=/tmp/iiab-wiki
 OUTPUT=/tmp/iiab-wiki.out
-DESTPATH=/library/www/html/info
+DESTPATH="{{ doc_root }}/info    # /library/www/html/info
+DOCSPATH=$DESTPATH/docs          # /library/www/html/info/docs
 
 rm -rf $INPUT
 rm -rf $OUTPUT
 mkdir -p $INPUT
 mkdir -p $OUTPUT
+mkdir -p $DOCSPATH
 
 git clone https://github.com/iiab/iiab.wiki.git $INPUT
 
@@ -38,12 +40,12 @@ lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.1.md > $DESTPATH/ReleaseNotes6.1.html
 
 # Download Raspberry Pi guides
-wget -nc -P $DESTPATH https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf
-wget -nc -P $DESTPATH https://dn.odroid.com/IoT/other_doc.pdf
+wget -nc https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf -O $DOCSPATH/Raspberry_Pi_Beginners_Guide_v1.pdf
+wget -nc https://dn.odroid.com/IoT/other_doc.pdf -O $DOCSPATH/Raspberry_Pi_User_Guide_v4.pdf
 
 # Update Raspberry Pi guide links on main page (http://box/info)
-sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
-sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|other_doc.pdf|g" $DESTPATH/index.html
+sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|docs/Raspberry_Pi_Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
+sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|docs/Raspberry_Pi_User_Guide_v4.pdf|g" $DESTPATH/index.html
 
 # Make links refer to local items
 for f in $DESTPATH/*.html; do

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -x
 
-# Pull down iiab/iiab repo's entire Tech Docs Wiki (and scrape/download other
-# docs!) to create IIAB's offline docs collection: http://box/info
+# This /opt/iiab/iiab/roles/httpd/templates/refresh-wiki-docs.sh becomes
+# /usr/bin/iiab-refresh-wiki-docs during IIAB's install.
+
+# This pulls down iiab/iiab repo's entire Tech Docs Wiki (and scrapes/downloads
+# other docs!) to create IIAB's offline docs collection: http://box/info
 
 set -e                           # Exit on error (avoids snowballing)
 source {{ iiab_env_file }}       # /etc/iiab/iiab.env

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -44,8 +44,8 @@ lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6
 lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6.1.md > $DESTPATH/ReleaseNotes6.1.html
 
 # Download Raspberry Pi guides
-wget -nc https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf -O $DOCSPATH/Raspberry_Pi_Beginners_Guide_v1.pdf
-wget -nc https://dn.odroid.com/IoT/other_doc.pdf -O $DOCSPATH/Raspberry_Pi_User_Guide_v4.pdf
+wget -nc https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf -O $DOCSPATH/Raspberry_Pi_Beginners_Guide_v1.pdf || true    # Overrides set -e
+wget -nc https://dn.odroid.com/IoT/other_doc.pdf -O $DOCSPATH/Raspberry_Pi_User_Guide_v4.pdf || true
 
 cp -p "{{ iiab_dir }}/roles/lokole/The Lokole-IIAB User's Manual.pdf" $DOCSPATH    # /opt/iiab/iiab
 

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -52,7 +52,7 @@ cp -p "{{ iiab_dir }}/roles/lokole/The Lokole-IIAB User's Manual.pdf" $DOCSPATH 
 # Update Raspberry Pi guide links on main page (http://box/info)
 sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|docs/Raspberry_Pi_Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
 sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|docs/Raspberry_Pi_User_Guide_v4.pdf|g" $DESTPATH/index.html
-sed -i -r "s|https://github.com/iiab/iiab/blob/master/roles/lokole/The%20Lokole-IIAB%20User's%20Manual.pdf|docs/The Lokole-IIAB User's Manual.pdf|g" $DESTPATH/index.html
+sed -i -r "s|https://github.com/iiab/iiab/blob/master/roles/lokole/The%20Lokole-IIAB%20User&#39;s%20Manual.pdf|docs/The%20Lokole-IIAB%20User\&#39;s%20Manual.pdf|g" $DESTPATH/index.html
 
 # Make links refer to local items
 for f in $DESTPATH/*.html; do

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -x
 
-# Pull down repo's entire wiki (and similar) to create offline docs
+# Pull down iiab/iiab repo's entire Tech Docs Wiki (and scrape/download other
+# docs!) to create IIAB's offline docs collection: http://box/info
 
-set -e
+set -e                           # Exit on error (avoids snowballing)
 source {{ iiab_env_file }}       # /etc/iiab/iiab.env
 INPUT=/tmp/iiab-wiki
 OUTPUT=/tmp/iiab-wiki.out
@@ -43,9 +44,12 @@ lynx -reload -source https://github.com/XSCE/xsce/blob/release-6.2/ReleaseNotes6
 wget -nc https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf -O $DOCSPATH/Raspberry_Pi_Beginners_Guide_v1.pdf
 wget -nc https://dn.odroid.com/IoT/other_doc.pdf -O $DOCSPATH/Raspberry_Pi_User_Guide_v4.pdf
 
+cp -p "{{ iiab_dir }}/roles/lokole/The Lokole-IIAB User's Manual.pdf" $DOCSPATH    # /opt/iiab/iiab
+
 # Update Raspberry Pi guide links on main page (http://box/info)
 sed -i -r "s|https://www.raspberrypi.org/magpi-issues/Beginners_Guide_v1.pdf|docs/Raspberry_Pi_Beginners_Guide_v1.pdf|g" $DESTPATH/index.html
 sed -i -r "s|https://dn.odroid.com/IoT/other_doc.pdf|docs/Raspberry_Pi_User_Guide_v4.pdf|g" $DESTPATH/index.html
+sed -i -r "s|https://github.com/iiab/iiab/blob/master/roles/lokole/The%20Lokole-IIAB%20User's%20Manual.pdf|docs/The Lokole-IIAB User's Manual.pdf|g" $DESTPATH/index.html
 
 # Make links refer to local items
 for f in $DESTPATH/*.html; do

--- a/roles/httpd/templates/refresh-wiki-docs.sh
+++ b/roles/httpd/templates/refresh-wiki-docs.sh
@@ -10,7 +10,7 @@ set -e                           # Exit on error (avoids snowballing)
 source {{ iiab_env_file }}       # /etc/iiab/iiab.env
 INPUT=/tmp/iiab-wiki
 OUTPUT=/tmp/iiab-wiki.out
-DESTPATH="{{ doc_root }}/info    # /library/www/html/info
+DESTPATH={{ doc_root }}/info     # /library/www/html/info
 DOCSPATH=$DESTPATH/docs          # /library/www/html/info/docs
 
 rm -rf $INPUT

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -131,11 +131,6 @@
     name: "{{ apache_service }}"
     state: restarted
 
-- name: Copy "The Lokole-IIAB User's Manual.pdf" for offline reading at http://box/info
-  copy:
-    src: "{{ iiab_dir }}/roles/lokole/The Lokole-IIAB User's Manual.pdf"    # /opt/iiab/iiab
-    dest: "{{ doc_root }}/info/docs"    # /library/www/html
-
 - name: Add 'lokole' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -131,6 +131,11 @@
     name: "{{ apache_service }}"
     state: restarted
 
+- name: Copy "The Lokole-IIAB User's Manual.pdf" for offline reading at http://box/info
+  copy:
+    src: "{{ iiab_dir }}/roles/lokole/The Lokole-IIAB User's Manual.pdf"    # /opt/iiab/iiab
+    dest: "{{ doc_root }}/info/docs"    # /library/www/html
+
 - name: Add 'lokole' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -1,3 +1,6 @@
+# Lokole PDF (User's Guide) gets copied for offline use (http://box/info) here:
+# https://github.com/iiab/iiab/blob/master/roles/httpd/templates/refresh-wiki-docs.sh#L47
+
 - name: "Install 7 packages for Lokole: python3, python3-pip, python3-venv, python3-dev, libffi-dev, libssl-dev, bcrypt"
   apt:
     name:


### PR DESCRIPTION
Per @m-anish's suggestion, working in conjunction with the scraping of Lokole link(s) added near the bottom of https://github.com/iiab/iiab/wiki