### PR TITLE
Fix $OS in scripts/local_facts.fact for Mint

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -27,7 +27,9 @@ SYSTEMD_NETWORKD="none"
 # doesn't exist, or (2) iiab.env exists but fails to set STAGE=<something>
 source /etc/iiab/iiab.env || true    # STAGE var auto-set, so no "if" required.
 
-if tmp=$(grep ^ID= /etc/*elease); then
+# /etc/lsb-release could also be grep'd.  But /etc/upstream-release/lsb-release
+# on Linux Mint 20 caused grep of /etc/*elease to fail (on directory not file)
+if tmp=$(grep ^ID= /etc/os-release); then
     OS=$(echo $tmp | cut -d= -f2)
     OS=${OS//\"/}    # Remove all '"'
 fi
@@ -35,8 +37,6 @@ if [ -f /etc/rpi-issue ]; then
     OS="raspbian"
 fi
 
-# /etc/lsb-release could also be grep'd.  But /etc/upstream-release/lsb-release
-# on Linux Mint 20 caused grep of /etc/*elease to fail (on directory not file)
 if tmp=$(grep ^VERSION_ID= /etc/os-release); then
     VERSION_ID=$(echo $tmp | cut -d= -f2)
     VERSION_ID=${VERSION_ID//\"/}   # Remove all '"'


### PR DESCRIPTION
Fixes PR #2593 and earlier.

Thanks @jvonau for catching this, as sourcing variables from `/etc/iiab/iiab.env` was masking the bug on a prior install.

Ref: #2585