### PR TITLE
25 of 26 install.yml's + 10 others tasks/*.yml now write to /etc/iiab/iiab_state.yml

### DIFF
--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -76,8 +76,8 @@
   shell: /usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=schoolserver -update
   # when: awstats_enabled | bool
 
-- name: "Add 'awstats_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'awstats_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^awstats_installed'
     line: 'awstats_installed: True'

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -81,4 +81,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^awstats_installed'
     line: 'awstats_installed: True'
-    state: present

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -64,8 +64,8 @@
   args:
     chdir: "{{ azuracast_host_dir }}"
 
-- name: "Add 'azuracast_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'azuracast_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^azuracast_installed'
     line: 'azuracast_installed: True'

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -69,4 +69,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^azuracast_installed'
     line: 'azuracast_installed: True'
-    state: present

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -55,8 +55,8 @@
     regexp: '^#DiscoverableTimeout'
     line: 'DiscoverableTimeout = 0'
 
-- name: "Add 'bluetooth_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'bluetooth_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^bluetooth_installed'
     line: 'bluetooth_installed: True'

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -60,4 +60,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^bluetooth_installed'
     line: 'bluetooth_installed: True'
-    state: present

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -107,4 +107,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'
-    state: present

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -102,8 +102,8 @@
   when: not metadatadb.stat.exists
   #when: calibreweb_provision | bool
 
-- name: "Add 'calibreweb_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'calibreweb_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'

--- a/roles/calibre/tasks/install.yml
+++ b/roles/calibre/tasks/install.yml
@@ -79,8 +79,8 @@
   include_tasks: create-db.yml
   when: not calibre_db.stat.exists
 
-- name: "Add 'calibre_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'calibre_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^calibre_installed'
     line: 'calibre_installed: True'

--- a/roles/calibre/tasks/install.yml
+++ b/roles/calibre/tasks/install.yml
@@ -82,6 +82,5 @@
 - name: "Add 'calibre_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
   lineinfile:
     dest: "{{ iiab_state_file }}"
-    regexp: '^calibreweb_installed'
+    regexp: '^calibre_installed'
     line: 'calibre_installed: True'
-    state: present

--- a/roles/captiveportal/tasks/main.yml
+++ b/roles/captiveportal/tasks/main.yml
@@ -88,9 +88,9 @@
     state: absent
   when: not captiveportal_enabled
 
-- name: "Add 'captiveportal_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'captiveportal_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^captiveportal_installed'
     line: 'captiveportal_installed: True'
 

--- a/roles/captiveportal/tasks/main.yml
+++ b/roles/captiveportal/tasks/main.yml
@@ -93,7 +93,6 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^captiveportal_installed'
     line: 'captiveportal_installed: True'
-    state: present
 
 #- name: Restart dnsmasq
 #  systemd:
@@ -114,4 +113,3 @@
     name: dnsmasq
     state: started
   when: dnsmasq_enabled | bool
-  

--- a/roles/cups/tasks/main.yml
+++ b/roles/cups/tasks/main.yml
@@ -17,9 +17,9 @@
     src: cups.conf
     dest: "/etc/{{ apache_config_dir }}/"
 
-- name: "Add 'cups_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'cups_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^cups_installed'
     line: 'cups_installed: True'
 

--- a/roles/cups/tasks/main.yml
+++ b/roles/cups/tasks/main.yml
@@ -7,13 +7,6 @@
   tags:
     - download
 
-- name: "Add 'cups_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-  lineinfile:
-    dest: "{{ iiab_state_file }}"
-    regexp: '^cups_installed'
-    line: 'cups_installed: True'
-    state: present
-
 - name: Install our own /etc/cups/cupsd.conf from template, to permit local LAN admin
   template:
     src: cupsd.conf
@@ -24,12 +17,15 @@
     src: cups.conf
     dest: "/etc/{{ apache_config_dir }}/"
 
