### PR TITLE
google is almost an essential url, so do not divert it [Captive Portal: remove www.msn.com & www.google.com]

### DIFF
--- a/roles/captiveportal/templates/checkurls
+++ b/roles/captiveportal/templates/checkurls
@@ -10,7 +10,7 @@ ipv6.msftncsi.com.edgesuite.net
 www.msftncsi.com
 www.msftncsi.com.edgesuite.net
 www.msftconnecttest.com
-www.msn.com
+#www.msn.com
 teredo.ipv6.microsoft.com
 teredo.ipv6.microsoft.com.nsatc.net
 captive.apple.com

--- a/roles/captiveportal/templates/checkurls
+++ b/roles/captiveportal/templates/checkurls
@@ -16,7 +16,7 @@ teredo.ipv6.microsoft.com.nsatc.net
 captive.apple.com
 init-p01st.push.apple.com
 connectivitycheck.android.com
-www.google.com
+#www.google.com
 mtalk.google.com
 alt4-mtalk.google.com
 alt6-mtalk.google.com


### PR DESCRIPTION
With captive portal enabled, and doing pass through testing of upstream and downstream WiFi, I have disabled the diversion of www.google.com without any noticeable malfunction of captive portal. 

It is really annoying to get browser errors when trying to look something up.