### PR TITLE
drop kolibri_url_without_slash

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -32,8 +32,7 @@ kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest
 # Kolibri folder to store its data and configuration files.
 kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
 
-kolibri_url_without_slash: /kolibri
-kolibri_url: "{{ kolibri_url_without_slash }}/"    # /kolibri/
+kolibri_url: /kolibri
 
 kolibri_exec_path: /usr/bin/kolibri
 

--- a/roles/kolibri/templates/kolibri-nginx.conf.j2
+++ b/roles/kolibri/templates/kolibri-nginx.conf.j2
@@ -1,8 +1,8 @@
-location {{ kolibri_url }} {
+location {{ kolibri_url }}/ {
     proxy_set_header        Host            $http_host;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Scheme        $scheme;
-    proxy_set_header        X-Script-Name   /kolibri;
+    proxy_set_header        X-Script-Name   {{ kolibri_url }};
     proxy_pass http://127.0.0.1:8009;
 }
 

--- a/roles/kolibri/templates/kolibri.conf.j2
+++ b/roles/kolibri/templates/kolibri.conf.j2
@@ -1,5 +1,5 @@
 # SEE https://github.com/iiab/iiab/blob/master/roles/kiwix/templates/kiwix.conf.j2
-RedirectMatch ^{{ kolibri_url_without_slash }}$ {{ kolibri_url }}
+RedirectMatch ^{{ kolibri_url }}$ {{ kolibri_url }}/
 
 ProxyPreserveHost   On
 ProxyPass           {{ kolibri_url }}          http://localhost:{{ kolibri_http_port }}{{ kolibri_url }}

--- a/roles/kolibri/templates/kolibri.service.j2
+++ b/roles/kolibri/templates/kolibri.service.j2
@@ -7,7 +7,7 @@ RemainAfterExit=yes
 Environment=KOLIBRI_USER={{ kolibri_user }}
 Environment=KOLIBRI_HOME={{ kolibri_home }}
 Environment=KOLIBRI_HTTP_PORT={{ kolibri_http_port }}
-Environment=KOLIBRI_URL_PATH_PREFIX={{ kolibri_url_without_slash }}
+Environment=KOLIBRI_URL_PATH_PREFIX={{ kolibri_url }}
 User={{ kolibri_user }}
 Group={{ apache_user }}
 # 2020-04-18 @jvonau: comment out both timeouts for now, in favor of 90 seconds


### PR DESCRIPTION
less confusing to use one variable that would set the user facing uri
