### PR TITLE
Only install python-virtualenv on older OS's (where does python3-virtualenv come from?)

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -65,8 +65,8 @@
     state: present
 
 # 2019-10-31: roles/kalite crashed without the following python-virtualenv -- weirdly python3-virtualenv was installed on Raspbian (not sure why) but insufficient
-- name: Install package python-virtualenv for KA Lite and Calibre-Web (if raspbian-9, raspbian-10, debian-9 or ubuntu-16)
+- name: Install package python-virtualenv for KA Lite and Calibre-Web, on older OS's (raspbian-9, raspbian-10, debian-9, debian-10, ubuntu-16, ubuntu-18)
   package:
     name: python-virtualenv
     state: present
-  when: is_raspbian_9 or is_raspbian_10 or is_debian_9 or is_ubuntu_16
+  when: is_raspbian_9 or is_raspbian_10 or is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_18

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -65,7 +65,7 @@
     state: present
 
 # 2019-10-31: roles/kalite crashed without the following python-virtualenv -- weirdly python3-virtualenv was installed on Raspbian (not sure why) but insufficient
-- name: Install package python-virtualenv for KA Lite and Calibre-Web
+- name: Install package python-virtualenv for KA Lite and Calibre-Web (if raspbian-9, raspbian-10, debian-9 or ubuntu-16)
   package:
     name: python-virtualenv
     state: present

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -66,6 +66,7 @@
 
 # 2019-10-31: roles/kalite crashed without the following python-virtualenv -- weirdly python3-virtualenv was installed on Raspbian (not sure why) but insufficient
 - name: Install package python-virtualenv for KA Lite and Calibre-Web
-  package:	
+  package:
     name: python-virtualenv
     state: present
+  when: is_raspbian_9 or is_raspbian_10 or is_debian_9 or is_ubuntu_16


### PR DESCRIPTION
Refines PR #2025 (fix for PR #2024) migrating Ansible to Python 3.

Background explanations under https://github.com/iiab/iiab/pull/2025#issuecomment-548669853