### PR TITLE
Near-final Release Cleanup of validate_vars, default_vars, local_vars, Stages 0-4, SSHD, Moodle, MediaWiki 1.34.4

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -96,46 +96,6 @@
     gui_port: 443
   when: adm_cons_force_ssl | bool
 
-- name: Turn on both vars for MySQL (mandatory in Stage 3!)
-  set_fact:
-    mysql_install: True
-    mysql_enabled: True
-
-# We decided to enable mysql unconditionally.
-#  when: elgg_enabled or rachel_enabled or owncloud_enabled or phpmyadmin_enabled or wordpress_enabled or iiab_menu_install
-
-- name: "Set python_path: /lib/python2.7/site-packages/ (redhat)"
-  set_fact:
-    python_path: /lib/python2.7/site-packages/
-  when: is_redhat | bool
-
-- name: "Set python_path: /usr/local/lib/python2.7/dist-packages/ (debuntu)"
-  set_fact:
-    python_path: /usr/local/lib/python2.7/dist-packages/
-  when: is_debuntu | bool
-
-# For various reasons the mysql service cannot be enabled on Fedora 20, but
-# 'mariadb', which is its real name can.  On Fedora 18 we need to use 'mysqld'.
-
-# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-#- name: "Set mysql_service: mariadb by default"
-#  set_fact:
-#    mysql_service: mariadb
-
-- name: "Set mysql_service: mysqld etc (Fedora 18)"
-  set_fact:
-    # BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-    #mysql_service: mysqld
-    no_NM_reload: True
-    is_F18: True
-  when: (ansible_distribution_release == "based on Fedora 18" or ansible_distribution_version == "18") and ansible_distribution == "Fedora"
-
-# BETTER TO USE /opt/iiab/iiab/vars/<OS>.yml
-#- name: "Set mysql_service: mysql (debuntu)"
-#  set_fact:
-#    mysql_service: mysql
-#  when: is_debuntu | bool
-
 - name: "Set iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}"
   set_fact:
     iiab_fqdn: "{{ iiab_hostname }}.{{ iiab_domain }}"

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -54,8 +54,6 @@
       - wondershaper
       - sshd
       - openvpn
-      - admin_console
-      - apache
       - squid
       - dansguardian
       - cups

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -60,7 +60,6 @@
       - mysql
       - squid
       - dansguardian
-      - postgresql
       - cups
       - samba
       - usb_lib

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -42,7 +42,7 @@
 # are officially now UNMAINTAINED in default_vars.yml and
 # https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt etc?
 
-- name: Set vars_checklist for 53 + 53 + up-to-53 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
+- name: Set vars_checklist for 46 + 46 + up-to-46 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
     vars_checklist:
       - hostapd

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -55,7 +55,6 @@
       - sshd
       - openvpn
       - admin_console
-      - nginx
       - apache
       - squid
       - dansguardian

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -42,7 +42,7 @@
 # are officially now UNMAINTAINED in default_vars.yml and
 # https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt etc?
 
-- name: Set vars_checklist for 46 + 46 + up-to-46 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
+- name: Set vars_checklist for 47 + 47 + up-to-47 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
     vars_checklist:
       - hostapd
@@ -54,8 +54,13 @@
       - wondershaper
       - sshd
       - openvpn
+      - admin_console
+      #- nginx     # MANDATORY
+      #- apache    # Dependency installed on demand, by other apps/services
+      #- mysql     # MANDATORY
       - squid
       - dansguardian
+      #- postgresql    # Dependency installed on demand, by other apps/services
       - cups
       - samba
       - usb_lib
@@ -71,6 +76,7 @@
       - lokole
       - mediawiki
       - mosquitto
+      #- nodejs    # Dependency installed on demand, by other apps/services
       - nodered
       - nextcloud
       - pbx
@@ -79,6 +85,7 @@
       - kolibri
       - kiwix
       - moodle
+      #- mongodb    # Dependency installed on demand, by other apps/services
       - sugarizer
       - osm_vector_maps
       - transmission

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -60,7 +60,6 @@
       #- mysql     # MANDATORY
       - squid
       - dansguardian
-      #- postgresql    # Dependency installed on demand, by other apps/services
       - cups
       - samba
       - usb_lib
@@ -84,6 +83,7 @@
       - kalite
       - kolibri
       - kiwix
+      #- postgresql    # Dependency installed on demand, by other apps/services
       - moodle
       #- mongodb    # Dependency installed on demand, by other apps/services
       - sugarizer
@@ -94,6 +94,7 @@
       - munin
       - phpmyadmin
       - vnstat
