### PR TITLE
strict ordering of resize service

### DIFF
--- a/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
+++ b/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
@@ -6,6 +6,7 @@
 # Only works on F22 + where resizepart command exists
 # Assumes sd card style partition name like <device>p<partition number>
 
+echo "Checking for .resize-rootfs"
 if [  -f /.resize-rootfs ];then
   echo "$0: maximizing rootfs partion"
   # Calculate root partition
@@ -18,3 +19,4 @@ if [  -f /.resize-rootfs ];then
   resize2fs /dev/$root_part
   rm /.resize-rootfs
 fi
+exit 0

--- a/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
+++ b/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
@@ -18,5 +18,6 @@ if [  -f /.resize-rootfs ];then
   growpart /dev/$root_dev $root_part_no
   resize2fs /dev/$root_part
   rm /.resize-rootfs
+  systemctl disable iiab-rpi-root-resize.service
 fi
 exit 0

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -7,7 +7,6 @@ Before=dphys-swapfile.service
 [Service]
 Environment=TERM=linux
 Type=oneshot
-TimeoutStartSec=300
 ExecStart=/usr/sbin/iiab-rpi-max-rootfs.sh
 StandardError=syslog
 RemainAfterExit=yes

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -8,7 +8,7 @@ Before=dphys-swapfile.service
 
 [Service]
 Environment=TERM=linux
-Type=oneshot
+Type=forking
 TimeoutStartSec=300
 ExecStart=/usr/sbin/iiab-rpi-max-rootfs.sh
 StandardError=syslog

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -6,7 +6,7 @@ Before=dphys-swapfile.service
 
 [Service]
 Environment=TERM=linux
-Type=forking
+Type=oneshot
 TimeoutStartSec=300
 ExecStart=/usr/sbin/iiab-rpi-max-rootfs.sh
 StandardError=syslog

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -1,9 +1,7 @@
 [Unit]
 Description=Root Filesystem Auto-Resizer
 DefaultDependencies=no
-After=systemd-fsckd.service
-After=systemd-fsck-root.service
-Before=systemd-remount-fs.service
+After=systemd-remount-fs.service
 Before=dphys-swapfile.service
 
 [Service]

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -13,4 +13,4 @@ StandardError=syslog
 RemainAfterExit=yes
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=local-fs.target

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Root Filesystem Auto-Resizer
 DefaultDependencies=no
-After=fake-hwclock.service
-Before=systemd-fsck-root.service
-Before=systemd-fsckd.service
+After=systemd-fsckd.service
+After=systemd-fsck-root.service
+Before=systemd-remount-fs.service
 Before=dphys-swapfile.service
 
 [Service]

--- a/roles/1-prep/templates/iiab-rpi-root-resize.service
+++ b/roles/1-prep/templates/iiab-rpi-root-resize.service
@@ -1,12 +1,18 @@
 [Unit]
 Description=Root Filesystem Auto-Resizer
+DefaultDependencies=no
+After=fake-hwclock.service
+Before=systemd-fsck-root.service
+Before=systemd-fsckd.service
+Before=dphys-swapfile.service
 
 [Service]
 Environment=TERM=linux
 Type=oneshot
+TimeoutStartSec=300
 ExecStart=/usr/sbin/iiab-rpi-max-rootfs.sh
 StandardError=syslog
-RemainAfterExit=no
+RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target


### PR DESCRIPTION
Strict ordering to preform the resizing while mounted read only.
>pi@box:~ $ sudo systemctl status fake-hwclock.service 
● fake-hwclock.service - Restore / save the current clock
   Loaded: loaded (/lib/systemd/system/fake-hwclock.service; enabled; vendor preset: enabled
   Active: active (exited) since Tue 2020-09-15 10:07:37 BST; 15min ago
     Docs: man:fake-hwclock(8)
  Process: 124 ExecStart=/sbin/fake-hwclock load $FORCE (code=exited, status=0/SUCCESS)
 Main PID: 124 (code=exited, status=0/SUCCESS)

124
> pi@box:~ $ sudo systemctl status iiab-rpi-root-resize.service 
● iiab-rpi-root-resize.service - Root Filesystem Auto-Resizer
   Loaded: loaded (/etc/systemd/system/iiab-rpi-root-resize.service; enabled; vendor preset:
   Active: active (exited) since Tue 2020-09-15 10:07:37 BST; 16min ago
  Process: 136 ExecStart=/usr/sbin/iiab-rpi-max-rootfs.sh (code=exited, status=0/SUCCESS)
 Main PID: 136 (code=exited, status=0/SUCCESS)
Sep 15 10:07:37 box.lan iiab-rpi-max-rootfs.sh[136]: Checking for .resize-rootfs
Sep 15 10:07:37 box.lan iiab-rpi-max-rootfs.sh[136]: + echo 'Checking for .resize-rootfs'
Sep 15 10:07:37 box.lan iiab-rpi-max-rootfs.sh[136]: + '[' -f /.resize-rootfs ']'
Sep 15 10:07:37 box.lan iiab-rpi-max-rootfs.sh[136]: + exit 0

136
> pi@box:~ $ sudo systemctl status systemd-fsck-root.service 
● systemd-fsck-root.service - File System Check on Root Device
   Loaded: loaded (/lib/systemd/system/systemd-fsck-root.service; enabled-runtime; vendor pr
   Active: active (exited) since Tue 2020-09-15 10:07:37 BST; 17min ago
     Docs: man:systemd-fsck-root.service(8)
  Process: 137 ExecStart=/lib/systemd/systemd-fsck (code=exited, status=0/SUCCESS)
 Main PID: 137 (code=exited, status=0/SUCCESS)
Sep 15 10:07:37 box.lan systemd-fsck[137]: e2fsck 1.44.5 (15-Dec-2018)
Sep 15 10:07:37 box.lan systemd-fsck[137]: rootfs: clean, 691125/7638432 files, 16226570/311
Sep 15 10:07:37 box.lan systemd[1]: Started File System Check on Root Device.

137
>pi@box:~ $ sudo systemctl status systemd-fsckd
● systemd-fsckd.service - File System Check Daemon to report status
   Loaded: loaded (/lib/systemd/system/systemd-fsckd.service; static; vendor preset: enabled
   Active: inactive (dead) since Tue 2020-09-15 10:08:10 BST; 17min ago
     Docs: man:systemd-fsckd.service(8)
  Process: 139 ExecStart=/lib/systemd/systemd-fsckd (code=exited, status=0/SUCCESS)
 Main PID: 139 (code=exited, status=0/SUCCESS)
Sep 15 10:08:10 box.lan systemd[1]: systemd-fsckd.service: Succeeded.
lines 1-8/8 (END)

139

Could allow these two to run and resize before remounting read write, that will be the second commit 
>pi@box:~ $ sudo systemctl status systemd-remount-fs.service
● systemd-remount-fs.service - Remount Root and Kernel File Systems
   Loaded: loaded (/lib/systemd/system/systemd-remount-fs.service; static; vendor preset: en
   Active: active (exited) since Tue 2020-09-15 10:07:37 BST; 25min ago
     Docs: man:systemd-remount-fs.service(8)
           https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
  Process: 143 ExecStart=/lib/systemd/systemd-remount-fs (code=exited, status=0/SUCCESS)
 Main PID: 143 (code=exited, status=0/SUCCESS)
Sep 15 10:07:37 box.lan systemd[1]: Starting Remount Root and Kernel File Systems...
Sep 15 10:07:37 box.lan systemd[1]: Started Remount Root and Kernel File Systems.

143
