### PR TITLE
Samba role standardized/modularized, for runrole etc

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -78,12 +78,12 @@
 - name: SSHD
   include_role:
     name: sshd
-  # has no "when: XXXXX_install" flag
+  #when: sshd_install | bool    # Flag might be created in future?
 
 - name: IIAB-ADMIN
   include_role:
     name: iiab-admin
-  # has no "when: XXXXX_install" flag
+  #when: iiab-admin_install | bool    # Flag might be created in future?
 
 - name: OPENVPN
   include_role:

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -27,6 +27,7 @@
 - name: WWW_BASE (WWW_OPTIONS should be installed later)
   include_role:
     name: www_base
+  #when: www_base_install | bool    # Flag might be created in future?
 
 - name: Recording STAGE 3 HAS COMPLETED =====================
   lineinfile:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -5,7 +5,10 @@
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
   register: iiab_state_file_check
 
-# STRICT CHECK in case {iiab-stages.yml, run-one-role.yml, etc} omit this:
+# 2020-09-21: Why is checking for iiab_state.yml in Stage 4 out of curiosity?
+# Possibly move this to Stage 0?  Either way...this is a STRICT CHECK in case
+# {iiab-stages.yml, run-one-role.yml, etc} omit the file from "vars_files:"
+
 - name: ENFORCE precondition that {{ iiab_state_file }} MUST exist
   assert:
     that: iiab_state_file_check.stat.exists

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -1,19 +1,25 @@
 # Server Options
 
 - name: ...IS BEGINNING ==================================
-  file:
-    path: "{{ iiab_state_file }}"
-    state: touch
+  stat:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+  register: iiab_state_file_check
 
