### PR TITLE
WIP: Validate 46+46 boolean vars in 0-init (*_install + *_enabled). Similarly when invoking {Munin, WordPress} to fine-tune this for other playbooks etc

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -33,6 +33,9 @@
   setup:
     filter: ansible_local
 
+# Check that ~46+46 XYZ_install+XYZ_enabled vars are defined, bool & plausible!
+- include_tasks: validate_vars.yml
+
 - name: Set top-level variables from local_facts for convenience
   set_fact:
     xo_model: "{{ ansible_local.local_facts.xo_model }}"

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -1,0 +1,117 @@
+# 2020-01-21: Ansible Input Validation (basic sanity checking for now) to check
+# that /etc/iiab/local_vars.yml *_install and *_enabled variables appear
+# coherent (i.e. defined, have type boolean & with plausible values!)  Stricter
+# validation is needed when roles/playbooks/tasks are later invoked.  Risks
+# abound, but Ansible's inverting logic when boolean vars are accidentally
+# declared as strings is especially dangerous, so it's the main focus below.
+
+# "Ansible 2.8+ ADVISORY: avoid warnings by using 'when: var | bool' for
+# top-level BARE vars (in case they're strings, instead of boolean)"
+# https://github.com/iiab/iiab/issues/1632
+
+# "How Exactly Does Ansible Parse Boolean Variables?"
+# https://stackoverflow.com/questions/47877464/how-exactly-does-ansible-parse-boolean-variables/47877502#47877502
+# ...is very helpful but has it slightly wrong, as Ansible implements only ~18
+# of YAML's 22 definitions of boolean (https://yaml.org/type/bool.html).
+# i.e. Ansible fails to implement y|Y|n|N, only allowing ~18 boolean values:
+#
+# yes|Yes|YES|no|No|NO
+# |true|True|TRUE|false|False|FALSE
+# |on|On|ON|off|Off|OFF
+#
+# Otherwise 'var != (var | bool)' is dangerously common, e.g. (1) when a var
+# is not one of the above ~18 words (forcing it to become a string) or (2) when
+# a var is accidentally set using quotes (forcing it to become a string) these
+# ~18 words too WILL FAIL as strings (as will any non-empty string...so beware
+# casting strings to boolean later on...can make the situation worse!)
+# https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html#bare-variables-in-conditionals
+
+# "How do i fail a task in Ansible if the variable contains a boolean value?
+# I want to perform input validation for Ansible playbooks"
+# https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
+
+- name: Set vars_checklist for 46 + 46 vars ("XYZ_install" + "XYZ_enabled") to be checked
+  set_fact:
+    vars_checklist:
+      - hostapd
+      - dhcpd
+      - named
+      - dnsmasq
+      - captiveportal
+      - bluetooth
+      - wondershaper
+      - sshd
+      - openvpn
+      - nginx
+      - apache
+      - mysql
+      - squid
+      - dansguardian
+      - postgresql
+      - cups
+      - samba
+      - idmgr
+      - azuracast
+      - dokuwiki
+      - ejabberd
+      - elgg
+      - gitea
+      - lokole
+      - mediawiki
+      - mosquitto
+      - nodered
+      - nextcloud
+      - pbx
+      - wordpress
+      - kalite
+      - kolibri
+      - kiwix
+      - moodle
+      - mongodb
+      - sugarizer
+      - transmission
+      - awstats
+      - monit
+      - munin
+      - phpmyadmin
+      - vnstat
+      - internetarchive
+      - minetest
+      - calibre
+      - calibreweb
+
+- name: Assert that 46 "XYZ_install" vars are defined
+  assert:
+    that: "{{ item }}_install is defined"
+    quiet: yes
+  loop: "{{ vars_checklist }}"
+  #register: install_vars_defined
+
+- name: Assert that 46 "XYZ_enabled" vars are defined
+  assert:
+    that: "{{ item }}_enabled is defined"
+    quiet: yes
+  loop: "{{ vars_checklist }}"
+  #register: enabled_vars_defined
+
+- name: Assert that 46 "XYZ_install" vars are type boolean (not type string, which can invert logic!)
+  assert:
+    that: "{{ item }}_install | type_debug == 'bool'"
+    quiet: yes
+  loop: "{{ vars_checklist }}"
+  #register: install_vars_boolean
+
+- name: Assert that 46 "XYZ_enabled" vars are type boolean (not type string, which can invert logic!)
+  assert:
+    that: "{{ item }}_enabled | type_debug == 'bool'"
+    quiet: yes
+  loop: "{{ vars_checklist }}"
+  #register: enabled_vars_boolean
+
+- name: 'DISALLOW "XYZ_install: False" WITH "XYZ_enabled: True" for 46 var pairs'
+  assert:
+    that: "{{ item }}_install or not {{ item }}_enabled"
+    #fail_msg: '{{ item }}_install or not {{ item }}_enabled    {{ item }}_install is {{ {{ item }}_install }}    {{ item }}_enabled is {{ {{ item }}_enabled }}'   # Is there a way to output var values ?
+    quiet: yes
+  loop: "{{ vars_checklist }}"
+  #register: var_pairs_validation

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -1,15 +1,17 @@
 # 2020-01-21: Ansible Input Validation (basic sanity checking for now) to check
