### PR TITLE
vnStat workaround for #2367

### DIFF
--- a/roles/vnstat/tasks/main.yml
+++ b/roles/vnstat/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Create database for LAN to collect vnStat data if not appliance config
   shell: /usr/bin/vnstat -i {{ iiab_lan_iface }}
-  when: iiab_lan_iface is defined
+  when: iiab_lan_iface is defined and iiab_lan_iface != "none"
 
 
 # RECORD vnStat AS INSTALLED


### PR DESCRIPTION
Resolves #2367 "vnStat playbook cannot be rerun on a VM w/o LAN? Is iiab-from-console.yml part of the issue?"

A more thorough solution might be in order later?