### PR TITLE
Remove quotes from ./runrole's run-one-role.yml as with all other .yml's

### DIFF
--- a/run-one-role.yml
+++ b/run-one-role.yml
@@ -4,7 +4,7 @@
 
   vars_files:
   - vars/default_vars.yml
-  - "vars/{{ ansible_local.local_facts.os_ver }}.yml"
+  - vars/{{ ansible_local.local_facts.os_ver }}.yml
   - /etc/iiab/local_vars.yml
   - /etc/iiab/iiab_state.yml
 


### PR DESCRIPTION
Tested.