### PR TITLE
No /etc/network/interfaces.d/iiab [fixes RPi 3 B+, allowing WiFi firmware & hostapd to launch reliably on boot]

### DIFF
--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -41,6 +41,12 @@
     dest: /etc/network/interfaces.d/iiab
     src: network/rpi.j2
     #src: network/iiab.j2    2019-02-05: caused ./iiab-network to fail repeatedly in recent days on one particular RPi 3, even after reboot ("Unable to start service networking: Job for networking.service failed..." at "Restart the networking service if appropriate") ...leaving dnsmasq off (#1452)
+  when: iiab_wired_lan_iface is defined
+
+- name: Use bind-dynamic for dnsmasq
+  template:
+    dest: /etc/dnsmasq.d/dnsmasq-iiab
+    src: network/dnsmasq-iiab
   when: iiab_lan_iface == "br0"
 
 - name: Stopping services
@@ -60,6 +66,7 @@
     name: networking
     enabled: yes
     state: restarted
+  when: iiab_wired_lan_iface is defined
 
 - name: Restart hostapd when WiFi is present but not when using WiFi as gateway 
   systemd:

--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,12 +1,11 @@
 #IIAB
-{% if is_raspbian is true %}
+{% if is_raspbian %}
 bind-dynamic
 {% else %}
 bind-interfaces
 {% endif %}
-
-# Wan nameserver if manually set
 {% if wan_nameserver is not none %}
+# Wan nameserver if manually set
 no-resolv
 server={{ wan_nameserver }}
 {% endif %}

--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,5 +1,10 @@
 #IIAB
+{% if is_raspbian is true %}
+bind-dynamic
+{% else %}
 bind-interfaces
+{% endif %}
+
 # Wan nameserver if manually set
 {% if wan_nameserver is not none %}
 no-resolv


### PR DESCRIPTION
### Fixes bug:
br0 race base on the down and dirty move test, but may impact bluetooth if AP is turned off so there would be no br0 but bluetooth might create it anyway.

