### PR TITLE
Begin transition to Ansible 2.10 (now that ansible-base 2.10.1 is released & appears solid!)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -61,6 +61,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 	      python3-pymysql python3-psycopg2 python3-passlib python3-pip \
 	      python3-setuptools python3-venv virtualenv
 
+# IIAB requires these 2 Ansible Collections: (starting with Ansible 2.10)
 ansible-galaxy collection install community.general
 ansible-galaxy collection install community.mysql
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -2,14 +2,14 @@
 
 APT_PATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.9.6"    # For XO laptops (pip install) & CentOS (yum install rpm)
+GOOD_VER="2.10.1"    # For XO laptops (pip install) & CentOS (yum install rpm)
 # On most/other OS's we install the latest (likely more recent!) from PPA:
 # https://launchpad.net/~ansible/+archive/ubuntu/ansible
 
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "\n\nYOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible (TO INSTALL ANSIBLE)"
-#echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible-2.8.x ("Slow Food")\n'
+#echo -e 'Alternative:     /opt/iiab/iiab/scripts/ansible-2.9.x ("Slow Food")\n'
 
 echo -e "RECOMMENDED PREREQUISITES:"
 echo -e "(1) Verify you're online"
@@ -18,104 +18,62 @@ echo -e "    'apt purge ansible' and/or 'pip uninstall ansible'"
 echo -e "(3) Remove all lines containing 'ansible' from"
 echo -e "    /etc/apt/sources.list and /etc/apt/sources.list.d/*\n"
 
-echo -e "COMPLETE INSTALL INSTRUCTIONS:"
+echo -e "IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)"
 echo -e "https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n"
 
