### PR TITLE
7.2 maps [OSM]

### DIFF
--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -6,12 +6,14 @@
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
-#osm_map_url: https://github.com/iiab/maps/raw/master
-# for testing, use the new unpublished version of regions.json
-#osm_repo_url: https://raw.githubusercontent.com/iiab/maps
-osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
+
+# The following soft coded variables allow testing, before pulling PR's into master
+osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+#osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
+maps_branch: 'master'
+#maps_branch: '7.2-maps'
+
+# soft code sources
 archive_org_url: https://archive.org/download
-satellite_version: satellite_z0-z9_v3.mbtiles
-#maps_branch: 'master'
-maps_branch: '7.2-maps'
 map_catalog_url: http://download.iiab.io/content/OSM/vector-tiles
+satellite_version: satellite_z0-z9_v3.mbtiles

--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -8,8 +8,10 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 #osm_map_url: https://github.com/iiab/maps/raw/master
 # for testing, use the new unpublished version of regions.json
-osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+#osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
 archive_org_url: https://archive.org/download
 satellite_version: satellite_z0-z9_v3.mbtiles
-maps_branch: 'master'
+#maps_branch: 'master'
+maps_branch: '7.2-maps'
 map_catalog_url: http://download.iiab.io/content/OSM/vector-tiles

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -74,7 +74,6 @@
      dest: '{{ vector_map_path }}/viewer/'
   with_items:
       - mbtileinfo.php
-      - ol-contextmenu.css
       - popup.css
       - searchapi.php
       - tileserver.php
@@ -119,6 +118,7 @@
       - countries.json
       - fonts.css
       - ol5-layerswitcher.css
+      - ol-contextmenu.css
       - pin_drop.png
       - sprite@2x.json
       - sprite@2x.png
@@ -170,7 +170,7 @@
 
 - name: Copy a scripts to download tiles
   get_url:
-      url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/{{ item }}"
+      url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/scripts/{{ item }}"
       dest: /usr/bin/
       mode: 0755
   with_items:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -118,7 +118,9 @@
       - countries.json
       - fonts.css
       - ol5-layerswitcher.css
+      - ol5-layerswitcher.js
       - ol-contextmenu.css
+      - ol-contextmenu.js
       - pin_drop.png
       - sprite@2x.json
       - sprite@2x.png

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -49,13 +49,13 @@
     dest: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
-- name: Download the JavaScript bundle with OpenLayers (main.js) for test page http://box/maps/maplist
+- name: Download the JavaScript bundle with OpenLayers (test-page-bundle.js) for test page http://box/maps/maplist
 # At this point, fetches from github.com/georgejhunt/maps from test branch
   get_url:
     url: "{{ item }}"
     dest: '{{ vector_map_path }}/test-page/'
   with_items:
-    - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/main.js"
+    - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/test-page-bundle.js"
     - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/index.html"
 
 - name: Fetch the javascript bundle with openlayers for Viewer page
@@ -65,8 +65,8 @@
      dest: '{{ vector_map_path }}/viewer/'
   with_items:
       - index.html
-      - main.js
-      - main.js.map
+      - viewer-bundle.js
+      - viewer-bundle.js.map
 
 - name: Get the helper files for viewer
   get_url:
@@ -95,7 +95,7 @@
     dest: '{{ vector_map_path }}/installer/'
   with_items:
       - index.html
-      - main.js
+      - installer-bundle.js
 
 - name: Fetch the action routines for installer
   get_url:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -117,10 +117,8 @@
       - center.png
       - countries.json
       - fonts.css
-      - ol5-layerswitcher.css
-      - ol5-layerswitcher.js
+      - ol-layerswitcher.css
       - ol-contextmenu.css
-      - ol-contextmenu.js
       - pin_drop.png
       - sprite@2x.json
       - sprite@2x.png

--- a/roles/osm-vector-maps/tasks/nginx.yml
+++ b/roles/osm-vector-maps/tasks/nginx.yml
@@ -2,13 +2,14 @@
   template:
     src: osm-vector-maps-nginx.conf.j2
     dest: "{{ nginx_conf_dir }}/osm-vector-maps-nginx.conf"    # /etc/nginx/conf.d
-  when: osm_vector_maps_enabled | bool
+  when: osm_vector_maps_install | bool
+# Note that the above change from enabled->install is required by the OSM command line installer
 
 - name: Disable http://box/maps & http://box/osm-vector-maps via NGINX, by removing {{ nginx_conf_dir }}/osm-vector-maps-nginx.conf
   file:
     path: "{{ nginx_conf_dir }}/osm-vector-maps-nginx.conf"    # /etc/nginx/conf.d
     state: absent
-  when: not osm_vector_maps_enabled
+  when: not osm_vector_maps_install
 
 - name: Reload 'nginx' systemd service
   systemd:

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -297,7 +297,7 @@ moodle_enabled: True
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
-osm_vector_maps_enabled: True
+osm_vector_maps_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -297,7 +297,7 @@ moodle_enabled: False
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
-osm_vector_maps_enabled: True
+osm_vector_maps_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -297,7 +297,7 @@ moodle_enabled: False
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
-osm_vector_maps_enabled: True
+osm_vector_maps_enabled: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957


### PR DESCRIPTION
Change defaults such that small, medium, large local_vars.yml do not download tiles. 
Change viewer to examine viewer/tiles/ and redirect to installer if no tiles are present.
Change main.js to <function>_bundles.js as output names for webpack.