### PR TITLE
Respect iiab_admin_user_install better [and iiab-admin design discussion]

### DIFF
--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -51,3 +51,35 @@
   file:
     path: /etc/sudoers
     mode: 0440
+
+- name: Install /etc/profile.d/sshpwd-profile-iiab.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
+  template:
+    src: sshpwd-profile-iiab.sh
+    dest: /etc/profile.d/
+    mode: '0644'
+
+- name: Is this LXDE-pi?
+  stat:
+    path: /etc/xdg/lxsession/LXDE-pi
+  register: lx
+
+- name: "Likewise for Raspbian, installing: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
+  template:
+    src: sshpwd-lxde-iiab.sh
+    dest: /etc/xdg/lxsession/LXDE-pi/
+    mode: '0755'
+  when: lx.stat.isdir is defined and lx.stat.isdir and is_raspbian and is_debuntu
+
+# 2019-03-07: This popup (/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh) does
+# not actually appear when triggered by /etc/xdg/autostart/pprompt-iiab.desktop
+# (or pprompt.desktop as Raspbian has working since 2018-11-13!)  Too bad as it
+# would be really nice to standardize this popup across Ubermix & all distros..
+# Is this a permissions/security issue presumably?  Official autostart spec is:
+# https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html
+# Raspbian's 2016-2018 evolution here: https://github.com/iiab/iiab/issues/1537
+
+- name: Put line in /etc/xdg/lxsession/LXDE-pi/autostart to run the above (raspbian)
+  lineinfile:
+    path: /etc/xdg/lxsession/LXDE-pi/autostart
+    line: "@/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
+  when: lx.stat.isdir is defined and lx.stat.isdir and is_raspbian and is_debuntu

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -3,38 +3,6 @@
 
 - include_tasks: access.yml
 
-- name: Install /etc/profile.d/sshpwd-profile-iiab.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
-  template:
-    src: sshpwd-profile-iiab.sh
-    dest: /etc/profile.d/
-    mode: '0644'
-
-- name: Is this LXDE-pi?
-  stat:
-    path: /etc/xdg/lxsession/LXDE-pi
-  register: lx
-
-- name: "Likewise for Raspbian, installing: /etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
-  template:
-    src: sshpwd-lxde-iiab.sh
-    dest: /etc/xdg/lxsession/LXDE-pi/
-    mode: '0755'
-  when: lx.stat.isdir is defined and lx.stat.isdir and is_raspbian and is_debuntu
-
-# 2019-03-07: This popup (/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh) does
-# not actually appear when triggered by /etc/xdg/autostart/pprompt-iiab.desktop
-# (or pprompt.desktop as Raspbian has working since 2018-11-13!)  Too bad as it
-# would be really nice to standardize this popup across Ubermix & all distros..
-# Is this a permissions/security issue presumably?  Official autostart spec is:
-# https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html
-# Raspbian's 2016-2018 evolution here: https://github.com/iiab/iiab/issues/1537
-
-- name: Put line in /etc/xdg/lxsession/LXDE-pi/autostart to run the above (raspbian)
-  lineinfile:
-    path: /etc/xdg/lxsession/LXDE-pi/autostart
-    line: "@/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh"
-  when: lx.stat.isdir is defined and lx.stat.isdir and is_raspbian and is_debuntu
-
 
 # RECORD iiab-admin AS INSTALLED
 


### PR DESCRIPTION
Install {{ iiab_admin_user }} password checks only when asked to create user.
Augments #2566 by allowing enduser to bypass iiab-admin creation should in field testing show
stange behavior with unknown/untested desktops and/or OSs.

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
