### PR TITLE
Nextcloud Liberation Front: Unblock Nextcloud in 192.168.1.* schools & all others!

### DIFF
--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -10,3 +10,4 @@ Login to Nextcloud at http://box/nextcloud, http://box.lan/nextcloud, http://172
 Going forward, should Internet-in-a-Box consider integrating optimizations (or more!) from these below?
 - https://github.com/nextcloud/nextcloudpi
 - https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/
+- https://ownyourbits.com/nextcloudpi/

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -1,0 +1,7 @@
+# Nextcloud
+
+This Ansible playbook was derived from an earlier ownCloud playbook thanks to Josh Dennis in ~2017.
+
+Going forward, should Internet-in-a-Box consider integrating optimizations (or more!) from these below?
+- https://github.com/nextcloud/nextcloudpi
+- https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -2,6 +2,11 @@
 
 This Ansible playbook was derived from an earlier ownCloud playbook thanks to [Josh Dennis](https://github.com/floydianslips) in 2016/2017.
 
+Login to Nextcloud at http://box/nextcloud, http://box.lan/nextcloud, http://172.18.96.1/nextcloud (or similar) using:
+
+    Username: Admin
+    Password: changeme
+
 Going forward, should Internet-in-a-Box consider integrating optimizations (or more!) from these below?
 - https://github.com/nextcloud/nextcloudpi
 - https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -1,6 +1,6 @@
 # Nextcloud
 
-This Ansible playbook was derived from an earlier ownCloud playbook thanks to Josh Dennis in ~2017.
+This Ansible playbook was derived from an earlier ownCloud playbook thanks to [Josh Dennis](https://github.com/floydianslips) in 2016/2017.
 
 Going forward, should Internet-in-a-Box consider integrating optimizations (or more!) from these below?
 - https://github.com/nextcloud/nextcloudpi

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -8,6 +8,7 @@ Login to Nextcloud at http://box/nextcloud, http://box.lan/nextcloud, http://172
     Password: changeme
 
 Going forward, should Internet-in-a-Box consider integrating optimizations (or more!) from these below?
+
 - https://github.com/nextcloud/nextcloudpi
 - https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/
 - https://ownyourbits.com/nextcloudpi/

--- a/roles/nextcloud/templates/nextcloud.conf.j2
+++ b/roles/nextcloud/templates/nextcloud.conf.j2
@@ -6,6 +6,7 @@ Alias {{ nextcloud_url }} {{ nextcloud_prefix }}/nextcloud
 
     <IfModule mod_authz_core.c>
     # Apache 2.4
+    # http://httpd.apache.org/docs/2.4/mod/mod_authz_core.html
     Require host localhost
     # PERMIT ACCESS FROM ALL IPv4 ADDRESSES:
     Require all granted

--- a/roles/nextcloud/templates/nextcloud.conf.j2
+++ b/roles/nextcloud/templates/nextcloud.conf.j2
@@ -7,7 +7,12 @@ Alias {{ nextcloud_url }} {{ nextcloud_prefix }}/nextcloud
     <IfModule mod_authz_core.c>
     # Apache 2.4
     Require host localhost
-    Require ip 127.0.0.1 {{ lan_ip }}/{{ lan_netmask }} {{ nextcloud_required_ip }} {{ openvpn_server_virtual_ip }}/255.255.255.0
+    # PERMIT ACCESS FROM ALL IPv4 ADDRESSES:
+    Require all granted
+    # USE THIS LINE INSTEAD, IF YOU WANT BASIC SECURITY BASED ON IPv4 ADDRESSES:
+    #Require ip 127.0.0.1 172.18.96.1/255.255.224.0 192.168 10
+    # DON'T USE THIS LINE WHICH CAUSES PROBLEMS IN SCHOOLS WITH 192.168.1.x etc:
+    #Require ip 127.0.0.1 {{ lan_ip }}/{{ lan_netmask }} {{ nextcloud_required_ip }} {{ openvpn_server_virtual_ip }}/255.255.255.0
     </IfModule>
     <IfModule !mod_authz_core.c>
     # Apache 2.2

--- a/roles/nextcloud/templates/nextcloud.conf.j2
+++ b/roles/nextcloud/templates/nextcloud.conf.j2
@@ -9,9 +9,9 @@ Alias {{ nextcloud_url }} {{ nextcloud_prefix }}/nextcloud
     Require host localhost
     # PERMIT ACCESS FROM ALL IPv4 ADDRESSES:
     Require all granted
-    # USE THIS LINE INSTEAD, IF YOU WANT BASIC SECURITY BASED ON IPv4 ADDRESSES:
+    # WANT BASIC SECURITY BASED ON IPv4 ADDRESSES? THEN USE THIS LINE INSTEAD:
     #Require ip 127.0.0.1 172.18.96.1/255.255.224.0 192.168 10
-    # DON'T USE THIS LINE WHICH CAUSES PROBLEMS IN SCHOOLS WITH 192.168.1.x etc:
+    # AVOID THIS LINE WHICH CAUSES PROBLEMS IN SCHOOLS WITH 192.168.1.x etc:
     #Require ip 127.0.0.1 {{ lan_ip }}/{{ lan_netmask }} {{ nextcloud_required_ip }} {{ openvpn_server_virtual_ip }}/255.255.255.0
     </IfModule>
     <IfModule !mod_authz_core.c>


### PR DESCRIPTION
Work In Progress.  In short: arbitrary security rules are hurting real users (e.g. in Chiapas, Mexico schools) so it's time for a completely new approach.