-# that /etc/iiab/local_vars.yml *_install and *_enabled variables appear
-# coherent (i.e. defined, have type boolean & with plausible values!)  Stricter
-# validation is needed when roles/playbooks/tasks are later invoked.  Risks
-# abound, but Ansible's inverting logic when boolean vars are accidentally
-# declared as strings is especially dangerous, so it's the main focus below.
+# that *_install and *_enabled variables (as set in places like
+# /etc/iiab/local_vars.yml) appear coherent i.e. (1) are confirmed defined, (2)
+# have type boolean (Ansible often inverts logic when boolean vars are
+# accidentally declared as strings, see below!) and (3) have plausible values.
 
-# "Ansible 2.8+ ADVISORY: avoid warnings by using 'when: var | bool' for
+# Stricter validation is needed later, when roles/playbooks/tasks are invoked
+# by various scripts, possibly bypassing 0-init?  Either way, risks abound :/
+
+# 1. "Ansible 2.8+ ADVISORY: avoid warnings by using 'when: var | bool' for
 # top-level BARE vars (in case they're strings, instead of boolean)"
 # https://github.com/iiab/iiab/issues/1632
 
-# "How Exactly Does Ansible Parse Boolean Variables?"
+# 2. "How Exactly Does Ansible Parse Boolean Variables?"
 # https://stackoverflow.com/questions/47877464/how-exactly-does-ansible-parse-boolean-variables/47877502#47877502
 # ...is very helpful but has it slightly wrong, as Ansible implements only ~18
 # of YAML's 22 definitions of boolean (https://yaml.org/type/bool.html).
@@ -26,7 +28,7 @@
 # casting strings to boolean later on...can make the situation worse!)
 # https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html#bare-variables-in-conditionals
 
-# "How do i fail a task in Ansible if the variable contains a boolean value?
+# 3. "How do i fail a task in Ansible if the variable contains a boolean value?
 # I want to perform input validation for Ansible playbooks"
 # https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 

--- a/roles/5-xo-services/tasks/main.yml
+++ b/roles/5-xo-services/tasks/main.yml
@@ -15,6 +15,7 @@
   when: ejabberd_xs_install | bool
   #tags: olpc, ejabberd-xs
 
+# UNMAINTAINED
 - name: IDMGR
   include_role:
     name: idmgr

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -1,10 +1,24 @@
-- assert:
-    that: munin_install is defined and munin_install is sameas true
-    success_msg: munin_install is defined and munin_install is sameas true
+# "How do i fail a task in Ansible if the variable contains a boolean value?
+# I want to perform input validation for Ansible playbooks"
+# https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-- assert:
-    that: munin_enabled is defined and munin_enabled | type_debug == 'bool'
-    success_msg: munin_enabled is defined and munin_enabled | type_debug == 'bool'
+# If 0-init/tasks/validate_vars.yml has DEFINITELY been run (?) perhaps no need
+# to re-check whether vars are defined here.  As Ansible vars cannot be unset:
+# https://serverfault.com/questions/856729/how-to-destroy-delete-unset-a-variable-value-in-ansible
+
+- name: Assert that "munin_install is sameas true" (boolean not string etc)
+  assert:
+    that: munin_install is sameas true
+    quiet: yes
+    #that: munin_install is defined and munin_install is sameas true
+    #success_msg: munin_install is defined and munin_install is sameas true
+
+- name: Assert that "munin_enabled | type_debug == 'bool'" (boolean not string etc)
+  assert:
+    that: munin_enabled | type_debug == 'bool'
+    quiet: yes
+    #that: munin_enabled is defined and munin_enabled | type_debug == 'bool'
+    #success_msg: munin_enabled is defined and munin_enabled | type_debug == 'bool'
 
 - name: Install Munin if 'munin_installed' is not defined in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: install.yml

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -1,3 +1,11 @@
+- assert:
+    that: munin_install is defined and munin_install is sameas true
+    success_msg: munin_install is defined and munin_install is sameas true
+
+- assert:
+    that: munin_enabled is defined and munin_enabled | type_debug == 'bool'
+    success_msg: munin_enabled is defined and munin_enabled | type_debug == 'bool'
+
 - name: Install Munin if 'munin_installed' is not defined in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: install.yml
   when: munin_installed is undefined

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -23,6 +23,7 @@
 # hostapd_secure: False
 # hostapd_password: changeme
 #
