### PR TITLE
Sugarizer-Server v1.1.1 -> v1.2.0

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -13,7 +13,7 @@ sugarizer_dir_version: sugarizer-1.2.0    # WAS: sugarizer-1.0, sugarizer-master
 sugarizer_git_version: v1.2.0             # WAS: v1.0.1, master, v1.1.0
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
-sugarizer_server_dir_version: sugarizer-server-1.1.1    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0
-sugarizer_server_git_version: v1.1.1                    # WAS: v1.0.1, master, dev, f27bf6acd56aba6d99116ef471ca713b0f0dfed3, v1.1.0
+sugarizer_server_dir_version: sugarizer-server-1.2.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0, sugarizer-server-1.1.1
+sugarizer_server_git_version: v1.2.0                    # WAS: v1.0.1, master, dev, f27bf6acd56aba6d99116ef471ca713b0f0dfed3, v1.1.0, v1.1.1
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer-server/commits/dev
 #                 AND https://github.com/llaske/sugarizer-server/releases


### PR DESCRIPTION
Needs testing on those remaining OS's that still support MongoDB...like Ubuntu 18.04 and Raspbian?