### PR TITLE
maps_from_internet_archive & tidying of iiab-network, default_vars.yml, local_vars.yml, iiab-admin/README.rst, osm-vector-maps/README.md [Aside: iiab_home_url clarif ongoing, recommend ansible-base 2.10.2]

### DIFF
--- a/iiab-network
+++ b/iiab-network
@@ -93,4 +93,4 @@ echo
 echo "iiab-network run start: $Start"
 echo "iiab-network run end: $End"
 echo
-echo "Please REBOOT to fully verify your network -- graphical desktops especially!"
+echo "Please REBOOT to fully verify your network -- graphical desktops MUST reboot!"

--- a/iiab-network
+++ b/iiab-network
@@ -92,3 +92,5 @@ brctl show
 echo
 echo "iiab-network run start: $Start"
 echo "iiab-network run end: $End"
+echo
+echo "Please REBOOT to fully verify your network -- graphical desktops especially!"

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -56,9 +56,11 @@
     name: samba
   when: samba_install | bool
 
-# 2020-02-17: what was roles/homepage lives in roles/www_options.  Eventually
-# softcoding of iiab_home_url should happen everywhere (incl Admin Console) for
-# more field options, e.g. changing /library/www/html/home even when offline...
+# 2020-02-17: What was roles/homepage lives in roles/www_options
+# 2020-10-08: Softcoded iiab_home_url should work (e.g. using local_vars.yml or
+# Admin Console) for more field options, e.g. changing /library/www/html/home
+# to WordPress or Moodle even when offline?  @tim-moody cautions that this is
+# untested for several years, so let's keep an eye on it!  iiab/iiab#2560
 
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:

--- a/roles/iiab-admin/README.rst
+++ b/roles/iiab-admin/README.rst
@@ -13,17 +13,25 @@
 iiab-admin README
 =================
 
-This role is home to a number of administrative playbooks.  Those implemented are:
+This role is home to a number of administrative (Ansible) playbooks:
 
 Add Administrative User
 -----------------------
 
