### PR TITLE
Recommend Ansible 2.9.0 -> 2.9.1

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.9.0"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.1"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.9.0"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.1"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Even though Ansible 2.9.1 has not yet been published here:
https://launchpad.net/~ansible/+archive/ubuntu/ansible (should happen in coming hours/days)
(for scripts/ansible)

Ansible 2.9.1 has been published here:
https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.9
https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst
(for scripts/ansible-2.9.x)

Ansible 2.8.7 has been published here:
https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.8
https://github.com/ansible/ansible/blob/stable-2.8/changelogs/CHANGELOG-v2.8.rst
(for scripts/ansible-2.8.x)