### PR TITLE
U20test / Ubuntu 20.04 to offer PHP 7.3 and 7.4 [Nextcloud PHP deps, php-stem on U20, ap0 prep, KA Lite on Ubermix, etc]

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -69,10 +69,9 @@
 
 # Discover: do we have a gateway?
 # If Ansible detects gateway, becomes WAN candidate.
-- name: "Do we have a gateway? If so set discovered_wan_iface: {{ ansible_default_ipv4.alias }}, iiab_wan_iface: {{ discovered_wan_iface }}"
+- name: "Do we have a gateway? If so set discovered_wan_iface: {{ ansible_default_ipv4.alias }}"
   set_fact:
     discovered_wan_iface: "{{ ansible_default_ipv4.alias }}"
-    iiab_wan_iface: "{{ discovered_wan_iface }}"
   when: ansible_default_ipv4.gateway is defined
 
 - name: "Verify gateway active: ping -c4 {{ ansible_default_ipv4.gateway }}"
@@ -80,12 +79,13 @@
   when: discovered_wan_iface != "none"
   register: gw_active_test
 
-- name: If so, set gw_active
+- name: If so, set gw_active, iiab_wan_iface to {{ discovered_wan_iface }}
   set_fact:
+    iiab_wan_iface: "{{ discovered_wan_iface }}"
     gw_active: True
   when: discovered_wan_iface != "none" and gw_active_test.stdout == "1"
 
-- name: Test for Internet access ({{ iiab_download_url }}/heart-beat.txt)
+- name: Test with {{ iiab_wan_iface }} for Internet access ({{ iiab_download_url }}/heart-beat.txt)
   get_url:
     url: "{{ iiab_download_url }}/heart-beat.txt"
     dest: /tmp/heart-beat.txt

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -62,6 +62,14 @@
   when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
   #when: ro_dir.stat.exists
 
+# This effectively does nothing at all on Ubuntu & Raspbian, where libgeos-*
+# pkgs are not installed FWIW.  But it's included to safeguard us across all
+# OS's, in case others OS's like Ubermix later appear.  See #1382 for details.
+# Removing pkgs libgeos-3.6.2 & libgeos-c1v5 fixed the situation on Ubermix!
+- name: Remove libgeos-* pkgs, avoiding KA Lite Django failure on Ubermix
+  shell: apt -y remove "libgeos-*"
+  when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
+
 - name: SSHD
   include_role:
     name: sshd

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -62,6 +62,7 @@
   when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
   #when: ro_dir.stat.exists
 
+# 2020-03-19: for KA Lite, but moved from roles/kalite/tasks/install.yml
 # This effectively does nothing at all on Ubuntu & Raspbian, where libgeos-*
 # pkgs are not installed FWIW.  But it's included to safeguard us across all
 # OS's, in case others OS's like Ubermix later appear.  See #1382 for details.

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -11,6 +11,11 @@
 #  ignore_errors: yes
 #  when: is_raspbian | bool
 
+- name: Install python2
+  package: 
+    name: python2
+    state: present
+
 - name: Use pip to install KA Lite static to {{ kalite_venv }}
   pip:
     name: ka-lite-static

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -23,13 +23,6 @@
     #extra_args="--disable-pip-version-check"
   when: internet_available | bool
 
-# This effectively does nothing at all on Ubuntu & Raspbian, where libgeos-*
-# pkgs are not installed FWIW.  But it's included to safeguard us across all
-# OS's, in case others OS's like Ubermix later appear.  See #1382 for details.
-# Removing pkgs libgeos-3.6.2 & libgeos-c1v5 fixed the situation on Ubermix!
-- name: Remove libgeos-* pkgs, avoiding KA Lite Django failure on Ubermix
-  shell: apt -y remove "libgeos-*"
-
 - name: "Install from template: venv wrapper /usr/bin/kalite, systemd unit file kalite-serve.service, Apache's kalite.conf"
   template:
     backup: no

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -7,7 +7,7 @@
 - name: "Set fact 'kiwix_src_dir: {{ kiwix_version_armhf }}' (armv6l or armv71)"
   set_fact:
     kiwix_src_dir: "{{ kiwix_version_armhf }}"
-  when: ansible_machine == "armv7l" or ansible_machine == "armv6l"
+  when: ansible_machine == "armv7l" or ansible_machine == "armv6l" or ansible_machine == "aarch64"
 
 - name: "Set fact 'kiwix_src_dir: {{ kiwix_version_linux64 }}' (x86_64)"
   set_fact:

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -109,13 +109,13 @@
 # make it so number 2 vars should use user_wan_iface but we can cover a single
 # wired if dhcp fails the interface should revert to LAN, static address should
 # stick around but testing gateway response is not performed.
