### PR TITLE
Fix for Admin Console login popup loop: install NGINX after Apache & MySQL

### DIFF
--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -3,10 +3,6 @@
 - name: ...IS BEGINNING =====================================
   command: echo
 
-- name: Install NGINX (configured LATER, in Stage 9-LOCAL-ADDONS)
-  include_tasks: roles/nginx/tasks/install.yml
-  when: nginx_install | bool
-
 - name: HTTPD (APACHE)
   include_role:
     name: httpd
@@ -18,6 +14,10 @@
     name: mysql
   when: mysql_install | bool
   #tags: base, mysql
+
+- name: Install NGINX (configured LATER, in Stage 9-LOCAL-ADDONS)
+  include_tasks: roles/nginx/tasks/install.yml
+  when: nginx_install | bool
 
 - name: Install dnsmasq
   include_tasks: roles/network/tasks/dnsmasq.yml


### PR DESCRIPTION
Hopefully @jvonau & @tim-moody (or @georgejhunt ?) can explain why NGINX cannot currently be installed prior to Apache &/or MySQL!

CONTEXT: installing NGINX prior to Apache & MySQL (during an IIAB install, in [3-base-server](https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml)) currently causes Admin Console logins to ignore the username/password you type into the browser popup (typically iiab-admin/g0adm1n) and then another login popup keeps appearing every time (about 1-2 seconds after each username/password attempt).

FYI this failure occurred regardless of OS {Ubuntu 18.04, 19.10 and Debian 10.2}.

Ref: #2142