### PR TITLE
Munin & vnStat in BIG only (these are barely used, and can be slow to install)

### DIFF
--- a/roles/munin/defaults/main.yml
+++ b/roles/munin/defaults/main.yml
@@ -1,5 +1,5 @@
-# munin_install: True
-# munin_enabled: True
+# munin_install: False
+# munin_enabled: False
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -538,15 +538,15 @@ watchdog:
   - postgresql
   - squid
 
-munin_install: True
-munin_enabled: True
+munin_install: False
+munin_enabled: False
 
 # Handy for maintaining tables, but DANGEROUS if not locked down
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
-vnstat_install: True
-vnstat_enabled: True
+vnstat_install: False
+vnstat_enabled: False
 
 
 # 9-LOCAL-ADDONS

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -322,15 +322,15 @@ awstats_enabled: True
 monit_install: False
 monit_enabled: False
 
-munin_install: True
-munin_enabled: True
+munin_install: False
+munin_enabled: False
 
 # Handy for maintaining tables, but DANGEROUS if not locked down
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
-vnstat_install: True
-vnstat_enabled: True
+vnstat_install: False
+vnstat_enabled: False
 
 
 # 9-LOCAL-ADDONS

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -322,15 +322,15 @@ awstats_enabled: True
 monit_install: False
 monit_enabled: False
 
-munin_install: True
-munin_enabled: True
+munin_install: False
+munin_enabled: False
 
 # Handy for maintaining tables, but DANGEROUS if not locked down
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
-vnstat_install: True
-vnstat_enabled: True
+vnstat_install: False
+vnstat_enabled: False
 
 
 # 9-LOCAL-ADDONS


### PR DESCRIPTION
Implements #2203, as Munin & vnStat certainly don't make for attractive outreach.

This change is now documented in the table of ~30 IIAB Apps @ http://FAQ.IIAB.IO -> "9 What services (IIAB apps) are suggested during installation?"

If in future we determine that they subtract value more than adding value, they (or anything) can be removed from BIG-sized, towards presenting newcomers with far more practical/modern options.

We're not at that point yet as of Q1 2020 (as far as I know anyway!) so it seems fine for them to live on in BIG-sized for now.