### PR TITLE
Use alternate hosts file /etc/hosts.dnsmasq [so dnsmasq DOESN'T send "127.0.0.1 box box.lan" from /etc/hosts to client machines]

### DIFF
--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -54,6 +54,12 @@
     dest: /etc/dnsmasq.d/iiab.conf
   when: dnsmasq_install and dnsmasq_enabled and (iiab_network_mode != "Appliance")
 
+- name: Install /etc/hosts.dnsmasq from template, sourced by /etc/dnsmasq.d/iiab.conf
+  template:
+    src: network/hosts-dnsmasq.j2
+    dest: /etc/hosts.dnsmasq
+  when: dnsmasq_install and dnsmasq_enabled and (iiab_network_mode != "Appliance")
+
 ## Another way to skin the cat
 ##- name: Check if systemd service networkd-dispatcher is enabled
 ##  systemd:

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -54,7 +54,7 @@
     dest: /etc/dnsmasq.d/iiab.conf
   when: dnsmasq_install and dnsmasq_enabled and (iiab_network_mode != "Appliance")
 
-- name: Install /etc/hosts.dnsmasq from template, sourced by /etc/dnsmasq.d/iiab.conf
+- name: Install /etc/hosts.dnsmasq from template for /etc/dnsmasq.d/iiab.conf (instead of using /etc/hosts)
   template:
     src: network/hosts-dnsmasq.j2
     dest: /etc/hosts.dnsmasq

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -49,11 +49,11 @@
 #  when: 'iiab_wan_iface != "none" and wan_ip != "dhcp"'
 ##### End static ip address info
 
-- include_tasks: hosts.yml
-  tags:
-    - network
-    - hostname
-    - domain
+#- include_tasks: hosts.yml
+#  tags:
+#    - network
+#    - hostname
+#    - domain
 
 - name: Configure wondershaper
   include_tasks: wondershaper.yml

--- a/roles/network/templates/network/dnsmasq.conf.j2
+++ b/roles/network/templates/network/dnsmasq.conf.j2
@@ -12,6 +12,13 @@ address=/#/{{ lan_ip }}
 interface={{ iiab_lan_iface }}
 # Set the domain for dnsmasq
 domain={{ iiab_domain }}
+# don't use /etc/hosts
+no-hosts
+# instead use
+addn-hosts=/etc/hosts.dnsmasq
+# append 'local' to hostnames found
+expand-hosts
+
 # Specify the range of IP addresses the DHCP server will lease out to devices, and the duration of the lease
 dhcp-range=172.18.100.1,172.18.126.254,1h
 # Specify the default route

--- a/roles/network/templates/network/hosts-dnsmasq.j2
+++ b/roles/network/templates/network/hosts-dnsmasq.j2
@@ -1,3 +1,3 @@
 # Supplied by IIAB sourced by /etc/dnsmasq.d/iiab.conf
-{{ iiab_hostname }}  {{ lan_ip }}
+{{ iiab_hostname }}   {{ lan_ip }}
 box   {{ lan_ip }}

--- a/roles/network/templates/network/hosts-dnsmasq.j2
+++ b/roles/network/templates/network/hosts-dnsmasq.j2
@@ -1,0 +1,3 @@
+# Supplied by IIAB sourced by /etc/dnsmasq.d/iiab.conf
+{{ iiab_hostname }}  {{ lan_ip }}
+box   {{ lan_ip }}


### PR DESCRIPTION
### Fixes Bug
Mexico testing