### PR TITLE
Published password auto-warnings: cleaner bash code & explanations (in sshpwd-profile-iiab.sh and sshpwd-lxde-iiab.sh)

### DIFF
--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -12,8 +12,9 @@
 # bash syntax "function check_user_pwd() {" was removed, as it prevented all
 # lightdm/graphical logins (incl autologin) on Raspbian: #1252 -> PR #1253
 check_user_pwd() {
-    id -u $1 > /dev/null 2>&1 || return 2    # FORCE ERROR if no such user
-    # *BUT* overall bash script still returns exit code 0 ("success")
+    #id -u $1 > /dev/null 2>&1 || return 2    # Not needed if return 1 is good
+    # enough when user does not exist.  Or uncomment to FORCE ERROR CODE 2.
+    # Either way, overall bash script still returns exit code 0 ("success")
 
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh
@@ -16,6 +16,11 @@ check_user_pwd() {
     # enough when user does not exist.  Or uncomment to FORCE ERROR CODE 2.
     # Either way, overall bash script still returns exit code 0 ("success")
 
+    # sudo works below (unlike in sshpwd-profile-iiab.sh) b/c RaspiOS ships w/
+    # /etc/sudoers.d/010_pi-nopasswd containing "pi ALL=(ALL) NOPASSWD: ALL"
+    # (read access to /etc/shadow is otherwise restricted to just root and
+    # group www-data i.e. Apache, NGINX get special access).  SEE: #2431, #2561
+
     # $meth (hashing method) is typically '6' which implies 5000 rounds
     # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
     meth=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)


### PR DESCRIPTION
Builds on #2431 -> PR #2434 and #2561 -> PR #2566.

Tested on "RaspiOS with desktop" and Ubuntu Desktop 20.04.1