### PR TITLE
wifi install dnsmasq restart issue

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -91,7 +91,6 @@ systemd_networkd_active: False
 # The values here are default local variables
 gui_wan_iface: "unset"
 gui_static_wan_ip: "unset"
-gui_desired_network_role: Gateway
 wondershaper_dspeed: "4096"
 wondershaper_upspeed: "1024"
 

--- a/roles/network/tasks/down-debian.yml
+++ b/roles/network/tasks/down-debian.yml
@@ -22,4 +22,4 @@
   service:
     name: dnsmasq
     state: stopped
-  when: dnsmasq_install | bool
+  when: dnsmasq_install | bool and not no_net_restart

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -74,6 +74,6 @@
   systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
+  when: not no_net_restart
   #when: (iiab_network_mode != "Appliance")    # Sufficient b/c br0 exists thanks to /etc/network/interfaces.d/iiab
-  #when: (iiab_network_mode != "Appliance") and (not no_net_restart)
   #when: iiab_network_mode != "Appliance" and iiab_wan_iface != discovered_wireless_iface

--- a/roles/network/templates/network/rpi.j2
+++ b/roles/network/templates/network/rpi.j2
@@ -1,6 +1,7 @@
 # iiab_network_mode is {{ iiab_network_mode  }}
+{% if gui_desired_network_role is defined %}
 # gui_desired_network_role is {{ gui_desired_network_role }}
-
+{% endif %}
 {% if iiab_network_mode != "Appliance"  %}
 #################   LANCONTROLLER   ###################
 auto br0


### PR DESCRIPTION
#2220 restart fails as br0's creation is being suppressed by not restarting NetworkManager.
Restore preexisting default_vars variable's functionality.