### PR TITLE
Install common Apache modules in roles/httpd, for {http://box/kiwix, http://box/kolibri, http://box/nodered, etc}

### DIFF
--- a/roles/activity-server/tasks/main.yml
+++ b/roles/activity-server/tasks/main.yml
@@ -77,6 +77,7 @@
             group=root
             mode=0644
 
+# SEE ALSO THE apache2_module SECTION IN roles/httpd/tasks/main.yml
 - name: enable mod_expires for debian
   command: a2enmod expires
   when: is_debuntu | bool

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -18,6 +18,7 @@
   tags:
     - download
 
+# SEE ALSO THE apache2_module SECTION IN roles/httpd/tasks/main.yml
 - name: Enable cgi execution (debuntu)
   command: a2enmod cgi
   when: is_debuntu | bool

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -112,8 +112,10 @@
 #    - rewrite
 #  when: is_debuntu | bool
 #
-# 2019-10-07: proxy_http is definitely essential!  (WHICH OF THE OTHER 4 ARE NOT NEEDED ?)
-- name: 'Enable the 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for {http://box/kiwix, http://box/kolibri, http://box/nodered, etc}, if debuntu)'
+# NOTE: activity-server/tasks/main.yml runs "a2enmod expires"
+# NOTE: awstats/tasks/install.yml      runs "a2enmod cgi"
+# 2019-10-07: proxy_http is definitely essential!  (ARE THE OTHER 4 REALLY NEEDED ?)
+- name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc--if debuntu)'
   apache2_module:
     name: "{{ item }}"
   with_items:

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -103,12 +103,24 @@
     - mpm_prefork.load
   when: is_debuntu | bool
 
-- name: 'Turn on mod_proxy using a2enmod with: proxy, proxy_html, headers, rewrite (debuntu)'
-  command: a2enmod {{ item }}
+#- name: 'Turn on mod_proxy using a2enmod with: proxy, proxy_html, headers, rewrite (debuntu)'
+#  command: a2enmod {{ item }}
+#  with_items:
+#    - proxy
+#    - proxy_html
+#    - headers
+#    - rewrite
+#  when: is_debuntu | bool
+#
+# 2019-10-07: proxy_http is definitely essential!  (WHICH OF THE OTHER 4 ARE NOT NEEDED ?)
+- name: 'Enable the 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for {http://box/kiwix, http://box/kolibri, http://box/nodered, etc}, if debuntu)'
+  apache2_module:
+    name: "{{ item }}"
   with_items:
+    - headers
     - proxy
     - proxy_html
-    - headers
+    - proxy_http
     - rewrite
   when: is_debuntu | bool
 

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -114,7 +114,8 @@
 #
 # NOTE: activity-server/tasks/main.yml runs "a2enmod expires"
 # NOTE: awstats/tasks/install.yml      runs "a2enmod cgi"
-# 2019-10-07: proxy_http is definitely essential!  (ARE THE OTHER 4 REALLY NEEDED ?)
+# NOTE: nodered/tasks/main.yml uses apache2_module to install "proxy_wstunnel"
+# 2019-10-07: proxy_http is definitely essential!  (ARE THE OTHER 4 BELOW REALLY NEEDED ?)
 - name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc--if debuntu)'
   apache2_module:
     name: "{{ item }}"

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -71,16 +71,17 @@
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU
 
+# 2019-10-07: Moved to roles/httpd/tasks/main.yml
 # 2019-09-29: Compare roles/kolibri/defaults/main.yml using just 1 (proxy_http)
-- name: Enable the 4 mods which permit Apache to proxy (debuntu)
-  apache2_module:
-    name: "{{ item }}"
-  with_items:
-    - proxy
-    - proxy_html
-    - proxy_http
-    - rewrite
-  when: is_debuntu | bool
+#- name: Enable the 4 mods which permit Apache to proxy (debuntu)
+#  apache2_module:
+#    name: "{{ item }}"
+#  with_items:
+#    - proxy
+#    - proxy_html
+#    - proxy_http
+#    - rewrite
+#  when: is_debuntu | bool
 
 # 4. CREATE/ENABLE/RESTART (OR DISABLE) KIWIX SERVICE & ITS CRON JOB
 

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -105,11 +105,12 @@
   when: kolibri_provision | bool
 
 
+# 2019-10-07: Moved to roles/httpd/tasks/main.yml
 # 2019-09-29: roles/kiwix/tasks/kiwix_install.yml installs 4 Apache modules
 # for similar purposes (not all nec?)  Only 1 (proxy_http) is needed here.
-- name: Enable Apache module proxy_http for http://box{{ kolibri_url }}    # i.e. http://box/kolibri
-  apache2_module:
-    name: proxy_http
+#- name: Enable Apache module proxy_http for http://box{{ kolibri_url }}    # i.e. http://box/kolibri
+#  apache2_module:
+#    name: proxy_http
 
 - name: Start 'kolibri' systemd service, if kolibri_enabled
   systemd:

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -186,6 +186,7 @@
     state: absent
   when: not nodered_enabled
 
+# SEE ALSO THE apache2_module SECTION IN roles/httpd/tasks/main.yml
 - name: Enable proxy_wstunnel apache2 module
   apache2_module:
     state: present


### PR DESCRIPTION
Resolves #1986, helping more playbooks' short URL's work immediately, i.e. right after running each IIAB app/service's Ansible playbook.

e.g. http://box/kiwix, http://box/kolibri, http://box/nodered, etc.