### PR TITLE
hosts file wrong sequence

### DIFF
--- a/roles/network/templates/network/hosts-dnsmasq.j2
+++ b/roles/network/templates/network/hosts-dnsmasq.j2
@@ -1,3 +1,3 @@
 # Supplied by IIAB sourced by /etc/dnsmasq.d/iiab.conf
-{{ iiab_hostname }}   {{ lan_ip }}
-box   {{ lan_ip }}
+{{ lan_ip }}  {{ iiab_hostname }}
+{{ lan_ip }}   box


### PR DESCRIPTION
smoke tested.
Functions after clearing browser cache, and reboot.