### PR TITLE
Infastructure for proper versioning.

### DIFF
--- a/roles/0-init/defaults/main.yml
+++ b/roles/0-init/defaults/main.yml
@@ -8,6 +8,8 @@
 first_run: False
 rpi_model: none
 xo_model: none
+do_upgrade: False
+do_reinstall: False
 gw_active: False
 internet_available: False
 discovered_wan_iface: none

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -1,20 +1,21 @@
 # Initialize
 - name: ...IS BEGINNING ============================================
-  stat:
-    path: "{{ iiab_env_file }}"
-  register: NewInstall
-
-- name: Set first_run flag
-  set_fact:
-    first_run: True
-  when: not NewInstall.stat.exists
-
-- name: Set top-level variables from local_facts for convenience
+#- name: Re-read local_facts.facts from /etc/ansible/facts.d
+#  setup:
+#    filter: ansible_local
+#- name: Set top-level variables from local_facts for convenience
   set_fact:
     rpi_model: "{{ ansible_local.local_facts.rpi_model }}"
     xo_model: "{{ ansible_local.local_facts.xo_model }}"
     phplib_dir: "{{ ansible_local.local_facts.phplib_dir }}"
     iiab_stage: "{{ ansible_local.local_facts.stage }}"
+    installed_release: "{{ ansible_local.local_facts.installed_release }}"
+    installed_revision: "{{ ansible_local.local_facts.installed_revision }}"
+
+- name: Set first_run flag
+  set_fact:
+    first_run: True
+  when: iiab_stage | int == 0
 
 # We need to inialize the ini file and only write the location and version
 # sections once and only once to preserve the install date and git hash.
@@ -35,10 +36,6 @@
     state: directory
     path: /etc/iiab/diag
     mode: '0777'
-
-- name: Re-read local_facts.facts from /etc/ansible/facts.d
-  setup:
-    filter: ansible_local
 
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -40,6 +40,25 @@
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml
 
+# the below 2 stanza don't do anything functional at the moment, more
+# informational you will see 'changed'. The real work would be done by
+# iiab-upgrade via auto deleting the *_installed flag in iiab_state.yml
+# based on entries in upgrade_roles. It is just plain easier to delete the
+# marker before ansible loads iiab_state.yml like runrole --reinstall does.
+# https://github.com/jvonau/iiab-factory/blob/iiab-upgrade/iiab-upgrade
+# Might work on loading iiab_state.yml on demand via conditionals in the future.
+
+# leave at 7.2 when branching to 7.3 bump to 7.3 when 7.4 comes along
+- name: Upgrade situation detected
+  set_fact:
+    do_upgrade: True
+  when: not installed_release == "0" and installed_release == "7.2"
+
+- name: Reinstall situation detected
+  set_fact:
+    do_reinstall: True
+  when: installed_revision|int < iiab_revision|int
+
 # Discover: do we have a gateway?
 # If Ansible detects gateway, becomes WAN candidate.
 - name: "Do we have a gateway? If so set discovered_wan_iface: {{ ansible_default_ipv4.alias }}"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -48,16 +48,19 @@
 # https://github.com/jvonau/iiab-factory/blob/iiab-upgrade/iiab-upgrade
 # Might work on loading iiab_state.yml on demand via conditionals in the future.
 
-# leave at 7.2 when branching to 7.3 bump to 7.3 when 7.4 comes along
+# this one is informational you will see 'changed'.
 - name: Upgrade situation detected
   set_fact:
     do_upgrade: True
-  when: not installed_release == "0" and installed_release == "7.2"
+  when: installed_revision|int < iiab_revision|int
 
+# leave at 7.2 when branching to 7.3, bump to 7.3 when 7.4 or 8.0 comes along.
+# does nothing at the moment for future use, just denotes a major change in the
+# starting point of the install.
 - name: Reinstall situation detected
   set_fact:
     do_reinstall: True
-  when: installed_revision|int < iiab_revision|int
+  when: not installed_release == "0" and installed_release == "7.2"
 
 # Discover: do we have a gateway?
 # If Ansible detects gateway, becomes WAN candidate.

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -30,6 +30,12 @@
     name: calibre-web
   when: calibreweb_install | bool
 
