### PR TITLE
Skip yarn add if installed, but allow yarn upgrade if set in local_vars.yml

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -124,6 +124,7 @@ if [ -f /etc/iiab/iiab.env ]; then
         echo "Removed /etc/iiab/iiab.env effectively resetting STAGE (counter)."
     elif [ "$1" == "--reinstall" ]; then
         STAGE=0
+        ARGS="$ARGS --extra-vars reinstall=True"
         sed -i 's/^STAGE=.*/STAGE=0/' /etc/iiab/iiab.env
         echo "Wrote STAGE=0 (counter) to /etc/iiab/iiab.env"
     elif [ "$STAGE" -ge 2 ] && [ "$1" == "--debug" ]; then

--- a/roles/0-init/tasks/first_run.yml
+++ b/roles/0-init/tasks/first_run.yml
@@ -1,2 +1,8 @@
+- name: Create symlink /usr/bin/iiab-diagnostics
+  file:
+    src: "{{ iiab_dir }}/scripts/iiab-diagnostics"
+    dest: /usr/bin/iiab-diagnostics
+    state: link
+
 - name: Create {{ iiab_ini_file }}
   include_tasks: iiab_ini.yml

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -1,11 +1,4 @@
 # Initialize
-
-- name: Create symlink /usr/bin/iiab-diagnostics
-  file:
-    src: "{{ iiab_dir }}/scripts/iiab-diagnostics"
-    dest: /usr/bin/iiab-diagnostics
-    state: link
-
 - name: ...IS BEGINNING ============================================
   stat:
     path: "{{ iiab_env_file }}"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -11,12 +11,10 @@
 
 # We need to inialize the ini file and only write the location and version
 # sections once and only once to preserve the install date and git hash.
-- name: Create IIAB directory structure and {{ iiab_ini_file }}, if first_run
+- name: Create IIAB tools and {{ iiab_ini_file }}, if first_run
   include_tasks: first_run.yml
   when: first_run | bool
 
-#- name: Loading computed_vars
-#  include_tasks: roles/0-init/tasks/computed_vars.yml
 - name: Re-read local_facts.facts from /etc/ansible/facts.d
   setup:
     filter: ansible_local

--- a/roles/internetarchive/defaults/main.yml
+++ b/roles/internetarchive/defaults/main.yml
@@ -7,3 +7,4 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 internetarchive_dir: '{{ iiab_base }}/internetarchive'
+IA_upgrade: False

--- a/roles/internetarchive/defaults/main.yml
+++ b/roles/internetarchive/defaults/main.yml
@@ -7,4 +7,4 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 internetarchive_dir: '{{ iiab_base }}/internetarchive'
-IA_upgrade: False
+internetarchive_upgrade: False

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -73,7 +73,10 @@
     state: stopped
 
 - name: 'Update pre-existing install: sudo yarn upgrade'
-  command: sudo yarn upgrade
+  command: yarn upgrade
+  become: yes
+  become_method: sudo
+  become_user: root
   args:
     chdir: "{{ internetarchive_dir }}"
   when: not internetarchive_installing.changed and internetarchive_upgrade

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -19,7 +19,10 @@
     owner: "root"
 
 - name: Run yarn install to get needed modules (CAN TAKE ~15 MINUTES)
-  command: sudo yarn add @internetarchive/dweb-archive @internetarchive/dweb-mirror
+  command: yarn add @internetarchive/dweb-archive @internetarchive/dweb-mirror
+  become: yes
+  become_method: sudo
+  become_user: root
   args:
     chdir: "{{ internetarchive_dir }}"
     creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -72,7 +72,7 @@
     daemon_reload: yes
     state: stopped
 
-- name: 'Update pre-existing install: sudo yarn upgrade'
+- name: 'Update pre-existing install: yarn upgrade'
   command: yarn upgrade
   args:
     chdir: "{{ internetarchive_dir }}"

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -22,13 +22,21 @@
   command: sudo yarn add @internetarchive/dweb-archive @internetarchive/dweb-mirror
   args:
     chdir: "{{ internetarchive_dir }}"
+    creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"
   when: internet_available | bool
+  register: IA_installing
 
 - name: Create directory /library/archiveorg
   file:
     path: "/library/archiveorg"
     state: directory
     owner: "root"
+
+- name: Update pre-existing install
+  command: sudo yarn upgrade
+  args:
+    chdir: "{{ internetarchive_dir }}"
+  when: not IA_installing.changed and IA_upgrade
 
 
 # CONFIG FILES

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -24,7 +24,7 @@
     chdir: "{{ internetarchive_dir }}"
     creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"
   when: internet_available | bool
-  register: IA_installing
+  register: internetarchive_installing
 
 - name: Create directory /library/archiveorg
   file:
@@ -32,11 +32,11 @@
     state: directory
     owner: "root"
 
-- name: Update pre-existing install
+- name: 'Update pre-existing install: sudo yarn upgrade'
   command: sudo yarn upgrade
   args:
     chdir: "{{ internetarchive_dir }}"
-  when: not IA_installing.changed and IA_upgrade
+  when: not internetarchive_installing.changed and internetarchive_upgrade
 
 
 # CONFIG FILES

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -20,9 +20,6 @@
 
 - name: Run yarn install to get needed modules (CAN TAKE ~15 MINUTES)
   command: yarn add @internetarchive/dweb-archive @internetarchive/dweb-mirror
-  become: yes
-  become_method: sudo
-  become_user: root
   args:
     chdir: "{{ internetarchive_dir }}"
     creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"
