### PR TITLE
For now, keep python-geojson on OS's prior to Ubuntu 19.10 (can python3-geojson be made to work?) [OSM]

### DIFF
--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -34,11 +34,20 @@
     url: "{{ iiab_map_url }}/assets/bboxes.geojson"
     dest: '{{ vector_map_path }}/maplist/assets/'
 
-- name: Install python3-geojson package, that helps with geojson
+# REMOVE this stanza once the transition to Python 3 is confirmed
+- name: Install python-geojson package (OS's prior to Ubuntu 19.10)
   package:
-    #name: python-geojson does not exist on Ubuntu 19.10
-    name: python3-geojson    # 2019-10-14: should work across modern Linux OS's
+    name: python-geojson
     state: present
+  when: is_raspbian_9 or is_raspbian_10 or is_ubuntu_16 or is_ubuntu_18 or is_debian_9 or is_debian_10
+
+# 2019-10-19: Above python-geojson does not exist on Ubuntu 19.10, so let's
+# begin the transition to Python 3...
+
+- name: Install python3-geojson package (especially for new OS's like Ubuntu 19.10+)
+  package:
+    name: python3-geojson    # 2019-10-19: available across most/all recent
+    state: present           # OS's, but not yet used by osm-vector-maps code?
 
 - name: Install /usr/bin/iiab-update-map for updating of Map Pack catalog & descriptions
   template:


### PR DESCRIPTION
Builds on PR #2002 

Thanks @georgejhunt and @jvonau for reviewing, as we enable osm-vector-maps to transition to Python 3, per new OS requirements (Ubuntu 19.10, 20.04 LTS, etc).