### PR TITLE
lineinfile tweak, per Ansible docs/norms

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -135,4 +135,4 @@
 - name: Recording STAGE 1 HAS COMPLETED ============================
   template:
     src: roles/1-prep/templates/iiab.env.j2
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -135,4 +135,4 @@
 - name: Recording STAGE 1 HAS COMPLETED ============================
   template:
     src: roles/1-prep/templates/iiab.env.j2
-    path: "{{ iiab_env_file }}"
+    dest: "{{ iiab_env_file }}"

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -52,6 +52,6 @@
 
 - name: Recording STAGE 2 HAS COMPLETED ==========================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=2'

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -23,6 +23,6 @@
 
 - name: Recording STAGE 3 HAS COMPLETED =====================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=3'

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -50,6 +50,6 @@
 
 - name: Recording STAGE 4 HAS COMPLETED ==================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=4'

--- a/roles/5-xo-services/tasks/main.yml
+++ b/roles/5-xo-services/tasks/main.yml
@@ -23,6 +23,6 @@
 
 - name: Recording STAGE 5 HAS COMPLETED =====================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=5'

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -67,6 +67,6 @@
 
 - name: Recording STAGE 6 HAS COMPLETED ====================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=6'

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -47,6 +47,6 @@
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=7'

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -35,6 +35,6 @@
 
 - name: Recording STAGE 8 HAS COMPLETED ======================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=8'

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -51,6 +51,6 @@
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^STAGE=*'
     line: 'STAGE=9'

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -109,6 +109,6 @@
 
 - name: "Add 'awstats_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^awstats_installed'
     line: 'awstats_installed: True'

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -73,6 +73,6 @@
 
 - name: "Add 'azuracast_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^azuracast_installed'
     line: 'azuracast_installed: True'

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -64,6 +64,6 @@
 
 - name: "Add 'bluetooth_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^bluetooth_installed'
     line: 'bluetooth_installed: True'

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -109,6 +109,6 @@
 
 - name: "Add 'calibreweb_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'

--- a/roles/calibre/tasks/install.yml
+++ b/roles/calibre/tasks/install.yml
@@ -93,6 +93,6 @@
 
 - name: "Add 'calibre_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^calibre_installed'
     line: 'calibre_installed: True'

--- a/roles/captiveportal/tasks/install.yml
+++ b/roles/captiveportal/tasks/install.yml
@@ -61,6 +61,6 @@
 
 - name: "Add 'captiveportal_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^captiveportal_installed'
     line: 'captiveportal_installed: True'

--- a/roles/cups/tasks/main.yml
+++ b/roles/cups/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: "Add 'cups_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^cups_installed'
     line: 'cups_installed: True'
 

--- a/roles/elgg/tasks/install.yml
+++ b/roles/elgg/tasks/install.yml
@@ -96,6 +96,6 @@
 
 - name: "Add 'elgg_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^elgg_installed'
     line: 'elgg_installed: True'

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -114,6 +114,6 @@
 
 - name: "Add 'gitea_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^gitea_installed'
     line: 'gitea_installed: True'

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -149,6 +149,6 @@
 
 - name: "Add 'apache_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^apache_installed'
     line: 'apache_installed: True'

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -67,6 +67,6 @@
 
 - name: "Add 'internetarchive_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^internetarchive_installed'
     line: 'internetarchive_installed: True'

--- a/roles/kalite/tasks/setup.yml
+++ b/roles/kalite/tasks/setup.yml
@@ -27,6 +27,6 @@
 
 - name: "Add 'kalite_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kalite_installed'
     line: 'kalite_installed: True'

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -93,6 +93,6 @@
 
 - name: "Add 'kiwix_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kiwix_installed'
     line: 'kiwix_installed: True'

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -121,6 +121,6 @@
 
 - name: "Add 'kolibri_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^kolibri_installed'
     line: 'kolibri_installed: True'

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -100,6 +100,6 @@
 
 - name: "Add 'lokole_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^lokole_installed'
     line: 'lokole_installed: True'

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -94,6 +94,6 @@
 
 - name: "Add 'mediawiki_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mediawiki_installed'
     line: 'mediawiki_installed: True'

--- a/roles/minetest/tasks/provision.yml
+++ b/roles/minetest/tasks/provision.yml
@@ -78,6 +78,6 @@
 
 - name: "Add 'minetest_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^minetest_installed'
     line: 'minetest_installed: True'

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -135,6 +135,6 @@
 
 - name: "Add 'mongodb_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mongodb_installed'
     line: 'mongodb_installed: True'

--- a/roles/monit/tasks/install.yml
+++ b/roles/monit/tasks/install.yml
@@ -63,6 +63,6 @@
 
 - name: "Add 'monit_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^monit_installed'
     line: 'monit_installed: True'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -163,6 +163,6 @@
 
 - name: "Add 'moodle_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^moodle_installed'
     line: 'moodle_installed: True'

