### PR TITLE
scripts/local_facts.fact: quoting vars is safer...on these 3 lines

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -28,7 +28,7 @@ SYSTEMD_NETWORKD="none"
 source /etc/iiab/iiab.env || true    # STAGE var auto-set, so no "if" required.
 
 if tmp=$(grep ^ID= /etc/*elease); then
-    OS=$(echo $tmp | cut -d= -f2)
+    OS=$(echo "$tmp" | cut -d= -f2)
     OS=${OS//\"/}    # Remove all '"'
 fi
 if [ -f /etc/rpi-issue ]; then
@@ -38,7 +38,7 @@ fi
 # /etc/lsb-release could also be grep'd.  But /etc/upstream-release/lsb-release
 # on Linux Mint 20 caused grep of /etc/*elease to fail (on directory not file)
 if tmp=$(grep ^VERSION_ID= /etc/os-release); then
-    VERSION_ID=$(echo $tmp | cut -d= -f2)
+    VERSION_ID=$(echo "$tmp" | cut -d= -f2)
     VERSION_ID=${VERSION_ID//\"/}   # Remove all '"'
     VERSION_ID=${VERSION_ID%%.*}    # Remove all '.' & stuff to the right of em
 fi
@@ -85,7 +85,7 @@ tmp=$(cat /proc/device-tree/model) &&
     RPI_MODEL=$tmp
 
 tmp=$(ansible --version) &&
-    ANSIBLE_VERSION=$(echo $tmp | head -n 1 | cut -f 2 -d " ")
+    ANSIBLE_VERSION=$(echo "$tmp" | head -n 1 | cut -f 2 -d " ")
 
 
 # THESE LAST 3 ARE DIFFEENT as "systemctl is-enabled" unhelpfully returns the


### PR DESCRIPTION
As recommended by @jvonau at:

- https://github.com/iiab/iiab/pull/2593#issuecomment-717398600
- https://github.com/jvonau/iiab/blob/shellcheck/scripts/local_facts.fact

As lint-like programs go, [ShellCheck](https://www.shellcheck.net/) (shell script analysis tool) isn't perfect but it's far better than nothing to surface common errors!