### PR TITLE
calibre_via_debs: False [was True] + calibre_via_python: True [was False] in vars/debian-10.yml

### DIFF
--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -26,4 +26,4 @@ postgresql_version: 11
 systemd_location: /lib/systemd/system
 # Upgrade OS's own Calibre to very latest:
 calibre_via_debs: False
-calibre_via_python: False
+calibre_via_python: True

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -25,5 +25,5 @@ php_version: 7.3
 postgresql_version: 11
 systemd_location: /lib/systemd/system
 # Upgrade OS's own Calibre to very latest:
-calibre_via_debs: True
+calibre_via_debs: False
 calibre_via_python: False


### PR DESCRIPTION
So Debian 10.1 implementers have easy access to the latest Calibre (https://calibre-ebook.com/whats-new shows 4.1 for now) just like Ubuntu folk &mdash; instead of being locked into the distro's aging deb-based install of Calibre 3.48