### PR TITLE
iiab-diagnostics: relabel Raspbian as "Raspberry Pi OS"

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -119,13 +119,13 @@ cat_file /etc/rpi-issue
 echo "-IIAB-EXPLANATION-OF-THE-ABOVE-------------------------------------------------" >> $outfile
 echo >> $outfile
 if [ -f /etc/rpi-issue ]; then
-    echo "stage2 = Raspbian Lite" >> $outfile
-    echo "stage4 = Raspbian With Desktop" >> $outfile
-    echo "stage5 = Raspbian With Desktop + Recommended Software" >> $outfile
+    echo "stage2 = Raspberry Pi OS Lite" >> $outfile
+    echo "stage4 = Raspberry Pi OS with desktop" >> $outfile
+    echo "stage5 = Raspberry Pi OS with desktop + recommended software" >> $outfile
     echo >> $outfile
     echo "SEE https://github.com/RPi-Distro/pi-gen#stage-anatomy" >> $outfile
 else
-    echo "(This is NOT Raspbian!)" >> $outfile
+    echo "(This is NOT Raspberry Pi OS!)" >> $outfile
 fi
 echo >> $outfile
 cat_file /etc/issue.net


### PR DESCRIPTION
No functional changes...this brings the output of command 'iiab-diagnostics' up-to-date with the new name of the OS at https://www.raspberrypi.org/downloads/raspberry-pi-os/