### PR TITLE
Bug fix: Split http/apache

### DIFF
--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -3,21 +3,24 @@
 - name: ...IS BEGINNING =====================================
   command: echo
 
-- name: HTTPD (APACHE)
+- name: HTTPD
   include_role:
     name: httpd
-  when: apache_install | bool
 
 - name: MYSQL
   include_role:
     name: mysql
   when: mysql_install | bool
 
-- name: Install NGINX (configured LATER, in Stage 9-LOCAL-ADDONS)
+- name: Install APACHE (configured LATER, in Stage 4)
+  include_tasks: roles/httpd/tasks/install.yml
+  when: apache_install | bool
+
+- name: Install NGINX (configured LATER, in Stage 4)
   include_tasks: roles/nginx/tasks/install.yml
   when: nginx_install | bool
 
-- name: Install dnsmasq
+- name: Install dnsmasq (configured LATER, in network)
   include_tasks: roles/network/tasks/dnsmasq.yml
   when: dnsmasq_install | bool
 

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -12,11 +12,11 @@
     name: mysql
   when: mysql_install | bool
 
-- name: Install APACHE (configured LATER, in Stage 4)
+- name: Install APACHE (configured LATER, in Stage 9)
   include_tasks: roles/httpd/tasks/install.yml
   when: apache_install | bool
 
-- name: Install NGINX (configured LATER, in Stage 4)
+- name: Install NGINX (configured LATER, in Stage 9)
   include_tasks: roles/nginx/tasks/install.yml
   when: nginx_install | bool
 

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -29,10 +29,10 @@
 
 # This is in Stage 4-SERVER-OPTIONS (rather than 3-BASE-SERVER) because var
 # iiab_home_url changes, and may need to be re-run in the field/offline/etc.
-- name: HOMEPAGE
+- name: HOMEPAGE under Apache
   include_role:
     name: homepage
-  # has no "when: XXXXX_install" flag
+  when: not nginx_enabled
 
 - name: CUPS
   include_role:

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -1,15 +1,11 @@
-# 2020-01-23 TO DO / Questions:
-# - Validate input vars apache_install & apache_enabled here.
-#   - Use as nec, with 'when: apache_installed is undefined'
-# - Encapsulate all 3 tasks below into httpd/roles/install.yml ?
-# - Similarly sanity-check httpd/roles/enable.yml or httpd/roles/enable-or-disable.yml...
-#   - Verify that 9-local-addons/tasks/main.yml's invocation of
-#     roles/httpd/tasks/enable.yml (via roles/httpd-enable/tasks/main.yml, if
-#     apache_enabled is True) does the right thing!
-#   - And that we really don't want to invoke it hereunder?
-# - Save relevant apache_* vars to /etc/iiab/iiab.ini
+- name: Create dir {{ doc_root }}/home
+  file:
+    state: directory
+    path: "{{ doc_root }}/home"    # /library/www/html
+    owner: "{{ apache_user }}"
+    group: "{{ apache_user }}"
+    mode: '0755'
 
-#- include_tasks: install.yml
 - include_tasks: html.yml
 - include_tasks: php-stem.yml
 

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -9,7 +9,7 @@
 #   - And that we really don't want to invoke it hereunder?
 # - Save relevant apache_* vars to /etc/iiab/iiab.ini
 
-- include_tasks: install.yml
+#- include_tasks: install.yml
 - include_tasks: html.yml
 - include_tasks: php-stem.yml
 


### PR DESCRIPTION
### Fixes Bug
Setting apache_install: False would suppress running html.yml breaking menus and/or admin-console
### Description of changes proposed in this pull request.
splits apache/httpd 
### Smoke-tested in operating system.
subset of #2200 testing
