### PR TITLE
Revise @jvonau's PR #2028: explain new python3-* pkg's installed by scripts/ansible (etc)

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -63,10 +63,3 @@
       - usbutils
       - wget
     state: present
-
-# 2019-10-31: roles/kalite crashed without the following python-virtualenv -- weirdly python3-virtualenv was installed on Raspbian (not sure why) but insufficient
-- name: Install package python-virtualenv for KA Lite and Calibre-Web, on older OS's (raspbian-9, raspbian-10, debian-9, debian-10, ubuntu-16, ubuntu-18)
-  package:
-    name: python-virtualenv
-    state: present
-  when: is_raspbian_9 or is_raspbian_10 or is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_18

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -23,27 +23,17 @@
   when: squid_install | bool
   tags: base, squid, network, domain
 
-# until porting is complete
-- name: Install python
-  package: 
-    name: python
-    state: present
-
-- name: Create a Python interface to iiab.env
-  template:
-    src: roles/1-prep/templates/iiab_env.py.j2
-    dest: /etc/iiab/iiab_env.py
-
-- name: Installing captive portal
-  include_tasks: roles/captive-portal/tasks/main.yml
-  when: captive_portal_install | bool
-  tags: base, captive-portal, network, domain
-
 - name: Install Bluetooth - only on Raspberry Pi
   include_role:
     name: bluetooth
   when: is_rpi and bluetooth_install
   tags: bluetooth
+
+- name: USB-LIB
+  include_role:
+    name: usb-lib
+  when: usb_lib_install | bool
+  tags: usb-lib
 
 # NETWORK moved to the very end, after Stage 9 (9-LOCAL-ADDONS)
 # It can also be run manually using: cd /opt/iiab/iiab; ./iiab-network
@@ -68,11 +58,11 @@
   tags: postgresql, pathagar, moodle
 
 # UNMAINTAINED
-- name: AUTHSERVER
-  include_role:
-    name: authserver
-  when: authserver_install is defined and authserver_install
-  tags: olpc, authserver
+#- name: AUTHSERVER
+#  include_role:
+#    name: authserver
+#  when: authserver_install is defined and authserver_install
+#  tags: olpc, authserver
 
 - name: CUPS
   include_role:
@@ -85,12 +75,6 @@
     name: samba
   when: samba_install | bool
   tags: samba
-
-- name: USB-LIB
-  include_role:
-    name: usb-lib
-  when: usb_lib_install | bool
-  tags: usb-lib
 
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed at the beginning of Stage 3 = roles/3-base-server/tasks/main.yml, which ran Apache playbook = roles/httpd/tasks/main.yml)
   command: /usr/bin/iiab-refresh-wiki-docs

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -57,13 +57,6 @@
   when: postgresql_install | bool
   tags: postgresql, pathagar, moodle
 
-# UNMAINTAINED
-#- name: AUTHSERVER
-#  include_role:
-#    name: authserver
-#  when: authserver_install is defined and authserver_install
-#  tags: olpc, authserver
-
 - name: CUPS
   include_role:
     name: cups

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -22,11 +22,11 @@
   tags: mediawiki
 
 # unmaintained
-#- name: EJABBERD
-#  include_role:
-#    name: ejabberd
-#  when: ejabberd_install | bool
-#  tags: ejabberd
+- name: EJABBERD
+  include_role:
+    name: ejabberd
+  when: ejabberd_install | bool
+  tags: ejabberd
 
 - name: ELGG
   include_role:

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -21,7 +21,7 @@
   when: mediawiki_install | bool
   tags: mediawiki
 
-# unmaintained
+# UNMAINTAINED
 - name: EJABBERD
   include_role:
     name: ejabberd

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -21,11 +21,12 @@
   when: mediawiki_install | bool
   tags: mediawiki
 
-- name: EJABBERD
-  include_role:
-    name: ejabberd
-  when: ejabberd_install | bool
-  tags: ejabberd
+# unmaintained
+#- name: EJABBERD
+#  include_role:
+#    name: ejabberd
+#  when: ejabberd_install | bool
+#  tags: ejabberd
 
 - name: ELGG
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -34,18 +34,18 @@
   tags: osm, maps
 
 # UNMAINTAINED
-#- name: OSM
-#  include_role:
-#    name: osm
-#  when: osm_install is defined and osm_install
-#  tags: osm, maps
+- name: OSM
+  include_role:
+    name: osm
+  when: osm_install is defined and osm_install
+  tags: osm, maps
 
 # UNMAINTAINED
