### PR TITLE
pastebinit bugs: try dpaste.com instead (for iiab-diagnostics command)

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -214,10 +214,10 @@ read ans < /dev/tty
 echo -e "\e[1m"
 if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
     echo -ne "PUBLISHING TO URL... "
-    pastebinit < $outfile
+    pastebinit -b dpaste.com < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
 else
     echo -e "If you later decide to publish it, run:"
     echo
-    echo -e "   pastebinit < $outfile"
+    echo -e "   pastebinit -b dpaste.com < $outfile"
 fi
 echo -e "\e[0m"

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -47,7 +47,7 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
    Or, you can later/manually upload it using the ``pastebinit`` command:
 
    ```
-   pastebinit < /etc/iiab/diag/NEW-FILE-NAME
+   pastebinit -b dpaste.com < /etc/iiab/diag/NEW-FILE-NAME
    ```
 
    Either way, this will generate an actual web link (URL).


### PR DESCRIPTION
Tested on Raspbian Lite on RPi 4.

If pastebinit fails to work with http://dpaste.com in future, remember to try `pastebinit -l` to list other possible pastebin site URLs &mdash; many of which no longer work &mdash; but that's the place to start!