### PR TITLE
OSM Vector Map Packs - Fix Instructions

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -549,7 +549,7 @@ minetest_flat_world: False
 # 2018: http://download.iiab.io/content/OSM/vector-tiles/
 # 2017: http://oer2go.org/viewmod/en-worldmap-10
 #
-# Unmaintained:
+# Unmaintained
 # osm_install: False
 # osm_enabled: False
 # Changed in June 2017, from the original:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -407,11 +407,12 @@ mongodb_install: False
 mongodb_enabled: False
 mongodb_port: 27018
 
-# Regional OSM vector maps use much less disk space than bitmap/raster versions
+# Regional OSM vector maps use far less disk space than bitmap/raster versions.
+# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
 iiab_map_url : http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
-vector_map_path: "{{ content_base }}/www/osm-vector-maps"
+vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 
 # roles/sugarizer/meta/main.yml auto-invokes 2 above prereqs: mongodb & nodejs
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
@@ -542,12 +543,11 @@ minetest_flat_world: False
 # authserver_install: False
 # authserver_enabled: False
 
-# CONSIDER THESE 2 NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD, AS OF 2018:
-# - http://download.iiab.io/content/OSM/vector-tiles/
-# - http://oer2go.org/viewmod/en-worldmap-10
+# CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
 #
-# DOWNLOAD EITHER OSM MANUALLY, OR BETTER YET TRY IIAB'S ADMIN CONSOLE:
-#   http://box/admin -> Install Content -> Get OER2GO(RACHEL) Modules
+# 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
+# 2018: http://download.iiab.io/content/OSM/vector-tiles/
+# 2017: http://oer2go.org/viewmod/en-worldmap-10
 #
 # Unmaintained:
 # osm_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -272,7 +272,8 @@ moodle_install: True
 moodle_enabled: True
 # If using Moodle intensively, set apache_high_php_limits in 3-BASE-SERVER
 
-# Regional OSM vector maps use much less disk space than bitmap/raster versions
+# Regional OSM vector maps use far less disk space than bitmap/raster versions.
+# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
 
@@ -360,12 +361,11 @@ minetest_install: True
 minetest_enabled: True
 
 
-# CONSIDER THESE 2 NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD, AS OF 2018:
-# - http://download.iiab.io/content/OSM/vector-tiles/
-# - http://oer2go.org/viewmod/en-worldmap-10
+# CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
 #
-# DOWNLOAD EITHER OSM MANUALLY, OR BETTER YET TRY IIAB'S ADMIN CONSOLE:
-#   http://box/admin -> Install Content -> Get OER2GO(RACHEL) Modules
+# 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
+# 2018: http://download.iiab.io/content/OSM/vector-tiles/
+# 2017: http://oer2go.org/viewmod/en-worldmap-10
 #
 # Unmaintained
 # osm_install: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -269,7 +269,8 @@ moodle_install: False
 moodle_enabled: False
 # If using Moodle intensively, set apache_high_php_limits in 3-BASE-SERVER
 
-# Regional OSM vector maps use much less disk space than bitmap/raster versions
+# Regional OSM vector maps use far less disk space than bitmap/raster versions.
+# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
 
@@ -357,12 +358,11 @@ minetest_install: False
 minetest_enabled: False
 
 
-# CONSIDER THESE 2 NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD, AS OF 2018:
-# - http://download.iiab.io/content/OSM/vector-tiles/
-# - http://oer2go.org/viewmod/en-worldmap-10
+# CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
 #
-# DOWNLOAD EITHER OSM MANUALLY, OR BETTER YET TRY IIAB'S ADMIN CONSOLE:
-#   http://box/admin -> Install Content -> Get OER2GO(RACHEL) Modules
+# 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
+# 2018: http://download.iiab.io/content/OSM/vector-tiles/
+# 2017: http://oer2go.org/viewmod/en-worldmap-10
 #
 # Unmaintained
 # osm_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -269,7 +269,8 @@ moodle_install: False
 moodle_enabled: False
 # If using Moodle intensively, set apache_high_php_limits in 3-BASE-SERVER
 
-# Regional OSM vector maps use much less disk space than bitmap/raster versions
+# Regional OSM vector maps use far less disk space than bitmap/raster versions.
+# Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
 
@@ -357,12 +358,11 @@ minetest_install: False
 minetest_enabled: False
 
 
-# CONSIDER THESE 2 NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD, AS OF 2018:
-# - http://download.iiab.io/content/OSM/vector-tiles/
-# - http://oer2go.org/viewmod/en-worldmap-10
+# CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
 #
-# DOWNLOAD EITHER OSM MANUALLY, OR BETTER YET TRY IIAB'S ADMIN CONSOLE:
-#   http://box/admin -> Install Content -> Get OER2GO(RACHEL) Modules
+# 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
+# 2018: http://download.iiab.io/content/OSM/vector-tiles/
+# 2017: http://oer2go.org/viewmod/en-worldmap-10
 #
 # Unmaintained
 # osm_install: False


### PR DESCRIPTION
As local_vars.yml & default_vars.yml had been pointing to obsolete info from 2017 & 2018.