### PR TITLE
Mediawiki 1.34.0 strictly disallows password 'changeme' so for now let's use 'changeme2020'

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -13,11 +13,12 @@ mediawiki_src: "mediawiki-{{ mediawiki_version }}.tar.gz"
 
 mediawiki_db_name: iiab_mediawiki
 mediawiki_db_user: iiab_mediawiki_user
-mediawiki_db_user_password: changeme
+mediawiki_db_user_password: changeme2020
 
 mediawiki_admin_user: Admin
-mediawiki_admin_user_password: changeme
-# http://box/wiki will ask you for a stronger password on login, per:
+mediawiki_admin_user_password: changeme2020
+# 2020-01-17: MediaWiki 1.34.0 NO LONGER ACCEPTS 'changeme' as a password.
+# 2019-09-30: http://box/mediawiki asked for a stronger password on login, per:
 # https://www.mediawiki.org/wiki/Wikimedia_Security_Team/Password_strengthening_2019#Password_requirements
 
 mediawiki_site_name: Community Wiki


### PR DESCRIPTION
Until we come up with something better!

Builds on PR #1973 from 2019-09-30, and PR #2158 from 2020-01-16.