### PR TITLE
gui_desired_network_role is defined in systemd.j2 [solves two Debian 11 issues?]

### DIFF
--- a/roles/network/templates/network/systemd.j2
+++ b/roles/network/templates/network/systemd.j2
@@ -1,5 +1,7 @@
 # iiab_network_mode is {{ iiab_network_mode  }}
+{% if gui_desired_network_role is defined %}
 # gui_desired_network_role is {{ gui_desired_network_role }}
+{% endif %}
 
 {% if iiab_network_mode != "Appliance"  %}
 #################   LANCONTROLLER   ###################


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
