### PR TITLE
Mint might need static mapping to Ubuntu

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -71,7 +71,7 @@
     args:
       warn: false
 
-  - name: Add mongodb repo for Debian 10 (only amd64 support available)
+  - name: Use mongodb-org's Debian buster repo for Debian 10 (only amd64 support available)
     apt_repository:
       repo: deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main
       state: present
@@ -79,26 +79,26 @@
     when: is_debian_10 and (ansible_architecture == "x86_64")
 
   # Debian 10 aarch64 might work below but is blocked in main.yml
-  - name: Add mongodb repo for RaspOS-aarch64
+  - name: Use mongodb-org's Ubuntu bionic repo for RaspOS-aarch64
     apt_repository:
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
     when: (ansible_architecture == "aarch64" and is_raspbian_10)
 
-  - name: Add mongodb repo for Ubuntu 64bit only
-    apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
-      state: present
-      filename: mongodb-org
-    when: is_ubuntu and not is_mint
-
-  - name: Add mongodb repo for Mint 64bit only
+  - name: Use mongodb-org's Ubuntu focal repo for Mint 20 - 64bit only
     apt_repository:
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
     when: is_mint_20
+
+  - name: Use mongodb-org's Ubuntu repo for Ubuntu all -  64bit only
+    apt_repository:
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
+      state: present
+      filename: mongodb-org
+    when: is_ubuntu and not is_mint
 
   - name: "Install packages: mongodb-org, mongodb-org-server"
     package:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -71,12 +71,12 @@
     args:
       warn: false
 
-  - name: Use mongodb-org's Debian buster repo for Debian 10 (only amd64 support available)
+  - name: Use mongodb-org's Debian repo for Debian (only amd64 support available)
     apt_repository:
-      repo: deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main
+      repo: deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       state: present
       filename: mongodb-org
-    when: is_debian_10 and (ansible_architecture == "x86_64")
+    when: is_debian and (ansible_architecture == "x86_64")
 
   # Debian 10 aarch64 might work below but is blocked in main.yml
   - name: Use mongodb-org's Ubuntu bionic repo for RaspOS-aarch64

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -91,7 +91,14 @@
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
-    when: is_ubuntu
+    when: is_ubuntu and not is_mint
+
+  - name: Add mongodb repo for Mint 64bit only
+    apt_repository:
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
+      state: present
+      filename: mongodb-org
+    when: is_mint_20
 
   - name: "Install packages: mongodb-org, mongodb-org-server"
     package:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -704,6 +704,10 @@ is_ubuntu_18: False
 is_ubuntu_17: False
 is_ubuntu_16: False
 
+is_mint: False       # subset of is_ubuntu
+is_mint_20: False
+
+
 is_debian: False    # Covers both: Debian, Raspbian (Raspberry Pi OS)
 is_debian_10: False
 is_debian_9: False

--- a/vars/linuxmint-20.yml
+++ b/vars/linuxmint-20.yml
@@ -1,6 +1,9 @@
 is_debuntu: True
 is_ubuntu: True
 is_ubuntu_20: True
+is_mint: True
+is_mint_20: True
+
 
 # 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
 # (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)


### PR DESCRIPTION
If it turn out not to be a transient network issue: 
### Fixes bug:
>did BIG build on Linux Mint 20 running on Dell Latitue D630. Two failures. First after System update when I had to reboot the desktop. The sudo iiab continued with running the scrip. Second failure with mongo db with this error: TASK [mongodb : Add mongodb repo for Ubuntu 64bit only] ************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "apt cache update failed"}
PLAY RECAP *********************************************************************
127.0.0.1 : ok=85 changed=16 unreachable=0 failed=1 skipped=50 rescued=0 ignored=0 

Would like to see the iiab-install.log or `grep ansible_distribution_release /opt/iiab/iiab/iiab-install.log`



