### PR TITLE
NetworkManager (NM) detection for Ubuntu 20.10&All + remove long-deprecated phplib_dir + Linux Mint /etc/os-release fix

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -13,7 +13,6 @@
   set_fact:
     rpi_model: "{{ ansible_local.local_facts.rpi_model }}"
     xo_model: "{{ ansible_local.local_facts.xo_model }}"
-    phplib_dir: "{{ ansible_local.local_facts.phplib_dir }}"
     iiab_stage: "{{ ansible_local.local_facts.stage }}"
 
 # We need to inialize the ini file and only write the location and version
@@ -123,8 +122,6 @@
       value: "{{ iiab_base_ver }}"
     - option: iiab_revision
       value: "{{ iiab_revision }}"
-    - option: runtime_php
-      value: "{{ phplib_dir }}"
     - option: runtime_branch
       value: "{{ ansible_local.local_facts.iiab_branch }}"
     - option: runtime_commit

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -99,7 +99,7 @@ tmp=$(systemctl is-enabled dhcpcd)
 
 # is_redhat uses "NetworkManager".  Debian 7 & Ubuntu 14.10 required
 # "network-manager" (prior to 2015/systemd).  Ubuntu 20.10 dropped the
-# legacy symlink from "network-manager" to "NetworkManager"
+# legacy symlink from "network-manager.service" to "NetworkManager.service"
 tmp=$(systemctl is-enabled NetworkManager)
 [[ $tmp != "" ]] &&
     NETWORK_MANAGER=$tmp

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# 2020-10-19: Most of the 12 variables require a command[*] to be run to
+# 2020-10-27: Most of the 11 variables require a command[*] to be run to
 # establish the var's value.  WE DISPLAY ALL ERRORS / DIAGNOSTICS AND CONTINUE.
 #
 # [*] DOESN'T MATTER WHAT COMMAND: so long as it fails with Return Code != 0
@@ -11,7 +11,6 @@ OS="none"
 VERSION_ID="none"    # This var's combined with the above, before being output
 IIAB_BRANCH="none"
 IIAB_COMMIT="none"
-PHPLIB_DIR="none"
 XO_MODEL="none"
 RPI_MODEL="none"
 ANSIBLE_VERSION="none"
@@ -77,14 +76,6 @@ tmp=$(git rev-parse --abbrev-ref HEAD) &&
 tmp=$(git rev-parse --verify HEAD) &&
     IIAB_COMMIT=$tmp
 
-if [ -d /usr/lib64/php ]; then
-    PHPLIB_DIR=/usr/lib64/php
-elif [ -d /usr/lib/php5 ]; then
-    PHPLIB_DIR=/usr/lib/php5
-elif [ -d /usr/lib/php ]; then
-    PHPLIB_DIR=/usr/lib/php
-fi
-
 tmp=$(cat /proc/device-tree/mfg-data/MN) &&
     XO_MODEL=$tmp
 
@@ -117,8 +108,7 @@ tmp=$(systemctl is-enabled systemd-networkd)
 
 
 cat <<EOF
-{"phplib_dir"             : "$PHPLIB_DIR",
-"stage"                   : "$STAGE",
+{"stage"                  : "$STAGE",
 "dhcpcd"                  : "$DHCPCD",
 "network_manager"         : "$NETWORK_MANAGER",
 "systemd_networkd"        : "$SYSTEMD_NETWORKD",

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -104,8 +104,10 @@ tmp=$(systemctl is-enabled dhcpcd)
     DHCPCD=$tmp
 #[[ $tmp ]] && DHCPCD=$tmp    # Short Ain't Sweet (less understandable)
 
-# Debian family only, as is_redhat would use NetworkManager as the service name
-tmp=$(systemctl is-enabled network-manager)
+# is_redhat uses "NetworkManager".  Debian 7 & Ubuntu 14.10 required
+# "network-manager" (prior to 2015/systemd).  Ubuntu 20.10 dropped the
+# legacy symlink from "network-manager" to "NetworkManager"
+tmp=$(systemctl is-enabled NetworkManager)
 [[ $tmp != "" ]] &&
     NETWORK_MANAGER=$tmp
 

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -35,7 +35,9 @@ if [ -f /etc/rpi-issue ]; then
     OS="raspbian"
 fi
 
-if tmp=$(grep ^VERSION_ID= /etc/*elease); then
+# /etc/lsb-release could also be grep'd.  But /etc/upstream-release/lsb-release
+# on Linux Mint 20 caused grep of /etc/*elease to fail (on directory not file)
+if tmp=$(grep ^VERSION_ID= /etc/os-release); then
     VERSION_ID=$(echo $tmp | cut -d= -f2)
     VERSION_ID=${VERSION_ID//\"/}   # Remove all '"'
     VERSION_ID=${VERSION_ID%%.*}    # Remove all '.' & stuff to the right of em


### PR DESCRIPTION
Partial fix for #2585, aligning IIAB with Debian and Ubuntu's 2015 change from `network-manager.service` to `NetworkManager.service`

Thanks to @jvonau and @floydianslips for tracking this down.

Related: PR #2592

