### PR TITLE
Recommend Ansible 2.8.5 -> 2.9.0; update scripts/ansible-2.8.x & scripts/ansible-2.9.x

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.8.5
+MIN_ANSIBLE_VER=2.8.6
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/iiab-install
+++ b/iiab-install
@@ -9,7 +9,7 @@ ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-MIN_RPI_KERN=4.9.59-v7+
+MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when serious Oct 2019 Raspbian kernel fix (https://github.com/iiab/iiab/issues/1993 etc) is finally mainlined!
 MIN_ANSIBLE_VER=2.7.14
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then

--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.8.6
+MIN_ANSIBLE_VER=2.8.7
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.8.7
+MIN_ANSIBLE_VER=2.7.14
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/iiab-install
+++ b/iiab-install
@@ -9,7 +9,7 @@ ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when serious Oct 2019 Raspbian kernel fix (https://github.com/iiab/iiab/issues/1993 etc) is finally mainlined!
+MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when Raspbian's Oct 2019 kernels are finally fixed (https://github.com/iiab/iiab/issues/1993 etc)
 MIN_ANSIBLE_VER=2.7.14
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then

--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+
-MIN_ANSIBLE_VER=2.6.16
+MIN_ANSIBLE_VER=2.8.5
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -68,7 +68,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
     apt update
     apt -y install dirmngr    # Raspbian needs.  Formerly: python-pip python-setuptools python-wheel patch
-    echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
+    echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
@@ -88,7 +88,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     #wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
     #apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
 
-    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"'
+    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main"'
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
     
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.8.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.0"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible (TO INSTALL ANSIBLE)"
-echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible-2.7.x ("Slow Food")\n'
+echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible-2.8.x ("Slow Food")\n'
 
 echo -e "RECOMMENDED PREREQUISITES:"
 echo -e "(1) Verify you're online"

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -68,7 +68,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
     apt update
     apt -y install dirmngr    # Raspbian needs.  Formerly: python-pip python-setuptools python-wheel patch
-    echo "deb http://ppa.launchpad.net/ansible/ansible-2.7/ubuntu xenial main" \
+    echo "deb http://ppa.launchpad.net/ansible/ansible-2.8/ubuntu bionic main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
@@ -88,7 +88,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     #wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
     #apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
 
-    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible-2.7/ubuntu xenial main"'
+    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible-2.8/ubuntu bionic main"'
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
     
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.8.6"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.8.7"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.8.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.8.6"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.7.13"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.8.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible-2.7.x (TO INSTALL ANSIBLE)"
+echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible-2.8.x (TO INSTALL ANSIBLE)"
 echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible ("for the very latest Ansible")\n'
 
 echo -e "RECOMMENDED PREREQUISITES:"

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -68,7 +68,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
     apt update
     apt -y install dirmngr    # Raspbian needs.  Formerly: python-pip python-setuptools python-wheel patch
-    echo "deb http://ppa.launchpad.net/ansible/ansible-2.8/ubuntu xenial main" \
+    echo "deb http://ppa.launchpad.net/ansible/ansible-2.9/ubuntu bionic main" \
          > /etc/apt/sources.list.d/iiab-ansible.list
 
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
@@ -88,7 +88,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     #wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
     #apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
 
-    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible-2.8/ubuntu xenial main"'
+    echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible-2.9/ubuntu bionic main"'
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
     
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.8.5"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.0"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible-2.8.x (TO INSTALL ANSIBLE)"
+echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible-2.9.x (TO INSTALL ANSIBLE)"
 echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible ("for the very latest Ansible")\n'
 
 echo -e "RECOMMENDED PREREQUISITES:"


### PR DESCRIPTION
Resolves #1996, building on #1953.

This will likely be merged tmrw (2019-10-16) after [Ansible 2.9.0 (Porting Guide)](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.9.html) is released and confirmed working with IIAB's installer (http://download.iiab.io).

See also:

"What is Ansible and what version should I use?"
http://FAQ.IIAB.IO Item 11
http://wiki.laptop.org/go/IIAB/FAQ#What_is_Ansible_and_what_version_should_I_use.3F