### PR TITLE
Iashim [internetarchive shim for http://box/archive with NGINX]

### DIFF
--- a/roles/internetarchive/tasks/enable.yml
+++ b/roles/internetarchive/tasks/enable.yml
@@ -1,13 +1,12 @@
-- name: Create symlink internetarchive.conf from sites-enabled to sites-available, for short URL http://box/archive (if debuntu and internetarchive_enabled)
-  file:
-    src: /etc/apache2/sites-available/internetarchive.conf
-    path: /etc/apache2/sites-enabled/internetarchive.conf
-    state: link
+- name: Install nginx config for nternetarchive for short URL http://box/archive (if debuntu and internetarchive_enabled)
+  template:
+    src: internetarchive.nginx.conf
+    path: /etc/nginx/conf.d
   when: is_debuntu and internetarchive_enabled
 
-- name: Remove symlink /etc/apache2/sites-enabled/internetarchive.conf (if debuntu and not internetarchive_enabled)
+- name: Remove config /etc/nginx/conf.d/internetarchive.conf (if debuntu and not internetarchive_enabled)
   file:
-    path: /etc/apache2/sites-enabled/internetarchive.conf
+    path: /etc/nginx/conf.d/internetarchive.conf
     state: absent
   when: is_debuntu and not internetarchive_enabled
 
@@ -26,9 +25,9 @@
     state: restarted
   when: internetarchive_enabled | bool
 
-- name: Restart Apache service ({{ apache_service }}) to enable/disable http://box/archive (not just http://box:{{ internetarchive_port }})
+- name: Restart to enable/disable http://box/archive (not just http://box:{{ internetarchive_port }})
   systemd:
-    name: "{{ apache_service }}"    # httpd or apache2
+    name: nginx    # httpd or apache2
     state: restarted
   when: internetarchive_enabled | bool
 

--- a/roles/internetarchive/tasks/enable.yml
+++ b/roles/internetarchive/tasks/enable.yml
@@ -1,7 +1,7 @@
 - name: Install nginx config for nternetarchive for short URL http://box/archive (if debuntu and internetarchive_enabled)
   template:
     src: internetarchive.nginx.conf
-    path: /etc/nginx/conf.d
+    dest: /etc/nginx/conf.d
   when: is_debuntu and internetarchive_enabled
 
 - name: Remove config /etc/nginx/conf.d/internetarchive.conf (if debuntu and not internetarchive_enabled)

--- a/roles/internetarchive/templates/internetarchive.nginx.conf
+++ b/roles/internetarchive/templates/internetarchive.nginx.conf
@@ -5,5 +5,7 @@ rewrite ^/archive.org$ /archive;
 rewrite ^/internetarchive$ /archive;
 
 location /archive {
+  proxy_set_header   X-Forwarded-For $remote_addr;
+  proxy_set_header   Host $http_host;
   proxy_pass http://127.0.0.1:{{ internetarchive_port }};
 }

--- a/roles/internetarchive/templates/internetarchive.nginx.conf
+++ b/roles/internetarchive/templates/internetarchive.nginx.conf
@@ -1,0 +1,9 @@
+# internetarchive_port is set to 4244 in roles/internetarchive/defaults/main.yml
+# If you need to change this, edit /etc/iiab/local_vars.yml prior to installing
+
+rewrite ^/archive.org$ /archive;
+rewrite ^/internetarchive$ /archive;
+
+location /archive {
+  proxy_pass http://127.0.0.1:{{ internetarchive_port }};
+}


### PR DESCRIPTION
Missed translating apache to nginx for internetarchive.
This still fails because internetarchive uses node, and is currently configured to listen on ipv6, but we've disabled ipv6 on IIAB.
The configuration that needs changing may be in dweb, but I cannot find it.