### PR TITLE
Connecting IIAB to 5 GHz WiFi effectively sabotages IIAB's internal hotspot: warn implementers loudly/broadly

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -90,6 +90,10 @@ iiab_home_url: /home
 # Internal Wi-Fi Access Point
 # Values are used if there is an internal Wi-Fi adapter and hostapd is enabled.
 #
+# WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz,
+# YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
+# CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
+#
 # Raspberry Pi OS requires WiFi country -- SET THIS IN /etc/iiab/local_vars.yml
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -43,6 +43,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz,
+# YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
+# CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
+#
 # Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -43,6 +43,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz,
+# YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
+# CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
+#
 # Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -43,6 +43,10 @@ iiab_domain: lan
 iiab_home_url: /home
 # You might also want to set captiveportal_splash_page (below!)
 
+# WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz,
+# YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
+# CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
+#
 # Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: "Internet in a Box"


### PR DESCRIPTION
Warnings in 13 places i.e. 8 (local_vars.yml) + 3 (iiab-factory) + 2 places (d.iiab.io) should be enough for now (!)

The new ALL CAPS warnings within http://download.iiab.io perhaps most important &mdash; to try to catch the attention of new IIAB implementers early on &mdash; even before they figure out what [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) is.

Builds on PR's:
- #2509
- iiab/iiab-factory#137
- iiab/iiab-factory#138
- iiab/iiab-factory#139