### PR TITLE
Document fast download option in nextcloud/defaults/main.yml

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -17,6 +17,11 @@
 nextcloud_url: /nextcloud
 nextcloud_prefix: /opt
 nextcloud_data_dir: "{{ content_base }}/nextcloud/data"    # /library/nextcloud/data
+
+# 2020-01-07: If installing IIAB frequently, download.nextcloud.com may throttle
+# you to ~100 kbit/sec, delaying your IIAB install by an hour or more (#2112).
+# The following line can avoid that: (but might install an older Nextcloud)
+# nextcloud_dl_url: http://d.iiab.io/packages
 nextcloud_dl_url: https://download.nextcloud.com/server/releases
 
 # For OLD OS's where PHP 7.1+ isn't detected -- e.g. Raspbian 9, Debian 9, Ubuntu 16.04


### PR DESCRIPTION
Cleans up PR #2114 workaround, mitigating Nextcloud download delays (#2112).