### PR TITLE
Wordpress/Munin Scaffolding: tiny enhancements

### DIFF
--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -98,3 +98,9 @@
   systemd:
     name: nginx
     state: reloaded
+
+- name: "Add 'osm_vector_maps_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^osm_vector_maps_installed'
+    line: 'osm_vector_maps_installed: True'

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -36,10 +36,10 @@
     msg: "{{ downloads_dir }}/wordpress.tar.gz is REQUIRED in order to install WordPress."
   when: not wp_link.stat.exists
 
-- name: "Unpack /opt/iiab/downloads/wordpress.tar.gz to permanent location /library/wordpress - owner: root, group: {{ apache_user }}, mode: 0664, keep_newer: yes"
+- name: "Unpack {{ downloads_dir }}/wordpress.tar.gz to permanent location {{ wp_install_path }}/wordpress - owner: root, group: {{ apache_user }}, mode: '0664', keep_newer: yes"
   unarchive:
-    src: "{{ downloads_dir }}/wordpress.tar.gz"
-    dest: "{{ wp_install_path }}"
+    src: "{{ downloads_dir }}/wordpress.tar.gz"    # /opt/iiab/downloads
+    dest: "{{ wp_install_path }}"    # /library
     owner: root    # 2020-01-17: confirmed that wordpress.tar.gz (otherwise) unpacks as nobody:nogroup, with all files as '0644', and all dirs as '0755'
     group: "{{ apache_user }}"    # DO WE REALLY STILL WANT THIS FOR NGINX?
     mode: '0664'    # PHP/Apache/NGINX apparently need g+rw (group write access, not just read) similar to '0775' for directory traversing below


### PR DESCRIPTION
Tiny enhancements:

1) Output during WordPress installation is now substantially cleaner, building on PR #2166.

2) For now these 3 below are saved into `/etc/iiab/iiab_state.yml` (upon installation of each, [so now a total of 36 instead of 35 markers](https://github.com/iiab/iiab/pull/2138#issue-361880590)) even if the option to (or need to) reinstall - enable - disable these 3 is still quite unusual today:

   - `apache_installed: True`
   - `nginx_installed: True`
   - `osm_vector_maps_installed: True`

   Still: 'iiab_state.yml' as an authoritative registry (showing whether these and other major apps/services have been installed of not) appears to be incredibly useful going forward...