### PR TITLE
while testing 2395 - handle no wifi

### DIFF
--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -55,6 +55,7 @@
   systemd:
     name: clone-wifi
     state: started
+  when: wifi_up_down and discovered_wireless_iface != "none"
 
 - name: Restart the systemd-networkd service
   systemd:


### PR DESCRIPTION
### Fixes Bug
U-20 no wireless
TASK [network : Clone wifi if needed] ****************************************** fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Could not find the requested service clone-wifi: host"}