### PR TITLE
internetarchive: wipe /opt/iiab/internetarchive/node_modules prior to --reinstall

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -159,7 +159,7 @@ if [ -f /etc/iiab/config_vars2.yml ]; then
     fi
 
 # TEMPORARY: another change to account for
-    sed -i -e 's/pan_bluetooth/bluetooth/' $IIAB_STATE_FILE
+#    sed -i -e 's/pan_bluetooth/bluetooth/' $IIAB_STATE_FILE
 
     if [ "$STAGE" -eq 2 ]; then
         echo -e "\nCompleting Stage 3 from IIAB image (starts systemd service iiab-setup-db to run the 'mysql' role)."

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -1,4 +1,4 @@
-# INSTALL 3 PREREQS
+# 1. INSTALL 3 PREREQS
 
 - name: "Set 'nodejs_install: True' and 'nodejs_enabled: True'"
   set_fact:
@@ -29,44 +29,43 @@
     state: present
 
 
-# CREATE 2 DIRS & RUN YARN
+# 2. CREATE 2 DIRS, WIPE /opt/iiab/internetarchive/node_modules & RUN YARN
 
 - name: mkdir {{ internetarchive_dir }}
   file:
     state: directory
     path: "{{ internetarchive_dir }}"    # /opt/iiab/internetarchive
-    # owner: root
 
-- name: Run yarn install to populate {{ internetarchive_dir }}/node_modules (CAN TAKE ~15 MINUTES)
+- name: Wipe dir {{ internetarchive_dir }}/node_modules (and its contents, typically 112+ MB) so './runrole --reinstall internetarchive' gets you the latest code
+  file:
+    state: absent
+    path: "{{ internetarchive_dir }}/node_modules"
+
+- name: Run 'yarn add @internetarchive/dweb-mirror' to download/populate {{ internetarchive_dir }}/node_modules (CAN TAKE ~15 MINUTES)
   shell: yarn config set child-concurrency 1 && yarn add @internetarchive/dweb-mirror
   args:
     chdir: "{{ internetarchive_dir }}"
     creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"
   when: internet_available | bool
-  # register: internetarchive_installing
 
 - name: mkdir {{ content_base }}/archiveorg
   file:
     state: directory
     path: "{{ content_base }}/archiveorg"    # /library
-    # owner: root
 
 
-# CONFIG FILES
+# 3. CONFIG FILES
 
 - name: "Install from templates: /etc/systemd/system/internetarchive.service, /etc/{{ apache_conf_dir }}/internetarchive.conf"
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    # owner: root
-    # group: root
-    # mode: '0644'
   with_items:
     - { src: 'internetarchive.service.j2', dest: '/etc/systemd/system/internetarchive.service' }
     - { src: 'internetarchive.conf', dest: '/etc/{{ apache_conf_dir }}/internetarchive.conf' }    # apache2/sites-available
 
 
-# RECORD Internet Archive AS INSTALLED
+# 4. RECORD Internet Archive AS INSTALLED
 
 - name: "Set 'internetarchive_installed: True'"
   set_fact:

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -19,27 +19,30 @@
     quiet: yes
 
 
-#- name: Set --reinstall fact
-#  set_fact:
-#    internetarchive_upgrade: True
-#  when: reinstall is defined
+# 2020-02-11: @mitra42 & @holta agree (#2247) that the following 2-stanza
+# "UPDATE internetarchive" block should run whenever one is isn't installing
+# (or reinstalling) internetarchive, for now.  We're aware this means slowness
+# during "./runrole internetarchive" but that's very intentional for now -- as
+# it leads to more testing of more recent versions of internetarchive, which
+# is strongly desired.  Finally, these current norms can and probably will be
+# changed in future, when broader IIAB norms develop around "./runrole
+# --upgrade internetarchive" or "./runrole --update internetarchive" or such,
+# as may evolve @ https://github.com/iiab/iiab/pull/2238#discussion_r376168178
 
-- block:    # UPDATE IF... internetarchive_installed is defined and internet_available
+- block:    # BEGIN 2-STANZA BLOCK
 
-  - name: Stop 'internetarchive' systemd service, if internetarchive_upgrade
+  - name: "UPGRADE: Stop 'internetarchive' systemd service, if internetarchive_installed is defined and internet_available"
     systemd:
       name: internetarchive
       daemon_reload: yes
       state: stopped
-    #when: internetarchive_enabled and internetarchive_upgrade
 
-  - name: Update pre-existing install (yarn upgrade) if internetarchive_upgrade
+  - name: "UPGRADE: Run 'yarn upgrade' in {{ internetarchive_dir }}, if internetarchive_installed is defined and internet_available"
     shell: yarn config set child-concurrency 1 && yarn install && yarn upgrade
     args:
       chdir: "{{ internetarchive_dir }}"
-    #when: internetarchive_enabled and internetarchive_upgrade
 
-  when: internetarchive_installed is defined and internet_available   # END BLOCK
+  when: internetarchive_installed is defined and internet_available    # END 2-STANZA BLOCK
 
 # "ELSE" INSTALL...
 

--- a/runrole
+++ b/runrole
@@ -7,6 +7,7 @@ REINSTALL=0
 CWD=`pwd`
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
 LOCAL_VARS_FILE=/etc/iiab/local_vars.yml
+
 if [ ! -f $PLAYBOOK ]; then
     echo "Exiting: IIAB Playbook not found."
     echo "Please run this in /opt/iiab/iiab (top level of the git repo)."
@@ -61,19 +62,15 @@ fi
 #fi
 
 if [ "$REINSTALL" == "1" ]; then
-    #if [ ! $1 == "internetarchive" ]; then # special handling
-        if [ $1 == "calibre-web" ]; then # role directory & installed marker differ
-            sed -i -e '/^calibreweb/d' $IIAB_STATE_FILE
-        elif [ $1 == "httpd" ]; then # role directory & installed marker differ
-            sed -i -e '/^apache/d' $IIAB_STATE_FILE
-        elif [ $1 == "osm-vector-maps" ]; then # role directory & installed marker differ
-            sed -i -e '/^osm_vector_maps/d' $IIAB_STATE_FILE
-        #elif [ $1 == "bluetooth" ]; then # role directory & installed marker differ
-        #    sed -i -e '/^pan_bluetooth/d' $IIAB_STATE_FILE
-        else
-            sed -i -e "/^$1/d" $IIAB_STATE_FILE
-        fi
-    #fi
+    if [ $1 == "calibre-web" ]; then # role directory & installed marker differ
+        sed -i -e '/^calibreweb/d' $IIAB_STATE_FILE
+    elif [ $1 == "httpd" ]; then # role directory & installed marker differ
+        sed -i -e '/^apache/d' $IIAB_STATE_FILE
+    elif [ $1 == "osm-vector-maps" ]; then # role directory & installed marker differ
+        sed -i -e '/^osm_vector_maps/d' $IIAB_STATE_FILE
+    else
+        sed -i -e "/^$1/d" $IIAB_STATE_FILE
+    fi
 fi
 
 if [ $# -eq 2 ]; then


### PR DESCRIPTION
Also cleans up code per discussion with @mitra42 at #2247

Tested on Ubuntu 19.10:
- `./runrole internetarchive` completed in 37 seconds (both times)
- `./runrole --reinstall internetarchive` completed in 42 sec (1st time) or 41 sec (2nd time)

(Interestingly the vast majority of both 2 above times appears to be consumed by IIAB's [0-init](https://github.com/iiab/iiab/tree/master/roles/0-init) stage, so there's certainly room to optimize that later, if @jvonau or someone else has time!)