### PR TITLE
Revert "use ansible_userspace_architecture for booted 64bit kernels a…

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -59,7 +59,7 @@
 
 
   # end block
-  when: not (ansible_userspace_architecture == "x86_64" or ansible_userspace_architecture == "aarch64")
+  when: not (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
 # 32 bit OS's get caught above should handle aarch32 including 32-bit ubuntu
 # from https://ubuntu.com/download/raspberry-pi. 20.4-32bit might fail untested
 # 32bit intel might puke as this was orginally deployed for raspbian. Haven't
@@ -76,7 +76,7 @@
       repo: deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main
       state: present
       filename: mongodb-org
-    when: is_debian_10 and (ansible_userspace_architecture == "x86_64")
+    when: is_debian_10 and (ansible_architecture == "x86_64")
 
   # Debian 10 aarch64 might work below but is blocked in main.yml
   - name: Add mongodb repo for RaspOS-aarch64
@@ -84,7 +84,7 @@
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
-    when: (ansible_userspace_architecture == "aarch64" and is_raspbian_10)
+    when: (ansible_architecture == "aarch64" and is_raspbian_10)
 
   - name: Add mongodb repo for Ubuntu 64bit only
     apt_repository:
@@ -108,7 +108,7 @@
       line: '  port: 27018'
 
   # end block
-  when: (ansible_userspace_architecture == "aarch64") or (ansible_userspace_architecture == "x86_64")
+  when: (ansible_architecture == "aarch64") or (ansible_architecture == "x86_64")
 
 
 # 2. CONFIGURE MongoDB FOR IIAB


### PR DESCRIPTION
…nd 32bit userspace"

This reverts commit 90eea1a31145c7742cf54f766349ad42e0db0610.

### Fixes bug:
#2497 
### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
