### PR TITLE
detect secondary gateway on wifi interface for no_net_restart

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -145,6 +145,15 @@
   with_items:
     - "{{ lan_list_result.stdout_lines }}"
 
+- name: Detect wifi gateway active
+  shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l
+  when: discovered_wireless_iface != "none"
+  register: wifi_gateway_found
+
+- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} if gateway is detected
+  set_fact:
+    has_wifi_gateway: True
+  when: wifi_gateway_found is defined and (wifi_gateway_found.stdout|int > 0)
 
 - name: Set iiab_wireless_lan_iface to {{ discovered_wireless_iface }} if not none
   set_fact:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -12,7 +12,7 @@
     # 0-init/defaults/main.yml, network/tasks/main.yml, debian.yml,
     # detected_network.yml, down-debian.yml, NM-debian.yml, restart.yml,
     # sysd-netd-debian.yml, computed_services.yml, rpi_debian.yml
-  when: discovered_wireless_iface == iiab_wan_iface
+  when: has_wifi_gateway is defined
 
 - name: computed_network
   include_tasks: computed_network.yml

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -6,12 +6,13 @@
 - name: detected_network
   include_tasks: detected_network.yml
 
-- name: "Set 'no_net_restart: True' if discovered_wireless_iface == iiab_wan_iface"
+#- name: "Set 'no_net_restart: True' if discovered_wireless_iface == iiab_wan_iface"
+- name: "Set 'no_net_restart: True' if has_wifi_gateway is defined"
   set_fact:
-    no_net_restart: True    # 2020-05-09: Var is currently used in 10 files:
-    # 0-init/defaults/main.yml, network/tasks/main.yml, debian.yml,
-    # detected_network.yml, down-debian.yml, NM-debian.yml, restart.yml,
-    # sysd-netd-debian.yml, computed_services.yml, rpi_debian.yml
+    no_net_restart: True    # 2020-09-12: Var is currently used in 11 files...
+    # 0-init/defaults/main.yml, network/tasks/main.yml, computed_services.yml,
+    # debian.yml, detected_network.yml, down-debian.yml, netplan.yml,
+    # NM-debian.yml, restart.yml, rpi_debian.yml, sysd-netd-debian.yml
   when: has_wifi_gateway is defined
 
 - name: computed_network


### PR DESCRIPTION
### Fixes bug:
It's not a bug but rather the use of `ansible_default_ipv4` as the normal usage to denote a default gateway that is present on the machine despite other default routes present in the routing table. Now this sort of issue can crop up with 2 wired interfaces with gateways, but shows up in other ways, that layout is not really supported. The use of both wired and wireless as gateway devices show this a weakness against the long standing assumption that only one interface has a default route to the internet. Now with both wired and wireless devices possessing a valid default route, `iiab_wan_iface` which is based on `ansible_default_ipv4.alias` just doesn't cut it. Need to treat the presence an active WiFi gateway the same whether only WiFi has a gateway or if both wired and wireless devices do.
### Description of changes proposed in this pull request:
preemptive patch #2497 should it be necessary. 
Update the WiFi detection to include default gateway presence to determine the need for `no_net_restart`
### Smoke-tested on which OS or OS's:
RaspOS wifi only with ap0 active
### Mention a team member @username e.g. to help with code review:
Reminder that active WiFi to the internet require a reboot it enable the internal hotspot with `no_net_restart`, this is done to ensure install actions that occur post-network configuration will not be disrupted. Same reboot requirement would hold true for the use of iiab-network with an active WiFi connection to the internet.