+      #- yarn    # Dependency installed on demand, by other apps/services
       - internetarchive
       - minetest
       - calibre

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -57,7 +57,6 @@
       - admin_console
       - nginx
       - apache
-      - mysql
       - squid
       - dansguardian
       - cups

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -75,7 +75,6 @@
       - lokole
       - mediawiki
       - mosquitto
-      - nodejs
       - nodered
       - nextcloud
       - pbx

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -85,7 +85,6 @@
       - kolibri
       - kiwix
       - moodle
-      - mongodb
       - sugarizer
       - osm_vector_maps
       - transmission

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -5,7 +5,6 @@
 
 - name: dnsmasq (install now, configure LATER in 'network', after Stage 9)
   include_tasks: roles/network/tasks/dnsmasq.yml
-  #when: dnsmasq_install | bool
 
 - name: Install uuid-runtime package (debuntu)
   package:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -5,6 +5,7 @@
 
 - name: dnsmasq (install now, configure LATER in 'network', after Stage 9)
   include_tasks: roles/network/tasks/dnsmasq.yml
+  #when: dnsmasq_install | bool    # Flag might be used in future?
 
 - name: Install uuid-runtime package (debuntu)
   package:
@@ -74,13 +75,16 @@
   shell: apt -y remove "libgeos-*"
   when: grep_ubermix.rc == 0    # 1 if absent in file, 2 if file doesn't exist
 
+# Required by OpenVPN below.  Also run by roles/4-server-options/tasks/main.yml
 - name: SSHD
   include_role:
     name: sshd
+  when: sshd_install | bool
 
 - name: IIAB-ADMIN
   include_role:
     name: iiab-admin
+  #when: iiab_admin_install | bool    # Flag might be created in future?
 
 - name: OPENVPN
   include_role:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -77,7 +77,6 @@
 - name: SSHD
   include_role:
     name: sshd
-  #when: sshd_install | bool    # Flag might be created in future?
 
 - name: IIAB-ADMIN
   include_role:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -81,7 +81,6 @@
 - name: IIAB-ADMIN
   include_role:
     name: iiab-admin
-  #when: iiab_admin_install | bool    # Flag might be created in future?
 
 - name: OPENVPN
   include_role:

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -40,7 +40,7 @@
       - htop
       - i2c-tools
       - logrotate
-      #- lynx    # Already installed by 1-prep's roles/iiab-admin/tasks/access.yml
+      #- lynx    # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
       - make
       - mlocate
       - netmask
@@ -50,6 +50,7 @@
       - pandoc
       - pastebinit
       - rsync
+      #- screen    # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
       - sqlite3
       - sudo
       - tar

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -6,6 +6,7 @@
 - name: MYSQL
   include_role:
     name: mysql
+  #when: mysql_install | bool
 
 # 2020-05-21: Apache role 'httpd' is installed as nec by any of these 7 roles:
 #
@@ -21,6 +22,7 @@
 - name: NGINX
   include_role:
     name: nginx
+  #when: nginx_install | bool
 
 - name: WWW_BASE (WWW_OPTIONS should be installed later)
   include_role:

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -6,7 +6,6 @@
 - name: MYSQL
   include_role:
     name: mysql
-  when: mysql_install | bool
 
 # 2020-05-21: Apache role 'httpd' is installed as nec by any of these 7 roles:
 #

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -21,7 +21,6 @@
 - name: NGINX
   include_role:
     name: nginx
-  when: nginx_install | bool
 
 - name: WWW_BASE (WWW_OPTIONS should be installed later)
   include_role:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -18,6 +18,10 @@
     name: pylibs
   #when: pylibs_install | bool    # Flag might be created in future?
 
