### PR TITLE
Comment out both kolibri.service timeout settings

### DIFF
--- a/roles/kolibri/templates/kolibri.service.j2
+++ b/roles/kolibri/templates/kolibri.service.j2
@@ -10,8 +10,10 @@ Environment=KOLIBRI_HTTP_PORT={{ kolibri_http_port }}
 Environment=KOLIBRI_URL_PATH_PREFIX={{ kolibri_url_without_slash }}
 User={{ kolibri_user }}
 Group={{ apache_user }}
-TimeoutStartSec=infinity
-TimeoutStopSec=10
+# 2020-04-18 @jvonau: comment out both timeouts for now, in favor of 90 seconds
+# or whatever systemd / Kolibri favor? https://github.com/iiab/iiab/issues/2318
+# TimeoutStartSec=infinity
+# TimeoutStopSec=10
 ExecStart={{ kolibri_exec_path }} start
 ExecStop={{ kolibri_exec_path }} stop
 


### PR DESCRIPTION
Implements @jvonau's suggestion at https://github.com/iiab/iiab/issues/2318#issuecomment-614727305 "Is Kolibri shutting down cleanly when IIAB powers off?"

Related:

#1832 "Tracking the best systemd unit file(s) for Kolibri?"