### PR TITLE
Enable http://box/kolibri without trailing slash too

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,7 +26,7 @@ kiwix_src_file_i686: "{{ kiwix_version_i686 }}.tar.gz"
 # Used for Kiwix proxy http://box/kiwix/
 kiwix_url_without_slash: /kiwix
 kiwix_url: "{{ kiwix_url_without_slash }}/"    # /kiwix/
-kiwix_path: "{{ iiab_base }}/kiwix"    # /opt/iiab
+kiwix_path: "{{ iiab_base }}/kiwix"            # /opt/iiab/kiwix
 
 # /library/zims contains 3 important things:
 # - library.xml

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -24,8 +24,8 @@ kiwix_src_file_linux64: "{{ kiwix_version_linux64 }}.tar.gz"
 kiwix_src_file_i686: "{{ kiwix_version_i686 }}.tar.gz"
 
 # Used for Kiwix proxy http://box/kiwix/
-kiwix_url: /kiwix/
-kiwix_alias_url: /kiwix
+kiwix_url_without_slash: /kiwix
+kiwix_url: "{{ kiwix_url_without_slash }}/"    # /kiwix/
 kiwix_path: "{{ iiab_base }}/kiwix"    # /opt/iiab
 
 # /library/zims contains 3 important things:

--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -1,9 +1,11 @@
+# SEE https://github.com/iiab/iiab/blob/master/roles/kolibri/templates/kolibri.conf.j2
+
 # 2018-08-31: FAILS to enable http://box/kiwix
 #RewriteEngine on
 #RewriteRule ^{{ kiwix_alias_url }}$ {{ kiwix_url }} [R]
 
 # 2018-08-31: SUCCEEDS in enabling http://box/kiwix
-RedirectMatch ^{{ kiwix_alias_url }}$ {{ kiwix_url }}
+RedirectMatch ^{{ kiwix_url_without_slash }}$ {{ kiwix_url }}
 
 # 2018-08-31: SUCCEEDS in enabling http://box/kiwix/ & http://box/kiwix/zim & http://box/kiwix/zim/
 #ProxyPreserveHost On

--- a/roles/kiwix/templates/kiwix.conf.j2
+++ b/roles/kiwix/templates/kiwix.conf.j2
@@ -2,7 +2,7 @@
 
 # 2018-08-31: FAILS to enable http://box/kiwix
 #RewriteEngine on
-#RewriteRule ^{{ kiwix_alias_url }}$ {{ kiwix_url }} [R]
+#RewriteRule ^{{ kiwix_url_without_slash }}$ {{ kiwix_url }} [R]
 
 # 2018-08-31: SUCCEEDS in enabling http://box/kiwix
 RedirectMatch ^{{ kiwix_url_without_slash }}$ {{ kiwix_url }}

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -12,8 +12,10 @@
 # Kolibri folder to store its data and configuration files.
 kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
 
-kolibri_url: /kolibri
-kolibri_venv_path: /usr/local/kolibri
+kolibri_url_without_slash: /kolibri
+kolibri_url: "{{ kolibri_url_without_slash }}/"    # /kolibri/
+
+kolibri_venv_path: /usr/local/kolibri    # For /usr/local/kolibri/bin/kolibri
 # 2018-07-16: IIAB recommends /usr/bin but @arky says this isn't yet possible, due to pip
 kolibri_exec_path: "{{ kolibri_venv_path }}/bin/kolibri"
 

--- a/roles/kolibri/templates/kolibri.conf.j2
+++ b/roles/kolibri/templates/kolibri.conf.j2
@@ -1,3 +1,6 @@
+# SEE https://github.com/iiab/iiab/blob/master/roles/kiwix/templates/kiwix.conf.j2
+RedirectMatch ^{{ kolibri_url_without_slash }}$ {{ kiwix_url }}
+
 ProxyPreserveHost   On
 ProxyPass           {{ kolibri_url }}          http://localhost:{{ kolibri_http_port }}{{ kolibri_url }}
 ProxyPassReverse    {{ kolibri_url }}          http://localhost:{{ kolibri_http_port }}{{ kolibri_url }}


### PR DESCRIPTION
Modeled on https://github.com/iiab/iiab/blob/master/roles/kiwix/templates/kiwix.conf.j2