### PR TITLE
logrotate daily disables captive portal after first day

### DIFF
--- a/roles/awstats/templates/logrotate.d.apache2
+++ b/roles/awstats/templates/logrotate.d.apache2
@@ -5,7 +5,7 @@
 	compress
 	delaycompress
 	notifempty
-	create 640 root www-data
+	create 640 www-data www-data
 	sharedscripts
 	postrotate
                 if /etc/init.d/apache2 status > /dev/null ; then \


### PR DESCRIPTION
### Fixes Bug

Logrotate for apache2 installed by awstats makes ownership root www-data with permissions 640 That means that captiveportal cannot write a log after the first day, and errors out after first day.

Perhaps this should wait until all of nginx logs get moved out of /var/log/apache2.