@@ -77,9 +74,6 @@
 
 - name: 'Update pre-existing install: sudo yarn upgrade'
   command: yarn upgrade
-  become: yes
-  become_method: sudo
-  become_user: root
   args:
     chdir: "{{ internetarchive_dir }}"
   when: not internetarchive_installing.changed and internetarchive_upgrade

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -37,12 +37,6 @@
     internetarchive_upgrade: True
   when: reinstall is defined
 
-- name: 'Update pre-existing install: sudo yarn upgrade'
-  command: sudo yarn upgrade
-  args:
-    chdir: "{{ internetarchive_dir }}"
-  when: not internetarchive_installing.changed and internetarchive_upgrade
-
 
 # CONFIG FILES
 
@@ -71,7 +65,25 @@
   when: is_debuntu and not internetarchive_enabled
 
 
-# RESTART/STOP SYSTEMD SERVICE
+# STOP SYSTEMD SERVICE
+- name: Stop 'internetarchive' systemd service
+  systemd:
+    name: internetarchive
+    daemon_reload: yes
+    state: stopped
+
+- name: 'Update pre-existing install: sudo yarn upgrade'
+  command: sudo yarn upgrade
+  args:
+    chdir: "{{ internetarchive_dir }}"
+  when: not internetarchive_installing.changed and internetarchive_upgrade
+
+ # RESTART/ENABLE SYSTEMD SERVICE
+- name: Disable 'internetarchive' systemd service (if not internetarchive_enabled)
+  systemd:
+    name: internetarchive
+    enabled: no
+  when: not internetarchive_enabled
 
 # with "systemctl daemon-reload" in case mongodb.service changed, etc
 - name: Enable & Restart 'internetarchive' systemd service (if internetarchive_enabled)
@@ -81,14 +93,6 @@
     enabled: yes
     state: restarted
   when: internetarchive_enabled | bool
-
-- name: Disable & Stop 'internetarchive' systemd service (if not internetarchive_enabled)
-  systemd:
-    name: internetarchive
-    daemon_reload: yes
-    enabled: no
-    state: stopped
-  when: not internetarchive_enabled
 
 - name: Restart Apache service ({{ apache_service }}) to enable/disable http://box/archive (not just http://box:{{ internetarchive_port }})
   systemd:

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -32,6 +32,11 @@
     state: directory
     owner: "root"
 
+- name: Set --reinstall fact
+  set_fact:
+    internetarchive_upgrade: True
+  when: reinstall is defined
+
 - name: 'Update pre-existing install: sudo yarn upgrade'
   command: sudo yarn upgrade
   args:

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -17,10 +17,6 @@
     line: 'deb http://dl.yarnpkg.com/debian/ stable main'
     state: present
 
-- name: "Yarn | Update APT cache"
-  apt:
-    update_cache: yes
-
 - name: "Yarn | Install"
   package:
     name: yarn

--- a/runrole
+++ b/runrole
@@ -5,8 +5,8 @@ PLAYBOOK="run-one-role.yml"
 ARGS=""
 CWD=`pwd`
 
-if [ $# -eq 2 ]; then
-   export ANSIBLE_LOG_PATH="$2"
+if [ $# -eq 3 ]; then
+   export ANSIBLE_LOG_PATH="$3"
 else
    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 fi

--- a/runrole
+++ b/runrole
@@ -2,8 +2,9 @@
 
 INVENTORY="ansible_hosts"
 PLAYBOOK="run-one-role.yml"
-#PLAYBOOK="iiab-stages.yml"
+ARGS=""
 CWD=`pwd`
+
 if [ $# -eq 2 ]; then
    export ANSIBLE_LOG_PATH="$2"
 else
@@ -22,10 +23,14 @@ if [ ! -f /etc/iiab/config_vars.yml ]; then
     echo "{}" > /etc/iiab/config_vars.yml
 fi
 
+if [ "$2" == "--reinstall" ]; then
+    ARGS="$ARGS --extra-vars reinstall=True"
+fi
+
 if [[ $# -eq 0 ]] ; then
     echo " usage: ./runrole <name of role>"
     echo " Can only take a single value."
     exit 0
 fi
 
-ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local -e "role_to_run=$1"
+ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local -e "role_to_run=$1"

--- a/runrole
+++ b/runrole
@@ -4,9 +4,13 @@ INVENTORY="ansible_hosts"
 PLAYBOOK="run-one-role.yml"
 ARGS=""
 CWD=`pwd`
+if [ "$1" == "--reinstall" ]; then
+    ARGS="$ARGS --extra-vars reinstall=True"
+    shift 1
+fi
 
-if [ $# -eq 3 ]; then
-   export ANSIBLE_LOG_PATH="$3"
+if [ $# -eq 2 ]; then
+   export ANSIBLE_LOG_PATH="$2"
 else
    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 fi
@@ -21,10 +25,6 @@ fi
 if [ ! -f /etc/iiab/config_vars.yml ]; then
     mkdir -p /etc/iiab
     echo "{}" > /etc/iiab/config_vars.yml
-fi
-
-if [ "$2" == "--reinstall" ]; then
-    ARGS="$ARGS --extra-vars reinstall=True"
 fi
 
 if [[ $# -eq 0 ]] ; then


### PR DESCRIPTION
### Fixes Bug #1812
Install only once to allow faster operation of [iiab-from-console](https://github.com/iiab/iiab/blob/master/iiab-from-console.yml) from the iiab admin page. Allows future upgrades with a fact that can be set via local_vars or some other logic to toggle the fact.