### PR TITLE
dnsmasq patch for PR #2395

### DIFF
--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,7 +1,7 @@
 #IIAB
 bind-interfaces
 # Wan nameserver if manually set
-{% if wan_nameserver != "" %}
+{% if wan_nameserver != "dhcp" %}
 no-resolv
 server={{ wan_nameserver }}
 {% endif %}

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -173,15 +173,15 @@ user_lan_iface: auto
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 # Ethernet - IF NECESSARY, CUSTOMIZE THESE 4+1 VARS IN /etc/iiab/local_vars.yml
-wan_ip: dhcp       # wan_ip: 192.168.1.99
-wan_netmask:       # wan_netmask: 255.255.255.0
-wan_gateway:       # wan_gateway: 192.168.1.254
+wan_ip: dhcp    # wan_ip: 192.168.1.99
+wan_netmask:    # wan_netmask: 255.255.255.0
+wan_gateway:    # wan_gateway: 192.168.1.254
 # If nec wan_nameserver can override ISP-provided DNS servers via dnsmasq:
 # /etc/resolv.conf dictates which backend is used for the machine itself, so
 # 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
-wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
+wan_nameserver: dhcp    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
 wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 # Details @ roles/network/templates/network/dhcpcd.conf.j2 for /etc/dhcpcd.conf
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -59,7 +59,7 @@ wan_gateway:       # wan_gateway: 192.168.1.254
 # 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
-wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
+wan_nameserver: dhcp    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
 wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -59,7 +59,7 @@ wan_gateway:       # wan_gateway: 192.168.1.254
 # 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
-wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
+wan_nameserver: dhcp    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
 wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -59,7 +59,7 @@ wan_gateway:       # wan_gateway: 192.168.1.254
 # 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
-wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
+wan_nameserver: dhcp    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
 wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # Enable "campus access" to ~10 common IIAB services like Kiwix (3000), KA Lite


### PR DESCRIPTION
Thanks @jvonau, Nzola & @shanti-bhardwa

Example error:

> [127.0.0.1] TASK [1-prep : Install uuid-runtime package (debuntu)] ***********************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"cache_update_time": 1589199254, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'uuid-runtime'' failed: E: Failed to fetch http://raspbian.raspberrypi.org/raspbian/pool/main/u/util-linux/uuid-runtime_2.33.1-0.1_armhf.deb  Temporary failure resolving 'raspbian.raspberrypi.org'\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, "stderr": "E: Failed to fetch http://raspbian.raspberrypi.org/raspbian/pool/main/u/util-linux/uuid-runtime_2.33.1-0.1_armhf.deb  Temporary failure resolving 'raspbian.raspberrypi.org'\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://raspbian.raspberrypi.org/raspbian/pool/main/u/util-linux/uuid-runtime_2.33.1-0.1_armhf.deb  Temporary failure resolving 'raspbian.raspberrypi.org'", "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  uuid-runtime\n0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.\nNeed to get 92.4 kB of archives.\nAfter this operation, 187 kB of additional disk space will be used.\nErr:1 http://raspbian.raspberrypi.org/raspbian buster/main armhf uuid-runtime armhf 2.33.1-0.1\n  Temporary failure resolving 'raspbian.raspberrypi.org'\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  uuid-runtime", "0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.", "Need to get 92.4 kB of archives.", "After this operation, 187 kB of additional disk space will be used.", "Err:1 http://raspbian.raspberrypi.org/raspbian buster/main armhf uuid-runtime armhf 2.33.1-0.1", "  Temporary failure resolving 'raspbian.raspberrypi.org'"]}