-#- name: PATHAGAR
-#  include_role:
-#    name: pathagar
-#  when: pathagar_install is defined and pathagar_install
-#  tags: pathagar
+- name: PATHAGAR
+  include_role:
+    name: pathagar
+  when: pathagar_install is defined and pathagar_install
+  tags: pathagar
 
 - name: SUGARIZER
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -34,18 +34,18 @@
   tags: osm, maps
 
 # UNMAINTAINED
-- name: OSM
-  include_role:
-    name: osm
-  when: osm_install is defined and osm_install
-  tags: osm, maps
+#- name: OSM
+#  include_role:
+#    name: osm
+#  when: osm_install is defined and osm_install
+#  tags: osm, maps
 
 # UNMAINTAINED
-- name: PATHAGAR
-  include_role:
-    name: pathagar
-  when: pathagar_install is defined and pathagar_install
-  tags: pathagar
+#- name: PATHAGAR
+#  include_role:
+#    name: pathagar
+#  when: pathagar_install is defined and pathagar_install
+#  tags: pathagar
 
 - name: SUGARIZER
   include_role:

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -34,18 +34,18 @@
   tags: phpmyadmin
 
 # UNMAINTAINED
-- name: SUGAR-STATS
-  include_role:
-    name: sugar-stats
-  when: sugar_stats_install is defined and sugar_stats_install and ansible_distribution != "CentOS"
-  tags: olpc, sugar-stats
+#- name: SUGAR-STATS
+#  include_role:
+#    name: sugar-stats
+#  when: sugar_stats_install is defined and sugar_stats_install and ansible_distribution != "CentOS"
+#  tags: olpc, sugar-stats
 
 # UNMAINTAINED
-- name: TEAMVIEWER
-  include_role:
-    name: teamviewer
-  when: teamviewer_install is defined and teamviewer_install
-  tags: teamviewer
+#- name: TEAMVIEWER
+#  include_role:
+#    name: teamviewer
+#  when: teamviewer_install is defined and teamviewer_install
+#  tags: teamviewer
 
 - name: VNSTAT
   include_role:
@@ -54,11 +54,11 @@
   tags: vnstat
 
 # UNMAINTAINED
-- name: XOVIS
-  include_role:
-    name: xovis
-  when: xovis_install is defined and xovis_install and ansible_distribution != "CentOS"
-  tags: xovis
+#- name: XOVIS
+#  include_role:
+#    name: xovis
+#  when: xovis_install is defined and xovis_install and ansible_distribution != "CentOS"
+#  tags: xovis
 
 - name: Recording STAGE 8 HAS COMPLETED ======================
   lineinfile:

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -33,32 +33,11 @@
   when: phpmyadmin_install | bool
   tags: phpmyadmin
 
-# UNMAINTAINED
-#- name: SUGAR-STATS
-#  include_role:
-#    name: sugar-stats
-#  when: sugar_stats_install is defined and sugar_stats_install and ansible_distribution != "CentOS"
-#  tags: olpc, sugar-stats
-
-# UNMAINTAINED
-#- name: TEAMVIEWER
-#  include_role:
-#    name: teamviewer
-#  when: teamviewer_install is defined and teamviewer_install
-#  tags: teamviewer
-
 - name: VNSTAT
   include_role:
     name: vnstat
   when: vnstat_install | bool
   tags: vnstat
-
-# UNMAINTAINED
-#- name: XOVIS
-#  include_role:
-#    name: xovis
-#  when: xovis_install is defined and xovis_install and ansible_distribution != "CentOS"
-#  tags: xovis
 
 - name: Recording STAGE 8 HAS COMPLETED ======================
   lineinfile:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -9,6 +9,23 @@
   when: internetarchive_install | bool
   tags: internetarchive
 
+# until porting is complete
+- name: Install python-2.7
+  package:
+    name: python
+    state: present
+
+# used by iiab-update-map supplied by osm-vector-maps
+- name: Create a Python interface to iiab.env
+  template:
+    src: roles/1-prep/templates/iiab_env.py.j2
+    dest: /etc/iiab/iiab_env.py
+
+- name: Installing captive portal
+  include_tasks: roles/captive-portal/tasks/main.yml
+  when: captive_portal_install | bool
+  tags: base, captive-portal, network, domain
+
 - name: MINETEST
   include_role:
     name: minetest

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -9,7 +9,7 @@
   when: internetarchive_install | bool
   tags: internetarchive
 
