### PR TITLE
add iiab-admin to netdev group so that gui can control networking

### DIFF
--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -19,7 +19,7 @@
 - name: 'Add user {{ iiab_admin_user }} to groups: wheel, sudo'
   user:
     name: "{{ iiab_admin_user }}"
-    groups: wheel,sudo
+    groups: wheel,sudo,netdev
 
 - name: Edit the sudoers file -- first make it editable
   file:


### PR DESCRIPTION
Found to be necessary in raspberry desktop, when clicking on network->Wireless and "Wired Network Settings
Smoke tested