### PR TITLE
Supplied by python-pip-whl/focal 20.0.2-5 [revert KA Lite workaround for Ubuntu 20.04]

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -20,14 +20,6 @@
   when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
-- name: Put wheel file in place if missing
-  get_url:
-    url: http://d.iiab.io/packages/ipaddress-0.0.0-py2.py3-none-any.whl
-    dest: /usr/share/python-wheels/ipaddress-0.0.0-py2.py3-none-any.whl
-  when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
-  # 2020-04-02: python-pip-whl 20.0.2-2 is missing ipaddress-0.0.0-py2.py3-none-any.whl
-  # https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1869247
-
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }} if Raspbian/Debian > 10 or Ubuntu > 19
   pip:
     name:
@@ -38,7 +30,7 @@
     virtualenv_python: python2.7
     extra_args: "--no-use-pep517 --no-cache-dir --no-python-version-warning"
   when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
-  # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
+  # long form of (is_ubuntu_20 or is_debian_11)
 
 - name: Use pip to install KA Lite static to {{ kalite_venv }}
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -30,7 +30,7 @@
     virtualenv_python: python2.7
     extra_args: "--no-use-pep517 --no-cache-dir --no-python-version-warning"
   when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
-  # long form of (is_ubuntu_20 or is_debian_11)
+  # long form of (is_debian_11+ or is_ubuntu_20+)
 
 - name: Use pip to install KA Lite static to {{ kalite_venv }}
   pip:


### PR DESCRIPTION
### Fixes Bug
remove workaround for #2312 