### PR TITLE
Revert #1886 to install patch_auto, on Debian 9+ (installs on Raspbian 9+ too, harmlessly)

### DIFF
--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -49,18 +49,18 @@
     src: network/rpi.j2
   when: is_rpi and iiab_lan_iface == "br0"
 
-- name: Workaround auto issue - ifupdown compatibility mode (debian-9)
+- name: Workaround auto issue - ifupdown compatibility mode (debian-9+)
   template:
     dest: /etc/network/interfaces.d/patch_auto
     src: network/debian-auto.j2
-  when: iiab_wan_iface != "none" and is_debian_9
+  when: iiab_wan_iface != "none" and is_debian and not is_debian_8
 
-- name: Clearing out /etc/network/interfaces for static addresses (debian-9)
+- name: Clearing out /etc/network/interfaces for static addresses (debian-9+)
   lineinfile:
     state: absent
     path: /etc/network/interfaces
     regexp: "{{ iiab_wan_iface }}"
-  when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian_9
+  when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian and not is_debian_8
 
 - name: BIND may be affected
   service:

--- a/roles/network/templates/network/debian-auto.j2
+++ b/roles/network/templates/network/debian-auto.j2
@@ -1,1 +1,3 @@
+# Supplied by iiab-install or iiab-network (in /opt/iiab/iiab)
+
 auto {{ iiab_wan_iface }}


### PR DESCRIPTION
Reverts https://github.com/iiab/iiab/pull/1886

`/etc/network/interfaces.d/patch_auto` turns out to be required, when restarting networking (during IIAB install's network role) even if it's not required on boot!