-- name: Install IIAB's python libs
+# STRICT CHECK in case {iiab-stages.yml, run-one-role.yml, etc} omit this:
+- name: ENFORCE precondition that {{ iiab_state_file }} MUST exist
+  assert:
+    that: iiab_state_file_check.stat.exists
+
+- name: Install pylibs (IIAB's python libs)
   include_role:
     name: pylibs
+  #when: pylibs_install | bool    # Flag might be created in future?
 
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
   when: named_install | bool
 
-- name: Installing dhcpd
+- name: Install dhcpd
   include_tasks: roles/network/tasks/dhcpd.yml
   when: dhcpd_install | bool
 
@@ -24,7 +30,7 @@
 - name: Install Bluetooth - only on Raspberry Pi
   include_role:
     name: bluetooth
-  when: rpi_model != "none" and bluetooth_install
+  when: bluetooth_install and rpi_model != "none"
 
 - name: USB_LIB
   include_role:
@@ -48,8 +54,7 @@
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:
     name: www_options
-  #when: www_options_install | bool
-  #when: apache_install or nginx_install
+  #when: www_options_install | bool    # Flag might be created in future?
 
 - name: Recording STAGE 4 HAS COMPLETED ==================
   lineinfile:

--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -3,10 +3,11 @@
 - name: ...IS BEGINNING ====================================
   command: echo
 
+# UNMAINTAINED
 - name: AZURACAST
   include_role:
     name: azuracast
-  when: azuracast_install | bool
+  when: azuracast_install is defined and azuracast_install
 
 # UNMAINTAINED
 - name: DOKUWIKI

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -10,7 +10,7 @@
 
 2. Without PHP available via FastCGI, any function at all for PHP-based applications validates NGINX.
 
-3. Current state of IIAB App/Service migrations as of 2020-09-12:
+3. Current state of IIAB App/Service migrations as of 2020-09-21:
 
    1. These support "Native" NGINX but ***NOT*** Apache
       * Admin Console
@@ -47,6 +47,7 @@
       * openvpn
       * pbx [*, requires Apache for now, as in Section iii.]
       * phpmyadmin [*, requires Apache for now, as in Section iii.]
+      * samba
       * transmission [*]
 
-[*] The 6 above starred roles could use improvement, as of 2020-09-12.
+[*] The 6 above starred roles could use improvement, as of 2020-09-21.

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -45,9 +45,11 @@
       * kalite (menu goes directly to ports 8006-8008)
       * minetest [*]
       * openvpn
+      * mosquitto [*]
       * pbx [*, requires Apache for now, as in Section iii.]
       * phpmyadmin [*, requires Apache for now, as in Section iii.]
       * samba
       * transmission [*]
+      * vnstat [*]
 
-[*] The 6 above starred roles could use improvement, as of 2020-09-21.
+[*] The 8 above starred roles could use improvement, as of 2020-09-21.

--- a/roles/samba/tasks/enable-or-disable.yml
+++ b/roles/samba/tasks/enable-or-disable.yml
@@ -1,0 +1,19 @@
+- name: Enable & Start Samba service ({{ smb_service }}) and NetBIOS name service ({{ nmb_service }}) if samba_enabled
+  systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  when: samba_enabled | bool
+  with_items:
+    - "{{ smb_service }}"
+    - "{{ nmb_service }}"
+
+- name: Disable & Stop Samba service ({{ smb_service }}) and NetBIOS name service ({{ nmb_service }}) if not samba_enabled
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  when: not samba_enabled
+  with_items:
+    - "{{ smb_service }}"
+    - "{{ nmb_service }}"

--- a/roles/samba/tasks/install.yml
+++ b/roles/samba/tasks/install.yml
@@ -4,7 +4,7 @@
     shell: /sbin/nologin
     password: "{{ smbpassword }}"
 
-- name: "Create public folder: {{ shared_dir }}"
+- name: "Create public folder: {{ shared_dir }}"    # /library/public
   file:
     path: "{{ shared_dir }}"
     owner: "{{ smbuser }}"

--- a/roles/samba/tasks/install.yml
+++ b/roles/samba/tasks/install.yml
@@ -1,0 +1,41 @@
+- name: "Create smb user: {{ smbuser }}"
+  user:
+    name: "{{ smbuser }}"
+    shell: /sbin/nologin
+    password: "{{ smbpassword }}"
+
+- name: "Create public folder: {{ shared_dir }}"
+  file:
+    path: "{{ shared_dir }}"
+    owner: "{{ smbuser }}"
+    group: "{{ smbuser }}"
+    mode: '0777'
+    state: directory
+
+# Install and configure samba server (requires ports 137, 138, 139, 445 open).
+- name: "Install 4 packages: samba, samba-client, samba-common, cifs-client"
+  package:
+    name:
+      - samba
+      - samba-client
+      - samba-common
+      - cifs-utils
+    state: present
+
+- name: Install /etc/samba/smb.conf from template
+  template:
+    src: smb.conf.j2
+    dest: /etc/samba/smb.conf
+
+
+# RECORD Samba AS INSTALLED
+
+- name: "Set 'samba_installed: True'"
+  set_fact:
+    samba_installed: True
+
+- name: "Add 'samba_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^samba_installed'
+    line: 'samba_installed: True'

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -1,73 +1,30 @@
-- name: "Create smb user: {{ smbuser }}"
-  user:
-    name: "{{ smbuser }}"
-    shell: /sbin/nologin
-    password: "{{ smbpassword }}"
+# "How do i fail a task in Ansible if the variable contains a boolean value?
+# I want to perform input validation for Ansible playbooks"
+# https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-- name: "Create public folder: {{ shared_dir }}"
-  file:
-    path: "{{ shared_dir }}"
-    owner: "{{ smbuser }}"
-    group: "{{ smbuser }}"
-    mode: '0777'
-    state: directory
+# We assume 0-init/tasks/validate_vars.yml has DEFINITELY been run, so no need
+# to re-check whether vars are defined here.  As Ansible vars cannot be unset:
+# https://serverfault.com/questions/856729/how-to-destroy-delete-unset-a-variable-value-in-ansible
 
-# Install and configure samba server (requires ports 137, 138, 139, 445 open).
-- name: "Install 4 packages: samba, samba-client, samba-common, cifs-client"
-  package:
-    name:
-      - samba
-      - samba-client
-      - samba-common
-      - cifs-utils
-    state: present
+- name: Assert that "samba_install is sameas true" (boolean not string etc)
+  assert:
+    that: samba_install is sameas true
+    fail_msg: "PLEASE SET 'samba_install: True' e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
 
-- name: Install /etc/samba/smb.conf from template
-  template:
-    src: smb.conf.j2
-    dest: /etc/samba/smb.conf
+- name: Assert that "samba_enabled | type_debug == 'bool'" (boolean not string etc)
+  assert:
+    that: samba_enabled | type_debug == 'bool'
+    fail_msg: "PLEASE GIVE VARIABLE 'samba_enabled' A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
 
 
-# RECORD Samba AS INSTALLED
-
-- name: "Set 'samba_installed: True'"
-  set_fact:
-    samba_installed: True
-
-- name: "Add 'samba_installed: True' to {{ iiab_state_file }}"
-  lineinfile:
-    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-    regexp: '^samba_installed'
-    line: 'samba_installed: True'
+- name: Install Samba if 'samba_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+  include_tasks: install.yml
+  when: samba_installed is undefined
 
 
-- name: Enable & Start Samba systemd service ({{ smb_service }}) if samba_enabled
-  service:
-    name: "{{ smb_service }}"
-    state: started
-    enabled: yes
-  when: samba_enabled | bool
-
-- name: Enable & Start NetBIOS name service ({{ nmb_service }}) if samba_enabled
-  service:
-    name: "{{ nmb_service }}"
-    state: started
-    enabled: yes
-  when: samba_enabled | bool
-
-- name: Disable & Stop Samba systemd service ({{ smb_service }}) if not samba_enabled
-  systemd:
-    name: "{{ smb_service }}"
-    state: stopped
-    enabled: no
-  when: not samba_enabled
-
-- name: Disable & Stop NetBIOS name service ({{ nmb_service }}) if not samba_enabled
-  systemd:
-    name: "{{ nmb_service }}"
-    state: stopped
-    enabled: no
-  when: not samba_enabled
+- include_tasks: enable-or-disable.yml
 
 
 - name: Add 'samba' variable values to {{ iiab_ini_file }}

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Add 'samba' variable values to {{ iiab_ini_file }}
   ini_file:
-    path: "{{ iiab_ini_file }}"
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: samba
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"


### PR DESCRIPTION
Resolves (Partially!) #2536

In recent years, IIAB's Samba role was unmaintained as several of us were thinking of deprecating it.  However this created sloppy usage with runrole etc.  Thanks @jvonau for identifying this within #2536.

To avoid those risks, this PR modernizes IIAB's Samba role, so it checks variables `samba_install` and `samba_enabled`, as other roles have been doing for many months now.

Tested on Ubuntu Desktop 20.04.1

(At the same time let's keep open the option of deprecating / de-supporting Samba completely in future, as it's very rarely used and might be more trouble than it's worth!)