-- name: Create symlink cups.conf from sites-enabled to sites-available (debuntu)
-  file:
-    src: /etc/apache2/sites-available/cups.conf
-    dest: /etc/apache2/sites-enabled/cups.conf
-    state: link
-  when: cups_enabled and is_debuntu
+- name: "Add 'cups_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  lineinfile:
+    dest: "{{ iiab_state_file }}"
+    regexp: '^cups_installed'
+    line: 'cups_installed: True'
+
+- name: Enable http://box/cups via Apache (MIGHT NOT WORK?)
+  command: a2ensite cups.conf
+  when: cups_enabled
 
 - name: Enable & Start services 'cups' and 'cups-browsed' (OS's other than Fedora 18)
   service:

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -47,8 +47,8 @@
 #     state: absent
 #   when: not dokuwiki_enabled and is_debuntu
 
-- name: "Add 'dokuwiki_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'dokuwiki_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^dokuwiki_installed'
     line: 'dokuwiki_installed: True'

--- a/roles/elgg/tasks/install.yml
+++ b/roles/elgg/tasks/install.yml
@@ -87,8 +87,8 @@
     src: elgg.conf
     dest: "/etc/{{ apache_config_dir }}/elgg.conf"
 
-- name: "Add 'elgg_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'elgg_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^elgg_installed'
     line: 'elgg_installed: True'

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -124,8 +124,8 @@
     - { src: 'gitea.service.j2', dest: '/etc/systemd/system/gitea.service' }
     - { src: 'gitea.conf.j2', dest: "/etc/{{ apache_config_dir }}/gitea.conf" }
 
-- name: "Add 'gitea_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'gitea_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^gitea_installed'
     line: 'gitea_installed: True'

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -129,4 +129,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^gitea_installed'
     line: 'gitea_installed: True'
-    state: present

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -107,9 +107,9 @@
 - name: Create Apache's pid dir /var/run/{{ apache_user }}
   file:
     path: "/var/run/{{ apache_user }}"
-    mode: 0755
     owner: root
     group: root
+    mode: '0755'
     state: directory
 
 - name: 'Create group: admin'
@@ -127,9 +127,9 @@
 - name: Create Apache dir /var/log/{{ apache_service }}
   file:
     path: "/var/log/{{ apache_service }}"
-    mode: 0755
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
+    mode: '0755'
     state: directory
 
 - name: Enable Apache systemd service ({{ apache_service }})
@@ -141,7 +141,13 @@
 - name: Create /library/www/html/info directory for http://box/info offline docs
   file:
     path: "{{ doc_root }}/info"
-    mode: 0755
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
+    mode: '0755'
     state: directory
+
+- name: "Add 'apache_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  lineinfile:
+    dest: "{{ iiab_state_file }}"
+    regexp: '^apache_installed'
+    line: 'apache_installed: True'

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -146,8 +146,8 @@
     mode: '0755'
     state: directory
 
-- name: "Add 'apache_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'apache_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^apache_installed'
     line: 'apache_installed: True'

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -45,8 +45,8 @@
     - { src: 'internetarchive.service.j2', dest: '/etc/systemd/system/internetarchive.service' }
     - { src: 'internetarchive.conf', dest: '/etc/apache2/sites-available/internetarchive.conf' }
 
-- name: "Add 'internetarchive_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'internetarchive_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^internetarchive_installed'
     line: 'internetarchive_installed: True'

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -50,4 +50,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^internetarchive_installed'
     line: 'internetarchive_installed: True'
-    state: present

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -83,8 +83,8 @@
     replace: 'a-zA-Z0-9\-'
 
 # SHOULD REALLY BE HERE...but for now this runs in kalite/tasks/setup.yml
-# - name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+# - name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"
 #   lineinfile:
-#     dest: "{{ iiab_state_file }}"
+#     dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
 #     regexp: '^kalite_installed'
 #     line: 'kalite_installed: True'

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -81,3 +81,10 @@
     path: /usr/local/kalite/venv/local/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py
     regexp: 'a-zA-Z0-9'
     replace: 'a-zA-Z0-9\-'
+
+# SHOULD REALLY BE HERE...but for now this runs in kalite/tasks/setup.yml
+# - name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+#   lineinfile:
+#     dest: "{{ iiab_state_file }}"
+#     regexp: '^kalite_installed'
+#     line: 'kalite_installed: True'

--- a/roles/kalite/tasks/setup.yml
+++ b/roles/kalite/tasks/setup.yml
@@ -3,9 +3,9 @@
 - name: Create {{ kalite_root }} directory
   file:
     path: "{{ kalite_root }}/httpsrv/static"    # /library/ka-lite
-    owner: root
-    group: root
-    mode: 0755
+    # owner: root
+    # group: root
+    # mode: 0755
     state: directory
 
 - name: Run the setup using 'kalite manage'
@@ -15,9 +15,9 @@
   async: 1800
   poll: 10
 
+# CAN WE MOVE THIS TO THE END OF kalite/tasks/install.yml (HENCE ITS FILENAME!)
 - name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
   lineinfile:
     dest: "{{ iiab_state_file }}"
     regexp: '^kalite_installed'
     line: 'kalite_installed: True'
-    state: present

--- a/roles/kalite/tasks/setup.yml
+++ b/roles/kalite/tasks/setup.yml
@@ -16,8 +16,8 @@
   poll: 10
 
 # CAN WE MOVE THIS TO THE END OF kalite/tasks/install.yml (HENCE ITS FILENAME!)
-- name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kalite_installed'
     line: 'kalite_installed: True'

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -83,8 +83,8 @@
 
 # 5. RECORD KIWIX AS INSTALLED IN /etc/iiab/iiab_state.yml
 
-- name: "Add 'kiwix_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'kiwix_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kiwix_installed'
     line: 'kiwix_installed: True'

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -88,4 +88,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^kiwix_installed'
     line: 'kiwix_installed: True'
-    state: present

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -118,4 +118,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^kolibri_installed'
     line: 'kolibri_installed: True'
-    state: present

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -113,8 +113,8 @@
 #  apache2_module:
 #    name: proxy_http
 
-- name: "Add 'kolibri_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'kolibri_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kolibri_installed'
     line: 'kolibri_installed: True'

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -86,8 +86,8 @@
 #     state: restarted
 #   when: lokole_enabled | bool
 
-- name: "Add 'lokole_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'lokole_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^lokole_installed'
     line: 'lokole_installed: True'

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -90,4 +90,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^mediawiki_installed'
     line: 'mediawiki_installed: True'
-    state: present

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -85,8 +85,8 @@
 
 # Install {{ nginx_config_dir }}/mediawiki-nginx.conf from template in enable.yml
 
-- name: "Add 'mediawiki_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'mediawiki_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mediawiki_installed'
     line: 'mediawiki_installed: True'

--- a/roles/minetest/tasks/provision.yml
+++ b/roles/minetest/tasks/provision.yml
@@ -9,12 +9,10 @@
 - name: Create /library/games
   file:
     state: directory
-    path: "{{ item }}"
-    owner: root
-    group: root
-    mode: 0755
-  with_items:
-    - /library/games
+    path: /library/games
+    # owner: root
+    # group: root
+    # mode: 0755
 
 # rpi only
 - include_tasks: rpi_minetest_install.yml
@@ -37,7 +35,7 @@
     recurse: yes
     owner: "{{ minetest_runas_user }}"
     group: "{{ minetest_runas_group }}"
-    mode: 0755
+    # mode: 0755
   when: minetest_default_game == "carbone-ng"
 
 # Install games
@@ -76,5 +74,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^minetest_installed'
     line: 'minetest_installed: True'
-    state: present
-

--- a/roles/minetest/tasks/provision.yml
+++ b/roles/minetest/tasks/provision.yml
@@ -69,8 +69,8 @@
     path: "{{ minetest_game_dir }}/mods/name_restrictions"
   when: minetest_default_game == "carbone-ng"
 
-- name: "Add 'minetest_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'minetest_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^minetest_installed'
     line: 'minetest_installed: True'

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -133,4 +133,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^mongodb_installed'
     line: 'mongodb_installed: True'
-    state: present

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -128,8 +128,8 @@
     - { src: 'mongodb.service.j2', dest: '/etc/systemd/system/mongodb.service', mode: '0644' }
     - { src: 'iiab-mongodb-repair-if-no-lock.j2', dest: '/usr/bin/iiab-mongodb-repair-if-no-lock', mode: '0755' }
 
-- name: "Add 'mongodb_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'mongodb_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mongodb_installed'
     line: 'mongodb_installed: True'

--- a/roles/monit/tasks/install.yml
+++ b/roles/monit/tasks/install.yml
@@ -58,8 +58,8 @@
     - option: enabled
       value: "{{ monit_enabled }}"
 
-- name: "Add 'monit_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'monit_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^monit_installed'
     line: 'monit_installed: True'

--- a/roles/monit/tasks/install.yml
+++ b/roles/monit/tasks/install.yml
@@ -57,3 +57,9 @@
       value: '"Monit is a background service monitor which can correct problems, send email, restart services."'
     - option: enabled
       value: "{{ monit_enabled }}"
+
+- name: "Add 'monit_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  lineinfile:
+    dest: "{{ iiab_state_file }}"
+    regexp: '^monit_installed'
+    line: 'monit_installed: True'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -138,8 +138,8 @@
     path: "{{ moodle_base }}/config.php"
     mode: '0644'
 
-- name: "Add 'moodle_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'moodle_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^moodle_installed'
     line: 'moodle_installed: True'

--- a/roles/mosquitto/tasks/install.yml
+++ b/roles/mosquitto/tasks/install.yml
@@ -35,4 +35,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^mosquitto_installed'
     line: 'mosquitto_installed: True'
-    state: present

--- a/roles/mosquitto/tasks/install.yml
+++ b/roles/mosquitto/tasks/install.yml
@@ -30,8 +30,8 @@
     group: root
     mode: 0755
 
-- name: "Add 'mosquitto_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'mosquitto_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mosquitto_installed'
     line: 'mosquitto_installed: True'

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -40,8 +40,8 @@
     create: yes
     state: present
 
-- name: "Add 'munin_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'munin_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^munin_installed'
     line: 'munin_installed: True'

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -45,4 +45,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^munin_installed'
     line: 'munin_installed: True'
-    state: present

--- a/roles/network/tasks/dansguardian.yml
+++ b/roles/network/tasks/dansguardian.yml
@@ -50,8 +50,8 @@
     state: directory
   when: ansible_distribution == "CentOS"
 
-- name: "Add 'dansguardian_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'dansguardian_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^dansguardian_installed'
     line: 'dansguardian_installed: True'

--- a/roles/network/tasks/dansguardian.yml
+++ b/roles/network/tasks/dansguardian.yml
@@ -11,7 +11,7 @@
     dest: /etc/dansguardian/dansguardian.conf
     owner: dansguardian
     group: dansguardian
-    mode: 0640
+    mode: '0640'
   when: ansible_distribution == "Fedora"
 
 - name: Install /etc/dansguardian/dansguardian.conf from template (debuntu)
@@ -20,7 +20,7 @@
     dest: /etc/dansguardian/dansguardian.conf
     owner: dansguardian
     group: dansguardian
-    mode: 0640
+    mode: '0640'
   when: is_debuntu | bool
 
 - name: Install /etc/dansguardian/dansguardian.conf from template (CentOS)
@@ -29,7 +29,7 @@
     dest: /etc/dansguardian/dansguardian.conf
     owner: dansguardian
     group: vscan
-    mode: 0640
+    mode: '0640'
   when: ansible_distribution == "CentOS"
 
 - name: Create directory /var/log/dansguardian (OS's other than CentOS)
@@ -37,7 +37,7 @@
     path: /var/log/dansguardian
     owner: dansguardian
     group: dansguardian
-    mode: 0750
+    mode: '0750'
     state: directory
   when: ansible_distribution != "CentOS"
 
@@ -46,7 +46,7 @@
     path: /var/log/dansguardian
     owner: dansguardian
     group: vscan
-    mode: 0750
+    mode: '0750'
     state: directory
   when: ansible_distribution == "CentOS"
 
@@ -55,4 +55,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^dansguardian_installed'
     line: 'dansguardian_installed: True'
-    state: present

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -3,16 +3,12 @@
     name: isc-dhcp-server
     state: present
   when: is_debuntu | bool
-  tags:
-    - download
 
 - name: Install dhcp package (not debuntu)
   package:
     name: dhcp
     state: present
   when: not is_debuntu
-  tags:
-    - download
 
 - name: Create non-privileged user 'dhcpd' (debuntu)
   user:
@@ -37,13 +33,11 @@
 
 - name: Install systemd unit file to /etc/systemd/system/dhcpd.service
   template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    owner: root
-    group: root
-    mode: "{{ item.mode }}"
-  with_items:
-   - { src: 'roles/network/templates/dhcp/dhcpd.service', dest: '/etc/systemd/system/dhcpd.service', mode: '0644' }
+    src: roles/network/templates/dhcp/dhcpd.service
+    dest: /etc/systemd/system/dhcpd.service
+    # owner: root
+    # group: root
+    # mode: '0644'
 
 - name: Create file /var/lib/dhcpd/dhcpd.leases (redhat)
   command: touch /var/lib/dhcpd/dhcpd.leases
@@ -56,8 +50,8 @@
     path: /var/lib/dhcpd/dhcpd.leases
     owner: dhcpd
     group: dhcpd
-    mode: 0644
-    state: file
+    mode: '0644'
+    # state: file
   when: is_redhat | bool
 
 - name: "Add 'dhcpd_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
@@ -65,4 +59,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^dhcpd_installed'
     line: 'dhcpd_installed: True'
-    state: present

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -54,8 +54,8 @@
     # state: file
   when: is_redhat | bool
 
-- name: "Add 'dhcpd_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'dhcpd_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^dhcpd_installed'
     line: 'dhcpd_installed: True'

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -5,8 +5,6 @@
       - bind9utils
     state: present
   when: is_debuntu | bool
-  tags:
-    - download
 
 - name: "Install named packages: bind, bind-utils (OS's other than debuntu)"
   package:
@@ -15,8 +13,6 @@
       - bind-utils
     state: present
   when: not is_debuntu
-  tags:
-    - download
 
 # or we have to change the serial number in the config files.
 - name: Stop named before copying files (if first_run and debuntu)
@@ -30,7 +26,7 @@
     path: "{{ item }}"
     owner: "{{ dns_user }}"
     group: root
-    mode: 0755
+    mode: '0755'
     state: directory
   with_items:
     - /var/named-iiab
@@ -72,7 +68,7 @@
   template:
     src: "roles/network/templates/named/{{ dns_service }}.service"
     dest: "/etc/systemd/system/{{ dns_service }}.service"
-    mode: 0644
+    mode: '0644'
 
 - name: "Install /etc/{{ apache_config_dir }}/dns-jail.conf from template: dns-jail redirect requires the named.blackhole, disabling recursion (if dns_jail_enabled)"
 #        in named-iiab.conf, and the redirection of 404 error documents to /
@@ -81,31 +77,19 @@
     dest: "/etc/{{ apache_config_dir }}/"
   when: dns_jail_enabled | bool
 
-- name: Create symlink dns-jail.conf from sites-enabled to sites-available (if debuntu and dns_jail_enabled)
-  file:
-    src: "/etc/{{ apache_config_dir }}/dns-jail.conf"
-    path: "/etc/{{ apache_service }}/sites-enabled/dns-jail.conf"
-    state: link
-  when: is_debuntu and dns_jail_enabled
-
-- name: Remove symlink /etc/{{ apache_service }}/sites-enabled/dns-jail.conf (if debuntu and not dns_jail_enabled)
-  file: 
-    path: "/etc/{{ apache_service }}/sites-enabled/dns-jail.conf"
-    state: absent
-  when: is_debuntu and not dns_jail_enabled
-
-- name: Remove symlink /etc/{{ apache_config_dir }}/dns-jail.conf (if not debuntu and not dns_jail_enabled)
-  file:
-    path: "/etc/{{ apache_config_dir }}/dns-jail.conf"
-    state: absent
-  when: not is_debuntu and not dns_jail_enabled
-
 - name: "Add 'named_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
   lineinfile:
     dest: "{{ iiab_state_file }}"
     regexp: '^named_installed'
     line: 'named_installed: True'
-    state: present
+
+- name: Enable dns-jail.conf via Apache
+  command: a2ensite dns-jail.conf
+  when: dns_jail_enabled | bool
+
+- name: Disable dns-jail.conf via Apache
+  command: a2dissite: dns-jail.conf
+  when: not dns_jail_enabled
 
 - name: Start named systemd service
   systemd:

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -77,9 +77,9 @@
     dest: "/etc/{{ apache_config_dir }}/"
   when: dns_jail_enabled | bool
 
-- name: "Add 'named_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'named_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^named_installed'
     line: 'named_installed: True'
 

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -80,9 +80,9 @@
 - include_tasks: roles/network/tasks/dansguardian.yml
   when: dansguardian_install | bool
 
-- name: "Add 'squid_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'squid_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^squid_installed'
     line: 'squid_installed: True'
 

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -4,8 +4,6 @@
       - "{{ proxy }}"
       - cadaver
     state: present
-  tags:
-    - download
 
 - name: "Bigger hammer for Ubuntu, run: /etc/init.d/squid stop"
   command: /etc/init.d/squid stop
@@ -68,7 +66,7 @@
     path: /library/cache
     owner: "{{ proxy_user }}"
     group: "{{ proxy_user }}"
-    mode: 0750
+    mode: '0750'
     state: directory
 
 - name: Create Squid directory /var/log/{{ proxy }}
@@ -76,7 +74,7 @@
     path: "/var/log/{{ proxy }}"
     owner: "{{ proxy_user }}"
     group: "{{ proxy_user }}"
-    mode: 0750
+    mode: '0750'
     state: directory
 
 - include_tasks: roles/network/tasks/dansguardian.yml
@@ -87,7 +85,6 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^squid_installed'
     line: 'squid_installed: True'
-    state: present
 
 # {{ proxy }} is normally "squid", but is "squid3" on raspbian-8 & debian-8
 - name: Add '{{ proxy }}' variable values to {{ iiab_ini_file }}

--- a/roles/network/tasks/wondershaper.yml
+++ b/roles/network/tasks/wondershaper.yml
@@ -3,39 +3,39 @@
     backup: yes
     src: roles/network/templates/wondershaper/wondershaper.service
     dest: /etc/systemd/system/wondershaper.service
-    mode: 0644
+    # mode: '0644'
 
 - name: Install /usr/bin/wondershaper from template
   template:
     backup: yes
     src: roles/network/templates/wondershaper/wondershaper.j2
     dest: /usr/bin/wondershaper
-    owner: root
-    group: root
-    mode: 0744
+    # owner: root
+    # group: root
+    # mode: '0744'
 
 - name: Create conf.d directory
   file:
     path: /etc/conf.d
-    owner: root
-    group: root
-    mode: 0755
+    # owner: root
+    # group: root
+    # mode: '0755'
     state: directory
 
 - name: Install /etc/conf.d/wondershaper.conf from template
   template:
     src: roles/network/templates/wondershaper/wondershaper.conf
     dest: /etc/conf.d/wondershaper.conf
-    owner: root
-    group: root
-    mode: 0600
+    # owner: root
+    # group: root
+    mode: '0600'
 
-- name: Create fact (link) for /etc/conf.d/wondershaper.conf
+- name: Create fact (symlink) /etc/ansible/facts.d/wondershaper.fact -> /etc/conf.d/wondershaper.conf
   file:
     src: /etc/conf.d/wondershaper.conf
     dest: /etc/ansible/facts.d/wondershaper.fact
-    owner: root
-    group: root
+    # owner: root
+    # group: root
     state: link
 
 - name: "Add 'wondershaper_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
@@ -43,7 +43,6 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^wondershaper_installed'
     line: 'wondershaper_installed: True'
-    state: present
 
 - name: Add 'wondershaper' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/network/tasks/wondershaper.yml
+++ b/roles/network/tasks/wondershaper.yml
@@ -38,9 +38,9 @@
     # group: root
     state: link
 
-- name: "Add 'wondershaper_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'wondershaper_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^wondershaper_installed'
     line: 'wondershaper_installed: True'
 

--- a/roles/network/tasks/wondershaper.yml
+++ b/roles/network/tasks/wondershaper.yml
@@ -12,7 +12,7 @@
     dest: /usr/bin/wondershaper
     # owner: root
     # group: root
-    # mode: '0744'
+    mode: '0744'
 
 - name: Create conf.d directory
   file:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -175,8 +175,8 @@
     src: nextcloud.conf.j2
     dest: "/etc/{{ apache_config_dir }}/nextcloud.conf"
 
-- name: "Add 'nextcloud_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'nextcloud_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nextcloud_installed'
     line: 'nextcloud_installed: True'

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -34,3 +34,9 @@
     path: /var/log/uwsgi/app
     state: directory
     owner: "{{ apache_user }}"
+
+- name: "Add 'nginx_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  lineinfile:
+    dest: "{{ iiab_state_file }}"
+    regexp: '^nginx_installed'
+    line: 'nginx_installed: True'

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -35,8 +35,8 @@
     state: directory
     owner: "{{ apache_user }}"
 
-- name: "Add 'nginx_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'nginx_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nginx_installed'
     line: 'nginx_installed: True'

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -35,7 +35,7 @@
 #  include_tasks: only_nginx.yml
 #  when: nginx_enabled | bool
 
-- name: Stop and disable NGINX, when not nginx_enabled
+- name: Stop & Disable 'nginx' systemd service, when not nginx_enabled
   systemd:
     name: nginx
     state: stopped

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -93,8 +93,8 @@
     state: present
     name: proxy_wstunnel
 
-- name: "Add 'nodered_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'nodered_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nodered_installed'
     line: 'nodered_installed: True'

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -30,9 +30,9 @@
     src: smb.conf.j2
     dest: /etc/samba/smb.conf
 
-- name: "Add 'samba_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'samba_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^samba_installed'
     line: 'samba_installed: True'
 

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -35,7 +35,6 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^samba_installed'
     line: 'samba_installed: True'
-    state: present
 
 - name: Enable & Start Samba systemd service
   service:

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -220,4 +220,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^sugarizer_installed'
     line: 'sugarizer_installed: True'
-    state: present

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -215,8 +215,8 @@
 #    # Use this instead, if tabs are truly nec:
 #    # block: "\tvar pathPrefix = '/sugarizer';\n\tapp.use(pathPrefix, require('path-prefix-proxy')(pathPrefix));"
 
-- name: "Add 'sugarizer_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'sugarizer_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^sugarizer_installed'
     line: 'sugarizer_installed: True'

--- a/roles/teamviewer/tasks/install.yml
+++ b/roles/teamviewer/tasks/install.yml
@@ -49,3 +49,9 @@
   with_items:
     - teamviewer*
   when: teamviewer_install and xo_model == "none" and ansible_distribution_version >= "22"
+
+- name: "Add 'teamviewer_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  lineinfile:
+    dest: "{{ iiab_state_file }}"
+    regexp: '^teamviewer_installed'
+    line: 'teamviewer_installed: True'

--- a/roles/teamviewer/tasks/install.yml
+++ b/roles/teamviewer/tasks/install.yml
@@ -50,8 +50,8 @@
     - teamviewer*
   when: teamviewer_install and xo_model == "none" and ansible_distribution_version >= "22"
 
-- name: "Add 'teamviewer_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'teamviewer_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^teamviewer_installed'
     line: 'teamviewer_installed: True'

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -90,8 +90,8 @@
     dest: "/etc/{{ apache_config_dir }}/wordpress.conf"
   when: apache_enabled | bool
 
-- name: "Add 'wordpress_installed: True' to {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+- name: "Add 'wordpress_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^wordpress_installed'
     line: 'wordpress_installed: True'

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -95,4 +95,3 @@
     dest: "{{ iiab_state_file }}"
     regexp: '^wordpress_installed'
     line: 'wordpress_installed: True'
-    state: present


### PR DESCRIPTION
Summary:

1. 4 install.yml files (httpd/tasks/install.yml, monit/tasks/install.yml, nginx/tasks/install.yml, teamviewer/tasks/install.yml) are hereby added to the list of files that write their respective `XYZ_installed: True` to /etc/iiab/iiab_state.yml
 
   So of all 26 files named `*/tasks/install.yml`, [roles/kalite/tasks/install.yml](https://github.com/iiab/iiab/blob/master/roles/kalite/tasks/install.yml) remains the 1-and-only exception that doesn't yet write its own `XYZ_installed: True` to /etc/iiab/iiab_state.yml

   ([roles/kalite/tasks/setup.yml](https://github.com/iiab/iiab/blob/master/roles/kalite/tasks/setup.yml) does that job, for now anyway...possibly this should change in future, such that `install.yml` always lives up to its name...or at least tried...and upon completion writes `kalite_installed: True` to /etc/iiab/iiab_state.yml like all the others?)

2. The 10 _other_ `*/tasks/*.yml` files (those not named `install.yml`, that also write their respective `XYZ_installed: True` to /etc/iiab/iiab_state.yml) are currently:

   1. captiveportal/tasks/main.yml
   2. cups/tasks/main.yml
   3. kalite/tasks/setup.yml (double-counting kalite, as it's also in the 25+1 install.yml's above!)
   4. minetest/tasks/provision.yml
   5. network/tasks/dansguardian.yml
   6. network/tasks/dhcpd.yml
   7. network/tasks/named.yml
   8. network/tasks/squid.yml
   9. network/tasks/wondershaper.yml
   10. samba/tasks/main.yml

   These 10 above should probably be renamed-or-worked-into `XYZ/tasks/install.yml` or if that's not possible `XYZ/tasks/XYZ-install.yml` e.g. if this is not viable for a playbook like network/tasks/install.yml

   _In any case, there are now 25 + 10 = 35 total (5 of which explicitly contained within network/tasks) playbooks-or-sub-playbooks writing the /etc/iiab/iiab_state.yml = {{ iiab_state_file }}.

3. The `state: present` lines were gratuitous, so I removed these unnecessary from all these 35 `lineinfile` stanzas.