### PR TITLE
Moodle 3.7.x -> 3.8.x

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -7,7 +7,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-moodle_version: 37
+moodle_version: 38
 #moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_repo_url: "git://git.moodle.org/moodle.git"
 moodle_base: "{{ iiab_base }}/moodle"    # /opt/iiab


### PR DESCRIPTION
As released 2019-11-18:
https://docs.moodle.org/dev/Moodle_3.8_release_notes
https://moodle.com/news/the-new-moodle-3-8-is-here/

Background: IIAB upgraded from Moodle 3.5.x LTS to 3.7.x due to OS/database/PHP/compatibility problems, as documented in mid-2009: #1658, PR #1857

Moodle 3.9 (LTS) is expected 2020-5-11:
https://docs.moodle.org/dev/Roadmap#Moodle_3.9_.28LTS.29_Dates