### PR TITLE
MongoDB for Ubuntu 20.10 (Groovy Gorilla)

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -96,7 +96,11 @@
 
   - name: Use mongodb-org's Ubuntu repo for all non-Mint Ubuntu - 64bit only
     apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
+      # 2020-10-27: https://repo.mongodb.org/apt/ubuntu/dists/ supports only
+      # {focal 20.04, bionic 18.04, xenial 16.04, trusty 14.04, precise 12.04}
+      # so other Ubuntu's like groovy 20.10 need to revert to recent LTS repo:
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
+      #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
     when: is_ubuntu and not is_linuxmint


### PR DESCRIPTION
For #2585, building on @jvonau's major cleanup of MongoDB (PR #2493) in August 2020.

Tested by installing Sugarizer which successfully pulled in MongoDB 4.4.1 on Ubuntu Desktop 20.10 on RPi 4.

Tangentially related: PR #2593, PR #2594.

cc: @floydianslips, @deldesir