+- name: SSHD
+  include_role:
+    name: sshd
+
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
   when: named_install | bool

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -16,7 +16,6 @@
 - name: Install pylibs (IIAB's python libs)
   include_role:
     name: pylibs
-  #when: pylibs_install | bool    # Flag might be created in future?
 
 - name: SSHD
   include_role:
@@ -61,7 +60,6 @@
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:
     name: www_options
-  #when: www_options_install | bool    # Flag might be created in future?
 
 - name: Recording STAGE 4 HAS COMPLETED ==================
   lineinfile:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -16,10 +16,13 @@
 - name: Install pylibs (IIAB's python libs)
   include_role:
     name: pylibs
+  #when: pylibs_install | bool    # Flag might be created in future?
 
+# Also run roles/1-prep/tasks/main.yml as required by OpenVPN.
 - name: SSHD
   include_role:
     name: sshd
+  when: sshd_install | bool
 
 - name: Install named / BIND
   include_tasks: roles/network/tasks/named.yml
@@ -60,6 +63,7 @@
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:
     name: www_options
+  #when: www_options_install | bool    # Flag might be created in future?
 
 - name: Recording STAGE 4 HAS COMPLETED ==================
   lineinfile:

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -18,7 +18,7 @@
     name: pylibs
   #when: pylibs_install | bool    # Flag might be created in future?
 
-# Also run roles/1-prep/tasks/main.yml as required by OpenVPN.
+# Also run by roles/1-prep/tasks/main.yml as required by OpenVPN.
 - name: SSHD
   include_role:
     name: sshd

--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: 1.34    # "1.34" also works
-mediawiki_minor_version: 3
+mediawiki_minor_version: 4
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -40,6 +40,11 @@
 #     enabled: no
 #   when: not moodle_enabled and not (pathagar_enabled is defined and pathagar_enabled)
 
+- name: "Set 'postgresql_install: True' if moodle_enabled"
+  set_fact:
+    postgresql_install: True
+  when: moodle_enabled | bool
+
 - name: "Set 'postgresql_enabled: True' if moodle_enabled"
   set_fact:
     postgresql_enabled: True

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -40,13 +40,9 @@
 #     enabled: no
 #   when: not moodle_enabled and not (pathagar_enabled is defined and pathagar_enabled)
 
-- name: "Set 'postgresql_install: True' if moodle_enabled"
+- name: "Set 'postgresql_install: True' and 'postgresql_enabled: True' if moodle_enabled"
   set_fact:
     postgresql_install: True
-  when: moodle_enabled | bool
-
-- name: "Set 'postgresql_enabled: True' if moodle_enabled"
-  set_fact:
     postgresql_enabled: True
   when: moodle_enabled | bool
 

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -43,7 +43,7 @@
   lineinfile:
     dest: /etc/avahi/services/ssh.service
     regexp: '</port>$'
-    line: '    <port>{{ ssh_port }}</port>'
+    line: '    <port>{{ sshd_port }}</port>'
     state: present
     backrefs: yes
 

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -46,7 +46,7 @@ echo -e "WAN: $wan\n"
 ports_externally_visible={{ ports_externally_visible }}
 #services_externally_visible= [deprecated]
 gw_block_https={{ gw_block_https }}
-ssh_port={{ ssh_port }}
+sshd_port={{ sshd_port }}
 #gui_wan= [no longer needed]
 gui_port={{ gui_port }}
 iiab_gateway_enabled={{ iiab_gateway_enabled }}
@@ -132,7 +132,7 @@ if [ "$wan" != "none" ]; then
 
     # 1 = ssh only
     if [ "$ports_externally_visible" -ge 1 ]; then
-        $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
+        $IPTABLES -A INPUT -p tcp --dport $sshd_port -m state --state NEW -i $wan -j ACCEPT
     fi
 
     # 2 = ssh + http-or-https (for Admin Console's box.lan/admin too)

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -10,7 +10,7 @@
 
 2. Without PHP available via FastCGI, any function at all for PHP-based applications validates NGINX.
 
-3. Current state of IIAB App/Service migrations as of 2020-09-22:
+3. Current state of IIAB App/Service migrations as of 2020-09-24:
 
    1. These support "Native" NGINX but ***NOT*** Apache
       * Admin Console
@@ -20,7 +20,7 @@
       * OER2Go/RACHEL modules
       * usb_lib
 
-   2. These support "Native" NGINX ***AND*** Apache, a.k.a. "dual support" for legacy testing (if suitable "Shims" from *Section iii.* below are preserved!)  Both "Native" NGINX and "Shim" proxying from NGINX to Apache port 8090 *cannot be enabled simultaneously* for these IIAB Apps/Service.  But if you want to attempt their "Shim" proxying legacy testing mode, try setting your *primary web server* to Apache using `apache_install: True` and `apache_enabled: True` (and `nginx_enabled: False` to disable NGINX) in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) before you install IIAB.  You may also need to run `cd /opt/iiab/iiab; ./runrole httpd` since this has been removed from [roles/3-base-server/tasks/main.yml](https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml)
+   2. These support "Native" NGINX ***AND*** Apache, a.k.a. "dual support" for legacy testing (if suitable "Shims" from *Section iii.* below are preserved!)  Both "Native" NGINX and "Shim" proxying from NGINX to Apache port 8090 *cannot be enabled simultaneously* for these IIAB Apps/Service:<!--But if you want to attempt their "Shim" proxying legacy testing mode, try setting your *primary web server* to Apache using `apache_install: True` and `apache_enabled: True` (and `nginx_enabled: False` to disable NGINX) in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) before you install IIAB.  You may also need to run `cd /opt/iiab/iiab; ./runrole httpd` since this has been removed from [roles/3-base-server/tasks/main.yml](https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml)-->
       * awstats
       * calibre-web
       * gitea
