### PR TITLE
2515 fix [another "secondary gateway" precaution, e.g. wired gateways especially]

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -59,7 +59,7 @@ virtual_network_devices: "-e ap0 -e lo -e br0 -e tun -e br- -e docker -e bridge0
 # Set defaults for discovery process as strings
 wifi1: "not found-1"
 wifi2: "not found-2"
-exclude_device: "none"
+exclude_devices: "none"
 device_gw: "none"
 prior_gw_device: ""
 

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -108,7 +108,7 @@
 
 - name: Set has_wifi_gateway for {{ discovered_wireless_iface }} if gateway is detected
   set_fact:
-    exclude_device: "-e {{ discovered_wireless_iface }}"
+    exclude_devices: "-e {{ discovered_wireless_iface }}"
     has_wifi_gateway: True
   when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout|int > 0)
 
@@ -117,16 +117,16 @@
 
 #- name: XO laptop override 2 WiFi on LAN
 #  set_fact:
-#    exclude_device: "eth0"
+#    exclude_devices: "-e eth0"
 #  when: iiab_wan_iface != "eth0" and discovered_wireless_iface != "none" and xo_model == "XO-1.5"
 
 - name: Exclude reserved Network Adapter if defined - takes adapter name
   set_fact:
-    exclude_device: "-e {{ reserved_device }} {{ exclude_device }}"
+    exclude_devices: "-e {{ reserved_device }} {{ exclude_devices }}"
   when: reserved_device is defined
 
 - name: Count LAN ifaces
-  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_device }} | wc -l
+  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_devices }} | wc -l
   register: num_lan_interfaces_result
 
 - name: Calculate number of LAN interfaces including WiFi
@@ -135,7 +135,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
-  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_device }}
+  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_devices }}
   when: num_lan_interfaces != "0"
   register: lan_list_result
 
@@ -241,8 +241,8 @@
     value: "{{ discovered_wireless_iface }}"
   - option: discovered_wired_iface
     value: "{{ discovered_wired_iface }}"
-#  - option: 'iiab_wireless_lan_iface
-#    value: '{{ iiab_wireless_lan_iface }}"
+  - option: 'exclude_devices'
+    value: "{{ exclude_devices }}"
   - option: num_lan_interfaces
     value: "{{ num_lan_interfaces }}"
   - option: gui_static_wan

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -106,11 +106,19 @@
   register: wifi_gateway_found
   when: discovered_wireless_iface != "none"
 
-- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} if gateway is detected
+- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} if WiFi gateway is detected
   set_fact:
-    exclude_devices: "-e {{ discovered_wireless_iface }}"
     has_wifi_gateway: True
   when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout|int > 0)
+
+- name: Detect secondary gateway active
+  shell: ip r | grep default | grep -v {{ discovered_wan_iface }} | awk '{print $5}'
+  register: second_gateway_found
+
+- name: Set exclude_devices for {{ second_gateway_found.stdout }} if gateway is detected
+  set_fact:
+    exclude_devices: "-e {{ second_gateway_found.stdout }}"
+  when: second_gateway_found.changed
 
 # XO hack here ap_device would not be active therefore not set with
 # wired as gw use ap_device to exclude eth0 from network calulations


### PR DESCRIPTION
Should address the rest of #1394 - 2 wired WAN gateways, with or without any LAN devices.
Tested here on RaspOS running ap0 with wifi gateway, both with and without a wired WAN connection.
I even stayed connected over ssh to br0 while running ./iiab-network!!