### PR TITLE
python2 package name exists only on Ubuntu 20 for now.

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -15,6 +15,7 @@
   package: 
     name: python2
     state: present
+  when: is_ubuntu_20 | bool
 
 - name: Use pip to install KA Lite static to {{ kalite_venv }}
   pip:


### PR DESCRIPTION
'python' renamed to python2 upstream as python2.7 is going away at some point but unchanged on Ubuntu 18

### Fixes Bug

### Description of changes proposed in this pull request.

### Smoke-tested in operating system.

### Mention a team member for further information or comment using @ name
