### PR TITLE
Prune validate

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -96,46 +96,6 @@
     gui_port: 443
   when: adm_cons_force_ssl | bool
 
-- name: Turn on both vars for MySQL (mandatory in Stage 3!)
-  set_fact:
-    mysql_install: True
-    mysql_enabled: True
-
-# We decided to enable mysql unconditionally.
-#  when: elgg_enabled or rachel_enabled or owncloud_enabled or phpmyadmin_enabled or wordpress_enabled or iiab_menu_install
-
-- name: "Set python_path: /lib/python2.7/site-packages/ (redhat)"
-  set_fact:
-    python_path: /lib/python2.7/site-packages/
-  when: is_redhat | bool
-
-- name: "Set python_path: /usr/local/lib/python2.7/dist-packages/ (debuntu)"
-  set_fact:
-    python_path: /usr/local/lib/python2.7/dist-packages/
-  when: is_debuntu | bool
-
-# For various reasons the mysql service cannot be enabled on Fedora 20, but
-# 'mariadb', which is its real name can.  On Fedora 18 we need to use 'mysqld'.
-
-# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-#- name: "Set mysql_service: mariadb by default"
-#  set_fact:
-#    mysql_service: mariadb
-
-- name: "Set mysql_service: mysqld etc (Fedora 18)"
-  set_fact:
-    # BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-    #mysql_service: mysqld
-    no_NM_reload: True
-    is_F18: True
-  when: (ansible_distribution_release == "based on Fedora 18" or ansible_distribution_version == "18") and ansible_distribution == "Fedora"
-
-# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-#- name: "Set mysql_service: mysql (debuntu)"
-#  set_fact:
-#    mysql_service: mysql
-#  when: is_debuntu | bool
-
 - name: "Set iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}"
   set_fact:
     iiab_fqdn: "{{ iiab_hostname }}.{{ iiab_domain }}"

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -54,8 +54,6 @@
       - wondershaper
       - sshd
       - openvpn
-      - admin_console
-      - apache
       - squid
       - dansguardian
       - cups

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -60,7 +60,6 @@
       - mysql
       - squid
       - dansguardian
-      - postgresql
       - cups
       - samba
       - usb_lib

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -42,7 +42,7 @@
 # are officially now UNMAINTAINED in default_vars.yml and
 # https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt etc?
 
-- name: Set vars_checklist for 53 + 53 + up-to-53 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
+- name: Set vars_checklist for 46 + 46 + up-to-46 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
     vars_checklist:
       - hostapd

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -55,7 +55,6 @@
       - sshd
       - openvpn
       - admin_console
-      - nginx
       - apache
       - squid
       - dansguardian

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -57,7 +57,6 @@
       - admin_console
       - nginx
       - apache
-      - mysql
       - squid
       - dansguardian
       - cups

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -75,7 +75,6 @@
       - lokole
       - mediawiki
       - mosquitto
-      - nodejs
       - nodered
       - nextcloud
       - pbx

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -85,7 +85,6 @@
       - kolibri
       - kiwix
       - moodle
-      - mongodb
       - sugarizer
       - osm_vector_maps
       - transmission

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -5,7 +5,6 @@
 
 - name: dnsmasq (install now, configure LATER in 'network', after Stage 9)
   include_tasks: roles/network/tasks/dnsmasq.yml
-  #when: dnsmasq_install | bool
 
 - name: Install uuid-runtime package (debuntu)
   package:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -77,7 +77,6 @@
 - name: SSHD
   include_role:
     name: sshd
-  #when: sshd_install | bool    # Flag might be created in future?
 
 - name: IIAB-ADMIN
   include_role:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -81,7 +81,6 @@
 - name: IIAB-ADMIN
   include_role:
     name: iiab-admin
-  #when: iiab_admin_install | bool    # Flag might be created in future?
 
 - name: OPENVPN
   include_role:

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -6,7 +6,6 @@
 - name: MYSQL
   include_role:
     name: mysql
-  when: mysql_install | bool
 
 # 2020-05-21: Apache role 'httpd' is installed as nec by any of these 7 roles:
 #

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -21,7 +21,6 @@
 - name: NGINX
   include_role:
     name: nginx