-# Until porting complete (@jvonau)
+# Until porting complete (@jvonau helping transition to Python 3)
 - name: 'Install Python 2.7 packages: python, python-pip'
   package:
     name:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -9,21 +9,21 @@
   when: internetarchive_install | bool
   tags: internetarchive
 
-# until porting is complete
-- name: Install python-2.7
+# Until porting complete (@jvonau)
+- name: 'Install Python 2.7 packages: python, python-pip'
   package:
     name:
       - python
-      - python-pip
+      - python-pip    # Used by Admin Console
     state: present
 
-# used by iiab-update-map supplied by osm-vector-maps
+# Used by iiab-update-map, supplied by osm-vector-maps
 - name: Create a Python interface to iiab.env
   template:
     src: roles/1-prep/templates/iiab_env.py.j2
     dest: /etc/iiab/iiab_env.py
 
-- name: Installing captive portal
+- name: CAPTIVE PORTAL
   include_tasks: roles/captive-portal/tasks/main.yml
   when: captive_portal_install | bool
   tags: base, captive-portal, network, domain

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -12,7 +12,9 @@
 # until porting is complete
 - name: Install python-2.7
   package:
-    name: python
+    name:
+      - python
+      - python-pip
     state: present
 
 # used by iiab-update-map supplied by osm-vector-maps

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -124,7 +124,7 @@
     enabled: yes
   when: mysql_enabled | bool
 
-- name: Install .my.cnf file from template, with root password credentials, if mysql_enabled
+- name: Install /root/.my.cnf file from template, with root password credentials, if mysql_enabled
   template:
     src: my.cnf.j2
     dest: /root/.my.cnf

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -75,7 +75,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
-    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n""
+    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
         python3-passlib python3-pip python3-setuptools virtualenv
@@ -95,7 +95,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
 
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
-    echo -e "ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n"
+    echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
     grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 else
     echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -76,7 +76,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
 
     echo -e "\napt update; apt install ansible and python3 dependencies\n"
     apt update
-    apt -y --allow-downgrades install ansible python3-distutils python3-mysqldb python3-passlib python3-pip python3-setuptools python3-virtualenv python3-psycopg2
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
+    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
 
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -77,8 +77,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
     echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n""
     apt update
-    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
+        python3-passlib python3-pip python3-setuptools virtualenv
 
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -74,10 +74,11 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
-    echo -e "\napt update; apt install ansible and python3 dependencies\n"
+    echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
+    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n""
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
+    python3-pip python3-setuptools virtualenv
 
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -77,8 +77,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
     echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update
-    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
+        python3-passlib python3-pip python3-setuptools virtualenv
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -74,10 +74,11 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
-    echo -e "\napt update; apt install ansible and python3 dependencies\n"
+    echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
+    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
+    python3-pip python3-setuptools virtualenv
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -94,7 +94,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
 
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
-    echo -e "ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n"
+    echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
     grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 else
     echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -79,6 +79,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
         python3-passlib python3-pip python3-setuptools virtualenv
+
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -76,7 +76,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
 
     echo -e "\napt update; apt install ansible and python3 dependencies\n"
     apt update
-    apt -y --allow-downgrades install ansible python3-distutils python3-mysqldb python3-passlib python3-pip python3-setuptools python3-virtualenv python3-psycopg2
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
+    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -94,7 +94,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
     
     echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
-    echo -e "ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n"
+    echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
     grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 else
     echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -77,8 +77,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
     echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update
-    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
+        python3-passlib python3-pip python3-setuptools virtualenv
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -74,10 +74,11 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 
-    echo -e "\napt update; apt install ansible and python3 dependencies\n"
+    echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
+    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
-    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
+    python3-pip python3-setuptools virtualenv
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -79,6 +79,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     apt update
     apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
         python3-passlib python3-pip python3-setuptools virtualenv
+
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -76,7 +76,8 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
 
     echo -e "\napt update; apt install ansible and python3 dependencies\n"
     apt update
