### PR TITLE
Fix PR #2024: Install package python-virtualenv for KA Lite and Calibre-Web

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,7 +10,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when Raspbian's Oct 2019 kernels are finally fixed (https://github.com/iiab/iiab/issues/1993 etc)
-MIN_ANSIBLE_VER=2.9.0
+MIN_ANSIBLE_VER=2.8.7      # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/iiab-install
+++ b/iiab-install
@@ -9,7 +9,7 @@ ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when Raspbian's Oct 2019 kernels are finally fixed (https://github.com/iiab/iiab/issues/1993 etc)
+MIN_RPI_KERN=4.19.79       # Can be further updated if necessary, when Raspbian's Oct 2019 kernels are more offially fixed such that running 'rpi-update' will no longer be nec soon, see: https://github.com/iiab/iiab/issues/1993
 MIN_ANSIBLE_VER=2.8.7      # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then

--- a/iiab-install
+++ b/iiab-install
@@ -9,7 +9,7 @@ ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-MIN_RPI_KERN=4.19.79       # Can be further updated if necessary, when Raspbian's Oct 2019 kernels are more offially fixed such that running 'rpi-update' will no longer be nec soon, see: https://github.com/iiab/iiab/issues/1993
+MIN_RPI_KERN=4.19.79       # Can be further updated if necessary, when Raspbian's Oct 2019 kernels are more officially fixed such that running 'rpi-update' will no longer be nec soon, see: https://github.com/iiab/iiab/issues/1993
 MIN_ANSIBLE_VER=2.8.7      # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -63,3 +63,8 @@
       - usbutils
       - wget
     state: present
+
+- name: Install package python-virtualenv for KA Lite and Calibre-Web
+  package:	
+    name:	python-virtualenv
+    state: present

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -64,6 +64,7 @@
       - wget
     state: present
 
+# 2019-10-31: roles/kalite crashed without the following python-virtualenv -- weirdly python3-virtualenv was installed on Raspbian (not sure why) but insufficient
 - name: Install package python-virtualenv for KA Lite and Calibre-Web
   package:	
     name: python-virtualenv

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -66,5 +66,5 @@
 
 - name: Install package python-virtualenv for KA Lite and Calibre-Web
   package:	
-    name:	python-virtualenv
+    name: python-virtualenv
     state: present


### PR DESCRIPTION
See PR #2024 which is mostly about transitioning Ansible to Python 3.

Mandates kernel 4.19.79+ on Raspbian for now, to address #1993.