### PR TITLE
Mandate Node.js 12.x for Sugarizer

### DIFF
--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -1,6 +1,6 @@
 - name: FAIL (STOP INSTALLING) IF nodejs_version is not set to 12.x
   fail:
-    msg: "Sugarizer install cannot proceed, as it currently requires Node.js 10.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+    msg: "Sugarizer install cannot proceed, as it currently requires Node.js 12.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
   when: sugarizer_install and (nodejs_version != "12.x")
 
 

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -1,7 +1,7 @@
-- name: FAIL (STOP INSTALLING) IF nodejs_version is not set to 10.x
+- name: FAIL (STOP INSTALLING) IF nodejs_version is not set to 12.x
   fail:
     msg: "Sugarizer install cannot proceed, as it currently requires Node.js 10.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
-  when: sugarizer_install and (nodejs_version != "10.x")
+  when: sugarizer_install and (nodejs_version != "12.x")
 
 
 # 1. DOWNLOAD+LINK /opt/iiab/sugarizer


### PR DESCRIPTION
Required alongside PR #2075 

Tested.