### PR TITLE
Lint for release: osm-vector-maps indentation/spacing/quotes

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -1,19 +1,19 @@
 - name: Make the required directories for Maps
   file:
-    path: '{{ item }}'
+    path: "{{ item }}"
     state: directory
     mode: '0755'
   with_items:
-    - '{{ vector_map_path }}/test-page/assets'
-    - '{{ vector_map_path }}/maplist/assets'
-    - '{{ vector_map_path }}/viewer/assets'
-    - '{{ vector_map_path }}/viewer/tiles'
-    - '{{ vector_map_path }}/installer'
+    - "{{ vector_map_path }}/test-page/assets"    # /library/www/osm-vector-maps
+    - "{{ vector_map_path }}/maplist/assets"
+    - "{{ vector_map_path }}/viewer/assets"
+    - "{{ vector_map_path }}/viewer/tiles"
+    - "{{ vector_map_path }}/installer"
 
 - name: Copy the map catalog to /etc/iiab/map-catalog.json
   get_url:
-    url: "{{ map_catalog_url }}/map-catalog.json"
-    dest: /etc/iiab/
+    url: "{{ map_catalog_url }}/map-catalog.json"    # http://download.iiab.io/content/OSM/vector-tiles
+    dest: "{{ iiab_etc_path }}"    # /etc/iiab
 
 - name: Download map catalog {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
   get_url:
@@ -28,24 +28,24 @@
 - name: Fetch the city database
   get_url:
     url: "{{ iiab_map_url }}/regional-resources/cities1000.sqlite"
-    dest: '{{ vector_map_path }}/viewer/cities1000.sqlite'
+    dest: "{{ vector_map_path }}/viewer/cities1000.sqlite"
   when: not cities_installed.stat.exists
 
 - name: Create a link to osm catalog in /common/assets
   file:
-    src: "/etc/iiab/map-catalog.json"
-    dest: "{{ doc_root }}/common/assets/map-catalog.json"
+    src: /etc/iiab/map-catalog.json
+    dest: "{{ doc_root }}/common/assets/map-catalog.json"    # /library/www/html
     state: link
 
 - name: Create a link to osm catalog in {{ vector_map_path }}/maplist/assets
   file:
-    src: "/etc/iiab/map-catalog.json"
+    src: /etc/iiab/map-catalog.json
     dest: "{{ vector_map_path }}/test-page/assets/map-catalog.json"
     state: link
 
 - name: Create a link to regions.json in {{ vector_map_path }}/maplist/assets
   file:
-    src: "/etc/iiab/regions.json"
+    src: /etc/iiab/regions.json
     dest: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
@@ -53,16 +53,16 @@
 # At this point, fetches from github.com/georgejhunt/maps from test branch
   get_url:
     url: "{{ item }}"
-    dest: '{{ vector_map_path }}/test-page/'
+    dest: "{{ vector_map_path }}/test-page/"
   with_items:
-    - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/test-page-bundle.js"
+    - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/test-page-bundle.js"    # https://raw.githubusercontent.com/iiab/maps / master
     - "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/index.html"
 
 - name: Fetch the javascript bundle with openlayers for Viewer page
 # At this point, fetches from github.com/iiab/maps from {{ maps_branch }} branch
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/{{ item }}"
-    dest: '{{ vector_map_path }}/viewer/'
+    dest: "{{ vector_map_path }}/viewer/"
   with_items:
     - index.html
     - viewer-bundle.js
@@ -71,7 +71,7 @@
 - name: Get the helper files for viewer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/{{ item }}"
-    dest: '{{ vector_map_path }}/viewer/'
+    dest: "{{ vector_map_path }}/viewer/"
   with_items:
     - mbtileinfo.php
     - popup.css
@@ -81,29 +81,29 @@
 - name: Copy the map installer mbtiles
   get_url:
     url: "{{ map_catalog_url }}/planet_z0-z6_2019.mbtiles"
-    dest: '{{ vector_map_path }}/installer/'
+    dest: "{{ vector_map_path }}/installer/"
 
 - name: Create a synlink from tiles to detail.mbtiles
   file:
-    src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'  
-    dest: '{{ vector_map_path }}/installer/detail.mbtiles'
+    src: "{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles"
+    dest: "{{ vector_map_path }}/installer/detail.mbtiles"
     state: link
 
 - name: Link to the World Map to zoom 6
   file:
-    src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'
-    dest: '{{ vector_map_path }}/viewer/tiles/planet_z0-z6_2019.mbtiles'
+    src: "{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles"
+    dest: "{{ vector_map_path }}/viewer/tiles/planet_z0-z6_2019.mbtiles"
     state: link
 
 - name: Copy the map abbreviated satellite images
   get_url:
     url: "{{ map_catalog_url }}/satellite_z0-z6_v3.mbtiles"
-    dest: '{{ vector_map_path }}/viewer/tiles/satellite_z0-z6_v3.mbtiles'
+    dest: "{{ vector_map_path }}/viewer/tiles/satellite_z0-z6_v3.mbtiles"
 
 - name: Fetch the javascript bundle for map installer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/build/{{ item }}"
-    dest: '{{ vector_map_path }}/installer/'
+    dest: "{{ vector_map_path }}/installer/"
   with_items:
     - index.html
     - installer-bundle.js
@@ -111,7 +111,7 @@
 - name: Fetch the action routines for installer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/{{ item }}"
-    dest: '{{ vector_map_path }}/installer/'
+    dest: "{{ vector_map_path }}/installer/"
   with_items:
     - map.css
     - style-osm.json
@@ -141,14 +141,14 @@
     - view_list.png
 
 - name: Place a link to bboxes.geojson for Admin Console
-  file: 
+  file:
     src: "{{ vector_map_path }}/viewer/assets/bboxes.geojson"
     dest: "{{ vector_map_path }}/maplist/assets/bboxes.geojson"
     state: link
     force: True
 
 - name: Place a link to countries.json for Admin Console
-  file: 
+  file:
     src: "{{ vector_map_path }}/viewer/assets/countries.json"
     dest: "{{ vector_map_path }}/maplist/assets/countries.json"
     state: link
@@ -195,7 +195,7 @@
 - name: Install /etc/nginx/osm-vector-maps-nginx.conf from template
   template:
     src: osm-vector-maps-nginx.conf.j2
-    dest: "/etc/nginx/conf.d/osm-vector-maps-nginx.conf"
+    dest: /etc/nginx/conf.d/osm-vector-maps-nginx.conf
   when:
     osm_vector_maps_install | bool
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -61,22 +61,22 @@
 - name: Fetch the javascript bundle with openlayers for Viewer page
 # At this point, fetches from github.com/iiab/maps from {{ maps_branch }} branch
   get_url:
-     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/{{ item }}"
-     dest: '{{ vector_map_path }}/viewer/'
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/{{ item }}"
+    dest: '{{ vector_map_path }}/viewer/'
   with_items:
-      - index.html
-      - viewer-bundle.js
-      - viewer-bundle.js.map
+    - index.html
+    - viewer-bundle.js
+    - viewer-bundle.js.map
 
 - name: Get the helper files for viewer
   get_url:
-     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/{{ item }}"
-     dest: '{{ vector_map_path }}/viewer/'
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/{{ item }}"
+    dest: '{{ vector_map_path }}/viewer/'
   with_items:
-      - mbtileinfo.php
-      - popup.css
-      - searchapi.php
-      - tileserver.php
+    - mbtileinfo.php
+    - popup.css
+    - searchapi.php
+    - tileserver.php
 
 - name: Copy the map installer mbtiles
   get_url:
@@ -85,15 +85,15 @@
 
 - name: Create a synlink from tiles to detail.mbtiles
   file:
-      src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'  
-      dest: '{{ vector_map_path }}/installer/detail.mbtiles'
-      state: link
+    src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'  
+    dest: '{{ vector_map_path }}/installer/detail.mbtiles'
+    state: link
 
 - name: Link to the World Map to zoom 6
   file:
-      src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'
-      dest: '{{ vector_map_path }}/viewer/tiles/planet_z0-z6_2019.mbtiles'
-      state: link
+    src: '{{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles'
+    dest: '{{ vector_map_path }}/viewer/tiles/planet_z0-z6_2019.mbtiles'
+    state: link
 
 - name: Copy the map abbreviated satellite images
   get_url:
@@ -105,92 +105,92 @@
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/build/{{ item }}"
     dest: '{{ vector_map_path }}/installer/'
   with_items:
-      - index.html
-      - installer-bundle.js
+    - index.html
+    - installer-bundle.js
 
 - name: Fetch the action routines for installer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/{{ item }}"
     dest: '{{ vector_map_path }}/installer/'
   with_items:
-      - map.css
-      - style-osm.json
-      - installer-functions.js
-      - tileserver.php
+    - map.css
+    - style-osm.json
+    - installer-functions.js
+    - tileserver.php
 
 # the following was changed to grab from the iiab/maps repo
 - name: Copy the common assets for the general purpose map viewer
   get_url:
-      url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/assets/{{ item }}"
-      dest: "{{ vector_map_path }}/viewer/assets"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/assets/{{ item }}"
+    dest: "{{ vector_map_path }}/viewer/assets"
   with_items:
-      - bboxes.geojson
-      - center.png
-      - countries.json
-      - fonts.css
-      - ol-layerswitcher.css
-      - ol-contextmenu.css
-      - pin_drop.png
-      - sprite@2x.json
-      - sprite@2x.png
-      - sprite.json
-      - sprite.png
-      - style-cdn.json
-      - style-osm.json
-      - style-sat.json
-      - view_list.png
+    - bboxes.geojson
+    - center.png
+    - countries.json
+    - fonts.css
+    - ol-layerswitcher.css
+    - ol-contextmenu.css
+    - pin_drop.png
+    - sprite@2x.json
+    - sprite@2x.png
+    - sprite.json
+    - sprite.png
+    - style-cdn.json
+    - style-osm.json
+    - style-sat.json
+    - view_list.png
 
 - name: Place a link to bboxes.geojson for Admin Console
   file: 
-      src: "{{ vector_map_path }}/viewer/assets/bboxes.geojson"
-      dest: "{{ vector_map_path }}/maplist/assets/bboxes.geojson"
-      state: link
-      force: True
-      
+    src: "{{ vector_map_path }}/viewer/assets/bboxes.geojson"
+    dest: "{{ vector_map_path }}/maplist/assets/bboxes.geojson"
+    state: link
+    force: True
+
 - name: Place a link to countries.json for Admin Console
   file: 
-      src: "{{ vector_map_path }}/viewer/assets/countries.json"
-      dest: "{{ vector_map_path }}/maplist/assets/countries.json"
-      state: link
-      force: True
-      
+    src: "{{ vector_map_path }}/viewer/assets/countries.json"
+    dest: "{{ vector_map_path }}/maplist/assets/countries.json"
+    state: link
+    force: True
+
 - name: Copy the fonts for the general purpose map viewer
   copy:
-        src: "{{ item }}"
-        dest: "{{ doc_root }}/common/fonts/"
-        mode: 0644
-        owner: root
-        group: root
+    src: "{{ item }}"
+    dest: "{{ doc_root }}/common/fonts/"
+    mode: 0644
+    owner: root
+    group: root
   with_fileglob:
-      - fonts/*
+    - fonts/*
 
 - name: Copy the redirect to the test page
   get_url:
-        url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect"
-        dest: "{{ vector_map_path }}/maplist/index.html"
-        force: yes
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect"
+    dest: "{{ vector_map_path }}/maplist/index.html"
+    force: yes
 
 - name: Get packages necessary for map installation
   package:
-      state: present
-      name:
-         - python3-wget
-         - "php{{ php_version }}-sqlite3"
-         - python3-geojson
-         - python3-pil
+    state: present
+    name:
+      - python3-wget
+      - "php{{ php_version }}-sqlite3"
+      - python3-geojson
+      - python3-pil
 
 - name: Copy a scripts to download tiles
   get_url:
-      url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/scripts/{{ item }}"
-      dest: /usr/bin/
-      mode: 0755
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/scripts/{{ item }}"
+    dest: /usr/bin/
+    mode: 0755
   with_items:
-      - iiab-install-map-region
-      - iiab-extend-sat.py
-      - iiab-summarize.sh
-      - iiab-maps-finish.py
-      - iiab-make-init.py
-      - iiab-update-map
+    - iiab-install-map-region
+    - iiab-extend-sat.py
+    - iiab-summarize.sh
+    - iiab-maps-finish.py
+    - iiab-make-init.py
+    - iiab-update-map
 
 - name: Install /etc/nginx/osm-vector-maps-nginx.conf from template
   template:
@@ -198,6 +198,7 @@
     dest: "/etc/nginx/conf.d/osm-vector-maps-nginx.conf"
   when:
     osm_vector_maps_install | bool
+
 
 # RECORD OSM Vector Maps AS INSTALLED
 

--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -14,6 +14,7 @@
 - name: Install OSM Vector Maps if 'osm_vector_maps_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: install.yml
   when: osm_vector_maps_installed is undefined
+  
 
 - name: Enable/Disable/Reload NGINX for OSM, if nginx_enabled
   include_tasks: nginx.yml

--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -19,6 +19,7 @@
   include_tasks: nginx.yml
   when: nginx_enabled | bool
 
+
 - name: Add 'osm-vector-maps' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini


### PR DESCRIPTION
Not a functional change.

Testing nonetheless, in case of Ansible snafus.

Ref: #1605 'New OSM Vector Maps need clean UX + clean instructions ("pick a continent or region")'