### PR TITLE
New pastebin service for iiab-diagnostics, as dpaste.com stopped working

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -234,10 +234,11 @@ read ans < /dev/tty
 echo -e "\e[1m"
 if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
     echo -ne "PUBLISHING TO URL... "
-    pastebinit -b dpaste.com < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
+    #pastebinit -b dpaste.com < $outfile
+    pastebinit -b sprunge.us < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
 else
     echo -e "If you later decide to publish it, run:"
     echo
-    echo -e "   pastebinit -b dpaste.com < $outfile"
+    echo -e "   pastebinit -b sprunge.us < $outfile"
 fi
 echo -e "\e[0m"

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -62,4 +62,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 105-218 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 106-218 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -49,7 +49,7 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
    Or, you can later/manually upload it using the ``pastebinit`` command:
 
    ```
-   pastebinit -b dpaste.com < /etc/iiab/diag/NEW-FILE-NAME
+   pastebinit -b sprunge.us < /etc/iiab/diag/NEW-FILE-NAME
    ```
 
    Either way, this will generate an actual web link (URL).


### PR DESCRIPTION
Results can be viewed in browser using http://sprunge.us/AaBbCc?en if you don't want to download using http://sprunge.us/AaBbCc

Where AsBbCc is auto-generated by the new pastebin service we're trying out for `/usr/bin/iiab-diagnostics`

Doc @ https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md