@@ -48,9 +48,10 @@
       * mosquitto
       * openvpn
       * pbx [*, requires Apache for now, as in Section iii.]
-      * phpmyadmin [requires Apache for now, as in Section iii.]
+      * phpmyadmin [*, requires Apache for now, as in Section iii.]
       * samba
+      * sshd
       * transmission
       * vnstat
 
-[*] The 3 above starred roles could use improvement, as of 2020-09-22.
+[*] The 4 above starred roles could use improvement, as of 2020-09-24.

--- a/roles/sshd/tasks/enable-or-disable.yml
+++ b/roles/sshd/tasks/enable-or-disable.yml
@@ -1,0 +1,15 @@
+- name: Enable & (Re)Start ssh daemon ({{ sshd_service }}) if sshd_enabled
+  systemd:
+    daemon_reload: yes
+    name: "{{ sshd_service }}"
+    enabled: yes
+    state: restarted
+  when: sshd_enabled | bool
+
+- name: Disable & Stop ssh daemon ({{ sshd_service }}) if not sshd_enabled
+  systemd:
+    daemon_reload: yes
+    name: "{{ sshd_service }}"
+    enabled: no
+    state: stopped
+  when: not sshd_enabled

--- a/roles/sshd/tasks/install.yml
+++ b/roles/sshd/tasks/install.yml
@@ -1,0 +1,55 @@
+# TODO:
+#
+# 1) Implement sshd_port IF it's truly needed? Mentioned here as of 2020-09-24:
+#
+#    vars/default_vars.yml  Line 283
+#    roles/sshd/tasks/main.yml  Lines 41-42
+#    roles/network/tasks/avahi.yml  Line 46
+#    roles/network/templates/gateway/iiab-gen-iptables  Line 49 & 135
+#
+# 2) Use Ansible handler to reload ssh?
+
+- name: "Install ssh daemon using package: {{ sshd_package }}"
+  package:
+    name: "{{ sshd_package }}"
+    state: present
+
+- name: Disable password-based logins to root
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin'
+    line: 'PermitRootLogin without-password'
+    state: present
+  #when: sshd_enabled | bool
+
+- name: mkdir /root/.ssh
+  file:
+    state: directory
+    path: /root/.ssh
+    owner: root
+    group: root
+    mode: '0700'
+  #when: sshd_enabled | bool
+
+- name: Install dummy root keys as placeholder
+  copy:
+    src: dummy_authorized_keys
+    dest: /root/.ssh/authorized_keys
+    owner: root
+    group: root
+    mode: '0600'
+    force: no
+  #when: sshd_enabled | bool
+
+
+# RECORD sshd AS INSTALLED
+
+- name: "Set 'sshd_installed: True'"
+  set_fact:
+    sshd_installed: True
+
+- name: "Add 'sshd_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^sshd_installed'
+    line: 'sshd_installed: True'

--- a/roles/sshd/tasks/install.yml
+++ b/roles/sshd/tasks/install.yml
@@ -2,7 +2,7 @@
 #
 # 1) Implement sshd_port IF it's truly needed? Mentioned here as of 2020-09-24:
 #
-#    vars/default_vars.yml  Line 283
+#    vars/default_vars.yml  Line 212
 #    roles/sshd/tasks/main.yml  Lines 41-42
 #    roles/network/tasks/avahi.yml  Line 46
 #    roles/network/templates/gateway/iiab-gen-iptables  Line 49 & 135

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -1,61 +1,44 @@
-- name: "Install ssh daemon using package: {{ sshd_package }}"
-  package:
-    name: "{{ sshd_package }}"
-    state: present
+# "How do i fail a task in Ansible if the variable contains a boolean value?
+# I want to perform input validation for Ansible playbooks"
+# https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-- name: Disable password-based logins to root
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: '^PermitRootLogin'
-    line: 'PermitRootLogin without-password'
-    state: present
-  #when: sshd_enabled | bool
-#TODO: use handler to reload ssh
+# We assume 0-init/tasks/validate_vars.yml has DEFINITELY been run, so no need
+# to re-check whether vars are defined here.  As Ansible vars cannot be unset:
+# https://serverfault.com/questions/856729/how-to-destroy-delete-unset-a-variable-value-in-ansible
 
-- name: mkdir /root/.ssh
-  file:
-    state: directory
-    path: /root/.ssh
-    owner: root
-    group: root
-    mode: '0700'
-  #when: sshd_enabled | bool
+- name: Assert that "sshd_install is sameas true" (boolean not string etc)
+  assert:
+    that: sshd_install is sameas true
+    fail_msg: "PLEASE SET 'sshd_install: True' e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
 
