### PR TITLE
NGINX: fancyindex instead of autoindex, for http://box/usb (for larger font on smartphones etc)

### DIFF
--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -4,11 +4,11 @@ location / {
 
 location /usb {
     alias /library/www/html/local_content/;
-    autoindex on;
+    fancyindex on;    # autoindex on;
 }
 
 location /local_content/ {
-    autoindex on;
+    fancyindex on;    # autoindex on;
 }
 
 location /modules/ {


### PR DESCRIPTION
Proposed by @jvonau & tested by @shanti-bhardwa