--- a/roles/mosquitto/tasks/install.yml
+++ b/roles/mosquitto/tasks/install.yml
@@ -38,6 +38,6 @@
 
 - name: "Add 'mosquitto_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mosquitto_installed'
     line: 'mosquitto_installed: True'

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -57,6 +57,6 @@
 
 - name: "Add 'munin_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^munin_installed'
     line: 'munin_installed: True'

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -123,7 +123,7 @@
 
 - name: "Add 'mysql_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^mysql_installed'
     line: 'mysql_installed: True'
 

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -174,14 +174,14 @@
 
 - name: Record IIAB_WAN_DEVICE to {{ iiab_env_file }}
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^IIAB_WAN_DEVICE=*'
     line: 'IIAB_WAN_DEVICE="{{ iiab_wan_iface }}"'
   when: not installing   #REMOVE THIS LINE IF installing IS ALWAYS false AS SET IN roles/0-init/defaults/main.yml
 
 - name: Record IIAB_LAN_DEVICE to {{ iiab_env_file }}
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^IIAB_LAN_DEVICE=*'
     line: 'IIAB_LAN_DEVICE="{{ iiab_lan_iface }}"'
     state: present

--- a/roles/network/tasks/dansguardian.yml
+++ b/roles/network/tasks/dansguardian.yml
@@ -50,6 +50,6 @@
 
 - name: "Add 'dansguardian_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^dansguardian_installed'
     line: 'dansguardian_installed: True'

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -56,6 +56,6 @@
 
 - name: "Add 'dhcpd_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^dhcpd_installed'
     line: 'dhcpd_installed: True'

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -174,7 +174,7 @@
 
 - name: Revert to 'HTTPCACHE_ON=False' if not squid_enabled
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^HTTPCACHE_ON=*'
     line: 'HTTPCACHE_ON=False'
     state: present

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -63,7 +63,7 @@
 
 - name: Record HOSTAPD_ENABLED to {{ iiab_env_file }}
   lineinfile:
-    dest: "{{ iiab_env_file }}"
+    path: "{{ iiab_env_file }}"
     regexp: '^HOSTAPD_ENABLED=*'
     line: 'HOSTAPD_ENABLED={{ hostapd_enabled }}'
     state: present

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -79,7 +79,7 @@
 
 - name: "Add 'named_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^named_installed'
     line: 'named_installed: True'
 

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -82,7 +82,7 @@
 
 - name: "Add 'squid_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^squid_installed'
     line: 'squid_installed: True'
 

--- a/roles/network/tasks/wondershaper.yml
+++ b/roles/network/tasks/wondershaper.yml
@@ -40,7 +40,7 @@
 
 - name: "Add 'wondershaper_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^wondershaper_installed'
     line: 'wondershaper_installed: True'
 

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -188,6 +188,6 @@
 
 - name: "Add 'nextcloud_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nextcloud_installed'
     line: 'nextcloud_installed: True'

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -52,6 +52,6 @@
 
 - name: "Add 'nginx_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nginx_installed'
     line: 'nginx_installed: True'

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -159,6 +159,6 @@
 
 - name: "Add 'nodejs_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nodejs_installed'
     line: 'nodejs_installed: True'

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -130,6 +130,6 @@
 
 - name: "Add 'nodered_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^nodered_installed'
     line: 'nodered_installed: True'

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -116,7 +116,7 @@
 
 - name: "Add 'openvpn_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^openvpn_installed'
     line: 'openvpn_installed: True'
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -75,6 +75,6 @@
 
 - name: "Add 'osm_vector_maps_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^osm_vector_maps_installed'
     line: 'osm_vector_maps_installed: True'

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -76,6 +76,6 @@
 
 - name: "Add 'pbx_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^pbx_installed'
     line: 'pbx_installed: True'

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -60,7 +60,7 @@
 
 - name: "Add 'phpmyadmin_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^phpmyadmin_installed'
     line: 'phpmyadmin_installed: True'
 

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -94,7 +94,7 @@
 
 - name: "Add 'postgresql_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^postgresql_installed'
     line: 'postgresql_installed: True'
 

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: "Add 'samba_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^samba_installed'
     line: 'samba_installed: True'
 

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: "Add 'sshd_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^sshd_installed'
     line: 'sshd_installed: True'
 

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -278,6 +278,6 @@
 
 - name: "Add 'sugarizer_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^sugarizer_installed'
     line: 'sugarizer_installed: True'

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: "Add 'transmission_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^transmission_installed'
     line: 'transmission_installed: True'
 

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - name: "Add 'usb_lib_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^usb_lib_installed'
     line: 'usb_lib_installed: True'
 

--- a/roles/vnstat/tasks/main.yml
+++ b/roles/vnstat/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: "Add 'vnstat_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^vnstat_installed'
     line: 'vnstat_installed: True'
 

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -100,6 +100,6 @@
 
 - name: "Add 'wordpress_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^wordpress_installed'
     line: 'wordpress_installed: True'

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -36,6 +36,6 @@
 
 - name: "Add 'yarn_installed: True' to {{ iiab_state_file }}"
   lineinfile:
-    dest: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^yarn_installed'
     line: 'yarn_installed: True'


### PR DESCRIPTION
Converts `dest:` to `path:` within Ansible `lineinfile` commands.

Smoke-tested on Debian 10.2