### PR TITLE
local_vars_big.yml: set monit_install & monit_enabled to False

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -333,8 +333,8 @@ awstats_install: True
 awstats_enabled: True
 
 # 2019-07-08 WARNING: both vars are IGNORED on Debian 10+ due to: github.com/iiab/iiab/issues/1849
-monit_install: True
-monit_enabled: True
+monit_install: False
+monit_enabled: False
 
 munin_install: True
 munin_enabled: True


### PR DESCRIPTION
I don't know of a single group using Monit.

And BIG-sized installs have issues on Debian 10 & 64-bit RaspiOS where the package is not available.

So let's remove Monit from BIG-sized IIAB install for now, if there are no objections?

Refs: #1849, #2422