### PR TITLE
Cal py3 [Calibre-Web: move to Python 3] ...uncovers 2 Calibre-Web issues: slow shutdown & "Perform Update" button risks

### DIFF
--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -16,7 +16,7 @@
 
 calibreweb_version: 0.6.5    # WAS: master, 0.6.4
 
-calibreweb_venv_path: /usr/local/calibre-web
+calibreweb_venv_path: /usr/local/calibre-web-py3
 calibreweb_exec_path: "{{ calibreweb_venv_path }}/cps.py"
 
 # Config files put in:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -51,14 +51,6 @@
 #    virtualenv_python: python3.7
   when: internet_available | bool
 
-# 2020-02-02: IS PYTHON 3 POSSIBLE ABOVE AND BELOW?
-
-#- name: Symlink {{ calibreweb_venv_path }}/vendor -> {{ calibreweb_venv_path }}/lib/python2.7/site-packages - to keep {{ calibreweb_venv_path }}/cps.py happy?
-#  file:
-#    src: "{{ calibreweb_venv_path }}/lib/python3.7/site-packages"
-#    path: "{{ calibreweb_venv_path }}/vendor"    # /usr/local/calibre-web-py3
-#    state: link
-
 - name: Install /etc/systemd/system/calibre-web.service from template
   template:
     src: calibre-web.service.j2

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -43,7 +43,7 @@
 ##
 # Implementing this with Ansible command module for now.
 - name: Download Calibre-Web dependencies (using pip) into python3.7 virtual environment {{ calibreweb_venv_path }}
-  pip:
+  pip3:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -42,13 +42,12 @@
 #  ignore_errors: True
 ##
 # Implementing this with Ansible command module for now.
-- name: Download Calibre-Web dependencies (using pip) into python3.7 virtual environment {{ calibreweb_venv_path }}
+- name: Download Calibre-Web dependencies (using pip) into python3 virtual environment {{ calibreweb_venv_path }}
   pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
     virtualenv_command:  python3 -m venv {{ calibreweb_venv_path }}
-#    virtualenv_python: python3.7
   when: internet_available | bool
 
 - name: Install /etc/systemd/system/calibre-web.service from template

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -42,21 +42,21 @@
 #  ignore_errors: True
 ##
 # Implementing this with Ansible command module for now.
-- name: Download Calibre-Web dependencies (using pip) into python2.7 virtual environment {{ calibreweb_venv_path }}
+- name: Download Calibre-Web dependencies (using pip) into python3.7 virtual environment {{ calibreweb_venv_path }}
   pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
-    virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web
+    virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
     virtualenv_command: /usr/bin/virtualenv
-    virtualenv_python: python2.7
+    virtualenv_python: python3.7
   when: internet_available | bool
 
 # 2020-02-02: IS PYTHON 3 POSSIBLE ABOVE AND BELOW?
 
-- name: Symlink {{ calibreweb_venv_path }}/vendor -> {{ calibreweb_venv_path }}/lib/python2.7/site-packages - to keep {{ calibreweb_venv_path }}/cps.py happy
+- name: Symlink {{ calibreweb_venv_path }}/vendor -> {{ calibreweb_venv_path }}/lib/python2.7/site-packages - to keep {{ calibreweb_venv_path }}/cps.py happy?
   file:
-    src: "{{ calibreweb_venv_path }}/lib/python2.7/site-packages"
-    path: "{{ calibreweb_venv_path }}/vendor"    # /usr/local/calibre-web
+    src: "{{ calibreweb_venv_path }}/lib/python3.7/site-packages"
+    path: "{{ calibreweb_venv_path }}/vendor"    # /usr/local/calibre-web-py3
     state: link
 
 - name: Install /etc/systemd/system/calibre-web.service from template

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -53,11 +53,11 @@
 
 # 2020-02-02: IS PYTHON 3 POSSIBLE ABOVE AND BELOW?
 
-- name: Symlink {{ calibreweb_venv_path }}/vendor -> {{ calibreweb_venv_path }}/lib/python2.7/site-packages - to keep {{ calibreweb_venv_path }}/cps.py happy?
-  file:
-    src: "{{ calibreweb_venv_path }}/lib/python3.7/site-packages"
-    path: "{{ calibreweb_venv_path }}/vendor"    # /usr/local/calibre-web-py3
-    state: link
+#- name: Symlink {{ calibreweb_venv_path }}/vendor -> {{ calibreweb_venv_path }}/lib/python2.7/site-packages - to keep {{ calibreweb_venv_path }}/cps.py happy?
+#  file:
+#    src: "{{ calibreweb_venv_path }}/lib/python3.7/site-packages"
+#    path: "{{ calibreweb_venv_path }}/vendor"    # /usr/local/calibre-web-py3
+#    state: link
 
 - name: Install /etc/systemd/system/calibre-web.service from template
   template:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -47,8 +47,8 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
-    virtualenv_command: /usr/bin/virtualenv
-    virtualenv_python: python3.7
+    virtualenv_command:  python3 -m venv {{ calibreweb_venv_path }}
+#    virtualenv_python: python3.7
   when: internet_available | bool
 
 # 2020-02-02: IS PYTHON 3 POSSIBLE ABOVE AND BELOW?

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -43,7 +43,7 @@
 ##
 # Implementing this with Ansible command module for now.
 - name: Download Calibre-Web dependencies (using pip) into python3.7 virtual environment {{ calibreweb_venv_path }}
-  pip3:
+  pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no

--- a/roles/calibre-web/templates/calibre-web.service.j2
+++ b/roles/calibre-web/templates/calibre-web.service.j2
@@ -3,7 +3,7 @@ Description=Calibre-Web
 [Service]
 Type=simple
 User={{ calibreweb_user }}
-ExecStart={{ calibreweb_exec_path }} -p {{ calibreweb_config }}/{{ calibreweb_settings_database }}
+ExecStart={{ calibreweb_venv_path }}/bin/python3 {{ calibreweb_exec_path }} -p {{ calibreweb_config }}/{{ calibreweb_settings_database }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Fixes Bug
move to python3
### Description of changes proposed in this pull request.
move calibre-web to python3 #2231 
### Smoke-tested in operating system.
raspbian-10
