### PR TITLE
Install python2 for KA Lite, if Raspbian/Debian > 10 or Ubuntu > 19

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -11,10 +11,11 @@
 #  ignore_errors: yes
 #  when: is_raspbian | bool
 
-- name: Install python2
-  package: 
+- name: Install python2, if Raspbian/Debian > 10 or Ubuntu > 19
+  package:
     name: python2
     state: present
+  when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)    # 2020-03-26: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 - name: Use pip to install KA Lite static to {{ kalite_venv }}
   pip:


### PR DESCRIPTION
Alternative to PR #2305 towards solving bug #2304.