### PR TITLE
copy won't try to overwrite another file if present [for OSM install]

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -11,17 +11,11 @@
     url: "{{ iiab_map_url }}/assets/regions.json"    # http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
     dest: "{{ vector_map_path }}/maplist/assets/"    # /library/www/osm-vector-maps
 
-# handle case where a dummy file is already here and would break the symlink step that follows
-- name: Remove {{ doc_root }}/common/assets/regions.json
-  file:
-    dest: "{{ doc_root }}/common/assets/regions.json"    # /library/www/html
-    state: absent
-
-- name: Symlink catalog {{ doc_root }}/common/assets/regions.json -> {{ vector_map_path }}/maplist/assets/regions.json
-  file:
+- name: Copy catalog {{ vector_map_path }}/maplist/assets/regions.json -> {{ doc_root }}/common/assets/regions.json
+  copy:
     src: "{{ vector_map_path }}/maplist/assets/regions.json"    # /library/www/osm-vector-maps
     dest: "{{ doc_root }}/common/assets/regions.json"    # /library/www/html
-    state: link
+    force: no
 
 - name: Download the JavaScript bundle with OpenLayers (main.js) into {{ vector_map_path }}/maplist/, for test page http://box/maps/maplist
   get_url:


### PR DESCRIPTION
### Fixes Bug
issue of replacing a later installed file with an earlier file. #2197
### Description of changes proposed in this pull request.
use copy in place of file, removes bogus fix, allowing later installed file to prevail.
### Smoke-tested in operating system.
unbuntu-20