-  when: nginx_install | bool
 
 - name: WWW_BASE (WWW_OPTIONS should be installed later)
   include_role:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -18,6 +18,10 @@
     name: pylibs
   #when: pylibs_install | bool    # Flag might be created in future?
 
+- name: SSHD
+  include_role:
+    name: sshd
+
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
   when: named_install | bool

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -16,7 +16,6 @@
 - name: Install pylibs (IIAB's python libs)
   include_role:
     name: pylibs
-  #when: pylibs_install | bool    # Flag might be created in future?
 
 - name: SSHD
   include_role:
@@ -61,7 +60,6 @@
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:
     name: www_options
-  #when: www_options_install | bool    # Flag might be created in future?
 
 - name: Recording STAGE 4 HAS COMPLETED ==================
   lineinfile:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -471,10 +471,8 @@ moodle_enabled: False
 # This role was formerly installed by roles/sugarizer/meta/main.yml
 #
 # 2020-02-04: mongodb_install is completely ignored as MongoDB is installed on
-# demand as a dependency -- by Sugarizer -- but for now we set fake value
-# 'mongodb_install: True' so that 'mongodb_installed is defined' input
-# validation works, e.g. in 0-init/tasks/validate_vars.yml
-mongodb_install: True
+# demand as a dependency -- by Sugarizer
+mongodb_install: False
 # FYI 'mongodb_enabled: False' works when Sugarizer is disabled.  Required by
 # mongodb/tasks/enable.yml to shut down the service and log status, but that is
 # misleading as Sugarizer starts mongodb's systemd service on its own, due to

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -296,11 +296,8 @@ dansguardian_install: False
 dansguardian_enabled: False
 
 # 2020-02-04: postgresql_install is completely ignored as PostgreSQL is
-# installed on demand as a dependency -- by Moodle &/or Pathagar -- but for now
-# we set fake value 'postgresql_install: True' so that
-# 'postgresql_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-postgresql_install: True
+# installed on demand as a dependency -- by Moodle &/or Pathagar
+postgresql_install: False
 postgresql_enabled: False
 
 # Common UNIX Printing System (CUPS)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -208,7 +208,7 @@ wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 # 1-PREP
 
 # SEE ssh_port var above.
-sshd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
+sshd_install: True
 sshd_enabled: True
 
 # roles/iiab-admin runs here

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -250,6 +250,7 @@ mysql_enabled: True
 
 # 2019-01-13: IIAB's use of NGINX is still evolving -- please review this
 # evolving doc: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
+# 2020-09-21: removed install |bool in stage 3, not optional and has no effect
 nginx_install: True
 nginx_enabled: True
 nginx_port: 80

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -272,10 +272,8 @@ apache_allow_sudo: True
 #
 # 2020-05-21: apache_install is completely ignored as Apache is installed on
 # demand as a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED and/or
-# phpMyAdmin -- but for now we set fake value 'apache_install: True' so that
-# 'apache_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-apache_install: True
+# phpMyAdmin
+apache_install: False
 apache_enabled: False
 #
 # NGINX proxies to Apache for legacy IIAB services, using:
@@ -558,10 +556,8 @@ vnstat_enabled: False
 # 9-LOCAL-ADDONS
 
 # 2020-02-04: yarn_install is completely ignored as the Yarn package manager is
-# installed on demand as a dependency -- by Internet Archive -- but for now we
-# set fake value 'yarn_install: True' so that 'yarn_installed is defined' input
-# validation works, e.g. in 0-init/tasks/validate_vars.yml
-yarn_install: True
+# installed on demand as a dependency -- by Internet Archive
+yarn_install: False
 yarn_enabled: False
 
 # Internet Archive Offline / Decentralized Web - create your own offline

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -392,10 +392,7 @@ mosquitto_port: 1883
 
 # 2020-02-04: nodejs_install is completely ignored as Node.js is installed on
 # demand as a dependency -- by Node-RED, Sugarizer and/or Internet Archive --
-# but for now we set fake value 'nodejs_install: True' so that
-# 'nodejs_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-nodejs_install: True
+nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")


### PR DESCRIPTION
The 7 removed roles are part of stage 3 and not user configurable due to the absence from local_vars_*.yml, installed on demand with the facts set in the calling role, or the role does not exist.