-- name: Install dummy root keys as placeholder
-  copy:
-    src: dummy_authorized_keys
-    dest: /root/.ssh/authorized_keys
-    owner: root
-    group: root
-    mode: '0600'
-    force: no
-  #when: sshd_enabled | bool
+- name: Assert that "sshd_enabled | type_debug == 'bool'" (boolean not string etc)
+  assert:
+    that: sshd_enabled | type_debug == 'bool'
+    fail_msg: "PLEASE GIVE VARIABLE 'sshd_enabled' A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
 
 
-# RECORD sshd AS INSTALLED
-
-- name: "Set 'sshd_installed: True'"
-  set_fact:
-    sshd_installed: True
-
-- name: "Add 'sshd_installed: True' to {{ iiab_state_file }}"
-  lineinfile:
-    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-    regexp: '^sshd_installed'
-    line: 'sshd_installed: True'
+- name: Install sshd if 'sshd_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+  include_tasks: install.yml
+  when: sshd_installed is undefined
 
 
-- name: Enable & Start ssh daemon ({{ sshd_service }}) if sshd_enabled
-  systemd:
-    name: "{{ sshd_service }}"
-    daemon_reload: yes
-    enabled: yes
-    state: started
-  when: sshd_enabled | bool
+- include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop ssh daemon ({{ sshd_service }}) if not sshd_enabled
-  systemd:
-    name: "{{ sshd_service }}"
-    enabled: no
-    state: stopped
-  when: not sshd_enabled
+
+- name: Add 'sshd' variable values to {{ iiab_ini_file }}
+  ini_file:
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+    section: sshd
+    option: "{{ item.option }}"
+    value: "{{ item.value | string }}"
+  with_items:
+  - option: name
+    value: sshd
+  - option: description
+    value: '"Secure Shell daemon (typically implemented by openssh-server) for remote login using the ''ssh'' low-level protocol."'
+  - option: sshd_port
+    value: "{{ sshd_port }}"
+  - option: sshd_enabled
+    value: "{{ sshd_enabled }}"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -239,13 +239,17 @@ pi_swap_file_size: 1024
 admin_console_install: True
 admin_console_enabled: True
 
-# MySQL MANDATORY - THESE 2 VARS HAVE NO EFFECT - SEE roles/0-init/tasks/main.yml & roles/mysql/tasks/main.yml
+# 2020-09-24: MySQL / MariaDB is MANDATORY but still evolving - please see:
+# https://github.com/iiab/iiab/blob/master/roles/mysql/tasks/install.yml
+# https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml
+# THESE 2 LEGACY VARS ARE PRESERVED BUT HAVE NO EFFECT:
 mysql_install: True
 mysql_enabled: True
 
-# 2019-01-13: IIAB's use of NGINX is still evolving -- please review this
-# evolving doc: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
-# 2020-09-24: NGINX is mandatory, SEE: roles/3-base-server/tasks/main.yml
+# 2020-09-24: NGINX is MANDATORY but still evolving - please see:
+# https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
+# https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml
+# THESE 2 LEGACY VARS ARE PRESERVED BUT HAVE NO EFFECT:
 nginx_install: True
 nginx_enabled: True
 nginx_port: 80

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -206,9 +206,13 @@ wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # 1-PREP
 
-# roles/iiab-admin runs here
-# SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE: e.g. iiab_admin_user_install,
-# iiab_admin_user, iiab_admin_published_pwd, iiab_admin_pwd_hash
+# SSHD runs here & also below in 4-SERVER-OPTIONS
+sshd_install: True    # Required by OpenVPN
+sshd_enabled: True
+sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+
+# IIAB-ADMIN runs here - see its vars near top of this file:
+# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
 
 openvpn_install: True
 openvpn_enabled: False
@@ -282,9 +286,7 @@ apache_interface: 127.0.0.1    # 2020-01-13: Var unused
 
 # 4-SERVER-OPTIONS
 
-sshd_install: True    # Required by OpenVPN
-sshd_enabled: True
-sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+# SSHD runs here & also above in 1-PREP
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -113,7 +113,6 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 # Gateway mode
 iiab_lan_enabled: True
 iiab_wan_enabled: True
-ssh_port: 22    # SEE sshd_* vars below.
 # Ties in what the user populated in the GUI for static WAN IP address info:
 gui_wan: True
 adm_cons_force_ssl: False
@@ -207,10 +206,6 @@ wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 
 # 1-PREP
 
-# SEE ssh_port var above.
-sshd_install: True
-sshd_enabled: True
-
 # roles/iiab-admin runs here
 # SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE: e.g. iiab_admin_user_install,
 # iiab_admin_user, iiab_admin_published_pwd, iiab_admin_pwd_hash
