### PR TITLE
Warn implementers: DansGuardian is NO LONGER AVAILABLE in Debian Buster etc

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -247,7 +247,8 @@ mysql_root_password: fixmysql
 squid_install: False
 squid_enabled: False
 
-# DansGuardian REQUIRES Squid (above) be installed & enabled
+# DansGuardian REQUIRES Squid (above) be installed & enabled.
+# DansGuardian is NO LONGER AVAILABLE in Debian Buster i.e. since June 2019.
 dansguardian_install: False
 dansguardian_enabled: False
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -153,7 +153,8 @@ apache_allow_sudo: True
 squid_install: False
 squid_enabled: False
 
-# DansGuardian REQUIRES Squid (above) be installed & enabled
+# DansGuardian REQUIRES Squid (above) be installed & enabled.
+# DansGuardian is NO LONGER AVAILABLE in Debian Buster i.e. since June 2019.
 dansguardian_install: False
 dansguardian_enabled: False
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -153,7 +153,8 @@ apache_allow_sudo: True
 squid_install: False
 squid_enabled: False
 
-# DansGuardian REQUIRES Squid (above) be installed & enabled
+# DansGuardian REQUIRES Squid (above) be installed & enabled.
+# DansGuardian is NO LONGER AVAILABLE in Debian Buster i.e. since June 2019.
 dansguardian_install: False
 dansguardian_enabled: False
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -153,7 +153,8 @@ apache_allow_sudo: True
 squid_install: False
 squid_enabled: False
 
-# DansGuardian REQUIRES Squid (above) be installed & enabled
+# DansGuardian REQUIRES Squid (above) be installed & enabled.
+# DansGuardian is NO LONGER AVAILABLE in Debian Buster i.e. since June 2019.
 dansguardian_install: False
 dansguardian_enabled: False
 


### PR DESCRIPTION
Ref #1980