### PR TITLE
Moodle git repo *VERY* slow: revert to GitHub repo

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -8,8 +8,8 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 moodle_version: 39
-#moodle_repo_url: "https://github.com/moodle/moodle.git"
-moodle_repo_url: "git://git.moodle.org/moodle.git"
+moodle_repo_url: https://github.com/moodle/moodle.git
+#moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 moodle_base: "{{ iiab_base }}/moodle"    # /opt/iiab
 #moodle_user: moodle
 moodle_data: "{{ content_base }}/moodle"    # /library/moodle


### PR DESCRIPTION
Downloading Moodle 3.9.2 (336 MB) from `git://git.moodle.org/moodle.git` to /opt/iiab/moodle took about 30 min.

Whereas it completed in 13 seconds when using https://github.com/moodle/moodle.git (also with --depth 1) as specified by:

https://github.com/iiab/iiab/blob/master/roles/moodle/tasks/install.yml#L56-L65

(In short, Moodle implementers and BIG-sized install need this.)