-* Add the iiab-admin user and password, if this has not already been done for you by IIAB's 1-line installer
+* Adds the Linux user that will allow you access to IIAB's Admin Console (http://box.lan/admin) if this has not already been done for you by IIAB's 1-line installer (http://download.iiab.io).
+* By default this is ``iiab-admin`` with password ``g0adm1n``
+   * *Do change the default password if you haven't yet, by running:* **sudo passwd iiab-admin**
+   * After IIAB is installed, you can also change the password by logging into Admin Console (http://box.lan/admin) > Utilities > Change Password
+   * If you prefer using a pre-existing user like ``pi`` or ``ubuntu`` etc, consider customizing variables ``iiab_admin_user_install``, ``iiab_admin_user`` and ``iiab_admin_user_group`` in your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ (please do this prior to installing IIAB !)
+* Please read more about what escalated (root) actions are authorized when you log into IIAB's Admin Console, and how this works: https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+
+Desiderata, for the historical record:
+
+* Auto-checking for the default password is implemented in `/etc/profile.d <https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-profile-iiab.sh>`_ (and `/etc/xdg/lxsession/LXDE-pi <https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh>`_ when it exists).
 * |ss| N.B. to create password hash use python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")' |se| |nbsp| (not recommended as of October 2020)
-* |ss| Make a sudoer |se| |nbsp| (likely going away in October 2020, group 'iiab-admin' will be recommended instead of group 'sudo')
-* |ss| Add /root/.ssh and dummy authorized_keys file as placeholder |se| |nbsp| (moved to playbook roles/sshd)
-* |ss| Force password for sudoers |se|
-* Please read more about the 'iiab-admin' Linux user and group, which allow you to log in to IIAB's Admin Console: https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+* |ss| Make a sudoer |se| |nbsp| (likely going away in October 2020, as group 'iiab-admin' should be recommended instead of group 'sudo')
+* |ss| Add /root/.ssh and dummy authorized_keys file as placeholder |se| |nbsp| (moved to `roles/openvpn/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/openvpn/tasks/install.yml>`_)
+* |ss| Force password for sudoers |se| |nbsp| (sudo flag ``NOPASSWORD:`` and the ``wheel`` group will no longer being used as of October 2020)
 
 Add Packages for Remote Access
 ------------------------------
@@ -34,4 +42,4 @@ Add Packages for Remote Access
 Admin Console
 -------------
 
-Has been moved to separate git repo: https://github.com/iiab/iiab-admin-console
+Has been moved to this separate git repo: https://github.com/iiab/iiab-admin-console

--- a/roles/iiab-admin/README.rst
+++ b/roles/iiab-admin/README.rst
@@ -18,11 +18,12 @@ This role is home to a number of administrative playbooks.  Those implemented ar
 Add Administrative User
 -----------------------
 
-* Add the iiab-admin user and password
-* N.B. to create password hash use python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
-* Make a sudoer
+* Add the iiab-admin user and password, if this has not already been done for you by IIAB's 1-line installer
+* |ss| N.B. to create password hash use python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")' |se| |nbsp| (not recommended as of October 2020)
+* |ss| Make a sudoer |se| |nbsp| (likely going away in October 2020, group 'iiab-admin' will be recommended instead of group 'sudo')
 * |ss| Add /root/.ssh and dummy authorized_keys file as placeholder |se| |nbsp| (moved to playbook roles/sshd)
-* Force password for sudoers
+* |ss| Force password for sudoers |se|
+* Please read more about the 'iiab-admin' Linux user and group, which allow you to log in to IIAB's Admin Console: https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
 
 Add Packages for Remote Access
 ------------------------------

--- a/roles/osm-vector-maps/README.md
+++ b/roles/osm-vector-maps/README.md
@@ -3,6 +3,7 @@
 1. If you install [IIAB 7.2](https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes) with [IIAB Maps](https://github.com/iiab/iiab/wiki/IIAB-Maps), a new **Install IIAB Maps** page is available (http://box/osm-vector-maps/installer/) with [instructions](https://github.com/iiab/iiab/wiki/IIAB-Maps#how-do-i-install-map-packs-and-satellite-photo-regions-on-iiab-72-), separate from IIAB's Admin Console:
    1. This [very visual page](https://user-images.githubusercontent.com/2458907/94740848-46c4eb00-0341-11eb-93ea-e3e4758dce48.png) facilitates selecting/downloading/installing of Map Pack(s) for your favorite "continent(s)".  (SEE 2. BELOW)
    2. If you've installed at least one Map Pack, you can then use this same page to select/download/install Hi-Res Satellite Photo Region(s) for your local communities.  (SEE 3. BELOW)
+   3. All these downloads can now happen 10X to 100X faster, thanks to [PR #38](https://github.com/iiab/maps/pull/38) !
 
 2. **Map Packs** no longer bundle both data and program in a .zip file.  All Map Packs are really now just a collection of 3 .mbtiles files:
    1. The main focus of a Map Pack remains Hi-Res Vector Map data from OpenStreetMap, for your selected "continent" — but Lo-Res vector map tiles (1.74GB .mbtiles) and Lo-Res satellite photos (932MB .mbtiles) are also included for the entire planet.  Read more at: https://github.com/iiab/iiab/wiki/IIAB-Maps

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -5,7 +5,7 @@
 
 APT_PATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.10.1"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
+GOOD_VER="2.10.2"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # We install latest 'ansible-base' from PPA: (may be more recent than GOOD-VER)
 # https://launchpad.net/~ansible/+archive/ubuntu/ansible
 # https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.10

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -72,9 +72,9 @@ local_tz: "{{ ansible_date_time.tz }}"
 admin_console_install: True
 admin_console_enabled: True
 #
-# Set to "False" if you do not want to use the latest js-menus
-# either because you use wordpress or another home page
-# or if you prefer the older https://github.com/iiab/iiab-menu (no longer maintained)
+# Set to "False" if you do not want to use the latest js-menus, either because
+# you use WordPress or another home page, or if you prefer the older
+# https://github.com/iiab/iiab-menu (no longer maintained)
 js_menu_install: True
 
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -50,13 +50,17 @@ language_priority: en es fr
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 # rtc_id: ds3231
 
-# Set iiab_admin_user_install: False if you don't want iiab_admin_user & wheel
-# group auto-created in roles/iiab-admin/tasks/main.yml (hence disabling sudo-
-# checks/warnings of published passwds like pi/raspberry & iiab-admin/g0adm1n).
+# Please read more about the 'iiab-admin' Linux user and group, which allow
+# you to log in to IIAB's Admin Console (http://box.lan/admin):
+# https://github.com/iiab/iiab/tree/master/roles/iiab-admin
+# https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+# Set iiab_admin_user_install: False if you don't want iiab_admin_user auto-
+# created e.g. by IIAB's 1-line installer and roles/iiab-admin/tasks/main.yml
 iiab_admin_user_install: True
-# If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
-# Linux user that has sudo access, for login to Admin Console http://box/admin
+# If iiab_admin_user_install: False, set iiab_admin_user to an existing Linux
+# user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
+iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
 iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to override above, if Ansible creates above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
@@ -611,12 +615,6 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 # =============================================================================
 # UNMAINTAINED LEGACY VARIABLES: YOU'RE TAKING BIG RISKS IF YOU USE ANY HERE...
 
-# CONSIDER THESE NEW OPENSTREETMAP (OSM) APPROACHES INSTEAD:
-#
-# 2019: https://github.com/iiab/iiab/wiki/IIAB-Maps SEE ABOVE osm_vector_maps_*
-# 2018: http://download.iiab.io/content/OSM/vector-tiles/
-# 2017: http://oer2go.org/viewmod/en-worldmap-10
-#
 # Unmaintained
 # osm_install: False
 # osm_enabled: False
@@ -627,10 +625,6 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 # Unmaintained
 # docker_install: False
 # docker_enabled: False
-
-# THOSE ABOVE WERE STILL OCCASIONALLY USED AS OF NOVEMBER 2019.
-# =============================================================================
-# THOSE BELOW WERE *NOT* USED FOR YEARS, AS OF NOVEMBER 2019.
 
 # Unmaintained
 # authserver_install: False
@@ -687,7 +681,7 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 
 # OS-DEPENDENT VARS: TURN OFF ALL VARS BELOW AND THEN THE CORRECT
 # /opt/iiab/iiab/vars/<OS>.yml WILL TURN ON WHAT'S APPROPRIATE.  See "How This
-# Works" ~30 lines below, and https://github.com/iiab/iiab/wiki/IIAB-Platforms
+# Works" ~32 lines below, and https://github.com/iiab/iiab/wiki/IIAB-Platforms
 
 # Wide to narrow (insofar as poss)
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -68,7 +68,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 # Time Zone (php needs timezone to be set)
 local_tz: "{{ ansible_date_time.tz }}"
 
-# Set these to False if you do not want to install IIAB Admin Console
+# Set these to False if you do not want to install/enable IIAB Admin Console
 admin_console_install: True
 admin_console_enabled: True
 #
@@ -216,7 +216,8 @@ sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 openvpn_install: True
 openvpn_enabled: False
 # For /etc/iiab/openvpn_handle
-openvpn_handle:
+openvpn_handle: ""    # Empty string on purpose since ~2016, for /etc/iiab/uuid
+# SEE https://github.com/iiab/iiab/blob/master/roles/openvpn/tasks/main.yml#L45
 # cron seems necessary on CentOS:
 openvpn_cron_enabled: False
 # General OpenVPN settings
@@ -463,6 +464,8 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: False
+# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
+maps_from_internet_archive: False
 iiab_map_url : http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -33,7 +33,6 @@ iiab_admin_user_install: True
 # user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
 iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
-iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -40,9 +40,9 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 admin_console_install: True
 admin_console_enabled: True
 #
-# Set to "False" if you do not want to use the latest js-menus
-# either because you use wordpress or another home page
-# or if you prefer the older https://github.com/iiab/iiab-menu (no longer maintained)
+# Set to "False" if you do not want to use the latest js-menus, either because
+# you use WordPress or another home page, or if you prefer the older
+# https://github.com/iiab/iiab-menu (no longer maintained)
 js_menu_install: True
 
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -22,13 +22,18 @@ language_priority: en es fr
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 # rtc_id: ds3231
 
-# Set iiab_admin_user_install: False if you don't want iiab_admin_user & wheel
-# group auto-created in roles/iiab-admin/tasks/main.yml (hence disabling sudo-
-# checks/warnings of published passwds like pi/raspberry & iiab-admin/g0adm1n).
+# Please read more about the 'iiab-admin' Linux user and group, which allow
+# you to log in to IIAB's Admin Console (http://box.lan/admin):
+# https://github.com/iiab/iiab/tree/master/roles/iiab-admin
+# https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+# Set iiab_admin_user_install: False if you don't want iiab_admin_user auto-
+# created e.g. by IIAB's 1-line installer and roles/iiab-admin/tasks/main.yml
 iiab_admin_user_install: True
-# If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
-# Linux user that has sudo access, for login to Admin Console http://box/admin
+# If iiab_admin_user_install: False, set iiab_admin_user to an existing Linux
+# user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
+iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
+iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -36,7 +36,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 # Obtain a password hash - OLD WAY:
 #    python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 
-# Set these to False if you do not want to install IIAB Admin Console
+# Set these to False if you do not want to install/enable IIAB Admin Console
 admin_console_install: True
 admin_console_enabled: True
 #
@@ -151,7 +151,7 @@ sshd_enabled: True
 openvpn_install: True
 openvpn_enabled: False
 # Set /etc/iiab/openvpn_handle in advance here:
-openvpn_handle:
+openvpn_handle: "BIG-sized - Put Your Name Here"
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -318,6 +318,8 @@ moodle_enabled: True
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
+# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
+maps_from_internet_archive: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -33,7 +33,6 @@ iiab_admin_user_install: True
 # user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
 iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
-iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -40,9 +40,9 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 admin_console_install: True
 admin_console_enabled: True
 #
-# Set to "False" if you do not want to use the latest js-menus
-# either because you use wordpress or another home page
-# or if you prefer the older https://github.com/iiab/iiab-menu (no longer maintained)
+# Set to "False" if you do not want to use the latest js-menus, either because
+# you use WordPress or another home page, or if you prefer the older
+# https://github.com/iiab/iiab-menu (no longer maintained)
 js_menu_install: True
 
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -22,13 +22,18 @@ language_priority: en es fr
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 # rtc_id: ds3231
 
-# Set iiab_admin_user_install: False if you don't want iiab_admin_user & wheel
-# group auto-created in roles/iiab-admin/tasks/main.yml (hence disabling sudo-
-# checks/warnings of published passwds like pi/raspberry & iiab-admin/g0adm1n).
+# Please read more about the 'iiab-admin' Linux user and group, which allow
+# you to log in to IIAB's Admin Console (http://box.lan/admin):
+# https://github.com/iiab/iiab/tree/master/roles/iiab-admin
+# https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+# Set iiab_admin_user_install: False if you don't want iiab_admin_user auto-
+# created e.g. by IIAB's 1-line installer and roles/iiab-admin/tasks/main.yml
 iiab_admin_user_install: True
-# If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
-# Linux user that has sudo access, for login to Admin Console http://box/admin
+# If iiab_admin_user_install: False, set iiab_admin_user to an existing Linux
+# user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
+iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
+iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -36,7 +36,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 # Obtain a password hash - OLD WAY:
 #    python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 
-# Set these to False if you do not want to install IIAB Admin Console
+# Set these to False if you do not want to install/enable IIAB Admin Console
 admin_console_install: True
 admin_console_enabled: True
 #
@@ -151,7 +151,7 @@ sshd_enabled: True
 openvpn_install: True
 openvpn_enabled: False
 # Set /etc/iiab/openvpn_handle in advance here:
-openvpn_handle:
+openvpn_handle: "MEDIUM-sized - Put Your Name Here"
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -318,6 +318,8 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
+# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
+maps_from_internet_archive: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -33,7 +33,6 @@ iiab_admin_user_install: True
 # user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
 iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
-iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -40,9 +40,9 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 admin_console_install: True
 admin_console_enabled: True
 #
-# Set to "False" if you do not want to use the latest js-menus
-# either because you use wordpress or another home page
-# or if you prefer the older https://github.com/iiab/iiab-menu (no longer maintained)
+# Set to "False" if you do not want to use the latest js-menus, either because
+# you use WordPress or another home page, or if you prefer the older
+# https://github.com/iiab/iiab-menu (no longer maintained)
 js_menu_install: True
 
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -36,7 +36,7 @@ iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGm
 # Obtain a password hash - OLD WAY:
 #    python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 
-# Set these to False if you do not want to install IIAB Admin Console
+# Set these to False if you do not want to install/enable IIAB Admin Console
 admin_console_install: True
 admin_console_enabled: True
 #
@@ -151,7 +151,7 @@ sshd_enabled: True
 openvpn_install: True
 openvpn_enabled: False
 # Set /etc/iiab/openvpn_handle in advance here:
-openvpn_handle:
+openvpn_handle: "MIN-sized - Put Your Name Here"
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -318,6 +318,8 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
+# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
+maps_from_internet_archive: False
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -22,13 +22,18 @@ language_priority: en es fr
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 # rtc_id: ds3231
 
-# Set iiab_admin_user_install: False if you don't want iiab_admin_user & wheel
-# group auto-created in roles/iiab-admin/tasks/main.yml (hence disabling sudo-
-# checks/warnings of published passwds like pi/raspberry & iiab-admin/g0adm1n).
+# Please read more about the 'iiab-admin' Linux user and group, which allow
+# you to log in to IIAB's Admin Console (http://box.lan/admin):
+# https://github.com/iiab/iiab/tree/master/roles/iiab-admin
+# https://github.com/iiab/iiab-admin-console/blob/master/Authentication.md
+# Set iiab_admin_user_install: False if you don't want iiab_admin_user auto-
+# created e.g. by IIAB's 1-line installer and roles/iiab-admin/tasks/main.yml
 iiab_admin_user_install: True
-# If iiab_admin_user_install: False, set iiab_admin_user (below) to an existing
-# Linux user that has sudo access, for login to Admin Console http://box/admin
+# If iiab_admin_user_install: False, set iiab_admin_user to an existing Linux
+# user that's a member of group sudo (or group below?) for Admin Console login:
 iiab_admin_user: iiab-admin
+iiab_admin_user_group: iiab-admin    # 2020-10-13: Coming Soon?
+iiab_admin_published_pwd: g0adm1n    # For live checks/alerts of published pwds
 # Password hash to be used if Ansible creates the above user:
 iiab_admin_pwd_hash: $6$xsce51$D.IrrEeLBYIuJkGDmi27pZUGOwPFp98qpl3hxMwWV4hXigFGmdSvy3s/j7tn6OnyTTLmlV7SsN0lCUAFzxSop.
 # Obtain a password hash - NEW MORE SECURE WAY:


### PR DESCRIPTION
For iiab/maps#38 (faster install of Map Packs) and the upcoming IIAB 7.2 RC3.

i.e. to resolve the 1st half of #2553 (speeding up OSM downloads, whereas Satellite Photo downloads [from Sentinel Cloudless, rate limited to ~300 kbit/s] are a whole other ball wax ;)

Refs: #2560