### PR TITLE
Raspbian renamed to Raspberry Pi OS / RaspiOS: so clean up IIAB's default_vars.yml & its 3 main local_vars.yml files [& rename 'RPi_firmware_retrieved' to 'rpi_firmware_downloaded' & in-line documentation refined]

### DIFF
--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -22,5 +22,5 @@
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-    regexp: '^RPi_firmware_retrieved'
-    line: 'RPi_firmware_retrieved: True'
+    regexp: '^rpi_firmware_downloaded'
+    line: 'rpi_firmware_downloaded: True'

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -1,5 +1,5 @@
 # check the timestamps, might want to preserve the old ones
-- name: Backup OS-provided firmware (for RPi's internal WiFi)
+- name: Back up OS-provided firmware (for RPi's internal WiFi)
   copy:
     src: "/lib/firmware/brcm/{{ item }}"
     dest: "/lib/firmware/brcm/{{ item }}.orig"

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -1,5 +1,5 @@
 # check the timestamps, might want to preserve the old ones
-- name: Backup OS provided Firmware
+- name: Backup OS-provided firmware (for RPi's internal WiFi)
   copy:
     src: "/lib/firmware/brcm/{{ item }}"
     dest: "/lib/firmware/brcm/{{ item }}.orig"
@@ -8,16 +8,22 @@
     - brcmfmac43455-sdio.bin
     - brcmfmac43455-sdio.clm_blob
 
-# grab the old firmware
-- name: Retrieve older firmware
+- name: Download older firmware (for RPi high-capacity internal WiFi)
   get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
+    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.clm_blob_2018-02-26_rpi', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab' }
+
+
+# RECORD RPi Firmware AS DOWNLOADED
+
+- name: "Set 'rpi_firmware_downloaded: True'"
+  set_fact:
+    rpi_firmware_downloaded: True
 
 - name: "Add 'firmware_retrieved: True' to {{ iiab_state_file }}"
   lineinfile:

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Include older RPi Firmware
   include_tasks: install.yml
-  when: RPi_firmware_retrieved is undefined
+  when: rpi_firmware_downloaded is undefined
 
 - name: Install check-firmware service files
   template:

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Backup/Download firmware (for RPi internal WiFi)
+- name: Back up/Download firmware (for RPi internal WiFi)
   include_tasks: install.yml
   when: rpi_firmware_downloaded is undefined
 

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -1,18 +1,18 @@
-- name: Include older RPi Firmware
+- name: Backup/Download firmware (for RPi internal WiFi)
   include_tasks: install.yml
   when: rpi_firmware_downloaded is undefined
 
-- name: Install check-firmware service files
+- name: 'Install from template: check-firmware.service, check-firmware.sh & fw_warn.sh'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: "{{ item.mode }}"
   with_items:
-    - { src: 'fw_warn.sh', dest: '/etc/profile.d/', mode: '0644' }
     - { src: 'check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
     - { src: 'check-firmware.sh', dest: '/usr/sbin/', mode: '0755' }
+    - { src: 'fw_warn.sh', dest: '/etc/profile.d/', mode: '0644' }
 
-- name: Enable and Start check-firmware.service
+- name: Enable & (Re)start check-firmware.service
   systemd:
     name: check-firmware.service
     daemon_reload: yes

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -90,7 +90,7 @@ iiab_home_url: /home
 # you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
 # from connecting to your IIAB's internal hotspot!  BAD IDEA (:
 #
-# Raspbian req WiFi country since March 2018.  CHANGE IT IN /etc/iiab/local_vars.yml
+# Raspberry Pi OS requires WiFi country -- SET THIS IN /etc/iiab/local_vars.yml
 host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
@@ -185,7 +185,7 @@ wan_netmask:       # wan_netmask: 255.255.255.0
 wan_gateway:       # wan_gateway: 192.168.1.254
 # If nec wan_nameserver can override ISP-provided DNS servers via dnsmasq:
 # /etc/resolv.conf dictates which backend is used for the machine itself, so
-# 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
+# 127.0.0.1 means you get dnsmasq (so it works right away on RaspiOS) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
 wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1
@@ -697,7 +697,7 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 # Works" ~30 lines below, and https://github.com/iiab/iiab/wiki/IIAB-Platforms
 
 # Wide to narrow (insofar as poss)
-is_debuntu: False    # Covers all 3: Ubuntu, Debian, Raspbian
+is_debuntu: False    # Covers all 3: Ubuntu, Debian, Raspbian (Raspberry Pi OS)
 
 is_ubuntu: False
 is_ubuntu_20: False
@@ -706,12 +706,12 @@ is_ubuntu_18: False
 is_ubuntu_17: False
 is_ubuntu_16: False
 
-is_debian: False    # Covers both: Debian, Raspbian
+is_debian: False    # Covers both: Debian, Raspbian (Raspberry Pi OS)
 is_debian_10: False
 is_debian_9: False
 is_debian_8: False
 
-is_raspbian: False    # Covers RPi HW and non-RPi HW versions of Raspbian
+is_raspbian: False    # Covers both: RPi HW + non-RPi HW versions of Raspbian (Raspberry Pi OS)
 is_raspbian_10: False
 is_raspbian_9: False
 is_raspbian_8: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -43,7 +43,7 @@ iiab_home_url: /home
 # you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
 # from connecting to your IIAB's internal hotspot!  BAD IDEA (:
 #
-# Raspbian requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
@@ -63,7 +63,7 @@ wan_netmask:       # wan_netmask: 255.255.255.0
 wan_gateway:       # wan_gateway: 192.168.1.254
 # If nec wan_nameserver can override ISP-provided DNS servers via dnsmasq:
 # /etc/resolv.conf dictates which backend is used for the machine itself, so
-# 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
+# 127.0.0.1 means you get dnsmasq (so it works right away on RaspiOS) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
 wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -43,7 +43,7 @@ iiab_home_url: /home
 # you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
 # from connecting to your IIAB's internal hotspot!  BAD IDEA (:
 #
-# Raspbian requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
@@ -63,7 +63,7 @@ wan_netmask:       # wan_netmask: 255.255.255.0
 wan_gateway:       # wan_gateway: 192.168.1.254
 # If nec wan_nameserver can override ISP-provided DNS servers via dnsmasq:
 # /etc/resolv.conf dictates which backend is used for the machine itself, so
-# 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
+# 127.0.0.1 means you get dnsmasq (so it works right away on RaspiOS) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
 wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -43,7 +43,7 @@ iiab_home_url: /home
 # you'll end up preventing older laptops/phones/tablets (which require 2.4 GHz)
 # from connecting to your IIAB's internal hotspot!  BAD IDEA (:
 #
-# Raspbian requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"
 host_wifi_mode: g
@@ -63,7 +63,7 @@ wan_netmask:       # wan_netmask: 255.255.255.0
 wan_gateway:       # wan_gateway: 192.168.1.254
 # If nec wan_nameserver can override ISP-provided DNS servers via dnsmasq:
 # /etc/resolv.conf dictates which backend is used for the machine itself, so
-# 127.0.0.1 means you get dnsmasq (so it works right away on Raspbian) while
+# 127.0.0.1 means you get dnsmasq (so it works right away on RaspiOS) while
 # 127.0.0.53 gives you systemd-networkd (so Ubuntu itself does NOT use this
 # dnsmasq-specified upstream DNS [e.g. wan_nameserver] but its LAN clients do!)
 wan_nameserver:    # wan_nameserver: 192.168.1.254 or 8.8.8.8 or 1.1.1.1


### PR DESCRIPTION
Building on PR's #2472 & #2477.