### PR TITLE
Fix for #2431: roles/httpd should preserve user www-data in group shadow

### DIFF
--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -100,13 +100,11 @@
 - name: 'Create group: admin'
   group:
     name: admin
-    state: present
 
-- name: Add user {{ apache_user }} (from variable apache_user) to group admin
+- name: Add user {{ apache_user }} (from variable apache_user) to groups admin,shadow
   user:
     name: "{{ apache_user }}"
-    groups: admin
-    state: present
+    groups: admin,shadow    # 2020-06-04: shadow nec for Admin Console login (this line had been clobbering user www-data's membership in group shadow, as set earlier by nginx/tasks/install.yml, SEE #2431)
     createhome: no
 
 - name: Create Apache dir /var/log/{{ apache_service }} ({{ apache_user }}:{{ apache_user }})

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -3,7 +3,7 @@
     #name: [u'apache2', u'php{{ php_version }}', u'php{{ php_version }}-curl']    # FAILS ('u' for Unicode strings)
     #name: ['apache2', 'php{{ php_version }}', 'php{{ php_version }}-curl']       # WORKS?
     name:
-      - apache2
+      - "{{ apache_service }}"    # apache2 on Debuntu
       - "php{{ php_version }}"
       - "php{{ php_version }}-curl"
     state: present
@@ -14,7 +14,7 @@
     #name: [u'apache2', u'php']    # FAILS ('u' for Unicode strings)
     #name: ['apache2', 'php']      # WORKS
     name:
-      - apache2
+      - "{{ apache_service }}"    # apache2 on Debuntu
       - php
     state: present
   when: is_ubuntu | bool
@@ -92,7 +92,7 @@
 - name: Create Apache's pid dir /var/run/{{ apache_user }}
   file:
     state: directory
-    path: "/var/run/{{ apache_user }}"
+    path: "/var/run/{{ apache_user }}"    # www-data on Debuntu
     #owner: root
     #group: root
     #mode: '0755'
@@ -103,15 +103,15 @@
 
 - name: Add user {{ apache_user }} (from variable apache_user) to groups admin,shadow
   user:
-    name: "{{ apache_user }}"
+    name: "{{ apache_user }}"    # www-data on Debuntu
     groups: admin,shadow    # 2020-06-04: shadow nec for Admin Console login (this line had been clobbering user www-data's membership in group shadow, as set earlier by nginx/tasks/install.yml, SEE #2431)
     createhome: no
 
 - name: Create Apache dir /var/log/{{ apache_service }} ({{ apache_user }}:{{ apache_user }})
   file:
     state: directory
-    path: "/var/log/{{ apache_service }}"
-    owner: "{{ apache_user }}"
+    path: "/var/log/{{ apache_service }}"    # apache2 on Debuntu
+    owner: "{{ apache_user }}"    # www-data on Debuntu
     group: "{{ apache_user }}"
     #mode: '0755'
 


### PR DESCRIPTION
Fixes #2431.

Tested on BIG-sized RaspiOS with desktop.

Related: https://github.com/iiab/iiab-admin-console/pull/329