### PR TITLE
MariaDB [rework security, eliminate {{ mysql_root_password }}]

### DIFF
--- a/roles/elgg/tasks/setup.yml
+++ b/roles/elgg/tasks/setup.yml
@@ -10,8 +10,8 @@
     password: "{{ dbpassword }}"
     priv: "{{ dbname }}.*:ALL"
   with_items:
-    - 127.0.0.1
-    - ::1
+#    - 127.0.0.1
+#    - ::1
     - localhost
 
 - name: Create /tmp/elggdb.sql from template, to load database

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,9 +1,0 @@
-# MySQL MANDATORY - THESE 2 VARS HAVE NO EFFECT - SEE roles/0-init/tasks/main.yml & roles/mysql/tasks/main.yml
-# mysql_install: True
-# mysql_enabled: True
-
-## mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0
-# mysql_root_password: fixmysql
-
-# All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
-# If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -129,15 +129,15 @@
 #    user: ""
 #    state: absent
 
-- name: Create MySQL root password for root accounts on (127.0.0.1, ::1)
-  mysql_user:
-    name: root
-    host: "{{ item }}"
-    password: "{{ mysql_root_password }}"
-    priv: "*.*:ALL,GRANT"
-  with_items:
-    - 127.0.0.1
-    - ::1
+#- name: Create MySQL root password for root accounts on (127.0.0.1, ::1)
+#  mysql_user:
+#    name: root
+#    host: "{{ item }}"
+#    password: "{{ mysql_root_password }}"
+#    priv: "*.*:ALL,GRANT"
+#  with_items:
+#    - 127.0.0.1
+#    - ::1
 
 
 # RECORD MySQL AS INSTALLED

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -113,21 +113,21 @@
     owner: root
     mode: '0600'
 
-- name: Remove the MySQL 'test' database
-  mysql_db:
-    db: test
-    state: absent
+#- name: Remove the MySQL 'test' database
+#  mysql_db:
+#    db: test
+#    state: absent
 
-- name: Delete anonymous MySQL server user for {{ ansible_hostname }}
-  mysql_user:
-    user: ""
-    host: "{{ ansible_hostname }}"
-    state: absent
+#- name: Delete anonymous MySQL server user for {{ ansible_hostname }}
+#  mysql_user:
+#    user: ""
+#    host: "{{ ansible_hostname }}"
+#    state: absent
 
-- name: Delete anonymous MySQL server user for localhost
-  mysql_user:
-    user: ""
-    state: absent
+#- name: Delete anonymous MySQL server user for localhost
+#  mysql_user:
+#    user: ""
+#    state: absent
 
 - name: Create MySQL root password for root accounts on (127.0.0.1, ::1)
   mysql_user:

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -106,6 +106,22 @@
     daemon_reload: yes
     state: restarted
 
+- name: Remove the MySQL 'test' database
+  mysql_db:
+    db: test
+    state: absent
+
+- name: Delete anonymous MySQL server user for {{ ansible_hostname }}
+  mysql_user:
+    user: ""
+    host: "{{ ansible_hostname }}"
+    state: absent
+
+- name: Delete anonymous MySQL server user for localhost
+  mysql_user:
+    user: ""
+    state: absent
+
 - name: Install /root/.my.cnf file from template, with root password credentials
   template:
     src: my.cnf.j2
@@ -133,22 +149,6 @@
     #- "{{ iiab_hostname }}.{{ iiab_domain }}"
     - 127.0.0.1
     - ::1
-
-- name: Delete anonymous MySQL server user for {{ ansible_hostname }}
-  mysql_user:
-    user: ""
-    host: "{{ ansible_hostname }}"
-    state: absent
-
-- name: Delete anonymous MySQL server user for localhost
-  mysql_user:
-    user: ""
-    state: absent
-
-- name: Remove the MySQL 'test' database
-  mysql_db:
-    db: test
-    state: absent
 
 
 # RECORD MySQL AS INSTALLED

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -106,6 +106,13 @@
     daemon_reload: yes
     state: restarted
 
