### PR TITLE
Try doubling hostapd_wait: to 10 sec, so dnsmasq restart works during IIAB install

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -27,7 +27,7 @@
 # hostapd_enabled: True
 # Above set in /opt/iiab/iiab/vars/default_vars.yml
 
-hostapd_wait: 5
+hostapd_wait: 10
 host_wireless_n: False
 driver_name: nl80211
 ap0_mac_addr: b8:27:99:12:34:56


### PR DESCRIPTION
@jvonau hopes this might solve the error that I (and apparently @shanti-bhardwa also) experienced when installing http://d.iiab.io (IIAB master branch) onto RPi 3 B+:

> TASK [network : User choice of dnsmasq or dhcpd - restarting dnsmasq] **********
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Unable to start service dnsmasq: Job for dnsmasq.service failed because the control process exited with error code.\nSee \"systemctl status dnsmasq.service\" and \"journalctl -xe\" for details.\n"}