### PR TITLE
Nextcloud 16 -> 17 on "2019-09-26"

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -23,7 +23,7 @@ nextcloud_dl_url: https://download.nextcloud.com/server/releases
 nextcloud_orig_src_file_old: latest-15.tar.bz2    
 nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
 # For NEW OS's where PHP 7.1+ is auto-detected -- e.g. Raspbian 10, Debian 10 & Ubuntu 18.04
-nextcloud_orig_src_file: latest-16.tar.bz2
+nextcloud_orig_src_file: latest-17.tar.bz2
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # We install on MySQL with these settings:


### PR DESCRIPTION
Per roadmap @ https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule