### PR TITLE
Does 'kiwix-serve --threads 8' help more users search Wikipedia simultaneously? ["capacity problems" in Mexico schools]

### DIFF
--- a/roles/kiwix/templates/kiwix-serve.service.j2
+++ b/roles/kiwix/templates/kiwix-serve.service.j2
@@ -4,7 +4,7 @@ After=syslog.target network.target local-fs.target
 
 [Service]
 Type=forking
-ExecStart={{ iiab_base }}/kiwix/bin/kiwix-serve --daemon --port {{ kiwix_port }} --nolibrarybutton --library {{ kiwix_library_xml }} --urlRootLocation={{ kiwix_url }}
+ExecStart={{ iiab_base }}/kiwix/bin/kiwix-serve --daemon --threads 8 --port {{ kiwix_port }} --nolibrarybutton --library {{ kiwix_library_xml }} --urlRootLocation={{ kiwix_url }}
 TimeoutStartSec=180
 Restart=on-abort
 RestartSec=5s


### PR DESCRIPTION
We still don't know the root cause of students being locked out of Wikipedia, as commonly happens (for about 2 min at time) in almost every Mexican school where [kiwix-serve 3.0.1-6](http://download.kiwix.org/release/kiwix-tools/) was deployed on RPi 3 last week.

But Emmanuel Engelhart suggests kiwix-serve '--threads 8' as a workaround (instead of the '--threads 4' default) for now.

Refs: #1993, kiwix/kiwix-tools#345