### PR TITLE
Dual WiFi WARNING: 5 GHz connection from internal WiFi to Internet...ends up sabotaging legacy WiFi client devices that require 2.4GHz !

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -84,8 +84,12 @@ iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
 # Internal Wi-Fi Access Point
-# Values are used if there is an internal Wi-Fi adapter and hostapd is enabled
-# The platform variable adapts install to specific hardware (raspberry pi=rpi2)
+# Values are used if there is an internal Wi-Fi adapter and hostapd is enabled.
+#
+# WARNING: If you connect your IIAB's internal WiFi to the Internet over 5 GHz,
+# you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
+# from connecting to your IIAB's internal hotspot!  BAD IDEA (:
+#
 # Raspbian req WiFi country since March 2018.  CHANGE IT IN /etc/iiab/local_vars.yml
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -39,6 +39,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: If you connect your IIAB's internal WiFi to the Internet over 5 GHz,
+# you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
+# from connecting to your IIAB's internal hotspot!  BAD IDEA (:
+#
 # Raspbian requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -39,6 +39,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: If you connect your IIAB's internal WiFi to the Internet over 5 GHz,
+# you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
+# from connecting to your IIAB's internal hotspot!  BAD IDEA (:
+#
 # Raspbian requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -39,6 +39,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: If you connect your IIAB's internal WiFi to the Internet over 5 GHz,
+# you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
+# from connecting to your IIAB's internal hotspot!  BAD IDEA (:
+#
 # Raspbian requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"


### PR DESCRIPTION
Thanks @jvonau for reviewing this verbiage/warning if poss.

Background: Willem in South Africa got stuck...when his phone could connect to IIAB's internal hotspot but his older laptop could not.  A big thank you to @jvonau for figuring out why this was happening!