### PR TITLE
Fix to ensure nginx_high_php_limits are enacted (if nginx_enabled)

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -25,7 +25,7 @@
   when: nginx_install | bool
 
 - debug:
-    msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled'
+    msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: (nginx_high_php_limits or moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled'
 
 - block:    # 3-STANZA BLOCK BEGINS
 
@@ -71,7 +71,7 @@
       name: "php{{ php_version }}-fpm"
       state: restarted
 
-  when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled    # 3-STANZA BLOCK ENDS
+  when: (nginx_high_php_limits or moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled    # 3-STANZA BLOCK ENDS
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'


### PR DESCRIPTION
Just in case other apps require acting upon variable `nginx_high_php_limits` in future, above and beyond the current 4 {Moodle, Nextcloud, PBX, WordPress}.

Ref: https://github.com/iiab/iiab/issues/2287#issuecomment-611143089