### PR TITLE
Softcoding kolibri-nginx.conf

### DIFF
--- a/roles/kolibri/templates/kolibri-nginx.conf.j2
+++ b/roles/kolibri/templates/kolibri-nginx.conf.j2
@@ -2,7 +2,7 @@ location {{ kolibri_url }} {
     proxy_set_header        Host            $http_host;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Scheme        $scheme;
-    proxy_set_header        X-Script-Name   /kolibri;
+    proxy_set_header        X-Script-Name   {{ kolibri_url_without_slash }};
     proxy_pass http://127.0.0.1:8009;
 }
 


### PR DESCRIPTION
Builds on PR #2354, softcoding kolibri-nginx.conf.j2

This is an alternative to PR #2355 which (unintentionally!) breaks the norm used across most every IIAB playbook.

Background: variables of the form {{ APP_url }} contain the trailing slash according to the current norm to avoid confusion.

If that norm needs change in future, we should change it across all IIAB playbooks.