-- name: User wants single wired interface as static or dhcp gateway
-  set_fact:
-    user_wan_iface: "{{ discovered_wan_iface }}"   # Jan 2018: Holt discovered_lan_iface was UNDEFINED on WiFi-installed
-                                                   # RPi (when re-running ./iiab-network) so "discovered_wan_iface" is a
-                                                   # workaround -- please see https://github.com/iiab/iiab/pull/649
-                                                   # This workaround can and should evolve as IIAB 6.5 matures!
-  when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
+#- name: User wants single wired interface as static or dhcp gateway
+#  set_fact:
+#    user_wan_iface: "{{ discovered_wan_iface }}"   # Jan 2018: Holt discovered_lan_iface was UNDEFINED on WiFi-installed
+#                                                   # RPi (when re-running ./iiab-network) so "discovered_wan_iface" is a
+#                                                   # workaround -- please see https://github.com/iiab/iiab/pull/649
+#                                                   # This workaround can and should evolve as IIAB 6.5 matures!
+#  when: num_lan_interfaces == "1" and user_lan_iface == "auto" and user_wan_iface == "auto"
 
 - name: Use old gateway device info if not detected and using static ip
   set_fact:
@@ -152,14 +152,14 @@
 - name: We're hosed no work interfaces
   set_fact:
     iiab_network_mode: "No_network_found"
-  when: adapter_count.stdout|int == "0"
+  when: adapter_count.stdout|int == 0
 
 # well if there ever was a point to tell the user things are FUBAR this is it.
 - name: I'm not guessing declare gateway please
   set_fact:
     iiab_network_mode: "Undetectable_use_local_vars"
     iiab_wan_iface: "none"
-  when: adapter_count.stdout|int >= "5" and device_gw == "none" and gui_wan_iface == "unset" and gui_static_wan is defined
+  when: adapter_count.stdout|int >= 5 and device_gw == "none" and gui_wan_iface == "unset" and gui_static_wan is defined
 
 - name: Record IIAB_WAN_DEVICE to {{ iiab_env_file }}
   lineinfile:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -75,7 +75,7 @@
   set_fact:
     wifi2: "{{ item|trim }}"
     discovered_wireless_iface: "{{ item|trim }}"
-  when: wireless_list2.stdout is defined
+  when: wireless_list2.stdout is defined and not wireless_list2.stdout == "ap0"
   with_items:
     - "{{ wireless_list2.stdout_lines }}"
 #item|trim != discovered_wan_iface
@@ -103,7 +103,7 @@
   when: reserved_wifi is defined and discovered_wireless_iface != iiab_wan_iface and num_wifi_interfaces >= "2"
 
 - name: Count LAN ifaces
-  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }} | wc -l
+  shell: ls /sys/class/net | grep -v -e ap0 -e wwlan -e ppp -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }} | wc -l
   register: num_lan_interfaces_result
 
 - name: Calculate number of LAN interfaces including WiFi
@@ -112,7 +112,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
-  shell: ls /sys/class/net | grep -v -e wwlan -e ppp -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }}
+  shell: ls /sys/class/net | grep -v -e ap0 -e wwlan -e ppp -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e {{ device_gw }} -e {{ ap_device }}
   when: num_lan_interfaces != "0"
   register: lan_list_result
 

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -48,44 +48,42 @@
       - ffmpeg           # Optional (for preview generation)
       - libxml2          # php-libxml requires libxml2 >= 2.7.0
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
-      - php-bz2          # Optional (for extraction of apps)
-      #- php-cli         # NOT REQUESTED by Nextcloud
-      #- php-common      # NOT REQUESTED by Nextcloud
-      - php-curl
-      - php-fpm          # ALSO INSTALLED IN roles/www_options (Stage 4) for nginx_high_php_limits
-      - php-gd
-      - php-gmp          # Optional (for SFTP storage)
-      - php-imagick      # Optional (for preview generation)
-      - php-intl         # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
-      - php-json
+      - php{{ php_version }}-bz2          # Optional (for extraction of apps)
+      - php{{ php_version }}-cli
+      - php{{ php_version }}-curl
+      - php{{ php_version }}-gd
+      - php{{ php_version }}-gmp          # Optional (for SFTP storage)
+      - php{{ php_version }}-imagick      # Optional (for preview generation)
+      - php{{ php_version }}-intl         # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
+      - php{{ php_version }}-json
       #- php-libxml      # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
-      - php-mbstring
-      - php-mysql 
+      - php{{ php_version }}-mbstring
+      - php{{ php_version }}-mysql
       #- php-openssl     # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php-pdo_mysql   # NOT INSTALLABLE: php-mysql handles this on all OS's?
       #- php-redis       # @m-anish future work?
       #- php-session     # NOT INSTALLABLE: ENABLED BY DEFAULT?
-      - php-smbclient    # Optional (SMB/CIFS integration
-      - php-xml          # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
-      - php-zip
+#      - php-smbclient    # Optional (SMB/CIFS integration
+      - php{{ php_version }}-xml          # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      - php{{ php_version }}-zip
       #- php-zlib        # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
 
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)
-  package:
-    name:
-      - php-ctype
-      - php-dom
-      - php-exif         # Optional (for image rotation in pictures app)
-      - php-fileinfo     # Optional (enhances file analysis performance)
-      - php-iconv
-      - php-posix
-      - php-simplexml
-      - php-xmlreader
-      - php-xmlwriter
-    state: present
-  when: not is_raspbian
+#- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)
+#  package:
+#    name:
+#      - php-ctype
+#      - php-dom
+#      - php-exif         # Optional (for image rotation in pictures app)
+#      - php-fileinfo     # Optional (enhances file analysis performance)
+#      - php-iconv
+#      - php-posix
+#      - php-simplexml
+#      - php-xmlreader
+#      - php-xmlwriter
+#    state: present
+#  when: not is_raspbian
 
 
 - name: Create dir {{ nextcloud_root_dir }}

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -44,44 +44,44 @@
 - name: Install ffmpeg + libxml2 + 13 php packages
   package:
     name:
