### PR TITLE
Rpi detect [for 64-bit RaspiOS]

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -18,7 +18,8 @@
   apt:
     deb: "{{ iiab_download_url }}/usbmount_0.0.14.1_all.deb"
     #timeout: "{{ download_timeout }}"    # Ansible's apt module doesn't support timeout parameter; that's ok as usbmount_0.0.14.1_all.deb is only 10KB
-  when: internet_available and (is_debian_9 or is_debian_10) and not is_raspbian
+  when: internet_available and (is_debian_9 or is_debian_10)
+# and not is_raspbian # handles Pi-OS-64bit
 
 - name: "Install 6 deb/apt packages: avahi-daemon, exfat-fuse, exfat-utils, inetutils-syslogd, libnss-mdns, wpasupplicant (debuntu)"
   package:
@@ -63,4 +64,4 @@
       - usbmount
       - usbutils
       - wget
-    state: present
+    state: latest

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -1,12 +1,13 @@
 # 1. INSTALL MongoDB PACKAGES OR BINARIES
 
-- name: "Install packages: mongodb, mongodb-server (not raspbian)"
+- name: "Install packages: mongodb, mongodb-server (not 32bit ARM)"
   package:
     name:
       - mongodb-server
       - mongodb    # 2019-01-31: this package does not exist on (cannot be installed on) Debian 10, SEE #1437
     state: present
-  when: internet_available and not is_raspbian
+  when: internet_available and ansible_machine.find('armv') == -1
+#  when: internet_available and not is_raspbian
 
 # 2019-02-02: Sugarizer with Node.js 10.x requires MongoDB 2.6+ so
 # https://andyfelong.com/2017/08/mongodb-3-0-14-for-raspbian-stretch/ is
@@ -18,87 +19,9 @@
 # CLARIF: mongodb_stretch_3_0_14_core.zip IS IN FACT 3.0.14 (core) BUT...
 #         mongodb_stretch_3_0_14_tools.zip IS REALLY 3.0.15 (tools)
 
