### PR TITLE
Kolibri timeout fix: 90 -> 1200 sec (yes, that's 20 minutes!)

### DIFF
--- a/roles/kolibri/templates/kolibri.service.j2
+++ b/roles/kolibri/templates/kolibri.service.j2
@@ -10,12 +10,17 @@ Environment=KOLIBRI_HTTP_PORT={{ kolibri_http_port }}
 Environment=KOLIBRI_URL_PATH_PREFIX={{ kolibri_url_without_slash }}
 User={{ kolibri_user }}
 Group={{ apache_user }}
+# 2020-10-03: Kolibri was timing out on RaspiOS & Ubuntu 20 NUC: iiab/iiab#2555
+TimeoutStartSec=1200
+# The following is the systemd default, which is too much for most teachers in
+# low-electricity environments (30-60 sec is about all they can handle before
+# pulling the power cord, typically every hour at the end of class).  But since
+# 90 seconds is the Linux / systemd default, it's prob good enough for now:
+# TimeoutStopSec=90
 # 2020-04-18 @jvonau: comment out both timeouts for now, in favor of 90 seconds
 # or whatever systemd / Kolibri favor? https://github.com/iiab/iiab/issues/2318
 # TimeoutStartSec=infinity
 # TimeoutStopSec=10
-# 2020-10-03: Kolibri was timing out on RaspiOS & Ubuntu 20 NUC: iiab/iiab#2555
-TimeoutStartSec=1200
 ExecStart={{ kolibri_exec_path }} start
 ExecStop={{ kolibri_exec_path }} stop
 

--- a/roles/kolibri/templates/kolibri.service.j2
+++ b/roles/kolibri/templates/kolibri.service.j2
@@ -14,6 +14,8 @@ Group={{ apache_user }}
 # or whatever systemd / Kolibri favor? https://github.com/iiab/iiab/issues/2318
 # TimeoutStartSec=infinity
 # TimeoutStopSec=10
+# 2020-10-03: Kolibri was timing out on RaspiOS & Ubuntu 20 NUC: iiab/iiab#2555
+TimeoutStartSec=1200
 ExecStart={{ kolibri_exec_path }} start
 ExecStop={{ kolibri_exec_path }} stop
 


### PR DESCRIPTION
Fixes #2555 "http://box/kolibri fails with "502 Bad Gateway" (especially when Kolibri 0.14.2 upgraded to 0.14.3 ?)"

I tested 1000 seconds (16min40sec) as Kolibri took 9 minutes to start on a Raspberry Pi with 1GB RAM, which worked.

@jvonau suggested bumping this up to 20min so why not, let's go with that.

`TimeoutStartSec=infinity` is another option...but that seemed a bit much ;)

Revises:

- PR #2343 "Comment out both kolibri.service timeout settings"

Refs:

- #1737 "Who can help test IIAB 7.2 on Ubuntu 20.04+, Debian 10.6, Linux Mint 20 & Raspberry Pi ? [Kolibri 502 Bad Gateway?]"
- #2318 "Is Kolibri shutting down cleanly when IIAB powers off?"