### PR TITLE
Node.js 12 -> 14 LTS for Node-RED, Sugarizer and Internet Archive

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -9,10 +9,10 @@
   include_role:
     name: nodejs
 
-- name: FAIL (STOP INSTALLING) IF nodejs_version is not set to 10.x or 12.x
+- name: FAIL (STOP INSTALLING) IF nodejs_version is not set to 10.x, 12.x or 14.x
   fail:
-    msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x or 12.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
-  when: (nodejs_version != "10.x") and (nodejs_version != "12.x")
+    msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x or 12.x or 14.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+  when: (nodejs_version != "10.x") and (nodejs_version != "12.x") and (nodejs_version != "14.x")
 
 - name: "Set 'yarn_install: True' and 'yarn_enabled: True'"
   set_fact:

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -26,10 +26,11 @@
     msg: "Node-RED install cannot proceed, as Node.js is not installed."
   when: nodejs_installed is undefined
 
-- name: FAIL (STOP THE INSTALL) IF 'nodejs_version != "12.x"'
-  fail:
-    msg: "Node-RED install cannot proceed, as it currently requires Node.js 12.x, whereas nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml, /etc/iiab/local_vars.yml, /opt/iiab/iiab/roles/nodejs, etc."
-  when: nodejs_version != "12.x"
+# 2020-10-29: not really be nec as Node-RED supports recent Node.js versions
+#- name: FAIL (STOP THE INSTALL) IF 'nodejs_version != "12.x"'
+#  fail:
+#    msg: "Node-RED install cannot proceed, as it currently requires Node.js 12.x, whereas nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml, /etc/iiab/local_vars.yml, /opt/iiab/iiab/roles/nodejs, etc."
+#  when: nodejs_version != "12.x"
 
 
 # BRUTAL but ensures consistency across OS's / distros like Raspbian Desktop &

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -395,7 +395,7 @@ nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)
-nodejs_version: 12.x    # was 8.x until 2019-02-02, was 10.x until 2019-12-21
+nodejs_version: 14.x    # was 8.x til 2019-02-02, 10.x until 2019-12-21, 12.x til 2020-10-29
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -395,7 +395,7 @@ nodejs_install: False
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)
-nodejs_version: 14.x    # was 8.x til 2019-02-02, 10.x until 2019-12-21, 12.x til 2020-10-29
+nodejs_version: 14.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
Node 14.x seems to work fine (e.g. with Sugarizer) but further testing is ongoing for Node-RED and https://github.com/iiab/iiab/tree/master/roles/internetarchive

cc: @mitra42

Related: PR #2604 "Clean MongoDB/Sugarizer for Debian 11/Sid & All OS's"