### PR TITLE
Further deprecate long-unmaintained roles for IIAB 7.2 release

### DIFF
--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -58,13 +58,13 @@
       - named
       - dnsmasq
       - bluetooth
-      #- wondershaper    # Umaintained
+      #- wondershaper       # Umaintained
       - sshd
       - openvpn
-      - admin_console    # Coming soon
-      #- nginx     # MANDATORY
-      #- apache    # Dependency installed on demand, by other apps/services
-      #- mysql     # MANDATORY
+      - admin_console       # Coming soon
+      #- nginx              # MANDATORY
+      #- apache             # Dependency installed on demand by other apps/svcs
+      #- mysql              # MANDATORY
       - squid
       - dansguardian
       - cups
@@ -75,14 +75,14 @@
       #- ejabberd_xs        # Umaintained
       #- idmgr              # Umaintained
       - azuracast
-      #- dokuwiki    # Umaintained
-      #- ejabberd    # Umaintained
+      #- dokuwiki           # Umaintained
+      #- ejabberd           # Umaintained
       - elgg
       - gitea
       - lokole
       - mediawiki
       - mosquitto
-      #- nodejs    # Dependency installed on demand, by other apps/services
+      #- nodejs             # Dependency installed on demand by other apps/svcs
       - nodered
       - nextcloud
       - pbx
@@ -90,9 +90,9 @@
       - kalite
       - kolibri
       - kiwix
-      #- postgresql    # Dependency installed on demand, by other apps/services
+      #- postgresql         # Dependency installed on demand by other apps/svcs
       - moodle
-      #- mongodb    # Dependency installed on demand, by other apps/services
+      #- mongodb            # Dependency installed on demand by other apps/svcs
       - sugarizer
       - osm_vector_maps
       - transmission
@@ -101,7 +101,7 @@
       - munin
       - phpmyadmin
       - vnstat
-      #- yarn    # Dependency installed on demand, by other apps/services
+      #- yarn               # Dependency installed on demand by other apps/svcs
       - internetarchive
       - captiveportal
       - minetest

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -60,7 +60,7 @@
       - named
       - dnsmasq
       - bluetooth
-      #- wondershaper       # Umaintained
+      #- wondershaper       # Unmaintained
       - sshd
       - openvpn
       - admin_console       # Coming soon
@@ -72,13 +72,13 @@
       - cups
       - samba
       - usb_lib
-      #- xo_services        # Umaintained
-      #- activity_server    # Umaintained
-      #- ejabberd_xs        # Umaintained
-      #- idmgr              # Umaintained
+      #- xo_services        # Unmaintained
+      #- activity_server    # Unmaintained
+      #- ejabberd_xs        # Unmaintained
+      #- idmgr              # Unmaintained
       - azuracast
-      #- dokuwiki           # Umaintained
-      #- ejabberd           # Umaintained
+      #- dokuwiki           # Unmaintained
+      #- ejabberd           # Unmaintained
       - elgg
       - gitea
       - lokole

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -38,12 +38,13 @@
 # https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
 # 2020-01-23: Checks 53 + 53 + up-to-53 vars...for now...expect this to change!
-# 2020-09-26: Commented out 13 vars that are {mandatory, dependencies, or
-# unmaintained-for-years} for IIAB 7.2 release.  Keep in mind that vars will
-# come and go as IIAB evolves, so here are 6 important places to try to align:
+# 2020-09-26: Commented out 14 vars that are {mandatory, dependencies, or
+# unmaintained-for-years} for IIAB 7.2 release.  Keeping in mind that vars
+# will come and go as IIAB evolves, let's try to keep these 7 aligned:
 #
 # https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
 # https://github.com/iiab/iiab/blob/master/tests/test.yml
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_min.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -37,24 +37,30 @@
 # I want to perform input validation for Ansible playbooks"
 # https://stackoverflow.com/questions/46664127/how-do-i-fail-a-task-in-ansible-if-the-variable-contains-a-boolean-value-i-want/46667499#46667499
 
-# 2020-01-23: checks 53 + 53 + up-to-53 vars...for now...expect this to change!
-# Should we remove {xo_services, activity_server, ejabberd_xs, idmgr} as these
-# are officially now UNMAINTAINED in default_vars.yml and
-# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt etc?
+# 2020-01-23: Checks 53 + 53 + up-to-53 vars...for now...expect this to change!
+# 2020-09-26: Commented out 13 vars that are {mandatory, dependencies, or
+# unmaintained-for-years} for IIAB 7.2 release.  Keep in mind that vars will
+# come and go as IIAB evolves, so here are 6 important places to try to align:
+#
+# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
+# https://github.com/iiab/iiab/blob/master/tests/test.yml
+# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_min.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_big.yml
 
