### PR TITLE
centralize map catalog for use by osm and admin console

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -6,21 +6,15 @@
     group: "{{ apache_user }}"
     mode: '0755'
 
-- name: Download map catalog {{ iiab_map_url }}/assets/regions.json to {{ vector_map_path }}/maplist/assets/
+- name: Download map catalog {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
   get_url:
     url: "{{ iiab_map_url }}/assets/regions.json"    # http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
-    dest: "{{ vector_map_path }}/maplist/assets/"    # /library/www/osm-vector-maps
+    dest: "{{ iiab_etc_path }}"
 
-# handle case where a dummy file is already here and would break the symlink step that follows
-- name: Remove {{ doc_root }}/common/assets/regions.json
+- name: Symlink map catalog {{ vector_map_path }}/maplist/assets/regions.json -> {{ iiab_etc_path }}
   file:
-    dest: "{{ doc_root }}/common/assets/regions.json"    # /library/www/html
-    state: absent
-
-- name: Symlink catalog {{ doc_root }}/common/assets/regions.json -> {{ vector_map_path }}/maplist/assets/regions.json
-  file:
-    src: "{{ vector_map_path }}/maplist/assets/regions.json"    # /library/www/osm-vector-maps
-    dest: "{{ doc_root }}/common/assets/regions.json"    # /library/www/html
+    src: "{{ iiab_etc_path }}/regions.json"
+    dest: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
 - name: Download the JavaScript bundle with OpenLayers (main.js) into {{ vector_map_path }}/maplist/, for test page http://box/maps/maplist


### PR DESCRIPTION
This is what we should have done in the first place, centralize the maps catalog, as was done for kiwix and rachel, and roles that use it create their own symlinks. (adm cons will need to create one as well or rather change the source for the one it already creates.)