### PR TITLE
iiab-diagnostics: collect last 100 lines from iiab-configure.log (generated by ./iiab-configure)

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -211,8 +211,9 @@ cat_cmd 'sudo iptables-save' 'Firewall rules'
 echo -e "\n  6. Log Files: (last 100 lines of each)\n"
 echo -e "\n\n\n\n6. LOG FILES (LAST 100 LINES OF EACH)\n" >> $outfile
 cat_tail /opt/iiab/iiab/iiab-install.log 100
-cat_tail /opt/iiab/iiab/iiab-network.log 100
+cat_tail /opt/iiab/iiab/iiab-configure.log 100
 cat_tail /opt/iiab/iiab/iiab-debug.log 100
+cat_tail /opt/iiab/iiab/iiab-network.log 100
 cat_tail /opt/iiab/iiab-admin-console/admin-install.log 100
 cat_tail /var/log/messages 100
 cat_tail /var/log/syslog 100

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -62,4 +62,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 106-218 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 106-219 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
`/usr/bin/iiab-diagnostics` pastebin snapshots are getting a bit overweight (around 2000 lines) but `/opt/iiab/iiab/iiab-configure.log` seems important, as generated by the `./iiab-configure` command, as is newly recommended here...

http://FAQ.IIAB.IO > "24 What is local_vars.yml and how do I customize it?"

Builds on PRs #2439 #2476 #2485