+- name: Install /root/.my.cnf file from template, with root password credentials
+  template:
+    src: my.cnf.j2
+    dest: /root/.my.cnf
+    owner: root
+    mode: '0600'
+
 - name: Remove the MySQL 'test' database
   mysql_db:
     db: test
@@ -122,31 +129,13 @@
     user: ""
     state: absent
 
-- name: Install /root/.my.cnf file from template, with root password credentials
-  template:
-    src: my.cnf.j2
-    dest: /root/.my.cnf
-    owner: root
-    mode: '0600'
-
-# 'localhost' needs to be the last item for idempotency, see
-# http://ansible.cc/docs/modules.html#mysql-user
-# unfortunately it still doesn't work
-- name: Update MySQL root password for localhost root accounts
-  mysql_user:
-    name: root
-    host: localhost
-    password: "{{ mysql_root_password }}"
-    priv: "*.*:ALL,GRANT"
-
-- name: Update MySQL root password for all remaining root accounts (127.0.0.1, ::1)
+- name: Create MySQL root password for root accounts on (127.0.0.1, ::1)
   mysql_user:
     name: root
     host: "{{ item }}"
     password: "{{ mysql_root_password }}"
     priv: "*.*:ALL,GRANT"
   with_items:
-    #- "{{ iiab_hostname }}.{{ iiab_domain }}"
     - 127.0.0.1
     - ::1
 

--- a/roles/mysql/templates/my.cnf.j2
+++ b/roles/mysql/templates/my.cnf.j2
@@ -1,4 +1,4 @@
 [client]
-user=root
-password={{ mysql_root_password }}
-socket=/run/mysqld/mysqld.sock
+user     = root
+password =
+socket   = /run/mysqld/mysqld.sock

--- a/roles/nextcloud/tasks/setup.yml
+++ b/roles/nextcloud/tasks/setup.yml
@@ -9,8 +9,8 @@
     password: "{{ nextcloud_dbpassword }}"
     priv: "{{ nextcloud_dbname }}.*:ALL,GRANT"
   with_items:
-    - 127.0.0.1
-    - ::1
+#    - 127.0.0.1
+#    - ::1
     - localhost
 
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -49,9 +49,9 @@
     name: "{{ asterisk_db_user }}"
     password: "{{ asterisk_db_password }}"
     priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
-    login_host: "{{ asterisk_db_host }}"
-    login_user: "root"
-    login_password: "{{ mysql_root_password }}"
+#    login_host: "{{ asterisk_db_host }}"
+#    login_user: "root"
+#    login_password: "{{ mysql_root_password }}"
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_default_ipv4.address) }}"
     state: present
 
@@ -60,9 +60,9 @@
     name: "{{ asterisk_db_dbname }}"
     encoding: utf8
     collation: utf8_general_ci
-    login_host: "{{ asterisk_db_host }}"
-    login_user: "root"
-    login_password: "{{ mysql_root_password }}"
+#    login_host: "{{ asterisk_db_host }}"
+#    login_user: "root"
+#    login_password: "{{ mysql_root_password }}"
     state: present
 
 - name: FreePBX - Add cdr mysql db

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -243,8 +243,6 @@ admin_console_enabled: True
 # MySQL MANDATORY - THESE 2 VARS HAVE NO EFFECT - SEE roles/0-init/tasks/main.yml & roles/mysql/tasks/main.yml
 mysql_install: True
 mysql_enabled: True
-# mysql_root_password: $6$iiab51$3ICIW0CLWxxMW2a3yrHZ38ukZItD5tcadL4rWcE9D.qIGStxhh8rRsaSxoj3b.MYxI/VRDNjpzSYK/V6zkWFI0
-mysql_root_password: fixmysql
 
 # 2019-01-13: IIAB's use of NGINX is still evolving -- please review this
 # evolving doc: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md


### PR DESCRIPTION
### Fixes bug:
proposed fix for #2475
### Description of changes proposed in this pull request:
don't set password for root using 'localhost', add second admin account(mariaDBadmin)
### Smoke-tested on which OS or OS's:
pending
### Mention a team member @username e.g. to help with code review:
@holta 