### PR TITLE
For TK alter use of second_gateway_found.changed

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -106,7 +106,7 @@
   register: wifi_gateway_found
   when: discovered_wireless_iface != "none"
 
-- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} when WiFi gateway has been detected
+- name: Set has_wifi_gateway if WiFi has default gateway detected for {{ discovered_wireless_iface }}
   set_fact:
     has_wifi_gateway: True
   when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout|int > 0)
@@ -118,7 +118,7 @@
 
 - name: Set exclude_devices if default gateway has been detected for {{ second_gateway_found.stdout }}
   set_fact:
-    exclude_devices: "-e {{ second_gateway_found.stdout }}"
+    exclude_devices: "{{ second_gateway_found.stdout }}"
   when: second_gateway_found.stdout != ""
 
 # XO hack here ap_device would not be active therefore not set with
@@ -131,11 +131,11 @@
 
 - name: Exclude reserved Network Adapter if defined - takes adapter name
   set_fact:
-    exclude_devices: "-e {{ reserved_device }} {{ exclude_devices }}"
+    exclude_devices: "{{ exclude_devices }} -e {{ reserved_device }}"
   when: reserved_device is defined
 
 - name: Count LAN ifaces
-  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_devices }} | wc -l
+  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} -e {{ exclude_devices }} | wc -l
   register: num_lan_interfaces_result
 
 - name: Calculate number of LAN interfaces including WiFi
@@ -144,7 +144,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
-  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} {{ exclude_devices }}
+  shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} -e wwlan -e ppp -e {{ device_gw }} -e {{ exclude_devices }}
   when: num_lan_interfaces != "0"
   register: lan_list_result
 

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -106,19 +106,20 @@
   register: wifi_gateway_found
   when: discovered_wireless_iface != "none"
 
-- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} if WiFi gateway is detected
+- name: Set has_wifi_gateway for {{ discovered_wireless_iface }} when WiFi gateway has been detected
   set_fact:
     has_wifi_gateway: True
   when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout|int > 0)
 
-- name: Detect secondary gateway active
+- name: Detect secondary gateway active on all interfaces
   shell: ip r | grep default | grep -v {{ discovered_wan_iface }} | awk '{print $5}'
   register: second_gateway_found
+  changed_when: False
 
-- name: Set exclude_devices for {{ second_gateway_found.stdout }} if gateway is detected
+- name: Set exclude_devices if default gateway has been detected for {{ second_gateway_found.stdout }}
   set_fact:
     exclude_devices: "-e {{ second_gateway_found.stdout }}"
-  when: second_gateway_found.changed
+  when: second_gateway_found.stdout != ""
 
 # XO hack here ap_device would not be active therefore not set with
 # wired as gw use ap_device to exclude eth0 from network calulations


### PR DESCRIPTION
… !=  and wording

### Fixes bug:
TK's wired slave device not being found Ref: http://sprunge.us/38kqYt
>exclude_devices = -e 
### Description of changes proposed in this pull request:
My original implementation with '.changed' is always firing and passing "" instead of "none", the intent is to pass 'none' to grep 
Replace second_gateway_found.changed with second_gateway_found.stdout !="" matching the wifi detection code.
Hind sight '.changed' works better when used with the templates modules, just looking for a more elegant method of detecting "" as the linting routine mentions the lines that use !="", maybe use 'not is none' but I'll leave that for the ansible experts to interpret explain to me.

