### PR TITLE
Lokole sync [transition from Apache lokole.conf -> NGINX lokole-nginx.conf ?]

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -143,7 +143,7 @@
   set_fact:
     lokole_installed: True
 
-- name: "Add 'lokole_insta lled: True' to {{ iiab_state_file }}"
+- name: "Add 'lokole_installed: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^lokole_installed'

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -72,7 +72,7 @@
     - "{{ lokole_venv }}/lib/python${python_version}/site-packages/opwen_email_client/webapp"
 
 - name: mkdir {{ lokole_run_directory }}
-  file: 
+  file:
     state: directory
     path: "{{ lokole_run_directory }}"
 
@@ -86,6 +86,28 @@
     src: webapp.sh.j2
     dest: "{{ lokole_run_directory }}/webapp.sh"
     mode: a+x
+
+- name: Install {{ lokole_run_directory }}/run-celery.sh from template
+  template:
+    src: run-celery.sh.j2
+    dest: "{{ lokole_run_directory }}/run-celery.sh"
+    mode: a+x
+
+- name: Install {{ lokole_run_directory }}/celerybeat.sh from template
+  template:
+    src: celerybeat.sh.j2
+    dest: "{{ lokole_run_directory }}/celerybeat.sh"
+    mode: a+x
+
+- name: Install /etc/systemd/system/celery.service unit file from template
+  template:
+    src: celery.service.j2
+    dest: /etc/systemd/system/celery.service
+
+- name: Install /etc/systemd/system/celerybeat.service unit file from template
+  template:
+    src: celerybeat.service.j2
+    dest: /etc/systemd/system/celerybeat.service
 
 - name: Create admin user with password, for http://box{{ lokole_url }}    # http://box/lokole
   shell: |
@@ -110,7 +132,7 @@
   set_fact:
     lokole_installed: True
 
-- name: "Add 'lokole_installed: True' to {{ iiab_state_file }}"
+- name: "Add 'lokole_insta lled: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^lokole_installed'

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -93,6 +93,12 @@
     dest: "{{ lokole_run_directory }}/run-celery.sh"
     mode: a+x
 
+- name: Install {{ lokole_run_directory }}/webapp-restart.sh from template
+  template:
+    src: webapp-restart.sh.j2
+    dest: "{{ lokole_run_directory }}/webapp-restart.sh"
+    mode: a+x
+
 - name: Install {{ lokole_run_directory }}/celerybeat.sh from template
   template:
     src: celerybeat.sh.j2
@@ -108,6 +114,11 @@
   template:
     src: celerybeat.service.j2
     dest: /etc/systemd/system/celerybeat.service
+
+- name: Install /etc/systemd/system/restarter.service unit file from template
+  template:
+    src: restarter.service.j2
+    dest: /etc/systemd/system/restarter.service
 
 - name: Create admin user with password, for http://box{{ lokole_url }}    # http://box/lokole
   shell: |

--- a/roles/lokole/tasks/main.yml
+++ b/roles/lokole/tasks/main.yml
@@ -46,6 +46,13 @@
     state: started
   when: lokole_enabled | bool
 
+- name: Enable restarter service
+  systemd:
+    name: restarter
+    enabled: yes
+    state: started
+  when: lokole_enabled | bool
+
 - name: Disable & Stop 'lokole' systemd service, if not lokole_enabled
   systemd:
     name: lokole

--- a/roles/lokole/tasks/main.yml
+++ b/roles/lokole/tasks/main.yml
@@ -32,6 +32,20 @@
     state: restarted
   when: lokole_enabled | bool
 
+- name: Enable and start celery systemd service
+  systemd:
+    name: celery
+    enabled: yes
+    state: restarted
+  when: lokole_enabled | bool
+
+- name: Enable celery beat service
+  systemd:
+    name: celerybeat
+    enabled: yes
+    state: started
+  when: lokole_enabled | bool
+
 - name: Disable & Stop 'lokole' systemd service, if not lokole_enabled
   systemd:
     name: lokole

--- a/roles/lokole/templates/celery.service.j2
+++ b/roles/lokole/templates/celery.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Celery service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash {{ lokole_run_directory }}/run-celery.sh
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill TERM $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/lokole/templates/celerybeat.service.j2
+++ b/roles/lokole/templates/celerybeat.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Celery beat timed service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash {{ lokole_run_directory }}/celerybeat.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/lokole/templates/celerybeat.sh.j2
+++ b/roles/lokole/templates/celerybeat.sh.j2
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+'{{lokole_venv}}/bin/celery' \
+  '--app=opwen_email_client.webapp.tasks' \
+  'beat' \
+  '--loglevel=info'

--- a/roles/lokole/templates/restarter.service.j2
+++ b/roles/lokole/templates/restarter.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Lokole webapp restarter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash {{ lokole_run_directory }}/webapp-restart.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/lokole/templates/run-celery.sh.j2
+++ b/roles/lokole/templates/run-celery.sh.j2
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+'{{lokole_venv}}/bin/celery' \
+  '--app=opwen_email_client.webapp.tasks' \
+  'worker' \
+  '--loglevel=info' \
+  '--concurrency=2'

--- a/roles/lokole/templates/webapp-restart.sh.j2
+++ b/roles/lokole/templates/webapp-restart.sh.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+'{{lokole_venv}}/bin/manage.py' \
+  'restarter' \
+  '--directory={{lokole_run_directory}}'


### PR DESCRIPTION
Currently, the IIAB version of the Lokole email client only works in local mode. To work towards online capability, Celery was enabled, which is depended upon by the webapp sync worker. For more information see: [Lokole issue 453](https://github.com/ascoderu/lokole/issues/453), and [Lokole issue 454](https://github.com/ascoderu/lokole/issues/454)

The [development environment repo](https://github.com/arky/iiab-dev-mode) linked in the contributors guide was used. The debian/stretch64 vagrant box was utilized.
@holta @c-w 
