### PR TITLE
Typos in iiab-hotspot-on, iiab-hotspot-off, systemd-static-net.j2 [networking]

### DIFF
--- a/roles/network/templates/network/iiab-hotspot-off
+++ b/roles/network/templates/network/iiab-hotspot-off
@@ -28,7 +28,7 @@ systemctl restart dhcpcd
 #fi
 {% else %}
 #ubuntu
-if [ -f /etc/NetworkManager/conf.d/wifi-manage.conf ]
+if [ -f /etc/NetworkManager/conf.d/wifi-manage.conf ]; then
     sed -i -e "s|managed=0|managed=1|" /etc/NetworkManager/conf.d/wifi-manage.conf
 fi
 echo -e "\nPlease reboot to enable upstream WiFi access.\n"

--- a/roles/network/templates/network/iiab-hotspot-on
+++ b/roles/network/templates/network/iiab-hotspot-on
@@ -29,7 +29,7 @@ systemctl start dnsmasq
 #fi
 {% else %}
 #ubuntu
-if [ -f /etc/NetworkManager/conf.d/wifi-manage.conf ]
+if [ -f /etc/NetworkManager/conf.d/wifi-manage.conf ]; then
     sed -i -e "s|managed=1|managed=0|" /etc/NetworkManager/conf.d/wifi-manage.conf
 fi
 systemctl enable hostapd

--- a/roles/network/templates/network/systemd-static-net.j2
+++ b/roles/network/templates/network/systemd-static-net.j2
@@ -1,4 +1,4 @@
-# /etc/systemd/network/IIAB-static.network
+# /etc/systemd/network/IIAB-Static.network
 [Match]
 Name={{ iiab_wan_iface }}
 
@@ -6,7 +6,5 @@ Name={{ iiab_wan_iface }}
 Address={{ wan_ip }}/{{ wan_cidr }}
 Gateway={{ wan_gateway }}
 LinkLocalAddressing=yes
-DNS={{ wan_namserver }}
+DNS={{ wan_nameserver }}
 Domains={{ iiab_domain }}
-
-


### PR DESCRIPTION
Thanks to @deldesir, @jvonau and TK Kang.

Not the final word, as [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md) also needs improvements, but getting these functional typos fixed allows everyone to advance testing,

Directly Related: PR #2582, #2587

Tangentially Related: #2585 (@shanti-bhardwa's testing of Ubuntu Desktop 20.10 and its Bluetooth snafu)