### PR TITLE
Overseas request for immediate testing of IIAB on Debian 11 Bullseye + similarly clean out long-deprecated apache_config_dir from high-level <OS>.yml vars files [ASIDE: dnsmasq & dhclient issues? host_country_code MUST match PC/HW, or hostapd won't start]

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -34,8 +34,12 @@ NM_PATH=`which NetworkManager`
     #"raspbian-8"   | \
     #"raspbian-9"   | \
 
+# 2020-10-21: Debian 11 (Bullseye) not yet supported but adding this line to
+# its /etc/os-release can help testing this unreleased OS: VERSION_ID="11"
+
 case $OS_VER in
     "debian-10"    | \
+    "debian-11"    | \
     "ubuntu-20"    | \
     "linuxmint-20" | \
     "raspbian-10")

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -12,7 +12,6 @@ proxy_user: squid
 apache_service: httpd
 apache_user: apache
 apache_conf_dir: httpd/conf.d
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/httpd
 smb_service: smb
 nmb_service: nmb

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -12,7 +12,6 @@ proxy: squid
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,0 +1,27 @@
+is_debuntu: True
+is_debian: True
+is_debian_11: True
+
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dhcp_service: isc-dhcp-server
+dns_user: bind
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_conf_dir: apache2/sites-available
+apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
+apache_user: www-data
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: 7.4
+postgresql_version: 13
+systemd_location: /lib/systemd/system

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -12,7 +12,6 @@ proxy: squid
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -11,7 +11,6 @@ proxy: squid3
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -12,7 +12,6 @@ proxy: squid
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -698,6 +698,7 @@ is_linuxmint: False    # Subset of is_ubuntu
 is_linuxmint_20: False
 
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
+is_debian_11: False
 is_debian_10: False
 is_debian_9: False
 is_debian_8: False

--- a/vars/fedora-18.yml
+++ b/vars/fedora-18.yml
@@ -12,7 +12,6 @@ proxy_user: squid
 apache_service: httpd
 apache_user: apache
 apache_conf_dir: httpd/conf.d
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/httpd
 smb_service: smb
 nmb_service: nmb

--- a/vars/fedora-22.yml
+++ b/vars/fedora-22.yml
@@ -12,7 +12,6 @@ proxy_user: squid
 apache_service: httpd
 apache_user: apache
 apache_conf_dir: httpd/conf.d
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/httpd
 smb_service: smb
 nmb_service: nmb

--- a/vars/linuxmint-20.yml
+++ b/vars/linuxmint-20.yml
@@ -15,7 +15,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd

--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -14,7 +14,6 @@ proxy: squid
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/raspbian-8.yml
+++ b/vars/raspbian-8.yml
@@ -13,7 +13,6 @@ proxy: squid3
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/raspbian-9.yml
+++ b/vars/raspbian-9.yml
@@ -14,7 +14,6 @@ proxy: squid
 proxy_user: proxy
 apache_service: apache2
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_user: www-data
 apache_log_dir: /var/log/apache2
 smb_service: smbd

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -13,7 +13,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd

--- a/vars/ubuntu-17.yml
+++ b/vars/ubuntu-17.yml
@@ -13,7 +13,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -13,7 +13,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd

--- a/vars/ubuntu-19.yml
+++ b/vars/ubuntu-19.yml
@@ -13,7 +13,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -13,7 +13,6 @@ proxy_user: proxy
 apache_service: apache2
 apache_user: www-data
 apache_conf_dir: apache2/sites-available
-apache_config_dir: "{{ apache_conf_dir }}"    # for iiab-admin-console/roles/console/tasks/main.yml Line 150
 apache_log_dir: /var/log/apache2
 smb_service: smbd
 nmb_service: nmbd


### PR DESCRIPTION
While Debian 11 (Bullseye) is an unreleased OS that's obviously not supported, vars are put in place here to encourage general testing in anticipation of 2021's Debian 11, Raspbian 11 a.k.a. RaspiOS 11 a.k.a. Raspberry Pi OS 11 &mdash; and other Debian derivatives like Qubes OS, etc.

Aside: a reminder that server/headless versions of Debian don't immediately jump on Wi-Fi (and don't permit bringing up your Wi-Fi network interface, even if the driver's installed!) unless you first run something like `allow-hotplug wlp2s0` as documented at https://wiki.debian.org/WiFi/HowToUse#Command_Line

cc: @sptankard, @deldesir, @arky and other Debian implementers (:

Tangentially related: iiab/iiab-factory#154