### PR TITLE
Fix for Graphical and TTY Logins [clean up auto-checking for iiab-admin's published password]

### DIFF
--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -1,25 +1,26 @@
-- name: Create user {{ iiab_admin_user }} for Admin Console; set password from iiab_admin_pwd_hash if newly creating account
+- name: Create user {{ iiab_admin_user }} in group sudo for Admin Console; set password from iiab_admin_pwd_hash if newly creating account
   user:
     name: "{{ iiab_admin_user }}"    # iiab-admin
     password: "{{ iiab_admin_pwd_hash }}"
     update_password: on_create
     shell: /bin/bash
+    groups: sudo
 
-- name: Create a wheel group
-  group:
-    name: wheel
-    state: present
+#- name: Create a wheel group
+#  group:
+#    name: wheel
+#    state: present
 
-- name: Create a sudo group (redhat)
-  group:
-    name: sudo
-    state: present
-  when: is_redhat | bool
+#- name: Create a sudo group (redhat)
+#  group:
+#    name: sudo
+#    state: present
+#  when: is_redhat | bool
 
-- name: 'Add user {{ iiab_admin_user }} to groups: wheel, sudo'
-  user:
-    name: "{{ iiab_admin_user }}"
-    groups: wheel,sudo
+#- name: 'Add user {{ iiab_admin_user }} to groups: wheel, sudo'
+#  user:
+#    name: "{{ iiab_admin_user }}"
+#    groups: wheel,sudo
 
 - name: Edit the sudoers file -- first make it editable
   file:
@@ -33,10 +34,12 @@
     dest: /etc/sudoers
     state: present
 
-- name: Lets wheel sudo without password
-  lineinfile:
-    line: "%wheel ALL= NOPASSWD: ALL"
-    dest: /etc/sudoers
+#- name: Lets {{ iiab_admin_user }} sudo without password
+##- name: Lets wheel sudo without password
+#  lineinfile:
+#    line: "{{ iiab_admin_user }} ALL=(ALL) NOPASSWD: ALL"
+##    line: "%wheel ALL= NOPASSWD: ALL"
+#    dest: /etc/sudoers
 
 - name: Remove the line which requires tty
   lineinfile:

--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -1,6 +1,6 @@
 - name: Create user {{ iiab_admin_user }} for Admin Console; set password from iiab_admin_pwd_hash if newly creating account
   user:
-    name: "{{ iiab_admin_user }}"
+    name: "{{ iiab_admin_user }}"    # iiab-admin
     password: "{{ iiab_admin_pwd_hash }}"
     update_password: on_create
     shell: /bin/bash

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -3,20 +3,6 @@
 
 - include_tasks: access.yml
 
-- name: Add 'iiab-admin' variable values to {{ iiab_ini_file }}
-  ini_file:
-    dest: "{{ iiab_ini_file }}"
-    section: iiab-admin
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: iiab-admin
-    - option: description
-      value: '"Admin User"'
-    - option: iiab_admin_user
-      value: "{{ iiab_admin_user }}"
-
 - name: Install /etc/profile.d/sshpwd-profile-iiab.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
   template:
     src: sshpwd-profile-iiab.sh
@@ -61,3 +47,18 @@
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^iiab_admin_installed'
     line: 'iiab_admin_installed: True'
+
+
+- name: Add 'iiab-admin' variable values to {{ iiab_ini_file }}
+  ini_file:
+    dest: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+    section: iiab-admin
+    option: "{{ item.option }}"
+    value: "{{ item.value | string }}"
+  with_items:
+    - option: name
+      value: iiab-admin
+    - option: description
+      value: '"Admin User"'
+    - option: iiab_admin_user
+      value: "{{ iiab_admin_user }}"

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
-export TEXTDOMAIN=pprompt-iiab
+# SEE ALSO: /etc/profile.d/sshpwd-profile-iiab.sh sourced from...
+# https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
 
-. gettext.sh
+# For Localization/Translation: (use /usr/bin/gettext below if later nec!)
+#export TEXTDOMAIN=pprompt-iiab
+#. gettext.sh
+# https://github.com/raspberrypi-ui/pam/blob/master/etc/profile.d/sshpwd.sh
+# https://github.com/raspberrypi-ui/pprompt/blob/master/sshpwd.sh
 
 # bash syntax "function check_user_pwd() {" was removed, as it prevented all
 # lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
 check_user_pwd() {
+    id -u $1 > /dev/null 2>&1 || return 2    # FORCE ERROR if no such user
+    # *BUT* overall bash script still returns exit code 0 ("success")
+
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
@@ -15,14 +23,10 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-# Credit to the folks at the Raspberry Pi Foundation
-check_hash() {
-   if ! id -u {{ iiab_admin_user }} > /dev/null 2> &1 ; then return 0 ; fi    # iiab-admin
-   if grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config ; then return 0 ; fi
-   if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then
-       zenity --warning --width=600 --text="SSH is enabled and the published password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
-   fi
-}
+#grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config && exit
+#systemctl is-active {{ sshd_service }} || exit
 
-systemctl is-active {{ sshd_service }} > /dev/null && check_hash
-unset check_hash
+if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin
+    zenity --warning --width=600 --text="Published password in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
+    #zenity --warning --width=600 --text="SSH is enabled and the published password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
+fi

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -23,8 +23,8 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-#grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config && exit
-#systemctl is-active {{ sshd_service }} || exit
+#grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config && return
+#systemctl is-active {{ sshd_service }} || return
 
 if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin
     zenity --warning --width=600 --text="Published password in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -17,10 +17,10 @@ check_user_pwd() {
 
 # Credit to the folks at the Raspberry Pi Foundation
 check_hash() {
-   if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
-   if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
-   if check_user_pwd "iiab-admin" "{{ iiab_admin_published_pwd }}"; then
-       zenity --warning --width=600 --text="SSH is enabled and the default password for user 'iiab-admin' is in use.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
+   if ! id -u {{ iiab_admin_user }} > /dev/null 2> &1 ; then return 0 ; fi    # iiab-admin
+   if grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config ; then return 0 ; fi
+   if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then
+       zenity --warning --width=600 --text="SSH is enabled and the default password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
    fi
 }
 

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -20,7 +20,7 @@ check_hash() {
    if ! id -u {{ iiab_admin_user }} > /dev/null 2> &1 ; then return 0 ; fi    # iiab-admin
    if grep -q "^PasswordAuthentication\s\+no\b" /etc/ssh/sshd_config ; then return 0 ; fi
    if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then
-       zenity --warning --width=600 --text="SSH is enabled and the default password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
+       zenity --warning --width=600 --text="SSH is enabled and the published password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
    fi
 }
 

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -26,7 +26,7 @@ check_user_pwd() {
     # if sudo access set with "%wheel ALL= NOPASSWD: ALL" in /etc/sudoers per
     # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/admin-user.yml
     # BUT: warning popups did not result on most OS's, much as mentioned here:
-    # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L38-L44
+    # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L24-L30
 
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -1,31 +1,43 @@
 #!/bin/bash
 
-export TEXTDOMAIN=Linux-PAM
+# SEE ALSO: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh sourced from...
+# https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+# ...invoked by customized /etc/xdg/lxsession/LXDE-pi/autostart
 
-. gettext.sh
+# For Localisation:
+#export TEXTDOMAIN=Linux-PAM
+#. gettext.sh
+# https://github.com/raspberrypi-ui/pam/blob/master/etc/profile.d/sshpwd.sh
+# https://github.com/raspberrypi-ui/pprompt/blob/master/sshpwd.sh
 
 # bash syntax "function check_user_pwd() {" was removed, as it prevented all
 # lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
 check_user_pwd() {
+
+    # 1. 'sudo su -' invokes this script as root:
+    [ $(id -un) = "root" ] || return 1    # FORCE ERROR IF RUN BY NON-root
+    # *BUT* overall bash script still returns exit code 0 ("success")
+    # as needed by Ubuntu 20.04 graphical logins, etc!
+
+    # 2. Graphical Logins invoke this script as the user logging in: (USELESSLY)
+    #[ $(id -un) = "$1" ] || [ $(id -un) = "root" ] || return 1
+    # SO FORMERLY: this could also be run by non-root accounts e.g. iiab-admin
+    # if sudo access set with "%wheel ALL= NOPASSWD: ALL" in /etc/sudoers per
+    # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/admin-user.yml
+    # BUT: warning popups did not result on most OS's, much as mentioned here:
+    # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L38-L44
+
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
-    meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
-    salt=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f3)
-    hash=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f4)
+    meth=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
+    salt=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f3)
+    hash=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f4)
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-# Credit to the folks at the Raspberry Pi Foundation
-check_hash() {
-    if ! id -u iiab-admin > /dev/null 2>&1 ; then return 0 ; fi
-    if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
-    if check_user_pwd "iiab-admin" "{{ iiab_admin_published_pwd }}"; then
-        echo
-        echo $(/usr/bin/gettext "SSH is enabled and the published password for user 'iiab-admin' is in use.")
-        echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd iiab-admin' to change it.")
-        echo
-     fi
-}
-
-systemctl is-active {{ sshd_service }} > /dev/null && check_hash
-unset check_hash
+if check_user_pwd "iiab-admin" "g0adm1n"; then
+    echo
+    echo $(/usr/bin/gettext "The published password for user 'iiab-admin' is in use.")
+    echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd iiab-admin' to change it.")
+    echo
+fi

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -26,17 +26,17 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-[ $(id -un) = "root" ] || exit   # Exit if run by non-root.  So non-root logins
-# don't block on above permissions to grep /etc/shadow.  As it's unreasonable
+[ $(id -un) = "root" ] || return   # MUST be executed as root!  Non-root logins
+# were blocking on above permissions to grep /etc/shadow.  As it's unreasonable
 # to provide sudo privs to every user (with "NOPASSWD:" password-free sudo
 # access or not, as required by graphical logins!)  iiab/iiab#2561
 