@@ -250,7 +245,7 @@ mysql_enabled: True
 
 # 2019-01-13: IIAB's use of NGINX is still evolving -- please review this
 # evolving doc: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
-# 2020-09-21: removed install |bool in stage 3, not optional and has no effect
+# 2020-09-24: NGINX is mandatory, SEE: roles/3-base-server/tasks/main.yml
 nginx_install: True
 nginx_enabled: True
 nginx_port: 80
@@ -271,7 +266,7 @@ apache_allow_sudo: True
 # See also Apache vars {default_language, language_priority} @ top of this file
 #
 # 2020-05-21: apache_install is completely ignored as Apache is installed on
-# demand as a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED and/or
+# demand as a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED, PBX and/or
 # phpMyAdmin
 apache_install: False
 apache_enabled: False
@@ -282,6 +277,10 @@ apache_interface: 127.0.0.1    # 2020-01-13: Var unused
 
 
 # 4-SERVER-OPTIONS
+
+sshd_install: True    # Required by OpenVPN
+sshd_enabled: True
+sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -471,10 +471,8 @@ moodle_enabled: False
 # This role was formerly installed by roles/sugarizer/meta/main.yml
 #
 # 2020-02-04: mongodb_install is completely ignored as MongoDB is installed on
-# demand as a dependency -- by Sugarizer -- but for now we set fake value
-# 'mongodb_install: True' so that 'mongodb_installed is defined' input
-# validation works, e.g. in 0-init/tasks/validate_vars.yml
-mongodb_install: True
+# demand as a dependency -- by Sugarizer
+mongodb_install: False
 # FYI 'mongodb_enabled: False' works when Sugarizer is disabled.  Required by
 # mongodb/tasks/enable.yml to shut down the service and log status, but that is
 # misleading as Sugarizer starts mongodb's systemd service on its own, due to

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -296,11 +296,8 @@ dansguardian_install: False
 dansguardian_enabled: False
 
 # 2020-02-04: postgresql_install is completely ignored as PostgreSQL is
-# installed on demand as a dependency -- by Moodle &/or Pathagar -- but for now
-# we set fake value 'postgresql_install: True' so that
-# 'postgresql_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-postgresql_install: True
+# installed on demand as a dependency -- by Moodle &/or Pathagar
+postgresql_install: False
 postgresql_enabled: False
 
 # Common UNIX Printing System (CUPS)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -208,7 +208,7 @@ wan_try_dhcp_before_static_ip: True   # Facilitate field updates w/ cablemodems
 # 1-PREP
 
 # SEE ssh_port var above.
-sshd_install: True    # 2020-01-21: do not rely on this var for now (might be implemented in future)
+sshd_install: True
 sshd_enabled: True
 
 # roles/iiab-admin runs here

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -250,6 +250,7 @@ mysql_enabled: True
 
 # 2019-01-13: IIAB's use of NGINX is still evolving -- please review this
 # evolving doc: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
+# 2020-09-21: removed install |bool in stage 3, not optional and has no effect
 nginx_install: True
 nginx_enabled: True
 nginx_port: 80

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -273,9 +273,8 @@ apache_allow_sudo: True
 
 # See also Apache vars {default_language, language_priority} @ top of this file
 #
-# 2020-05-21: apache_install is completely ignored as Apache is installed on
-# demand as a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED, PBX and/or
-# phpMyAdmin
+# 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Apache is installed on demand as
+# a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED, PBX &/or phpMyAdmin
 apache_install: False
 apache_enabled: False
 #
@@ -298,11 +297,6 @@ squid_enabled: False
 # DansGuardian is NO LONGER AVAILABLE in Debian Buster i.e. since June 2019.
 dansguardian_install: False
 dansguardian_enabled: False
-
-# 2020-02-04: postgresql_install is completely ignored as PostgreSQL is
-# installed on demand as a dependency -- by Moodle and/or Pathagar
-postgresql_install: False
-postgresql_enabled: False
 
 # Common UNIX Printing System (CUPS)
 cups_install: False
@@ -352,7 +346,7 @@ idmgr_enabled: False    # 2020-01-23: UNUSED
 
 # UNMAINTAINED as of September 2020
 azuracast_install: False
-azuracast_enabled: False    # This var is currently IGNORED.
+azuracast_enabled: False    # This var is currently IGNORED
 azuracast_http_port: 10080
 azuracast_https_port: 10443
 #
@@ -394,8 +388,8 @@ mosquitto_install: False
 mosquitto_enabled: False
 mosquitto_port: 1883
 
