### PR TITLE
nginx requires trailing slash [for Kolibri URL] to function properly

### DIFF
--- a/roles/kolibri/templates/kolibri-nginx.conf.j2
+++ b/roles/kolibri/templates/kolibri-nginx.conf.j2
@@ -1,4 +1,4 @@
-location {{ kolibri_url_without_slash }}/ {
+location {{ kolibri_url }} {
     proxy_set_header        Host            $http_host;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Scheme        $scheme;

--- a/roles/kolibri/templates/kolibri-nginx.conf.j2
+++ b/roles/kolibri/templates/kolibri-nginx.conf.j2
@@ -1,4 +1,4 @@
-location {{ kolibri_url_without_slash }} {
+location {{ kolibri_url_without_slash }}/ {
     proxy_set_header        Host            $http_host;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Scheme        $scheme;


### PR DESCRIPTION
### Fixes Bug
/kolibri not working and looping login
