### PR TITLE
Include a php clause in NGINX conf [for osm-vector-maps]

### DIFF
--- a/roles/osm-vector-maps/templates/osm-vector-maps-nginx.conf
+++ b/roles/osm-vector-maps/templates/osm-vector-maps-nginx.conf
@@ -1,7 +1,19 @@
 # For downloadable regional vector tilesets
 location /maps {
-   alias /library/www/osm-vector-maps;
+   rewrite ^/maps/(.*)$ /osm-vector-maps/$1;
 }
 location /osm-vector-maps {
    alias /library/www/osm-vector-maps;
+}
+location ~ ^/osm-vector-maps/(.*)\.php(.*)$ {
+    alias /library/www/osm-vector-maps/$1.php$2;
+    proxy_set_header X-Real-IP  $remote_addr;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header Host $host;
+    fastcgi_pass php;
+    include fastcgi_params;
+    fastcgi_split_path_info ^(.+\.php)(.*)$;
+    fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+    fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
+    fastcgi_param   PATH_INFO          $2;
 }


### PR DESCRIPTION
I cannot runrole on this role because of the hyphens in the role name.
But it has only line changes in the nginx config file. So I'm fairly sure it will smoke test.
The central-america map displays after rebooting the client, and clearing browser cache.
I'm willing to do more testing, in the next few days. Or you can just merge it, since the current master is broken, and this has a fairly high probability of fixing it.