-# 2020-02-04: nodejs_install is completely ignored as Node.js is installed on
-# demand as a dependency -- by Node-RED, Sugarizer and/or Internet Archive
+# 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Node.js is installed on demand
+# as a dependency -- by Node-RED, Sugarizer &/or Internet Archive
 nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
@@ -461,22 +455,14 @@ kiwix_incl_apk: False
 kiwix_apk_url: /software/kiwix
 kiwix_apk_src: https://download.kiwix.org/release/kiwix-android/kiwix.apk
 
+# 2020-09-24: BOTH VALUES BELOW ARE IGNORED as PostgreSQL is installed on
+# demand as a dependency -- by Moodle &/or Pathagar
+postgresql_install: False
+postgresql_enabled: False
+
 moodle_install: False
 moodle_enabled: False
 # If using Moodle intensively, set nginx_high_php_limits further above.
-
-# MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.
-# This role was formerly installed by roles/sugarizer/meta/main.yml
-#
-# 2020-02-04: mongodb_install is completely ignored as MongoDB is installed on
-# demand as a dependency -- by Sugarizer
-mongodb_install: False
-# FYI 'mongodb_enabled: False' works when Sugarizer is disabled.  Required by
-# mongodb/tasks/enable.yml to shut down the service and log status, but that is
-# misleading as Sugarizer starts mongodb's systemd service on its own, due to
-# 'Requires=mongodb.service' within /etc/systemd/system/sugarizer.service
-mongodb_enabled: False
-mongodb_port: 27018
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
@@ -484,6 +470,19 @@ osm_vector_maps_install: True
 osm_vector_maps_enabled: False
 iiab_map_url : http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
+
+# MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.
+# This role was formerly installed by roles/sugarizer/meta/main.yml
+#
+# 2020-09-24: BOTH VALUES BELOW ARE IGNORED as MongoDB is installed on demand
+# as a dependency -- by Sugarizer
+mongodb_install: False
+# 'mongodb_enabled: False' MAY work when Sugarizer is disabled.  Required by
+# mongodb/tasks/enable.yml to shut down the service and log status, but that is
+# misleading as Sugarizer starts mongodb's systemd service on its own, due to
+# 'Requires=mongodb.service' within /etc/systemd/system/sugarizer.service
+mongodb_enabled: False
+mongodb_port: 27018
 
 # roles/sugarizer/meta/main.yml auto-invokes 2 above prereqs: mongodb & nodejs
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
@@ -560,8 +559,8 @@ vnstat_enabled: False
 
 # 9-LOCAL-ADDONS
 
-# 2020-02-04: yarn_install is completely ignored as the Yarn package manager is
-# installed on demand as a dependency -- by Internet Archive
+# 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Yarn is installed on demand as a
+# dependency -- by Internet Archive
 yarn_install: False
 yarn_enabled: False
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -272,10 +272,8 @@ apache_allow_sudo: True
 #
 # 2020-05-21: apache_install is completely ignored as Apache is installed on
 # demand as a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED and/or
-# phpMyAdmin -- but for now we set fake value 'apache_install: True' so that
-# 'apache_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-apache_install: True
+# phpMyAdmin
+apache_install: False
 apache_enabled: False
 #
 # NGINX proxies to Apache for legacy IIAB services, using:
@@ -558,10 +556,8 @@ vnstat_enabled: False
 # 9-LOCAL-ADDONS
 
 # 2020-02-04: yarn_install is completely ignored as the Yarn package manager is
-# installed on demand as a dependency -- by Internet Archive -- but for now we
-# set fake value 'yarn_install: True' so that 'yarn_installed is defined' input
-# validation works, e.g. in 0-init/tasks/validate_vars.yml
-yarn_install: True
+# installed on demand as a dependency -- by Internet Archive
+yarn_install: False
 yarn_enabled: False
 
 # Internet Archive Offline / Decentralized Web - create your own offline

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -392,10 +392,7 @@ mosquitto_port: 1883
 
 # 2020-02-04: nodejs_install is completely ignored as Node.js is installed on
 # demand as a dependency -- by Node-RED, Sugarizer and/or Internet Archive --
-# but for now we set fake value 'nodejs_install: True' so that
-# 'nodejs_installed is defined' input validation works, e.g. in
-# 0-init/tasks/validate_vars.yml
-nodejs_install: True
+nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -300,7 +300,7 @@ dansguardian_install: False
 dansguardian_enabled: False
 
 # 2020-02-04: postgresql_install is completely ignored as PostgreSQL is
-# installed on demand as a dependency -- by Moodle &/or Pathagar
+# installed on demand as a dependency -- by Moodle and/or Pathagar
 postgresql_install: False
 postgresql_enabled: False
 
