### PR TITLE
Prune Elgg from MEDIUM-sized IIAB installs

### DIFF
--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -206,8 +206,8 @@ mediawiki_enabled: False
 ejabberd_install: False
 ejabberd_enabled: False
 
-elgg_install: True
-elgg_enabled: True
+elgg_install: False
+elgg_enabled: False
 
 # Gitea (lightweight self-hosted "GitHub") from https://gitea.io
 gitea_install: False


### PR DESCRIPTION
Elgg is no longer used as much as it was in the past, nor is it as well supported.

FYI Elgg 3.x is not running with IIAB at this time FWIW.