-    apt -y --allow-downgrades install ansible python3-distutils python3-mysqldb python3-passlib python3-pip python3-setuptools python3-virtualenv python3-psycopg2
+    apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 python3-passlib\
+    python3-pip python3-setuptools virtualenv # (pulls in python3-distutils python3-virtualenv)
     echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
 
     # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -11,7 +11,7 @@ Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ans
 
 2. Ansible modules: [mysql_db](https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html) and [mysql_user](https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html) (for [roles/mysql](https://github.com/iiab/iiab/tree/master/roles/mysql))
 
-   IIAB installs apt packages:
+   IIAB installs apt package:
    - **python3-pymysql** (see [iiab/iiab#1714](https://github.com/iiab/iiab/issues/1714) and [ansible/ansible#47736](https://github.com/ansible/ansible/issues/47736))
 
 4. Ansible modules: [postgresql_db](https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html) and [postgresql_dbuser](https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html)

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -12,7 +12,6 @@ Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ans
 2. Ansible modules: [mysql_db](https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html) and [mysql_user](https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html) (for [roles/mysql](https://github.com/iiab/iiab/tree/master/roles/mysql))
 
    IIAB installs apt packages:
-   - **python3-pymysql**
    - **python3-pymysql** (see [iiab/iiab#1714](https://github.com/iiab/iiab/issues/1714) and [ansible/ansible#47736](https://github.com/ansible/ansible/issues/47736))
 
 4. Ansible modules: [postgresql_db](https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html) and [postgresql_dbuser](https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html)

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -1,3 +1,5 @@
+Please read "What is Ansible and what version should I use?" at [http://FAQ.IIAB.IO](http://FAQ.IIAB.IO)
+
 Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ansible](https://github.com/iiab/iiab/blob/master/scripts/ansible)) began installing these python3-* apt packages, in support of the following Ansible modules:
 
 1. Ansible module: [pip](https://docs.ansible.com/ansible/latest/modules/pip_module.html)
@@ -12,14 +14,14 @@ Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ans
 2. Ansible modules: [mysql_db](https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html) and [mysql_user](https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html) (for [roles/mysql](https://github.com/iiab/iiab/tree/master/roles/mysql))
 
    IIAB installs apt package:
-   - **python3-pymysql** (see [iiab/iiab#1714](https://github.com/iiab/iiab/issues/1714) and [ansible/ansible#47736](https://github.com/ansible/ansible/issues/47736))
+   - **python3-pymysql** (see sudo's password-changing failure [iiab/iiab#1714](https://github.com/iiab/iiab/issues/1714) and [ansible/ansible#47736](https://github.com/ansible/ansible/issues/47736))
 
-4. Ansible modules: [postgresql_db](https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html) and [postgresql_dbuser](https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html)
+3. Ansible modules: [postgresql_db](https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html) and [postgresql_dbuser](https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html)
 
    IIAB installs apt package:
    - **python3-psycopg2** (does Moodle still need this now that Pathagar is on its way out?)
 
-5. Ansible module: [htpasswd](https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html)
+4. Ansible module: [htpasswd](https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html)
 
    IIAB installs apt package:
    - **python3-passlib** (for [roles/munin](https://github.com/iiab/iiab/tree/master/roles/munin))

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -1,0 +1,21 @@
+In order to use optional modules that ansible is capable of the libraries
+need to be installed, we make use of the following ansible modules:
+
+1. pip: we install python3-pip python3-setuptools virtualenv
+   as per https://docs.ansible.com/ansible/latest/modules/pip_module.html
+
+2. mysql_db: python3-pymysql
+   https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html#mysql-db-module
+
+3. mysql_user: python3-pymysql
+   https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html#mysql-user-module
+   https://github.com/ansible/ansible/issues/47736
+
+4. postgresql_db: python3-psycopg2
+   https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html#postgresql-db-module
+
+5. postgresql_dbuser: python3-psycopg2
+   https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html#postgresql-user-module
+
+6. htpasswd: python3-passlib
+   https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html?highlight=htpasswd

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -3,6 +3,9 @@ need to be installed, we make use of the following ansible modules:
 
 1. pip: we install python3-pip python3-setuptools virtualenv
    as per https://docs.ansible.com/ansible/latest/modules/pip_module.html
+   virtualenv is python3 only and pulls in python3-distutils python3-virtualenv
+   `apt show virtualenv` Depends: python3, python3-virtualenv
+   `apt show python3-virtualenv` Depends: python-pip-whl (>= 8.1.1-2), python3, python3-distutils, python3-pkg-resources
 
 2. mysql_db: python3-pymysql
    https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html#mysql-db-module

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -1,24 +1,26 @@
-In order to use optional modules that ansible is capable of the libraries
-need to be installed, we make use of the following ansible modules:
+Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ansible](https://github.com/iiab/iiab/blob/master/scripts/ansible)) began installing these python3-* apt packages, in support of the following Ansible modules:
 
-1. pip: we install python3-pip python3-setuptools virtualenv
-   as per https://docs.ansible.com/ansible/latest/modules/pip_module.html
-   virtualenv is python3 only and pulls in python3-distutils python3-virtualenv
-   `apt show virtualenv` Depends: python3, python3-virtualenv
-   `apt show python3-virtualenv` Depends: python-pip-whl (>= 8.1.1-2), python3, python3-distutils, python3-pkg-resources
+1. Ansible module: [pip](https://docs.ansible.com/ansible/latest/modules/pip_module.html)
 
-2. mysql_db: python3-pymysql
-   https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html#mysql-db-module
+   IIAB installs apt packages:
+   - **python3-pip** (for IIAB's [Admin Console](https://github.com/iiab/iiab-admin-console))
+   - **python3-setuptools**
+   - **virtualenv** (is Python 3 only, for [roles/kalite](https://github.com/iiab/iiab/tree/master/roles/kalite) & [roles/calibre-web](https://github.com/iiab/iiab/tree/master/roles/calibre-web) ?) and pulls in additional packages... (`apt show virtualenv` shows "Depends: python3, python3-virtualenv")
+      - **python3-virtualenv** and pulls in additional package... (`apt show python3-virtualenv` shows "Depends: python-pip-whl (>= 8.1.1-2), python3, python3-distutils, python3-pkg-resources") 
+         - **python3-distutils**
 
-3. mysql_user: python3-pymysql
-   https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html#mysql-user-module
-   https://github.com/ansible/ansible/issues/47736
+2. Ansible modules: [mysql_db](https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html) and [mysql_user](https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html) (for [roles/mysql](https://github.com/iiab/iiab/tree/master/roles/mysql))
 
-4. postgresql_db: python3-psycopg2
-   https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html#postgresql-db-module
+   IIAB installs apt packages:
+   - **python3-pymysql**
+   - **python3-pymysql** (see [iiab/iiab#1714](https://github.com/iiab/iiab/issues/1714) and [ansible/ansible#47736](https://github.com/ansible/ansible/issues/47736))
 
-5. postgresql_dbuser: python3-psycopg2
-   https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html#postgresql-user-module
+4. Ansible modules: [postgresql_db](https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html) and [postgresql_dbuser](https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html)
 
-6. htpasswd: python3-passlib
-   https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html?highlight=htpasswd
+   IIAB installs apt package:
+   - **python3-psycopg2** (does Moodle still need this now that Pathagar is on its way out?)
+
+5. Ansible module: [htpasswd](https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html)
+
+   IIAB installs apt package:
+   - **python3-passlib** (for [roles/munin](https://github.com/iiab/iiab/tree/master/roles/munin))

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -316,6 +316,7 @@ dokuwiki_enabled: False
 mediawiki_install: False
 mediawiki_enabled: False
 
+# Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
 
@@ -538,10 +539,6 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 # =============================================================================
 # UNMAINTAINED LEGACY VARIABLES: YOU'RE TAKING BIG RISKS IF YOU USE ANY HERE...
 
-# Unmaintained
-# authserver_install: False
-# authserver_enabled: False
-
 # CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
 #
 # 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
@@ -559,9 +556,13 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 # docker_install: False
 # docker_enabled: False
 
-# THOSE ABOVE WERE STILL OCCASIONALLY USED AS OF SEPTEMBER 2019.
+# THOSE ABOVE WERE STILL OCCASIONALLY USED AS OF NOVEMBER 2019.
 # =============================================================================
-# THOSE BELOW WERE *NOT* USED FOR YEARS, AS OF SEPTEMBER 2019.
+# THOSE BELOW WERE *NOT* USED FOR YEARS, AS OF NOVEMBER 2019.
+
+# Unmaintained
+# authserver_install: False
+# authserver_enabled: False
 
 # Unmaintained (better to install from http://teamviewer.com or prep scripts at http://download.iiab.io)
 # teamviewer_install: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -209,6 +209,7 @@ dokuwiki_enabled: True
 mediawiki_install: True
 mediawiki_enabled: True
 
+# Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -209,6 +209,7 @@ dokuwiki_enabled: False
 mediawiki_install: False
 mediawiki_enabled: False
 
+# Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -209,6 +209,7 @@ dokuwiki_enabled: False
 mediawiki_install: False
 mediawiki_enabled: False
 
+# Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
 


### PR DESCRIPTION
Builds on PRs #2006 #2019 #2024 #2025 #2026 #2027 #2010.  Also:

- Makes Ansible 2.9.0 more official, fulfilling #1996
- Begins deprecation of ejabberd
- More fully deprecates authserver