### PR TITLE
Fix #2399: legacy var {{ nextcloud_required_ip }} is still invoked for doc purposes

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -44,8 +44,8 @@ nextcloud_dbpassword: nextcloudmysql
 nextcloud_admin_user: 'Admin'
 nextcloud_admin_password: 'changeme'
 
-# 2019-09-04: UNUSED (due to changes in roles/nextcloud/templates/nextcloud.conf.j2)
-# nextcloud_required_ip: 10.0.0.0/8 192.168.0.0/16
+# 2020-05-09: Not functional but still templated by templates/nextcloud.conf.j2
+nextcloud_required_ip: 10.0.0.0/8 192.168.0.0/16
 
 # 2020-02-15: UNUSED at the time.  Legacy remains from Apache:
 # nextcloud_allow_public_ips: True


### PR DESCRIPTION
Fixes #2399