### PR TITLE
calibreweb_version: V0.6.4 -> 0.6.4 as it was re-released 5h ago

### DIFF
--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -14,7 +14,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-calibreweb_version: V0.6.4    # WAS: master
+calibreweb_version: 0.6.4    # WAS: master
 
 calibreweb_venv_path: /usr/local/calibre-web
 calibreweb_exec_path: "{{ calibreweb_venv_path }}/cps.py"


### PR DESCRIPTION
Builds on PRs #1863, essentially reversing PR #1864 as upstream naming convention keeps changing :)