-- name: Set vars_checklist for 47 + 47 + up-to-47 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
+- name: Set vars_checklist for 40 + 40 + up-to-40 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
     vars_checklist:
       - hostapd
       - dhcpd
       - named
       - dnsmasq
-      - captiveportal
       - bluetooth
-      - wondershaper
+      #- wondershaper    # Umaintained
       - sshd
       - openvpn
-      - admin_console
+      - admin_console    # Coming soon
       #- nginx     # MANDATORY
       #- apache    # Dependency installed on demand, by other apps/services
       #- mysql     # MANDATORY
@@ -63,13 +69,13 @@
       - cups
       - samba
       - usb_lib
-      - xo_services
-      - activity_server
-      - ejabberd_xs
-      - idmgr
+      #- xo_services        # Umaintained
+      #- activity_server    # Umaintained
+      #- ejabberd_xs        # Umaintained
+      #- idmgr              # Umaintained
       - azuracast
-      - dokuwiki
-      - ejabberd
+      #- dokuwiki    # Umaintained
+      #- ejabberd    # Umaintained
       - elgg
       - gitea
       - lokole
@@ -96,6 +102,7 @@
       - vnstat
       #- yarn    # Dependency installed on demand, by other apps/services
       - internetarchive
+      - captiveportal
       - minetest
       - calibre
       - calibreweb

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -40,15 +40,17 @@
 # 2020-01-23: Checks 53 + 53 + up-to-53 vars...for now...expect this to change!
 # 2020-09-26: Commented out 14 vars that are {mandatory, dependencies, or
 # unmaintained-for-years} for IIAB 7.2 release.  Keeping in mind that vars
-# will come and go as IIAB evolves, let's try to keep these 7 aligned:
+# will come and go as IIAB evolves, let's try to keep these 9 aligned:
 #
-# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
-# https://github.com/iiab/iiab/blob/master/tests/test.yml
-# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
-# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# http://FAQ.IIAB.IO > "What services (IIAB apps) are suggested during installation?"
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_min.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_big.yml
+# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
+# https://github.com/iiab/iiab/blob/master/roles/0-DEPRECATED-ROLES/
+# https://github.com/iiab/iiab/blob/master/tests/test.yml
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
 
 - name: Set vars_checklist for 40 + 40 + up-to-40 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -80,5 +80,12 @@
     - { role: yarn }
     #- { roles: xovis }
 
-# Let's try to keep the above list synchronized with:
+# Let's try to keep these 7 aligned:
+#
 # https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
+# https://github.com/iiab/iiab/blob/master/tests/test.yml
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
+# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_min.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml
+# https://github.com/iiab/iiab/blob/master/vars/local_vars_big.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -80,12 +80,14 @@
     - { role: yarn }
     #- { roles: xovis }
 
-# Let's try to keep these 7 aligned:
+# Let's try to keep these 9 aligned:
 #
-# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
-# https://github.com/iiab/iiab/blob/master/tests/test.yml
-# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
-# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# http://FAQ.IIAB.IO > "What services (IIAB apps) are suggested during installation?"
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_min.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_medium.yml
 # https://github.com/iiab/iiab/blob/master/vars/local_vars_big.yml
+# https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# https://github.com/iiab/iiab/blob/master/unmaintained-roles.txt
+# https://github.com/iiab/iiab/blob/master/roles/0-DEPRECATED-ROLES/
+# https://github.com/iiab/iiab/blob/master/tests/test.yml
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml

--- a/unmaintained-roles.txt
+++ b/unmaintained-roles.txt
@@ -6,6 +6,8 @@ docker
 dokuwiki
 ejabberd
 ejabberd_xs
+homepage
+httpd-enable
 idmgr
 moodle-1.9
 nodogsplash


### PR DESCRIPTION
With in-line documentation clarifying the need to keep these 9 (roughly) in synch:

- http://FAQ.IIAB.IO > "What services (IIAB apps) are suggested during installation?"
- vars/local_vars_min.yml
- vars/local_vars_medium.yml
- vars/local_vars_big.yml
- vars/defaults_vars.yml
- unmaintained-roles.txt
- roles/0-DEPRECATED-ROLES/
- tests/test.yml
- 0-init/tasks/validate_vars.yml

As a bonus, validate_vars.yml now runs faster, checking 40 sets of vars (instead of 53 or 54).

Ref: PR #2546