### PR TITLE
4 renames: network-manager -> NetworkManager for Ubuntu 20.10

### DIFF
--- a/roles/network/tasks/NM-debian.yml
+++ b/roles/network/tasks/NM-debian.yml
@@ -76,6 +76,6 @@
 
 - name: Restart the NetworkManager service
   systemd:
-    name: network-manager
+    name: NetworkManager
     state: restarted
   when: not nobridge is defined and not no_net_restart

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -93,7 +93,7 @@
     state: absent
   when: is_raspbian and not wifi_up_down
 
-- name: Create networkd-dispatcher diagnosic hook for recording network events
+- name: Create networkd-dispatcher diagnostic hook for recording network events
   template:
     owner: root
     group: root

--- a/roles/network/templates/hostapd/clone-wifi.service.j2
+++ b/roles/network/templates/hostapd/clone-wifi.service.j2
@@ -5,7 +5,7 @@ After=network-pre.target
 Before=dhcpcd.service
 Before=wpa_supplicant.service
 Before=wpa_supplicant@{{ discovered_wireless_iface }}.service
-Before=network-manager.service
+Before=NetworkManager.service
 Before=netplan-wpa@{{ discovered_wireless_iface }}.service
 Before=hostapd.service
 

--- a/roles/network/templates/hostapd/hostapd.service.j2
+++ b/roles/network/templates/hostapd/hostapd.service.j2
@@ -5,9 +5,9 @@ After=network-pre.target
 After=clone-wifi.service
 Requires=clone-wifi.service
 Before=dhcpcd.service
-Before=wpa_supplicant@{{ discovered_wireless_iface  }}.service
+Before=wpa_supplicant@{{ discovered_wireless_iface }}.service
 Before=NetworkManager.service
-Before=netplan-wpa-{{ discovered_wireless_iface  }}.service
+Before=netplan-wpa-{{ discovered_wireless_iface }}.service
 Before=network.target
 
 [Service]

--- a/roles/network/templates/hostapd/hostapd.service.j2
+++ b/roles/network/templates/hostapd/hostapd.service.j2
@@ -6,7 +6,7 @@ After=clone-wifi.service
 Requires=clone-wifi.service
 Before=dhcpcd.service
 Before=wpa_supplicant@{{ discovered_wireless_iface  }}.service
-Before=network-manager.service
+Before=NetworkManager.service
 Before=netplan-wpa-{{ discovered_wireless_iface  }}.service
 Before=network.target
 

--- a/roles/network/templates/hostapd/wifi-test.service.j2
+++ b/roles/network/templates/hostapd/wifi-test.service.j2
@@ -5,7 +5,7 @@ Wants=wpa_supplicant.service
 Before=hostapd.service
 Before=dhcpcd.service
 Before=wpa_supplicant@{{ discovered_wireless_iface  }}.service
-Before=network-manager.service
+Before=NetworkManager.service
 Before=netplan-wpa-{{ discovered_wireless_iface  }}.service
 Before=network.target
 

--- a/roles/network/templates/hostapd/wifi-test.service.j2
+++ b/roles/network/templates/hostapd/wifi-test.service.j2
@@ -4,9 +4,9 @@ After=wpa_supplicant.service
 Wants=wpa_supplicant.service
 Before=hostapd.service
 Before=dhcpcd.service
-Before=wpa_supplicant@{{ discovered_wireless_iface  }}.service
+Before=wpa_supplicant@{{ discovered_wireless_iface }}.service
 Before=NetworkManager.service
-Before=netplan-wpa-{{ discovered_wireless_iface  }}.service
+Before=netplan-wpa-{{ discovered_wireless_iface }}.service
 Before=network.target
 
 [Service]
@@ -16,4 +16,3 @@ ExecStart=/sbin/test-wifi
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
@jvonau please review if you can.

For @floydianslips's RPi 4 that got stuck running roles/network here:

```
2020-10-27 10:21:02,070 p=118431 u=root n=ansible | TASK [network : Restart the NetworkManager service] ****************************
2020-10-27 10:21:03,194 p=118431 u=root n=ansible | fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Could not find the requested service network-manager: host"}
```

fyi these 4 lines were changed by running:

```
root@box:/opt/iiab/iiab# grep -rl network-manager roles | xargs sed -i 's/network-manager/NetworkManager/'
```

Ref: #2585, PR #2593