### PR TITLE
RFC Firmware downgrading [WiFi hotspot capacity workaround, for Raspberry Pi]

### DIFF
--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -1,0 +1,23 @@
+# check the timestamps, might want to preserve the old ones
+- name: Backup OS provided Firmware
+  copy:
+    src: "/lib/firmware/brcm/{{ item }}"
+    dest: "/lib/firmware/brcm/{{ item }}.orig"
+  with_items:
+    - brcmfmac43430-sdio.bin
+    - brcmfmac43455-sdio.bin
+
+# grab the old firmware
+- name: Retrieve older firmware
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2020-02-16_7.45.98.97' dest:/lib/firmware/brcm/brcmfmac43430-sdio.bin_iiab } 
+    - { url: 'http://download.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1' dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin_iiab' } 
+
+- name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^RPi_firmware_retrieved'
+    line: 'RPi_firmware_retrieved: True'

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -13,8 +13,8 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2020-02-16_7.45.98.97' dest:/lib/firmware/brcm/brcmfmac43430-sdio.bin_iiab } 
-    - { url: 'http://download.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1' dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin_iiab' } 
+    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2020-02-16_7.45.98.97' dest:/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab }
+    - { url: 'http://download.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1' dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
 
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
   lineinfile:

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -6,6 +6,7 @@
   with_items:
     - brcmfmac43430-sdio.bin
     - brcmfmac43455-sdio.bin
+    - brcmfmac43455-sdio.clm_blob
 
 # grab the old firmware
 - name: Retrieve older firmware
@@ -16,6 +17,7 @@
     - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
+    - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.clm_blob_2018-02-26_rpi', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab' }
 
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
   lineinfile:

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -13,7 +13,7 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2020-02-16_7.45.98.97' dest:/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab }
+    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65' dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
     - { url: 'http://download.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1' dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
 
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -13,8 +13,9 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { url: 'http://download.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65' dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
-    - { url: 'http://download.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1' dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
+    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }
+    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
+    - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
 
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
   lineinfile:

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: "{{ item.dest }}"
     mode: "{{ item.mode }}"
   with_items:
-    - { src: 'fw-warn.sh', dest: '/usr/sbin/', mode: '0644' }
+    - { src: 'fw_warn.sh', dest: '/etc/profile.d/', mode: '0644' }
     - { src: 'check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
     - { src: 'check-firmware.sh', dest: '/usr/sbin/', mode: '0755' }
 

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Include older RPi Firmware
+  include_tasks: install.yml
+  when: RPi_firmware_retrieved is undefined
+
+- name: Install check-firmware service files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
+  with_items:
+    - { src: 'fw-warn.sh', dest: '/usr/sbin/' mode: '0644' }
+    - { src: 'check-firmware.service', dest: '/etc/systemd/system/' mode: '0644'}
+    - { src: 'check-firmware.sh', dest: '/usr/sbin/' mode: '0755' }
+
+- name: Enable and Start check-firmware.service
+  systemd:
+    name: check-firmware.service
+    state: reloaded    
+    enabled: yes
+    status: started

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -10,7 +10,7 @@
   with_items:
     - { src: 'fw-warn.sh', dest: '/usr/sbin/', mode: '0644' }
     - { src: 'check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
-    - { src: 'check-firmware.sh', dest: '/usr/sbin/' mode: '0755' }
+    - { src: 'check-firmware.sh', dest: '/usr/sbin/', mode: '0755' }
 
 - name: Enable and Start check-firmware.service
   systemd:

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -9,7 +9,7 @@
     mode: "{{ item.mode }}"
   with_items:
     - { src: 'fw-warn.sh', dest: '/usr/sbin/', mode: '0644' }
-    - { src: 'check-firmware.service', dest: '/etc/systemd/system/' mode: '0644'}
+    - { src: 'check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
     - { src: 'check-firmware.sh', dest: '/usr/sbin/' mode: '0755' }
 
 - name: Enable and Start check-firmware.service

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: "{{ item.dest }}"
     mode: "{{ item.mode }}"
   with_items:
-    - { src: 'fw-warn.sh', dest: '/usr/sbin/' mode: '0644' }
+    - { src: 'fw-warn.sh', dest: '/usr/sbin/', mode: '0644' }
     - { src: 'check-firmware.service', dest: '/etc/systemd/system/' mode: '0644'}
     - { src: 'check-firmware.sh', dest: '/usr/sbin/' mode: '0755' }
 

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -15,6 +15,6 @@
 - name: Enable and Start check-firmware.service
   systemd:
     name: check-firmware.service
-    state: reloaded    
+    daemon_reload: yes
+    state: restarted
     enabled: yes
-    status: started

--- a/roles/firmware/templates/check-firmware.service
+++ b/roles/firmware/templates/check-firmware.service
@@ -4,7 +4,7 @@ Before=clone-wifi.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/check-firmware
+ExecStart=/usr/sbin/check-firmware.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/firmware/templates/check-firmware.service
+++ b/roles/firmware/templates/check-firmware.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check Firmware service
+Before=clone-wifi.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/check-firmware
+
+[Install]
+WantedBy=multi-user.target
+

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -38,6 +38,8 @@ if [ "$WARN" = "1" ]; then
     #echo "rebooting..."
     #reboot
 else
-    rm /.fw_replaced
+    if [ -f /.fw_replaced ]; then
+        rm /.fw_replaced
+    fi
 fi
 exit 0

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -33,11 +33,13 @@ else
     fi
 fi
 if [ "$WARN" = "1" ]; then
-    echo "You should reboot now"
+    echo -e " \033[31;5mFirmware has been replaced\033[0m"
+    echo -e " \033[31;5mReboot is required to activate\033[0m"
     touch /.fw_replaced
     #echo "rebooting..."
     #reboot
 else
+    echo -e " Firmware check \033[32;5mPASSED\033[0m"
     if [ -f /.fw_replaced ]; then
         rm /.fw_replaced
     fi

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -12,6 +12,7 @@ else
     fi
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin); then
         cp /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
+        cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
         echo "replacing firmware"
         WARN=1
     fi

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -7,15 +7,25 @@ else
     echo "$FW_MODE"
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin); then
         cp /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
+        echo "replacing firmware"
         WARN=1
     fi
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin); then
         cp /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
+        echo "replacing firmware"
+        WARN=1
+    fi
+    if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob); then
+        cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
+        echo "replacing firmware"
         WARN=1
     fi
 fi
-if [ "$WARN" = "1" ]
+if [ "$WARN" = "1" ]; then
+    echo "You should reboot now"
     touch /.fw_replaced
+    #echo "rebooting..."
+    #reboot
 else
     rm /.fw_replaced
 fi

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+FW_MODE=$(grep wifi_hotspot_capacity_rpi_fix /etc/iiab/local_vars.yml| grep True)
+WARN=0
+if [ -z "$FW_MODE" ]; then
+    echo "FW marker not found"
+else
+    echo "$FW_MODE"
+    if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin); then
+        cp /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
+        WARN=1
+    fi
+    if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin); then
+        cp /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
+        WARN=1
+    fi
+fi
+if [ "$WARN" = "1" ]
+    touch /.fw_replaced
+else
+    rm /.fw_replaced
+fi
+exit 0

--- a/roles/firmware/templates/check-firmware.sh
+++ b/roles/firmware/templates/check-firmware.sh
@@ -1,22 +1,32 @@
 #!/bin/bash
 FW_MODE=$(grep wifi_hotspot_capacity_rpi_fix /etc/iiab/local_vars.yml| grep True)
 WARN=0
+DATE=$(date +%F-%T)
 if [ -z "$FW_MODE" ]; then
     echo "FW marker not found"
 else
     echo "$FW_MODE"
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin); then
+        mv /lib/firmware/brcm/brcmfmac43455-sdio.bin /lib/firmware/brcm/brcmfmac43455-sdio.bin.$DATE
         cp /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
         echo "replacing firmware"
         WARN=1
     fi