-# 2020-10-10 RECAP: logins (graphical or tty) were blocked on above "sudo grep"
+# 2020-10-10 RECAP: most logins (graphical or tty) blocked on above [sudo] grep
 # (at least tty logins finally let sudoers in, after entering password twice!)
-# EXCEPTION: ALL GRAPHICAL logins to Raspberry Pi OS still work, no matter
-# whether sshpwd-lxde-iiab.sh's "sudo grep" displays our popup warning or not!
+# EXCEPTION: ALL GRAPHICAL logins to Raspberry Pi OS still worked, no matter
+# whether sshpwd-lxde-iiab.sh's "sudo grep" displayed our popup warning or not!
 
-#[ $(id -un) = "{{ iiab_admin_user }}" ] || [ $(id -un) = "root" ] || exit
+#[ $(id -un) = "{{ iiab_admin_user }}" ] || [ $(id -un) = "root" ] || return
 # HISTORICAL: if password-free sudo access is truly nec, it can be set with
 # "iiab-admin ALL=(ALL) NOPASSWD: ALL" in /etc/sudoers as seen in the older:
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/admin-user.yml

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -36,9 +36,9 @@ check_user_pwd() {
     [ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]
 }
 
-if check_user_pwd "iiab-admin" "g0adm1n"; then
+if check_user_pwd "{{ iiab_admin_user }}" "g0adm1n"; then    # iiab-admin
     echo
