### PR TITLE
(1) recommend Ansible 2.9.6+ (2) mandate Ansible 2.8.10+ (3) mandate kernel 4.19.97+ on Raspbian

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,8 +10,8 @@ ARGS=""
 CWD=`pwd`
 OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
-MIN_RPI_KERN=4.19.79       # Can be further updated if necessary, when Raspbian's Oct 2019 kernels are more officially fixed such that running 'rpi-update' will no longer be nec soon, see: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.8.8      # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.
+MIN_RPI_KERN=4.19.97       # If using Raspbian, 'rpi-update' should no longer be nec -- please use Raspbian 2020-02-13 or higher: https://github.com/iiab/iiab/issues/1993
+MIN_ANSIBLE_VER=2.8.10     # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.9.4"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.6"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.8.x
+++ b/scripts/ansible-2.8.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.8.8"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.8.10"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/ansible-2.9.x
+++ b/scripts/ansible-2.9.x
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.9.4"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.9.6"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On other OS's we attempt the latest from PPA, which might be more recent
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Ansible 2.9.6 changelog:
https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#v2-9-6

Ansible current version (2.9.6) PPA site:
https://launchpad.net/~ansible/+archive/ubuntu/ansible