### PR TITLE
RPiOS - use dhcpcd hooks to restart hostapd when br0 appears [for Ubuntu too]

### DIFF
--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -85,23 +85,22 @@
 #- debug:
 #    var: nd_enabled
 
-#- name: Check if /etc/networkd-dispatcher/routable.d exists
-#  stat:
-#    path: /etc/networkd-dispatcher/routable.d
-#  register: nd_dir
+- name: Check if /etc/networkd-dispatcher/routable.d exists
+  stat:
+    path: /etc/networkd-dispatcher/routable.d
+  register: nd_dir
 
 #- debug:
 #    var: nd_dir
 
-#- name: To restart dnsmasq whenever br0 comes up, install /etc/networkd-dispatcher/routable.d/dnsmasq.sh from template (if isn't Appliance, and networkd-dispatcher is enabled, and directory /etc/networkd-dispatcher/routable.d exists, i.e. OS's like Ubuntu 18.04)
-#- name: To restart dnsmasq whenever br0 comes up, install /etc/networkd-dispatcher/routable.d/dnsmasq.sh from template (if isn't Appliance, and directory /etc/networkd-dispatcher/routable.d exists, i.e. OS's like Ubuntu 18.04)
-#  template:
-#    src: roles/network/templates/network/dnsmasq.sh.j2
-#    dest: /etc/networkd-dispatcher/routable.d/dnsmasq.sh
-#    mode: 0755
-#    owner: root
-#    group: root
-#  when: dnsmasq_install and dnsmasq_enabled and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
+- name: To restart dnsmasq whenever br0 comes up, install /etc/networkd-dispatcher/routable.d/dnsmasq.sh from template (if isn't Appliance, and directory /etc/networkd-dispatcher/routable.d exists, i.e. OS's like Ubuntu 18.04 or later)
+  template:
+    src: roles/network/templates/network/dnsmasq.sh.j2
+    dest: /etc/networkd-dispatcher/routable.d/dnsmasq.sh
+    mode: 0755
+    owner: root
+    group: root
+  when: dnsmasq_install and dnsmasq_enabled and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and nd_enabled is defined and nd_enabled.stdout == "enabled" and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and systemd_out.status.UnitFileState == "enabled" and networkd_dir.stat.exists and networkd_dir.stat.isdir and (iiab_network_mode != "Appliance")
 

--- a/roles/network/templates/hostapd/50-hostapd
+++ b/roles/network/templates/hostapd/50-hostapd
@@ -1,6 +1,7 @@
 if [ "$interface" = "br0" ] && [ $if_up = "true" ]; then
+    syslog info "50-iiab IF_UP br0 restarting dnsmasq"
     sleep 2
-    systemctl restart dnsmasq
+    systemctl --no-block restart dnsmasq
 fi
 
 if [ "$interface" = "wlan0" ]; then

--- a/roles/network/templates/hostapd/50-hostapd
+++ b/roles/network/templates/hostapd/50-hostapd
@@ -1,3 +1,7 @@
+if [ "$interface" = "br0" ] && [ $if_up = "true" ]; then
+    sleep 2
+    systemctl restart dnsmasq
+fi
 
 if [ "$interface" = "wlan0" ]; then
     REASON="$reason"

--- a/roles/network/templates/network/dnsmasq.sh.j2
+++ b/roles/network/templates/network/dnsmasq.sh.j2
@@ -3,5 +3,5 @@
 if [ "$IFACE" == "{{ iiab_lan_iface }}" ]; then
     echo "Restarting dnsmasq in 5 seconds"
     /bin/sleep 5 && /bin/systemctl --no-block restart dnsmasq.service
-    echo "Restarting dnsmasq"
+    echo "Restarted dnsmasq"
 fi


### PR DESCRIPTION
### Fixes bug:
on skype - if you stop and later start hostapd by hand, dnsmasq should be restarted once the bridge re-appears with an ip address. This removes the need to manually restart dnsmasq and should be better at dealing with bluetooth as the only device under the bridge.