### PR TITLE
Explain #2112 Nextcloud workaround for 1000X faster download

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -389,7 +389,7 @@ nextcloud_allow_public_ips: False
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
 #
 # 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
-# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# you to ~100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
 # Uncomment the following line to avoid that: (might install an older Nextcloud)
 # nextcloud_dl_url: http://d.iiab.io/packages
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -387,6 +387,11 @@ nextcloud_enabled: False
 nextcloud_allow_public_ips: False
 # Configuration tips for IPv4 access controls and tuning RAM/resources:
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
+#
+# 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
+# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# Uncomment the following line to avoid that: (might install an older Nextcloud)
+# nextcloud_dl_url: http://d.iiab.io/packages
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # Works on Ubuntu 18.04, Debian 9. Experimental on Rasp/RPi 3. Uses Node.js 10.x

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -245,7 +245,7 @@ nextcloud_allow_public_ips: False
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
 #
 # 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
-# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# you to ~100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
 # Uncomment the following line to avoid that: (might install an older Nextcloud)
 # nextcloud_dl_url: http://d.iiab.io/packages
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -243,6 +243,11 @@ nextcloud_enabled: True
 nextcloud_allow_public_ips: False
 # Configuration tips for IPv4 access controls and tuning RAM/resources:
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
+#
+# 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
+# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# Uncomment the following line to avoid that: (might install an older Nextcloud)
+# nextcloud_dl_url: http://d.iiab.io/packages
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # Works on Ubuntu 18.04, Debian 9. Experimental on Rasp/RPi 3. Uses Node.js 10.x

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -245,7 +245,7 @@ nextcloud_allow_public_ips: False
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
 #
 # 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
-# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# you to ~100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
 # Uncomment the following line to avoid that: (might install an older Nextcloud)
 # nextcloud_dl_url: http://d.iiab.io/packages
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -243,6 +243,11 @@ nextcloud_enabled: True
 nextcloud_allow_public_ips: False
 # Configuration tips for IPv4 access controls and tuning RAM/resources:
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
+#
+# 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
+# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# Uncomment the following line to avoid that: (might install an older Nextcloud)
+# nextcloud_dl_url: http://d.iiab.io/packages
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # Works on Ubuntu 18.04, Debian 9. Experimental on Rasp/RPi 3. Uses Node.js 10.x

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -243,6 +243,11 @@ nextcloud_enabled: False
 nextcloud_allow_public_ips: False
 # Configuration tips for IPv4 access controls and tuning RAM/resources:
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
+#
+# 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
+# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# Uncomment the following line to avoid that: (might install an older Nextcloud)
+# nextcloud_dl_url: http://d.iiab.io/packages
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # Works on Ubuntu 18.04, Debian 9. Experimental on Rasp/RPi 3. Uses Node.js 10.x

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -245,7 +245,7 @@ nextcloud_allow_public_ips: False
 # https://github.com/iiab/iiab/blob/master/roles/nextcloud/README.md
 #
 # 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
-# you to 100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# you to ~100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
 # Uncomment the following line to avoid that: (might install an older Nextcloud)
 # nextcloud_dl_url: http://d.iiab.io/packages
 


### PR DESCRIPTION
Mitigates the worst of #2112, when download.nextcloud.com decides to throttle you, e.g. during repeated/iterative testing of IIAB installs.