### PR TITLE
scripts/ansible patch for RPi: avoid multiple entries in /etc/apt/sources.list

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -81,8 +81,12 @@ elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
     fi
     if [ -f /etc/rpi-issue ]; then
         # 2020-06-06: https://www.raspberrypi.org/forums/viewtopic.php?t=276340
-        echo -e "\nAdd another apt source/mirror if Raspberry Pi OS, which can be flaky..."
-        sed -i '1i deb http://mirror.us.leaseweb.net/raspbian/raspbian buster main contrib non-free rpi' /etc/apt/sources.list
+        echo -e "\nAdd a mirror to /etc/apt/sources.list if Raspberry Pi OS, which can be flaky..."
+        mv --no-clobber /etc/apt/sources.list /etc/apt/sources.list.old || true
+        echo -e "deb http://mirror.us.leaseweb.net/raspbian/raspbian buster main contrib non-free rpi" > /etc/apt/sources.list
+        echo -e "deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi" >> /etc/apt/sources.list
+        echo -e "# Uncomment line below then 'apt-get update' to enable 'apt-get source'" >> /etc/apt/sources.list
+        echo -e "#deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi" >> /etc/apt/sources.list
     fi
     echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
     echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"


### PR DESCRIPTION
Refines PR #2436 to avoid multiple entries.