-if [ $(command -v ansible-playbook) ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
+if [ $(command -v ansible) ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
     CURR_VER=`ansible --version | head -1 | awk '{print $2}'`    # To match iiab-install.  Was: CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
     echo -e "CURRENTLY INSTALLED ANSIBLE: $CURR_VER -- LET'S TRY TO UPGRADE IT!"
     echo -e "(Internet-in-a-Box requests Ansible $GOOD_VER or higher)\n"
-    if [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
-        echo "Please use your system's package manager (or pip if nec) to update Ansible.\n"
-        exit 0
-    elif [ -f /etc/olpc-release ]; then
-        echo "Please use pip package manager to update Ansible.\n"
-        exit 0
-    fi
 else
     echo -e "ANSIBLE NOT FOUND ON THIS COMPUTER -- LET'S TRY TO INSTALL IT!"
     echo -e "(Internet-in-a-Box requests Ansible $GOOD_VER or higher)\n"
 fi
 
-if [ -f /etc/olpc-release ]; then
-    yum -y install ca-certificates nss
-    yum -y install git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
-    yum -y install python-pip python-setuptools python-wheel patch
-    # Can above 3 lines be merged into 1 line?
-    pip install --upgrade pip setuptools wheel #EOL just do it
-    pip install ansible==$GOOD_VER --disable-pip-version-check
-elif [ -f /etc/centos-release ]; then
-    yum -y install ansible
-# 2018-09-07: the next 4 lines aren't needed according to https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-release-via-dnf-or-yum
-#    yum -y install ca-certificates nss epel-release
-#    yum -y install git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
-#    yum -y install python-pip python-setuptools python-wheel patch
-#    yum -y install https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-$GOOD_VER-1.el7.ans.noarch.rpm
-#elif [ -f /etc/fedora-release ]; then
-#    CURR_VER=`grep VERSION_ID /etc/*elease | cut -d= -f2`
-#    URL=https://github.com/jvonau/iiab/blob/ansible/vars/fedora-$CURR_VER.yml
-#    dnf -y install ansible git bzip2 file findutils gzip hg svn sudo tar which unzip xz zip libselinux-python
-#    dnf -y install python-pip python-setuptools python-wheel patch
-## Parens are optional, but greatly clarify :)
-#elif (grep -qi ubuntu /etc/lsb-release 2> /dev/null) || (grep -qi ubuntu /etc/os-release); then
-#    apt update
-#    #apt -y install python-pip python-setuptools python-wheel patch    # 2018-09-05: fails on @kananigit's Ubuntu 18.04/Server.  Fix @ https://github.com/iiab/iiab/pull/1091
-#    apt -y install software-properties-common    # adds command "apt-add-repository"
-#    apt-add-repository -y ppa:ansible/ansible    # adds correct line to correct file e.g. adds line "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" to /etc/apt/sources.list.d/ansible-ubuntu-ansible-bionic.list
-## elif UBUNTU MUST REMAIN ABOVE (as Ubuntu ALSO contains /etc/debian_version, which would trigger the line just below)
-#elif [ -f /etc/debian_version ] || (grep -qi raspbian /etc/*elease) ; then
-#elif [ ! -f /etc/centos-release ] && [ ! -f /etc/fedora-release ] && [ ! -f /etc/olpc-release ]; then
-elif [ -f /etc/debian_version ]; then    # Includes Debian, Ubuntu & Raspbian
-    if ! grep -q focal /etc/os-release; then
-        echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
-        $APT_PATH/apt update
-        $APT_PATH/apt -y install dirmngr
-        echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
-            > /etc/apt/sources.list.d/iiab-ansible.list
-
-        # 2020-08-20: TEMP WORKAROUND (REVERT TO ANSIBLE 2.9.6) MITIGATING #2481 (Ansible 2.9.12 and 2.10.0's 666-TO-600 file permissions problem). This installs 2.9.6-1ppa~disco onto RaspiOS, from https://launchpad.net/~ansible/+archive/ubuntu/ansible
-        #echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu disco main" \
-        #    > /etc/apt/sources.list.d/iiab-ansible.list
-
-        echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
-        echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main"'
-        echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
-        echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
-        echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
-        grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
-    fi
-    # 2020-08-25: Let's revert to RaspiOS's own /etc/apt/sources.list for 64-bit RaspiOS etc
-    #if [ -f /etc/rpi-issue ]; then
-    #    # 2020-06-06: https://www.raspberrypi.org/forums/viewtopic.php?t=276340
-    #    echo -e "\nAdd a mirror to /etc/apt/sources.list if Raspberry Pi OS, which can be flaky..."
-    #    mv --no-clobber /etc/apt/sources.list /etc/apt/sources.list.old || true
-    #    echo -e "deb http://mirror.us.leaseweb.net/raspbian/raspbian buster main contrib non-free rpi" > /etc/apt/sources.list
-    #    echo -e "deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi" >> /etc/apt/sources.list
-    #    echo -e "# Uncomment line below then 'apt-get update' to enable 'apt-get source'" >> /etc/apt/sources.list
-    #    echo -e "#deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi" >> /etc/apt/sources.list
-    #fi
-    echo -e "\napt update; apt install ansible and python3 dependencies explained at:"
-    echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
-    $APT_PATH/apt update
-    $APT_PATH/apt -y --allow-downgrades install ansible python3-pymysql python3-psycopg2 \
-        python3-passlib python3-pip python3-setuptools python3-venv virtualenv
-
-    echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible'\n\n"
-
-    # TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")
-    #pip install ansible==2.4.4
-
-    # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. DETAILS @ https://github.com/iiab/iiab/issues/669
-    #echo "Install http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb"
-    #cd /tmp
-    #wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
-    #apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
-
-else
-    echo -e "\nEXITING: Could not detect your OS (unsupported?)\n"
+if [ ! -f /etc/debian_version ]; then    # e.g. Raspbian, Ubuntu, Mint & Debian
+    echo -e "\nEXITING: /etc/debian_version FILE NOT FOUND.  Linux OS support info here:"
+    echo -e "           https://github.com/iiab/iiab/wiki/IIAB-Platforms\n"
     exit 1
 fi
+
+echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
+$APT_PATH/apt update
+$APT_PATH/apt -y install dirmngr
+echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
+     > /etc/apt/sources.list.d/iiab-ansible.list
+
+# 2020-08-20: TEMP WORKAROUND (REVERT TO ANSIBLE 2.9.6) MITIGATING #2481 (Ansible 2.9.12 and 2.10.0's 666-TO-600 file permissions problem). This installs 2.9.6-1ppa~disco onto RaspiOS, from https://launchpad.net/~ansible/+archive/ubuntu/ansible
+#echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu disco main" \
+    #    > /etc/apt/sources.list.d/iiab-ansible.list
+
+echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
+echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main"'
+echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
+echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
+echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
+grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
+
+echo -e "\napt update; apt install ansible-base and python3 dependencies explained at:"
+echo -e "https://github.com/iiab/iiab/tree/master/scripts/ansible.md\n"
+$APT_PATH/apt update
+$APT_PATH/apt -y --allow-downgrades install ansible-base \
+	      python3-pymysql python3-psycopg2 python3-passlib python3-pip \
+	      python3-setuptools python3-venv virtualenv
+
+ansible-galaxy collection install community.general
+ansible-galaxy collection install community.mysql
+
+echo -e "\nSUCCESS: verify Ansible using 'ansible --version' and/or 'apt -a list ansible-base'\n\n"
+
+# TEMPORARILY USE ANSIBLE 2.4.4 (REMOVE IT WITH "pip uninstall ansible")
+#pip install ansible==2.4.4
+
+# TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. DETAILS @ https://github.com/iiab/iiab/issues/669
+#echo "Install http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb"
+#cd /tmp
+#wget http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb
+#apt -y --allow-downgrades install ./ansible_2.4.2.0-1ppa~xenial_all.deb
 
 # Needed?
 mkdir -p /etc/ansible

--- a/scripts/ansible.md
+++ b/scripts/ansible.md
@@ -12,6 +12,7 @@ Starting in November 2019, IIAB's Ansible installer ([/opt/iiab/iiab/scripts/ans
    - **virtualenv** (is Python 3 only, for [roles/kalite](https://github.com/iiab/iiab/tree/master/roles/kalite) & [roles/calibre-web](https://github.com/iiab/iiab/tree/master/roles/calibre-web) ?) and pulls in additional packages... (`apt show virtualenv` shows "Depends: python3, python3-virtualenv")
       - **python3-virtualenv** and pulls in additional package... (`apt show python3-virtualenv` shows "Depends: python-pip-whl (>= 8.1.1-2), python3, python3-distutils, python3-pkg-resources") 
          - **python3-distutils**
+   - **python3-venv** for Good Measure?
 
 2. Ansible modules: [mysql_db](https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html) and [mysql_user](https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html) (for [roles/mysql](https://github.com/iiab/iiab/tree/master/roles/mysql))
 


### PR DESCRIPTION
Building on and evolving from:

- #2479 'Validate Ansible 2.10 expected 2020-08-13 [with simplified auto-installation of "Collections" ETA 2020-09-22 ?]'
- #2481 'Ansible promised not to change things, but this seems like a big one: file permissions like 666 become 600, in new Ansible 2.10.0 (and in Ansible 2.9.12 too?)'
- PR #2512 'Revamp ansible for the future'