### PR TITLE
U20 [PHP 7.4 for Ubuntu 20.04]

### DIFF
--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -56,6 +56,7 @@
     src: "/etc/php/{{ php_version }}/mods-available/stem.ini"
     path: "/etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini"
     state: link
+  when: php_version != "7.4"
   #when: nginx_enabled | bool
 
 - name: Restart php{{ php_version }}-fpm systemd service

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -5,6 +5,7 @@
 
 
 - include_tasks: html.yml
+
 - include_tasks: php-stem.yml
   when: php_version != "7.4"
 

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -6,6 +6,7 @@
 
 - include_tasks: html.yml
 - include_tasks: php-stem.yml
+  when: php_version != "7.4"
 
 - name: Create dir {{ doc_root }}/home -- if you customized var iiab_home_url e.g. in /etc/iiab/local_vars.yml, that dir is created later -- by www_options/tasks/main.yml
   file:

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -23,7 +23,7 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.3    # 7.4 might be nec for Ubuntu 20.04 later?
+php_version: 7.4
 # "postgresql_version: 11.2" failed (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 19.04)
 postgresql_version: 12
 systemd_location: /lib/systemd/system


### PR DESCRIPTION
### Fixes Bug
noted changes in Ubuntu-20
### Description of changes proposed in this pull request.
Bump php to 7.4, 7.3 no longer offered. 
Disable php-stem till support is available
### Smoke-tested in operating system.
U-20 aarch64 arm daily as of March 30
### Mention a team member for further information or comment using @ name
