### PR TITLE
helper script to delete symlink in local_content [when teachers remove their USB sticks/drives]

### DIFF
--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -16,6 +16,7 @@
     - { src: 'usbmount.rules.j2', dest: '/etc/udev/rules.d/usbmount.rules', mode: '0644' }
     - { src: 'iiab-usb_lib-show-all-on', dest: '/usr/bin/', mode: '0755' }
     - { src: 'iiab-usb_lib-show-all-off', dest: '/usr/bin/', mode: '0755' }
+    - { src: 'iiab-clean-usb.sh', dest: '/usr/sbin/', mode: '0755' }
 
 - name: Enable exFAT and NTFS in /etc/usbmount/usbmount.conf
   lineinfile:

--- a/roles/usb_lib/templates/iiab-clean-usb.sh
+++ b/roles/usb_lib/templates/iiab-clean-usb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Remove symlink in /library/content to automounted usb drive
+#
+DEVICE=`echo $@ | sed -s 's|-|/|'`
+MNT_POINT=`findmnt -n /$DEVICE | awk '{print $1}'`
+CONTENT_LINK_USB=`basename $MNT_POINT | awk '{print toupper($0)}'`
+CONTENT_LINK="/library/www/html/local_content/$CONTENT_LINK_USB"
+logger -p user.notice -t "usbmount" -- "Attempting to remove link $CONTENT_LINK."
+
+if [ -L $CONTENT_LINK ]; then
+  /bin/rm $CONTENT_LINK
+  logger -p user.notice -t "usbmount" -- "$CONTENT_LINK removed."
+fi
+

--- a/roles/usb_lib/templates/usbmount@.service.j2
+++ b/roles/usb_lib/templates/usbmount@.service.j2
@@ -4,10 +4,11 @@ After=%i.device
 After=rc-local.service
 
 [Service]
-Type=oneshot
+#Type=oneshot
 TimeoutStartSec=0
 Environment=DEVNAME=%I
 ExecStart=/usr/share/usbmount/usbmount add
-ExecStop=/bin/umount /%I
+ExecStop=/usr/sbin/iiab-clean-usb.sh %I
+ExecStopPost=/bin/umount /%I
 RemainAfterExit=yes
 


### PR DESCRIPTION
### Fixes Bug
Removes symlinks in 'local_content' when stopping usbmount service, thereby removing the symlinks when powering off. 

Should there be no links present in local_content when booted without the usb drive inserted.  