-- name: Create dir /tmp/mongodb-3.0.1x (raspbian)
-  file:
-    path: /tmp/mongodb-3.0.1x
-    state: directory
-  when: internet_available and is_raspbian
-
-- name: Download & unzip 20MB http://download.iiab.io/packages/mongodb_stretch_3_0_14_core.zip to /tmp/mongodb-3.0.1x (raspbian)
-  unarchive:
-    remote_src: yes
-    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_core.zip"
-    dest: /tmp/mongodb-3.0.1x
-  when: internet_available and is_raspbian
-
-- name: Install (move) its 3 CORE binaries from /tmp/mongodb-3.0.1x/core to /usr/bin (raspbian)
-  shell: mv /tmp/mongodb-3.0.1x/core/* /usr/bin
-  when: internet_available and is_raspbian
-
-- name: Download & unzip 15MB http://download.iiab.io/packages/mongodb_stretch_3_0_14_tools.zip [IN FACT THIS ONE'S 3.0.15] to /tmp/mongodb-3.0.1x (raspbian)
-  unarchive:
-    remote_src: yes
-    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_tools.zip"
-    dest: /tmp/mongodb-3.0.1x
-  when: internet_available and is_raspbian
-
-- name: Install (move) its 9 TOOLS binaries from /opt/iiab/downloads/mongodb-3.0.1x/tools to /usr/bin (raspbian)
-  shell: mv /tmp/mongodb-3.0.1x/tools/* /usr/bin
-  when: internet_available and is_raspbian
-
-# OLD WAY / MUCH SLOWER: had put unnec duplicate copies in /opt/iiab/downloads/mongodb-3.0.1x
-#
-#- name: Create dir /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
-#  file:
-#    path: "{{ downloads_dir }}/mongodb-3.0.1x"
-#    state: directory
-#  when: internet_available and is_raspbian
-#
-#- name: Download & unzip MongoDB 3.0.14's 3 core binaries to /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
-#  unarchive:
-#    remote_src: yes
-#    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_core.zip"
-#    dest: "{{ downloads_dir }}/mongodb-3.0.1x"
-#  when: internet_available and is_raspbian
-#
-#- name: Install (copy) 3 binaries from /opt/iiab/downloads/mongodb-3.0.1x/core to /usr/bin (raspbian)
-#  copy:
-#    src: "{{ item }}"
-#    dest: /usr/bin
-#  with_fileglob:
-#    - "{{ downloads_dir }}/mongodb-3.0.1x/core/*"
-#  when: internet_available and is_raspbian
-#
-#- name: Download & unzip MongoDB 3.0.15's 9 tools binaries to /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
-#  unarchive:
-#    remote_src: yes
-#    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_tools.zip"
-#    dest: "{{ downloads_dir }}/mongodb-3.0.1x"
-#  when: internet_available and is_raspbian
-#
-#- name: Install (copy) 9 binaries from /opt/iiab/downloads/mongodb-3.0.1x/tools to /usr/bin (raspbian)
-#  copy:
-#    src: "{{ item }}"
-#    dest: /usr/bin
-#  with_fileglob:
-#    - "{{ downloads_dir }}/mongodb-3.0.1x/tools/*"
-#  when: internet_available and is_raspbian
-
-- name: Create Linux group mongodb (raspbian)
-  group:
-    name: mongodb
-    state: present
-  when: is_raspbian | bool
-
-- name: Create Linux user mongodb (raspbian)
-  user:
-    name: mongodb
-    group: mongodb    # primary group
-    groups: mongodb
-    home: /var/lib/mongodb
-    shell: /usr/sbin/nologin
-  when: is_raspbian | bool
-
+- name: Use tar install for raspbian|ubuntu on 32bit ARM
+  include_tasks: tar-install.yml
+  when: internet_available and ansible_machine.find('armv') != -1
 
 # 2. CONFIGURE MongoDB FOR IIAB
 

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -1,12 +1,12 @@
 # 1. INSTALL MongoDB PACKAGES OR BINARIES
 
-- name: "Install packages: mongodb, mongodb-server (not 32bit ARM)"
+- name: "Install packages: mongodb, mongodb-server (not 32bit ARM) on Ubuntu"
   package:
     name:
       - mongodb-server
       - mongodb    # 2019-01-31: this package does not exist on (cannot be installed on) Debian 10, SEE #1437
     state: present
-  when: internet_available and ansible_machine.find('armv') == -1
+  when: internet_available and ansible_machine.find('armv') == -1 and is_ubuntu
 #  when: internet_available and not is_raspbian
 
 # 2019-02-02: Sugarizer with Node.js 10.x requires MongoDB 2.6+ so

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -31,18 +31,17 @@
 - debug:
     var: is_raspbian
 
-- name: EXIT 'mongodb' ROLE & CONTINUE, IF 'is_debian and not is_raspbian' i.e. TRUE DEBIAN (where MongoDB no longer exists)
+- name: EXIT 'mongodb' ROLE & CONTINUE, IF 'is_debian and arch not armv* i.e. TRUE DEBIAN (where MongoDB no longer exists)
   fail:    # FORCE IT RED THIS ONCE!
     msg: ATTEMPTED MongoDB INSTALLATION WITH (TRUE) DEBIAN, which is no longer supported.  Nevertheless IIAB will continue (consider this a warning!)
-  when: is_debian and not is_raspbian
-  #when: (is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9)    # Test for Debian 10+
+  when: is_debian and ansible_machine.find('armv') == -1
   ignore_errors: yes
 
 # ELSE...
 
-- name: Install/Enable/Disable/Record MongoDB (main2.yml) if is_raspbian or not is_debian, i.e. not True Debian
+- name: Install/Enable/Disable/Record MongoDB (main2.yml) Ubuntu or 32bit armv*
   include_tasks: main2.yml
-  when: is_raspbian or not is_debian
+  when: is_ubuntu or ansible_machine.find('armv') != -1
 
 # THE block: APPROACH BELOW WORKS JUST LIKE main2.yml ABOVE.
 # BUT IT VISUALLY POLLUTES: MANY BLUE "skipping:" MESSAGES IN ANSIBLE'S OUTPUT.

--- a/roles/mongodb/tasks/tar-install.yml
+++ b/roles/mongodb/tasks/tar-install.yml
@@ -1,0 +1,68 @@
+- name: Create dir /tmp/mongodb-3.0.1x (raspbian)
+  file:
+    path: /tmp/mongodb-3.0.1x
+    state: directory
+
+- name: Download & unzip 20MB http://download.iiab.io/packages/mongodb_stretch_3_0_14_core.zip to /tmp/mongodb-3.0.1x (raspbian)
+  unarchive:
+    remote_src: yes
+    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_core.zip"
+    dest: /tmp/mongodb-3.0.1x
+
+- name: Install (move) its 3 CORE binaries from /tmp/mongodb-3.0.1x/core to /usr/bin (raspbian)
+  shell: mv /tmp/mongodb-3.0.1x/core/* /usr/bin
+
+- name: Download & unzip 15MB http://download.iiab.io/packages/mongodb_stretch_3_0_14_tools.zip [IN FACT THIS ONE'S 3.0.15] to /tmp/mongodb-3.0.1x (raspbian)
+  unarchive:
+    remote_src: yes
+    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_tools.zip"
+    dest: /tmp/mongodb-3.0.1x
+
+- name: Install (move) its 9 TOOLS binaries from /opt/iiab/downloads/mongodb-3.0.1x/tools to /usr/bin (raspbian)
+  shell: mv /tmp/mongodb-3.0.1x/tools/* /usr/bin
+
+# OLD WAY / MUCH SLOWER: had put unnec duplicate copies in /opt/iiab/downloads/mongodb-3.0.1x
+#
+#- name: Create dir /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
+#  file:
+#    path: "{{ downloads_dir }}/mongodb-3.0.1x"
+#    state: directory
+#
+#- name: Download & unzip MongoDB 3.0.14's 3 core binaries to /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
+#  unarchive:
+#    remote_src: yes
+#    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_core.zip"
+#    dest: "{{ downloads_dir }}/mongodb-3.0.1x"
+#
+#- name: Install (copy) 3 binaries from /opt/iiab/downloads/mongodb-3.0.1x/core to /usr/bin (raspbian)
+#  copy:
+#    src: "{{ item }}"
+#    dest: /usr/bin
+#  with_fileglob:
+#    - "{{ downloads_dir }}/mongodb-3.0.1x/core/*"
+#
+#- name: Download & unzip MongoDB 3.0.15's 9 tools binaries to /opt/iiab/downloads/mongodb-3.0.1x (raspbian)
+#  unarchive:
+#    remote_src: yes
+#    src: "{{ iiab_download_url }}/mongodb_stretch_3_0_14_tools.zip"
+#    dest: "{{ downloads_dir }}/mongodb-3.0.1x"
+#
+#- name: Install (copy) 9 binaries from /opt/iiab/downloads/mongodb-3.0.1x/tools to /usr/bin (raspbian)
+#  copy:
+#    src: "{{ item }}"
+#    dest: /usr/bin
+#  with_fileglob:
+#    - "{{ downloads_dir }}/mongodb-3.0.1x/tools/*"
+
+- name: Create Linux group mongodb (raspbian)
+  group:
+    name: mongodb
+    state: present
+
+- name: Create Linux user mongodb (raspbian)
+  user:
+    name: mongodb
+    group: mongodb    # primary group
+    groups: mongodb
+    home: /var/lib/mongodb
+    shell: /usr/sbin/nologin


### PR DESCRIPTION
### Fixes Bug
#2422 
### Description of changes proposed in this pull request.
always install fallback usbmount package, mongodb use ansible_machine for 32|64bit split in place of is_raspbian.
### Smoke-tested in operating system.
lightly tested on raspbian with `./runrole --reinstall mongodb`
### Mention a team member for further information or comment using @ name
