### PR TITLE
selective rfkill unblock for raspbian

### DIFF
--- a/roles/network/templates/hostapd/test-wifi
+++ b/roles/network/templates/hostapd/test-wifi
@@ -15,6 +15,10 @@ fi
 # covers raspbian
 if [ -f /etc/wpa_supplicant/wpa_supplicant.conf ]; then
     RASPBIAN=1
+    if /usr/sbin/rfkill list wifi | grep -q "Soft blocked: yes" ; then
+        echo "unblocking WiFi"
+        rfkill unblock wifi
+    fi
     SSID=`grep ssid /etc/wpa_supplicant/wpa_supplicant.conf | awk -F = '{print $2}' | sed -r s/\"// | sed -r s/\"//`
 fi
 


### PR DESCRIPTION
### Fixes Bug
#2265 
### Description of changes proposed in this pull request.
add rfkill unblock for Raspbian.
### Smoke-tested in operating system.
Hand toggling rfkill block wifi and rebooting with current master and wifi_up_down True

This change will not auto unblock with wifi_up_down: False as this service would be disabled.
