### PR TITLE
Alternative /etc/hosts.dnsmasq fix for PR #2051

### DIFF
--- a/roles/network/templates/network/hosts-dnsmasq.j2
+++ b/roles/network/templates/network/hosts-dnsmasq.j2
@@ -1,3 +1,2 @@
 # Supplied by IIAB sourced by /etc/dnsmasq.d/iiab.conf
-{{ iiab_hostname }}   {{ lan_ip }}
-box   {{ lan_ip }}
+{{ lan_ip }}   box {{ iiab_hostname }}


### PR DESCRIPTION
Concise alternative to PR #2065, to fix #2064, arising from PR #2051.