### PR TITLE
Remove bitrot from local_vars.yml & Clarify lesser-used vars in default_vars.yml (active & ongoing deprecation = critical for readability!)

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -556,13 +556,17 @@ minetest_flat_world: False
 # iiab_install: True
 # iiab_enabled: False
 
-# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
-# teamviewer_install: False
-# teamviewer_enabled: False
-
 # Unmaintained
 # docker_install: False
 # docker_enabled: False
+
+# THOSE ABOVE WERE STILL OCCASIONALLY USED AS OF SEPTEMBER 2019.
+# =============================================================================
+# THOSE BELOW WERE *NOT* USED FOR YEARS, AS OF SEPTEMBER 2019.
+
+# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
+# teamviewer_install: False
+# teamviewer_enabled: False
 
 # Unmaintained
 # schooltool_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -371,30 +371,6 @@ minetest_enabled: True
 # osm_install: False
 # osm_enabled: False
 
-# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
-# teamviewer_install: False
-# teamviewer_enabled: False
-
 # Unmaintained
 # docker_install: False
 # docker_enabled: False
-
-# Unmaintained
-# schooltool_install: False
-# schooltool_enabled: False
-
-# Unmaintained
-# debian_schooltool_install: False
-# debian_schooltool_enabled: False
-
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
-# Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -368,30 +368,6 @@ minetest_enabled: False
 # osm_install: False
 # osm_enabled: False
 
-# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
-# teamviewer_install: False
-# teamviewer_enabled: False
-
 # Unmaintained
 # docker_install: False
 # docker_enabled: False
-
-# Unmaintained
-# schooltool_install: False
-# schooltool_enabled: False
-
-# Unmaintained
-# debian_schooltool_install: False
-# debian_schooltool_enabled: False
-
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
-# Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -368,30 +368,6 @@ minetest_enabled: False
 # osm_install: False
 # osm_enabled: False
 
-# Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
-# teamviewer_install: False
-# teamviewer_enabled: False
-
 # Unmaintained
 # docker_install: False
 # docker_enabled: False
-
-# Unmaintained
-# schooltool_install: False
-# schooltool_enabled: False
-
-# Unmaintained
-# debian_schooltool_install: False
-# debian_schooltool_enabled: False
-
-# Unmaintained (consider Calibre or Calibre-Web above?)
-# pathagar_install: False
-# pathagar_enabled: False
-
-# Unmaintained
-# sugar_stats_install: False
-# sugar_stats_enabled: False
-
-# Unmaintained
-# xovis_install: False
-# xovis_enabled: False


### PR DESCRIPTION
Aside: Admin Console has accidentally introduced a bug whereby things in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) like...

```
# Unmaintained
# osm_install: False
# osm_enabled: False

# Unmaintained
# docker_install: False
# docker_enabled: False
```

Become...

```
# Unmaintained

# Unmaintained
```

(This happens after use of Admin Console, e.g. to enable/disable services.)

Above is not a fatal bug, but will hopefully be fixed in coming weeks, after release of [IIAB 7.0](https://github.com/iiab/iiab/wiki/IIAB-7.0-Release-Notes) if necessary.