### PR TITLE
Node.js 10.x -> 12.x

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -369,7 +369,7 @@ mosquitto_port: 1883
 
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)
-nodejs_version: 10.x    # was 8.x until 2019-02-02
+nodejs_version: 12.x    # was 8.x until 2019-02-02, was 10.x until 2019-12-21
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
We're almost halfway through the ~5 month transition from Node.js 10.x LTS to 12.x LTS, as per #2005, so let's now broaden testing to confirm we're ready for 2020-3-31 (when Node.js 10.x is no longer full LTS) with many more users.

https://nodejs.org/en/about/releases/