### PR TITLE
MediaWiki 1.34.2 -> 1.34.3 Security Patches

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: 1.34    # "1.34" also works
-mediawiki_minor_version: 2
+mediawiki_minor_version: 3
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
ANNC: https://lists.wikimedia.org/pipermail/mediawiki-announce/2020-September/000260.html

In anticipation of MediaWiki 1.35.0 LTS hopefully arriving very soon: #2535