### PR TITLE
Make http://box/js-menu publicly browsable [except where code/security is a risk]

### DIFF
--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -16,3 +16,7 @@ location /modules/ {
     fancyindex_exact_size off;  # Output human-readable file sizes.
     fancyindex_ignore index.htmlf rachel-index.php;
 }
+
+location /js-menu/ {
+    fancyindex on;    # autoindex on;
+}

--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -19,4 +19,10 @@ location /modules/ {
 
 location /js-menu/ {
     fancyindex on;    # autoindex on;
+    location /js-menu/menu-files/js/ {
+        fancyindex off;    # autoindex off;
+    }
+    location /js-menu/menu-files/services/ {
+        fancyindex off;    # autoindex off;
+    }
 }


### PR DESCRIPTION
As this used to work with Apache, and can sometimes be very useful, in the spirit of free/open source transparency.

e.g. to peruse/verify/borrow from http://iiab.me/js-menu/menu-files/menu-defs/ etc!