### PR TITLE
httpd: php_version: 7.2 -> 7.3; lokole: bcrypt -> python3-bcrypt; osm-vector-maps: python-geojson -> python3-geojson for Ubuntu 19.10 [Node.js should install via curl soon after release on 2019-10-17; cmdsrv requires python-systemd -> python3-systemd ?]

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -1,7 +1,7 @@
 # Lokole PDF (User's Guide) gets copied for offline use (http://box/info) here:
 # https://github.com/iiab/iiab/blob/master/roles/httpd/templates/refresh-wiki-docs.sh#L47
 
-- name: "Install 7 packages for Lokole: python3, python3-pip, python3-venv, python3-dev, libffi-dev, libssl-dev, bcrypt"
+- name: "Install 7 packages for Lokole: python3, python3-pip, python3-venv, python3-dev, libffi-dev, libssl-dev, python3-bcrypt"
   apt:
     name:
       - python3
@@ -10,7 +10,8 @@
       - python3-dev
       - libffi-dev
       - libssl-dev
-      - bcrypt
+      #- bcrypt does not exist on Ubuntu 19.10
+      - python3-bcrypt    # 2019-10-14: should work across modern Linux OS's
     state: present
   tags:
     - install

--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -36,7 +36,8 @@
 
 - name: Install python3-geojson package, that helps with geojson
   package:
-    name: python3-geojson
+    #name: python-geojson does not exist on Ubuntu 19.10
+    name: python3-geojson    # 2019-10-14: should work across modern Linux OS's
     state: present
 
 - name: Install /usr/bin/iiab-update-map for updating of Map Pack catalog & descriptions

--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -34,9 +34,9 @@
     url: "{{ iiab_map_url }}/assets/bboxes.geojson"
     dest: '{{ vector_map_path }}/maplist/assets/'
 
-- name: Install python-geojson package, that helps with geojson
+- name: Install python3-geojson package, that helps with geojson
   package:
-    name: python-geojson
+    name: python3-geojson
     state: present
 
 - name: Install /usr/bin/iiab-update-map for updating of Map Pack catalog & descriptions

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -22,7 +22,7 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.2
+php_version: 7.3
 # "postgresql_version: 11.2" fails (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 19.04)
 postgresql_version: 11
 systemd_location: /lib/systemd/system


### PR DESCRIPTION
More changes may be needed to support Ubuntu 19.10 (expected 2019-10-17) ?

In anticipation of Ubuntu 20.04 LTS coming April 2020.