### PR TITLE
Explanatory Error Msgs for var validation in 0-init/tasks/validate_vars.yml, munin/tasks/main.yml, wordpress/tasks/main.yml etc

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -33,8 +33,9 @@
   setup:
     filter: ansible_local
 
-# Check that ~46+46 XYZ_install+XYZ_enabled vars are defined, bool & plausible!
-- include_tasks: validate_vars.yml
+# 2020-01-21: checks 46+46 vars...for now...expect validate_vars.yml to change!
+- name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values
+  include_tasks: validate_vars.yml
 
 - name: Set top-level variables from local_facts for convenience
   set_fact:

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -86,6 +86,7 @@
 - name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... defined
   assert:
     that: "{{ item }}_install is defined"
+    fail_msg: "PLEASE GIVE THIS VARIABLE A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: install_vars_defined
@@ -93,6 +94,7 @@
 - name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... defined
   assert:
     that: "{{ item }}_enabled is defined"
+    fail_msg: "PLEASE GIVE THIS VARIABLE A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: enabled_vars_defined
@@ -100,6 +102,7 @@
 - name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... type boolean (NOT type string, which can invert logic!)
   assert:
     that: "{{ item }}_install | type_debug == 'bool'"
+    fail_msg: "PLEASE GIVE THIS VARIABLE A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: install_vars_boolean
@@ -107,6 +110,7 @@
 - name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... type boolean (NOT type string, which can invert logic!)
   assert:
     that: "{{ item }}_enabled | type_debug == 'bool'"
+    fail_msg: "PLEASE GIVE THIS VARIABLE A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: enabled_vars_boolean
@@ -114,6 +118,7 @@
 - name: 'DISALLOW "XYZ_install: False" WITH "XYZ_enabled: True" ...for all {{ vars_checklist | length }} var pairs'
   assert:
     that: "{{ item }}_install or not {{ item }}_enabled"
+    fail_msg: "PLEASE VERIFY THESE 2 VARIABLES e.g. in: /etc/iiab/local_vars.yml"
     #fail_msg: '{{ item }}_install or not {{ item }}_enabled    {{ item }}_install is {{ {{ item }}_install }}    {{ item }}_enabled is {{ {{ item }}_enabled }}'   # Is there a way to output var values ?
     quiet: yes
   loop: "{{ vars_checklist }}"

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -32,7 +32,8 @@
 # I want to perform input validation for Ansible playbooks"
 # https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-- name: Set vars_checklist for 46 + 46 vars ("XYZ_install" + "XYZ_enabled") to be checked
+# 2020-01-21: checks 46+46 vars...for now!
+- name: Set vars_checklist for ~46 + ~46 vars ("XYZ_install" + "XYZ_enabled") to be checked
   set_fact:
     vars_checklist:
       - hostapd
@@ -82,35 +83,35 @@
       - calibre
       - calibreweb
 
-- name: Assert that 46 "XYZ_install" vars are defined
+- name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... defined
   assert:
     that: "{{ item }}_install is defined"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: install_vars_defined
 
-- name: Assert that 46 "XYZ_enabled" vars are defined
+- name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... defined
   assert:
     that: "{{ item }}_enabled is defined"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: enabled_vars_defined
 
-- name: Assert that 46 "XYZ_install" vars are type boolean (not type string, which can invert logic!)
+- name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... type boolean (not type string, which can invert logic!)
   assert:
     that: "{{ item }}_install | type_debug == 'bool'"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: install_vars_boolean
 
-- name: Assert that 46 "XYZ_enabled" vars are type boolean (not type string, which can invert logic!)
+- name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... type boolean (not type string, which can invert logic!)
   assert:
     that: "{{ item }}_enabled | type_debug == 'bool'"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: enabled_vars_boolean
 
-- name: 'DISALLOW "XYZ_install: False" WITH "XYZ_enabled: True" for 46 var pairs'
+- name: 'DISALLOW "XYZ_install: False" WITH "XYZ_enabled: True" ...for all {{ vars_checklist | length }} var pairs'
   assert:
     that: "{{ item }}_install or not {{ item }}_enabled"
     #fail_msg: '{{ item }}_install or not {{ item }}_enabled    {{ item }}_install is {{ {{ item }}_install }}    {{ item }}_enabled is {{ {{ item }}_enabled }}'   # Is there a way to output var values ?

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -97,14 +97,14 @@
   loop: "{{ vars_checklist }}"
   #register: enabled_vars_defined
 
-- name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... type boolean (not type string, which can invert logic!)
+- name: Assert that {{ vars_checklist | length }} "XYZ_install" vars are all... type boolean (NOT type string, which can invert logic!)
   assert:
     that: "{{ item }}_install | type_debug == 'bool'"
     quiet: yes
   loop: "{{ vars_checklist }}"
   #register: install_vars_boolean
 
-- name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... type boolean (not type string, which can invert logic!)
+- name: Assert that {{ vars_checklist | length }} "XYZ_enabled" vars are all... type boolean (NOT type string, which can invert logic!)
   assert:
     that: "{{ item }}_enabled | type_debug == 'bool'"
     quiet: yes

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Assert that "munin_install is sameas true" (boolean not string etc)
   assert:
     that: munin_install is sameas true
+    fail_msg: "PLEASE SET 'munin_install: True' e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
     #that: munin_install is defined and munin_install is sameas true
     #success_msg: munin_install is defined and munin_install is sameas true
@@ -16,6 +17,7 @@
 - name: Assert that "munin_enabled | type_debug == 'bool'" (boolean not string etc)
   assert:
     that: munin_enabled | type_debug == 'bool'
+    fail_msg: "PLEASE GIVE VARIABLE 'munin_enabled' A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
     #that: munin_enabled is defined and munin_enabled | type_debug == 'bool'
     #success_msg: munin_enabled is defined and munin_enabled | type_debug == 'bool'

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: Assert that "wordpress_install is sameas true" (boolean not string etc)
   assert:
     that: wordpress_install is sameas true
+    fail_msg: "PLEASE SET 'wordpress_install: True' e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
     #that: wordpress_install is defined and wordpress_install is sameas true
     #success_msg: wordpress_install is defined and wordpress_install is sameas true
@@ -18,6 +19,7 @@
 - name: Assert that "wordpress_enabled | type_debug == 'bool'" (boolean not string etc)
   assert:
     that: wordpress_enabled | type_debug == 'bool'
+    fail_msg: "PLEASE GIVE VARIABLE 'wordpress_enabled' A PROPER (UNQUOTED) BOOLEAN VALUE e.g. in: /etc/iiab/local_vars.yml"
     quiet: yes
     #that: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'
     #success_msg: wordpress_enabled is defined and wordpress_enabled | type_debug == 'bool'


### PR DESCRIPTION
Building on PR #2179, in support of implementers/installers/devs/operators who modify [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) and (not infrequently!) leave it in a completely unusable state &mdash; accidentally of course &mdash; _but error messaging needs to be quite clear helping them understand where they've gone wrong!_

Not 100% there yet, but this is a good start-