+- name: Record IIAB_REVISION
+  lineinfile:
+    path: "{{ iiab_env_file }}"
+    regexp: '^IIAB_REVISION=*'
+    line: 'IIAB_REVISION={{ iiab_revision }}'
+
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     path: "{{ iiab_env_file }}"

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -5,8 +5,12 @@
 if [ -f /etc/iiab/iiab.env ]; then
     source /etc/iiab/iiab.env
     STAGE=$STAGE
+    INSTALLED_RELEASE=$IIAB_RELEASE
+    INSTALLED_REVISION=$IIAB_REVISION
 else
     STAGE=0
+    INSTALLED_RELEASE=0
+    INSTALLED_REVISION=0
 fi
 
 OS=`grep ^ID= /etc/*elease|cut -d= -f2`
@@ -84,6 +88,8 @@ SYSD_NETD=`systemctl is-enabled systemd-networkd`
 
 cat <<EOF
 {"phplib_dir"             : "$PHPLIB_DIR",
+"installed_release"       : "$INSTALLED_RELEASE",
+"installed_revision"      : "$INSTALLED_REVISION",
 "stage"                   : "$STAGE",
 "dhcpcd"                  : "$DHCPCD",
 "network_manager"         : "$NM",

--- a/upgrade_roles
+++ b/upgrade_roles
@@ -1,0 +1,1 @@
+mongodb

--- a/upgrade_roles
+++ b/upgrade_roles
@@ -1,1 +1,1 @@
-mongodb
+1 mongodb

--- a/upgrade_roles
+++ b/upgrade_roles
@@ -1,1 +1,2 @@
 1 mongodb
+2 gitea

--- a/upgrade_roles
+++ b/upgrade_roles
@@ -1,2 +1,3 @@
-1 mongodb
-2 gitea
+1 osm-vector-maps #2487
+2 gitea #2504
+3 lokole #2514

--- a/upgrade_roles
+++ b/upgrade_roles
@@ -1,3 +1,3 @@
-1 osm-vector-maps #2487
-2 gitea #2504
-3 lokole #2514
+1 osm_vector_maps
+2 gitea
+3 lokole

--- a/upgrade_roles.txt
+++ b/upgrade_roles.txt
@@ -8,4 +8,4 @@
 # mongodb #2487 #2584: bugfix for 64bit debian - upgrade on 64bit ubuntu
 # - no change for 32bit OSs
 2 gitea #2504
-4 lokole #2514
+3 lokole #2514

--- a/upgrade_roles.txt
+++ b/upgrade_roles.txt
@@ -1,0 +1,11 @@
+# tagged https://github.com/iiab/iiab/releases/tag/7.1.5-premap
+# git 5d64c066627f664d2a20da50d4a249c3ca87529a as 0 revision stating point
+# https://github.com/holta/iiab/compare/5GHz-warning-with-dual-wifi...iiab:master
+
+# pbx was non-installable prior to #2489 - no upgrade need
+# #2515 would need a pass through the network role via ./iiab-network or ICO
+1 osm-vector-maps #2487
+# mongodb #2487 #2584: bugfix for 64bit debian - upgrade on 64bit ubuntu
+# - no change for 32bit OSs
+2 gitea #2504
+4 lokole #2514

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -14,7 +14,7 @@
 
 # IIAB (PRE-)release version number, for {{ iiab_env_file }}
 iiab_base_ver: 7.2
-iiab_revision: 0
+iiab_revision: 1
 
 iiab_etc_path: /etc/iiab
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -14,7 +14,7 @@
 
 # IIAB (PRE-)release version number, for {{ iiab_env_file }}
 iiab_base_ver: 7.2
-iiab_revision: 2
+iiab_revision: 3
 
 iiab_etc_path: /etc/iiab
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -14,7 +14,7 @@
 
 # IIAB (PRE-)release version number, for {{ iiab_env_file }}
 iiab_base_ver: 7.2
-iiab_revision: 1
+iiab_revision: 2
 
 iiab_etc_path: /etc/iiab
 


### PR DESCRIPTION
Add the recording of IIAB_REVISION to stage 9 to allow incriminating the value to reflect major change in a role that would require a re-install where such roles would be recorded in upgrade_roles, works with https://github.com/iiab/iiab-factory/pull/134

Change the value for any roles' source version that would require a re-install, that gets noted in upgrade_roles and iiab_revision gets bumped. The big mongodb change is a perfect test subject.