### PR TITLE
Gitea 1.10.2 -> 1.10.3 security release

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -8,7 +8,7 @@
 # https://git.coolaj86.com/coolaj86/gitea-installer.sh
 
 # Information needed to install Gitea
-gitea_version: 1.10.2
+gitea_version: 1.10.3
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
Gitea 1.10.3 changelog:

https://github.com/go-gitea/gitea/releases/tag/v1.10.3