### PR TITLE
RaspiOS mirror flaky, so add another to /etc/apt/sources.list

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -80,6 +80,7 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
         grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
     fi
     if [ -f /etc/rpi-issue ]; then
+        # 2020-06-06: https://www.raspberrypi.org/forums/viewtopic.php?t=276340
         echo -e "\nAdd another apt source/mirror if Raspberry Pi OS, which can be flaky..."
         sed -i '1i deb http://mirror.us.leaseweb.net/raspbian/raspbian buster main contrib non-free rpi' /etc/apt/sources.list
     fi

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -79,6 +79,10 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
         echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
         grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
     fi
+    if [ -f /etc/rpi-issue ]; then
+        echo -e "\nAdd another apt source/mirror if Raspberry Pi OS, which can be flaky..."
+        sed -i '1i deb http://mirror.us.leaseweb.net/raspbian/raspbian buster main contrib non-free rpi' /etc/apt/sources.list
+    fi
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
     echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
     apt update


### PR DESCRIPTION
(Tested on branch release-7.1, so am now adding this to IIAB 7.2 pre-releases as well.)

Emergency patch so IIAB installs can proceed.

As Raspberry Pi OS has effectively been blocking all IIAB installs for ~24h now:
https://www.raspberrypi.org/forums/viewtopic.php?t=276340

Ref: PR #2436