### PR TITLE
Calibre-Web 0.6.8 -> master

### DIFF
--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -14,7 +14,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-calibreweb_version: 0.6.8    # WAS: master, 0.6.4, 0.6.5, 0.6.6, 0.6.7
+calibreweb_version: master    # WAS: master, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 0.6.8
 
 calibreweb_venv_path: /usr/local/calibre-web-py3
 calibreweb_exec_path: "{{ calibreweb_venv_path }}/cps.py"


### PR DESCRIPTION
Calibre-Web's master branch is generally very highly QA'd, so let's run with that for now.

This can be changed as part of IIAB 7.2's final release (to a fixed version of Calibre-Web) as necessary.