### PR TITLE
Clarify (1) gateway "passthrough" in vars/* (2) no_net_restart in network/tasks/main.yml

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: detected_network
   include_tasks: detected_network.yml
 
-- name: Set 'no_net_restart: True' if discovered_wireless_iface == iiab_wan_iface
+- name: "Set 'no_net_restart: True' if discovered_wireless_iface == iiab_wan_iface"
   set_fact:
     no_net_restart: True    # 2020-05-09: Var is currently used in 10 files:
     # 0-init/defaults/main.yml, network/tasks/main.yml, debian.yml,

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -9,10 +9,6 @@
     # sysd-netd-debian.yml, computed_services.yml, rpi_debian.yml
   when: discovered_wireless_iface == iiab_wan_iface
 
-# EITHER WAY: hostapd_enabled's state is RECORDED into {{ iiab_env_file }}
-# in hostapd.yml for later use by...
-# /usr/libexec/iiab-startup.sh, iiab-hotspot-off & iiab-hotspot-on
-#
 - name: computed_network
   include_tasks: computed_network.yml
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,11 +1,12 @@
 - name: detected_network
   include_tasks: detected_network.yml
 
-- name: IF WIFI IS PRIMARY GATEWAY, PLEASE RUN 'iiab-hotspot-on' MANUALLY
+- name: Set 'no_net_restart: True' if discovered_wireless_iface == iiab_wan_iface
   set_fact:
-    no_net_restart: True      # used below in (1) sysd-netd-debian.yml,
-                              # (2) debian.yml, (3) rpi_debian.yml,
-                              # (4) NM-debian.yml
+    no_net_restart: True    # 2020-05-09: Var is currently used in 10 files:
+    # 0-init/defaults/main.yml, network/tasks/main.yml, debian.yml,
+    # detected_network.yml, down-debian.yml, NM-debian.yml, restart.yml,
+    # sysd-netd-debian.yml, computed_services.yml, rpi_debian.yml
   when: discovered_wireless_iface == iiab_wan_iface
 
 # EITHER WAY: hostapd_enabled's state is RECORDED into {{ iiab_env_file }}

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -93,13 +93,11 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-hostapd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
+hostapd_install: True    # 2020-01-21: this var MIGHT be implemented in future.
 hostapd_enabled: True
-# Above is forcibly set to False (in roles/network/tasks/main.yml) if IIAB is
-# being WiFi-installed (run "iiab-hotspot-on" AFTER ./iiab-install completes
-# and content is downloaded, to enable the internal WiFi Access Point / AP!)
-wifi_up_down: True    # Creates a second virtual wifi adapter for WiFi upstream to internet
-                      # as well as classroom hotspot, use iiab_gateway_enabled for pass through
+wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+# (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
+# You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 
 # Gateway mode
 iiab_lan_enabled: True
@@ -125,10 +123,7 @@ ports_externally_visible: 3     # ssh + http-or-https + common IIAB services
 # /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
 # And then run: cd /opt/iiab/iiab; ./iiab-network
 
-# Gateway and Filters
-# Most all implementations use "iiab_gateway_enabled: False" within
-# local_vars.yml as they cannot afford Internet access for students
-# and teachers, and the many associated IT/support/training costs.
+# Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
 gw_squid_whitelist: False
 gw_block_https: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -46,8 +46,9 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a second virtual wifi adapter for WiFi upstream to internet
-                      # as well as classroom hotspot, use iiab_gateway_enabled for pass through
+wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+# (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
+# You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -71,7 +72,7 @@ ports_externally_visible: 3     # ssh + http-or-https + common IIAB services
 # /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
 # And then run: cd /opt/iiab/iiab; ./iiab-network
 
-# Make this True if client machines should have access to WAN/Internet:
+# Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
 
 dhcpd_install: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -46,8 +46,9 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a second virtual wifi adapter for WiFi upstream to internet
-                      # as well as classroom hotspot, use iiab_gateway_enabled for pass through
+wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+# (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
+# You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -71,7 +72,7 @@ ports_externally_visible: 3     # ssh + http-or-https + common IIAB services
 # /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
 # And then run: cd /opt/iiab/iiab; ./iiab-network
 
-# Make this True if client machines should have access to WAN/Internet:
+# Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
 
 dhcpd_install: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -46,8 +46,9 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a second virtual wifi adapter for WiFi upstream to internet
-                      # as well as classroom hotspot, use iiab_gateway_enabled for pass through
+wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+# (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
+# You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -71,7 +72,7 @@ ports_externally_visible: 3     # ssh + http-or-https + common IIAB services
 # /opt/iiab/iiab/roles/network/templates/gateway/iiab-gen-iptables
 # And then run: cd /opt/iiab/iiab; ./iiab-network
 
-# Make this True if client machines should have access to WAN/Internet:
+# Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
 
 dhcpd_install: False


### PR DESCRIPTION
@jvonau does `hostapd_enabled` need to be RE-clarified at https://github.com/holta/iiab/blob/gateway-passthrough-clarif/roles/network/tasks/main.yml#L12-L15 ?