+# hostapd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
 # hostapd_enabled: True
 # Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
 # being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -1,12 +1,26 @@
 # SEE "emergency" REINSTALL INSTRUCTIONS IN roles/wordpress/tasks/install.yml
 
-- assert:
-    that: wordpress_install is defined and wordpress_install is sameas true
-    success_msg: wordpress_install is defined and wordpress_install is sameas true
+# "How do i fail a task in Ansible if the variable contains a boolean value?
+# I want to perform input validation for Ansible playbooks"
+# https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-- assert:
-    that: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
-    success_msg: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
+# If 0-init/tasks/validate_vars.yml has DEFINITELY been run (?) perhaps no need
+# to re-check whether vars are defined here.  As Ansible vars cannot be unset:
+# https://serverfault.com/questions/856729/how-to-destroy-delete-unset-a-variable-value-in-ansible
+
+- name: Assert that "wordpress_install is sameas true" (boolean not string etc)
+  assert:
+    that: wordpress_install is sameas true
+    quiet: yes
+    #that: wordpress_install is defined and wordpress_install is sameas true
+    #success_msg: wordpress_install is defined and wordpress_install is sameas true
+
+- name: Assert that "wordpress_enabled | type_debug == 'bool'" (boolean not string etc)
+  assert:
+    that: wordpress_enabled | type_debug == 'bool'
+    quiet: yes
+    #that: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
+    #success_msg: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
 
 - name: Provision MySQL DB for WordPress, if 'wordpress_installed' is not defined in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: setup.yml

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -1,5 +1,13 @@
 # SEE "emergency" REINSTALL INSTRUCTIONS IN roles/wordpress/tasks/install.yml
 
+- assert:
+    that: wordpress_install is defined and wordpress_install is sameas true
+    success_msg: wordpress_install is defined and wordpress_install is sameas true
+
+- assert:
+    that: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
+    success_msg: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
+
 - name: Provision MySQL DB for WordPress, if 'wordpress_installed' is not defined in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: setup.yml
   when: wordpress_installed is undefined    # and not installing

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -351,9 +351,6 @@ dokuwiki_install: False
 dokuwiki_enabled: False
 dokuwiki_url: /dokuwiki
 
-mediawiki_install: False
-mediawiki_enabled: False
-
 # UNMAINTAINED as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
@@ -372,6 +369,9 @@ gitea_port: 61734
 # Lokole (email for rural communities) from https://ascoderu.ca
 lokole_install: False
 lokole_enabled: False
+
+mediawiki_install: False
+mediawiki_enabled: False
 
 # MQTT pub-sub broker for IoT on Raspberry Pi etc
 mosquitto_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -91,6 +91,7 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
+hostapd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
 hostapd_enabled: True
 # Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
 # being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
@@ -102,7 +103,7 @@ reboot_to_AP: False
 # Gateway mode
 iiab_lan_enabled: True
 iiab_wan_enabled: True
-ssh_port: 22
+ssh_port: 22    # SEE sshd_* vars below.
 # Ties in what the user populated in the GUI for static WAN IP address info:
 gui_wan: True
 adm_cons_force_ssl: False
@@ -165,7 +166,7 @@ bluetooth_term_enabled: False
 # (prior to IIAB 6.7, this had used https://github.com/iiab/iiab-menu)
 js_menu_install: True
 
-# Unmaintained as of October 2017: https://github.com/iiab/iiab/pull/382
+# UNMAINTAINED as of October 2017: https://github.com/iiab/iiab/pull/382
 wondershaper_install: False
 wondershaper_enabled: False
 
@@ -195,6 +196,8 @@ wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # 1-PREP
 
+# SEE ssh_port var above.
+sshd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
 sshd_enabled: True
 
 # roles/iiab-admin runs here
@@ -323,9 +326,10 @@ activity_server_enabled: False
 ejabberd_xs_install: False
 ejabberd_xs_enabled: False
 
+# UNMAINTAINED since about 2012-2017
 # Change calibre_port from 8080 to 8010 below, if you enable idmgr
 idmgr_install: False
-idmgr_enables: False
+idmgr_enabled: False
 
 
 # 6-GENERIC-APPS
@@ -342,7 +346,7 @@ azuracast_https_port: 10443
 # being reserved for AzuraCast:
 azuracast_port_range_prefix: 10
 
-# Unmaintained as of January 2020: https://github.com/iiab/iiab/issues/2056
+# UNMAINTAINED as of January 2020: https://github.com/iiab/iiab/issues/2056
 dokuwiki_install: False
 dokuwiki_enabled: False
 dokuwiki_url: /dokuwiki
@@ -350,7 +354,7 @@ dokuwiki_url: /dokuwiki
 mediawiki_install: False
 mediawiki_enabled: False
 
