### PR TITLE
bluetooth network support for ubuntu on rpi

### DIFF
--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Install Bluetooth - only on Raspberry Pi
   include_role:
     name: bluetooth
-  when: rpi_model =! "none" and bluetooth_install
+  when: not (rpi_model == "none") and bluetooth_install
 
 - name: USB_LIB
   include_role:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Install Bluetooth - only on Raspberry Pi
   include_role:
     name: bluetooth
-  when: not (rpi_model == "none") and bluetooth_install
+  when: rpi_model != "none" and bluetooth_install
 
 - name: USB_LIB
   include_role:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Install Bluetooth - only on Raspberry Pi
   include_role:
     name: bluetooth
-  when: is_raspbian and bluetooth_install
+  when: rpi_model =! "none" and bluetooth_install
 
 - name: USB_LIB
   include_role:

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -1,3 +1,10 @@
+- name: "Install pi-bluetooth package on Ubuntu"
+  package:
+    name:
+      - pi-bluetooth
+    state: present
+  when: is_ubuntu
+
 - name: "Install bluetooth packages"
   package:
     name:

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -1,11 +1,10 @@
-- name: "Install pi-bluetooth package on Ubuntu"
+- name: Install pi-bluetooth package on Ubuntu
   package:
-    name:
-      - pi-bluetooth
+    name: pi-bluetooth
     state: present
   when: is_ubuntu
 
-- name: "Install bluetooth packages"
+- name: Install bluetooth packages
   package:
     name:
       - bluetooth


### PR DESCRIPTION
### Fixes Bug
allows bluetooth networking with ubuntu when installing on a rpi.
### Description of changes proposed in this pull request.
adds ubuntu rpi specific package noted in /boot/firmware/nobtcfg.txt
requires 9d331e8 