-    echo $(/usr/bin/gettext "The published password for user 'iiab-admin' is in use.")
-    echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd iiab-admin' to change it.")
+    echo $(/usr/bin/gettext "The published password for user '{{ iiab_admin_user }}' is in use.")
+    echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.")
     echo
 fi

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -2,7 +2,8 @@
 
 # SEE ALSO: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh sourced from...
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
-# ...invoked by customized /etc/xdg/lxsession/LXDE-pi/autostart
+# ...invoked by /etc/xdg/lxsession/LXDE-pi/autostart which is customized by...
+# https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L46-L50
 
 # For Localisation:
 #export TEXTDOMAIN=Linux-PAM

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -38,7 +38,7 @@ check_user_pwd() {
 
 if check_user_pwd "{{ iiab_admin_user }}" "g0adm1n"; then    # iiab-admin
     echo
-    echo $(/usr/bin/gettext "The published password for user '{{ iiab_admin_user }}' is in use.")
+    echo $(/usr/bin/gettext "The published password is in use by user '{{ iiab_admin_user }}'.")
     echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.")
     echo
 fi

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -3,7 +3,7 @@
 # SEE ALSO: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh sourced from...
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
 # ...invoked by /etc/xdg/lxsession/LXDE-pi/autostart which is customized by...
-# https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L46-L50
+# https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L32-L36
 
 # For Localization/Translation: (use /usr/bin/gettext below if later nec!)
 #export TEXTDOMAIN=Linux-PAM

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -40,7 +40,7 @@ check_user_pwd() {
 # HISTORICAL: if password-free sudo access is truly nec, it can be set with
 # "iiab-admin ALL=(ALL) NOPASSWD: ALL" in /etc/sudoers as seen in the older:
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/admin-user.yml
-# BUT: popup warning still don't result on most OS's, much as mentioned here:
+# BUT: popup warnings still don't appear on most OS's, much as mentioned here:
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L24-L30
 
 if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh
@@ -5,7 +5,7 @@
 # ...invoked by /etc/xdg/lxsession/LXDE-pi/autostart which is customized by...
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/main.yml#L46-L50
 
-# For Localisation:
+# For Localization/Translation: (use /usr/bin/gettext below if later nec!)
 #export TEXTDOMAIN=Linux-PAM
 #. gettext.sh
 # https://github.com/raspberrypi-ui/pam/blob/master/etc/profile.d/sshpwd.sh
@@ -38,7 +38,7 @@ check_user_pwd() {
 
 if check_user_pwd "{{ iiab_admin_user }}" "g0adm1n"; then    # iiab-admin
     echo
-    echo $(/usr/bin/gettext "The published password is in use by user '{{ iiab_admin_user }}'.")
-    echo $(/usr/bin/gettext "THIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.")
+    echo "The published password is in use by user '{{ iiab_admin_user }}'."
+    echo "THIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it."
     echo
 fi

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -86,7 +86,7 @@
   template:
     src: 020_apache_poweroff.j2
     dest: /etc/sudoers.d/020_apache_poweroff
-    mode: '0755'
+    mode: '0440'
   when: apache_allow_sudo | bool
 
 - name: Remove {{ apache_user }} (per variable apache_user) permission to poweroff, removing /etc/sudoers.d/020_apache_poweroff


### PR DESCRIPTION
Resolves #2561 and its very serious `sudo` problem.

By greatly simplifying `/etc/profile.d/sshpwd-profile-iiab.sh` since the prior version was quite broken, for those with graphical desktops especially, as TK & @shanti-bhardwa confirmed.

Needs more testing on more OS's than just Ubuntu Desktop 20.04.1 (where it was smoke-tested & functionality tested) so this important fix can hopefully be merged in short order.

Refs: #1252, PR #1253, #1537, PR #1551, #2432, PR #2434, PR #2571