-# Unmaintained as of November 2019
+# UNMAINTAINED as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -199,6 +199,7 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+# UNMAINTAINED since about 2012-2017
 # Change calibre_port from 8080 to 8010 below, if you enable idmgr
 # idmgr_install: False
 # idmgr_enabled: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -214,9 +214,6 @@ azuracast_enabled: False
 dokuwiki_install: False
 dokuwiki_enabled: False
 
-mediawiki_install: True
-mediawiki_enabled: True
-
 # Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
@@ -231,6 +228,9 @@ gitea_enabled: True
 # Lokole (email for rural communities) from https://ascoderu.ca
 lokole_install: True
 lokole_enabled: True
+
+mediawiki_install: True
+mediawiki_enabled: True
 
 # MQTT pub-sub broker for IoT on Raspberry Pi etc
 mosquitto_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -199,6 +199,7 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+# UNMAINTAINED since about 2012-2017
 # Change calibre_port from 8080 to 8010 below, if you enable idmgr
 # idmgr_install: False
 # idmgr_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -214,9 +214,6 @@ azuracast_enabled: False
 dokuwiki_install: False
 dokuwiki_enabled: False
 
-mediawiki_install: False
-mediawiki_enabled: False
-
 # Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
@@ -231,6 +228,9 @@ gitea_enabled: False
 # Lokole (email for rural communities) from https://ascoderu.ca
 lokole_install: False
 lokole_enabled: False
+
+mediawiki_install: False
+mediawiki_enabled: False
 
 # MQTT pub-sub broker for IoT on Raspberry Pi etc
 mosquitto_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -199,6 +199,7 @@ iiab_usb_lib_show_all: True
 # ejabberd_xs_install: False
 # ejabberd_xs_enabled: False
 
+# UNMAINTAINED since about 2012-2017
 # Change calibre_port from 8080 to 8010 below, if you enable idmgr
 # idmgr_install: False
 # idmgr_enabled: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -214,9 +214,6 @@ azuracast_enabled: False
 dokuwiki_install: False
 dokuwiki_enabled: False
 
-mediawiki_install: False
-mediawiki_enabled: False
-
 # Unmaintained as of November 2019
 ejabberd_install: False
 ejabberd_enabled: False
@@ -231,6 +228,9 @@ gitea_enabled: False
 # Lokole (email for rural communities) from https://ascoderu.ca
 lokole_install: False
 lokole_enabled: False
+
+mediawiki_install: False
+mediawiki_enabled: False
 
 # MQTT pub-sub broker for IoT on Raspberry Pi etc
 mosquitto_install: False


### PR DESCRIPTION
Smoke-tested on Ubuntu 19.10 fresh install @ 10.8.0.42 = 192-u1910-desk-MED-0121-scaff

1. Obviously Ansible is not strongly typed, but let's reduce the chaos — by validating our more critical Ansible playbook input vars as legit booleans.  Ansible's new [assert module](https://docs.ansible.com/ansible/latest/modules/assert_module.html) is quite helpful here.  Further explained @ [0-init/tasks/validate_vars.yml](https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml)

2. Working hypothesis is that [IIAB's (roughly) 35-36 primary playbooks](https://github.com/iiab/iiab/pull/2138#issue-361880590) (#2167) should never be invoked unless that playbook/app's XYZ_APP_install is permanently set from False to True (one way trip, no going back!) in keeping with public warnings like https://github.com/iiab/iiab/blob/master/vars/default_vars.yml#L7-L8 here:

   ```
   # IIAB does NOT currently support uninstalling apps!  So: if any IIAB app is
   # installed with 'APP_XYZ_install: True' below, do NOT later change that.
   ```

   Of course there are 10 other `XYZ_install` vars + 10 other `XYZ_enabled` vars to extend this validation beyond full playbooks, bringing 36 to 46 total for now.  Adjustments will be necessary along the way, with @jvonau & others &mdash; such that more QA is built into IIAB's install process, if not quite industrial-strength CI/CD just yet of course!  But Still: a more bulletproof and more understandable install+implement experience is definitely the direction to aim for, so many more folks around the planet can build on [IIAB 7.1](https://github.com/iiab/iiab/wiki/IIAB-7.1-Release-Notes) coming rather soon~

Refs:

#1964 "Admin Console removes comments from local_vars.yml"
PR #2142 "(1) Quick clean high-level roles: NGINX, Apache, network, OpenVPN, numbered roles (stages) & defaults_vars.yml (2) Add vars/ubuntu-20.yml for Ubuntu 20.04 pre-releases (3) Fix http://box/mediawiki"
PR #2166 "Wordpress & Munin scaffolding (WIP)"
PR #2167 "Wordpress/Munin Scaffolding: tiny enhancements"
PR #2169 "Wordpress/Munin Scaffolding: tighten up as possible (super)model playbooks"