-      #- dnsutils        # NOT REQUESTED by Nextcloud
-      - ffmpeg           # Optional (for preview generation)
-      - libxml2          # php-libxml requires libxml2 >= 2.7.0
+      #- dnsutils    # NOT REQUESTED by Nextcloud
+      - ffmpeg       # Optional (for preview generation)
+      - libxml2      # php-libxml requires libxml2 >= 2.7.0
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
-      - php{{ php_version }}-bz2          # Optional (for extraction of apps)
-      - php{{ php_version }}-cli
+      - php{{ php_version }}-bz2           # Optional (for extraction of apps)
+      - php{{ php_version }}-cli           # Like optional?  @jvonau says this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
       - php{{ php_version }}-curl
       - php{{ php_version }}-gd
-      - php{{ php_version }}-gmp          # Optional (for SFTP storage)
-      - php{{ php_version }}-imagick      # Optional (for preview generation)
-      - php{{ php_version }}-intl         # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
+      - php{{ php_version }}-gmp           # Optional (for SFTP storage)
+      - php{{ php_version }}-imagick       # Optional (for preview generation)
+      - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
       - php{{ php_version }}-json
-      #- php-libxml      # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
+      #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
       - php{{ php_version }}-mbstring
       - php{{ php_version }}-mysql
-      #- php-openssl     # NOT INSTALLABLE: ENABLED BY DEFAULT?
-      #- php-pdo_mysql   # NOT INSTALLABLE: php-mysql handles this on all OS's?
-      #- php-redis       # @m-anish future work?
-      #- php-session     # NOT INSTALLABLE: ENABLED BY DEFAULT?
-#      - php-smbclient    # Optional (SMB/CIFS integration
-      - php{{ php_version }}-xml          # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-openssl      # NOT INSTALLABLE: ENABLED BY DEFAULT?
+      #- php{{ php_version }}-pdo_mysql    # NOT INSTALLABLE: php-mysql handles this on all OS's?
+      #- php{{ php_version }}-redis        # @m-anish future work?
+      #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
+      #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
+      - php{{ php_version }}-xml           # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       - php{{ php_version }}-zip
-      #- php-zlib        # NOT INSTALLABLE: ENABLED BY DEFAULT?
+      #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
 
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 #- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)
 #  package:
 #    name:
-#      - php-ctype
-#      - php-dom
-#      - php-exif         # Optional (for image rotation in pictures app)
-#      - php-fileinfo     # Optional (enhances file analysis performance)
-#      - php-iconv
-#      - php-posix
-#      - php-simplexml
-#      - php-xmlreader
-#      - php-xmlwriter
+#      - php{{ php_version }}-ctype
+#      - php{{ php_version }}-dom
+#      - php{{ php_version }}-exif        # Optional (for image rotation in pictures app)
+#      - php{{ php_version }}-fileinfo    # Optional (enhances file analysis performance)
+#      - php{{ php_version }}-iconv
+#      - php{{ php_version }}-posix
+#      - php{{ php_version }}-simplexml
+#      - php{{ php_version }}-xmlreader
+#      - php{{ php_version }}-xmlwriter
 #    state: present
 #  when: not is_raspbian
 

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -56,7 +56,7 @@
     src: "/etc/php/{{ php_version }}/mods-available/stem.ini"
     path: "/etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini"
     state: link
-  #when: nginx_enabled | bool
+  when: not is_ubuntu | bool
 
 - name: Restart php{{ php_version }}-fpm systemd service
   systemd:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -56,7 +56,7 @@
     src: "/etc/php/{{ php_version }}/mods-available/stem.ini"
     path: "/etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini"
     state: link
-  when: not is_ubuntu | bool
+  #when: nginx_enabled | bool
 
 - name: Restart php{{ php_version }}-fpm systemd service
   systemd:

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -11,7 +11,17 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: is_raspbian | bool
+  when: ansible_machine == "armv7l"
+
+- name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar to / (rpi)
+  unarchive:
+    src: http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar
+    dest: /
+    owner: root
+    group: root
+    #mode: ????
+    remote_src: yes
+  when: ansible_machine == "aarch64"
 
 - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.x64.tar to / (x64)
   unarchive:


### PR DESCRIPTION
### Fixes Bug
alternate to #2290 includes #2269 fixes nextcloud install when there is multiple php versions available to install.
### Description of changes proposed in this pull request.
U-20 offers php 7.3 and 7.4, we can use 7.3 for now.
### Smoke-tested in operating system.
[u20and64bit.txt](https://github.com/iiab/iiab/files/4354189/u20and64bit.txt)


### Mention a team member for further information or comment using @ name
