### PR TITLE
Nextcloud: download the very latest (latest.tar.bz2)

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -23,7 +23,7 @@ nextcloud_dl_url: https://download.nextcloud.com/server/releases
 nextcloud_orig_src_file_old: latest-15.tar.bz2    
 nextcloud_src_file_old: nextcloud_{{ nextcloud_orig_src_file_old }}
 # For NEW OS's where PHP 7.1+ is auto-detected -- e.g. Raspbian 10, Debian 10 & Ubuntu 18.04
-nextcloud_orig_src_file: latest-17.tar.bz2
+nextcloud_orig_src_file: latest.tar.bz2
 nextcloud_src_file: nextcloud_{{ nextcloud_orig_src_file }}
 
 # We install on MySQL with these settings:


### PR DESCRIPTION
@m-anish: as we do with WordPress, let's always download the latest (released) version of Nextcloud.

In preparation for Nextcloud 18.0.0. next week (#2084) but also in general, going forward.

Refs: #2084 #2092 #2108 #2111 #2112