### PR TITLE
runrole - emit 'Usage' when --reinstall is in the wrong position

### DIFF
--- a/runrole
+++ b/runrole
@@ -14,7 +14,7 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-if [[ $# -eq 0 ]] ; then
+if [[ $# -eq 0 ]] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ] ; then
     echo "Usage: ./runrole <name of role>"
     echo "Usage: ./runrole --reinstall <name of role>"
     echo


### PR DESCRIPTION
### Fixes Bug
#2370
### Description of changes proposed in this pull request.

### Smoke-tested in operating system.

### Mention a team member for further information or comment using @ name
