### PR TITLE
NGINX home page double slash (should be single slash)

### DIFF
--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -1,5 +1,5 @@
 location / {
-    rewrite ^/$ $1/{{ iiab_home_url }};
+    rewrite ^/$ $1{{ iiab_home_url }};
 }
 
 location /usb {


### PR DESCRIPTION
Fix #2073, partially cleaning up PR #2068 (might also need _rewrite_ change to _redirect_ ?)