### PR TITLE
Calibre-Web 0.6.4 -> master

### DIFF
--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -14,7 +14,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-calibreweb_version: 0.6.4    # WAS: master
+calibreweb_version: master    # WAS: master, 0.6.4
 
 calibreweb_venv_path: /usr/local/calibre-web
 calibreweb_exec_path: "{{ calibreweb_venv_path }}/cps.py"


### PR DESCRIPTION
@OzzieIsaacs Calibre-Web 0.6.4 from almost 5 months ago is getting too old, so I'm reverting http://internet-in-a-box.org to Calibre-Web's master branch just for now!

As schools (generally) prefer a more recent version, including such changes as seen within:
https://github.com/janeczku/calibre-web/commits/master