### PR TITLE
Introduce variable pi_swap_file_size: 1024

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -32,11 +32,11 @@
     name: ntp
     state: latest
 
-- name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_size }} in /etc/dphys-swapfile) as kalite pip download fails (debuntu)
+- name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails (debuntu)
   lineinfile:
     path: /etc/dphys-swapfile
     regexp: "^CONF_SWAPSIZE"
-    line: "CONF_SWAPSIZE={{ pi_swap_size }}"
+    line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
   when: is_debuntu | bool    # Redundant, given raspberry_pi.yml is only run when rpi_model: "rpi" (similar to is_rpi: True).  Until someone tries a non-debuntu OS on RPi?
 
 - name: Restart swap service "dphys-swapfile" (debuntu)

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -37,7 +37,7 @@
     path: /etc/dphys-swapfile
     regexp: "^CONF_SWAPSIZE"
     line: "CONF_SWAPSIZE={{ pi_swap_size }}"
-  when: is_debuntu | bool
+  when: is_debuntu | bool    # Redundant, given raspberry_pi.yml is only run when rpi_model: "rpi" (similar to is_rpi: True).  Until someone tries a non-debuntu OS on RPi?
 
 - name: Restart swap service "dphys-swapfile" (debuntu)
   #command: /etc/init.d/dphys-swapfile restart

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -32,11 +32,11 @@
     name: ntp
     state: latest
 
-- name: Increase swap file size (to CONF_SWAPSIZE=500 in /etc/dphys-swapfile) as kalite pip download fails (debuntu)
+- name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_size }} in /etc/dphys-swapfile) as kalite pip download fails (debuntu)
   lineinfile:
     path: /etc/dphys-swapfile
     regexp: "^CONF_SWAPSIZE"
-    line: CONF_SWAPSIZE=500
+    line: "CONF_SWAPSIZE={{ pi_swap_size }}"
   when: is_debuntu | bool
 
 - name: Restart swap service "dphys-swapfile" (debuntu)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -177,10 +177,6 @@ wan_nameserver:
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
-
 sshd_enabled: True
 
 # roles/iiab-admin runs here
@@ -201,6 +197,10 @@ openvpn_server_port: 1194
 # Newer versions of NMap do not include NCat which is used to announce handle
 # need_ncat is turned true by os-#.yml files that don't have ncat in nmap
 need_ncat: False
+
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
 
 
 # 2-COMMON

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -177,7 +177,7 @@ wan_nameserver:
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
 pi_swap_size: 1024
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -200,7 +200,7 @@ need_ncat: False
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
+pi_swap_file_size: 1024
 
 
 # 2-COMMON

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -177,6 +177,10 @@ wan_nameserver:
 
 # 1-PREP
 
+# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
+
 sshd_enabled: True
 
 # roles/iiab-admin runs here

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -90,7 +90,7 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
 pi_swap_size: 1024
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -104,7 +104,7 @@ openvpn_handle:
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
+pi_swap_file_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -90,10 +90,6 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
-
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
@@ -105,6 +101,10 @@ openvpn_enabled: False
 openvpn_handle: 
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
+
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -90,6 +90,10 @@ js_menu_install: True
 
 # 1-PREP
 
+# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
+
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -90,7 +90,7 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
 pi_swap_size: 1024
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -104,7 +104,7 @@ openvpn_handle:
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
+pi_swap_file_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -90,10 +90,6 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
-
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
@@ -105,6 +101,10 @@ openvpn_enabled: False
 openvpn_handle: 
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
+
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -90,6 +90,10 @@ js_menu_install: True
 
 # 1-PREP
 
+# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
+
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -90,7 +90,7 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
 pi_swap_size: 1024
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -104,7 +104,7 @@ openvpn_handle:
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
+pi_swap_file_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -90,10 +90,6 @@ js_menu_install: True
 
 # 1-PREP
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_size: 1024
-
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
@@ -105,6 +101,10 @@ openvpn_enabled: False
 openvpn_handle: 
 # The following seems necessary on CentOS:
 # openvpn_cron_enabled: True
+
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
 
 
 # 2-COMMON

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -90,6 +90,10 @@ js_menu_install: True
 
 # 1-PREP
 
+# Some prefer 512MB for Zero W, others 2048MB or higher for RPi 3 and 4.
+# Please see recommendations at: https://itsfoss.com/swap-size/
+pi_swap_size: 1024
+
 # roles/sshd & roles/iiab-admin run here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash


### PR DESCRIPTION
Per @jvonau's recommendation, default swap size for Raspberry Pi should rise from the current 500MB.

He asked for a default of 2048, but I asked him to reconsider given IIAB is used by folks with limited means (who value every GB of disk they can get, for content & similar!)

Refs:
#1911 "BIG-sized IIAB thrashes (memory/swap issues) on 1GB RPi 3 and 1GB RPi 4 ?"