@@ -395,7 +395,7 @@ mosquitto_enabled: False
 mosquitto_port: 1883
 
 # 2020-02-04: nodejs_install is completely ignored as Node.js is installed on
-# demand as a dependency -- by Node-RED, Sugarizer and/or Internet Archive --
+# demand as a dependency -- by Node-RED, Sugarizer and/or Internet Archive
 nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -99,6 +99,7 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
+dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"
@@ -168,6 +169,8 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+
+sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -133,7 +133,6 @@ js_menu_install: True
 # SSHD runs here & also below in 4-SERVER-OPTIONS
 sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
-sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -130,8 +130,12 @@ js_menu_install: True
 
 # 1-PREP
 
-# roles/sshd & roles/iiab-admin run here
-# SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
+# SSHD runs here & also below in 4-SERVER-OPTIONS
+sshd_install: True    # Required by OpenVPN
+sshd_enabled: True
+sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+
+# IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
 
 # SECURITY WARNING: See http://wiki.laptop.org/go/IIAB/Security
@@ -170,8 +174,7 @@ apache_allow_sudo: True
 
 # 4-SERVER-OPTIONS
 
-sshd_install: True    # Required by OpenVPN
-sshd_enabled: True
+# SSHD runs here & also above in 1-PREP
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -99,6 +99,7 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
+dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"
@@ -168,6 +169,8 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+
+sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -133,7 +133,6 @@ js_menu_install: True
 # SSHD runs here & also below in 4-SERVER-OPTIONS
 sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
-sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -130,8 +130,12 @@ js_menu_install: True
 
 # 1-PREP
 
-# roles/sshd & roles/iiab-admin run here
-# SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
+# SSHD runs here & also below in 4-SERVER-OPTIONS
+sshd_install: True    # Required by OpenVPN
+sshd_enabled: True
+sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+
+# IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
 
 # SECURITY WARNING: See http://wiki.laptop.org/go/IIAB/Security
@@ -170,8 +174,7 @@ apache_allow_sudo: True
 
 # 4-SERVER-OPTIONS
 
-sshd_install: True    # Required by OpenVPN
-sshd_enabled: True
+# SSHD runs here & also above in 1-PREP
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -99,6 +99,7 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
+dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"
@@ -168,6 +169,8 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+
+sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -133,7 +133,6 @@ js_menu_install: True
 # SSHD runs here & also below in 4-SERVER-OPTIONS
 sshd_install: True    # Required by OpenVPN
 sshd_enabled: True
-sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -130,8 +130,12 @@ js_menu_install: True
 
 # 1-PREP
 
-# roles/sshd & roles/iiab-admin run here
-# SEE IIAB-ADMIN VARIABLES NEAR TOP OF THIS FILE:
+# SSHD runs here & also below in 4-SERVER-OPTIONS
+sshd_install: True    # Required by OpenVPN
+sshd_enabled: True
+sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+
+# IIAB-ADMIN runs here - see its vars near top of this file:
 # e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
 
 # SECURITY WARNING: See http://wiki.laptop.org/go/IIAB/Security
@@ -170,8 +174,7 @@ apache_allow_sudo: True
 
 # 4-SERVER-OPTIONS
 
-sshd_install: True    # Required by OpenVPN
-sshd_enabled: True
+# SSHD runs here & also above in 1-PREP
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -99,7 +99,6 @@ named_install: False
 named_enabled: False
 
 # dnsmasq - handles DHCP and DNS
-dnsmasq_install: True
 dnsmasq_enabled: True
 
 # Enable AFTER installing IIAB!  Then run "cd /opt/iiab/iiab; ./iiab-network"

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -168,6 +168,7 @@ apache_allow_sudo: True
 
 
 # 4-SERVER-OPTIONS
+sshd_enabled: True
 
 # DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
 # after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")


### PR DESCRIPTION
In preparation for [IIAB 7.2](https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes) final release:

- Inspired by @jvonau's PR #2540
- Trims [validate_vars.yml](https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml) from 53 to 47 vars
- [SSHD role](https://github.com/iiab/iiab/tree/master/roles/sshd) standardized per IIAB norms
- Moodle fix to install PostgreSQL
- Emergency patch MediaWiki 1.34.3 -> [1.34.4](https://lists.wikimedia.org/pipermail/mediawiki-announce/2020-September/000262.html)
- Cleaner explanations in [default_vars.yml](https://github.com/iiab/iiab/blob/master/vars/default_vars.yml), local_vars.yml etc
- Tested on 32-bit RaspiOS Lite & 64-bit Ubuntu Desktop 20.04.1

Ref: PRs #2535 #2545