+    if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob); then
+        mv /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.$DATE
+        cp /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
+        echo "replacing firmware"
+        WARN=1
+    fi
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin); then
+        mv /lib/firmware/brcm/brcmfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.bin.$DATE
         cp /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
         cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
         echo "replacing firmware"
         WARN=1
     fi
     if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob); then
+        mv /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.$DATE
         cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
         echo "replacing firmware"
         WARN=1

--- a/roles/firmware/templates/fw_warn.sh
+++ b/roles/firmware/templates/fw_warn.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -f /.fw_replaced ]; then
+    echo -e " \033[31;5mFirmware has been replaced\033[0m"
+    echo -e " \033[31;5mReboot is required to activate\033[0m"
+fi
+

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Select RPi firmware mode
+  include_role:
+    name: firmware
+  when: rpi_model != "none"
+
 - name: detected_network
   include_tasks: detected_network.yml
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -95,7 +95,10 @@ hostapd_secure: False
 hostapd_password: changeme
 hostapd_install: True    # 2020-01-21: this var MIGHT be implemented in future.
 hostapd_enabled: True
-wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
+# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
+# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
+wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 # You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -46,7 +46,10 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
+# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
+# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
+wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 # You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -46,7 +46,10 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
+# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
+# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
+wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 # You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -46,7 +46,10 @@ host_wifi_mode: g
 host_channel: 6
 hostapd_secure: False
 hostapd_password: changeme
-wifi_up_down: True    # Creates a 2nd virtual wifi adapter for upstream WiFi
+wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
+# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
+# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
+wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 # You can set iiab_gateway_enabled below, to enable "passthrough" to Internet.
 


### PR DESCRIPTION
only forces downgrade with no provisions to undo the rolling back of the firmware.