### PR TITLE
Autostart -- Bring  up home page on console automatically if it's a Rpi desktop [Ubuntu Desktop 20.10 for RPi not ready for primetime...yet?]

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -33,19 +33,19 @@
       path: /usr/bin/chromium
   register: chromium_present
 
-- name:  Add a chromium-browser to autostart if session manager is LXDE
+- name: Add chromium-browser to /etc/xdg/lxsession/LXDE-pi/autostart if session manager is LXDE
   lineinfile:
       path:   /etc/xdg/lxsession/LXDE-pi/autostart
       regexp: '^/usr/bin/chromium-browser'
-      line:   '/usr/bin/chromium-browser  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+      line:   '/usr/bin/chromium-browser --ignore-certificate-errors --disable-restore-session-state http://box/home' 
   when:
       lxde_present.stat.exists and not chromium_present.stat.exists
 
-- name:  Add a chromium-browser to autostart if session manager is LXDE
+- name: Add chromium to /etc/xdg/lxsession/LXDE-pi/autostart if session manager is LXDE
   lineinfile:
       path:   /etc/xdg/lxsession/LXDE-pi/autostart
-      regexp: '^/usr/bin/chromium-browser'
-      line:   '/usr/bin/chromium  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+      regexp: '^/usr/bin/chromium'
+      line:   '/usr/bin/chromium --ignore-certificate-errors --disable-restore-session-state http://box/home' 
   when:
       lxde_present.stat.exists and chromium_present.stat.exists
 

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -37,7 +37,7 @@
   lineinfile:
       path:   /etc/xdg/lxsession/LXDE-pi/autostart
       regexp: '^/usr/bin/chromium-browser'
-      line:   '/usr/bin/chromium-browser --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+      line:   '/usr/bin/chromium-browser --disable-restore-session-state http://box/home' 
   when:
       lxde_present.stat.exists and not chromium_present.stat.exists
 
@@ -45,7 +45,7 @@
   lineinfile:
       path:   /etc/xdg/lxsession/LXDE-pi/autostart
       regexp: '^/usr/bin/chromium'
-      line:   '/usr/bin/chromium --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+      line:   '/usr/bin/chromium --disable-restore-session-state http://box/home' 
   when:
       lxde_present.stat.exists and chromium_present.stat.exists
 

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -28,13 +28,26 @@
       path: /etc/xdg/lxsession/LXDE-pi/autostart
   register: lxde_present
 
+- name: Check for Chromium name change
+  stat:
+      path: /usr/bin/chromium
+  register: chromium_present
+
 - name:  Add a chromium-browser to autostart if session manager is LXDE
   lineinfile:
       path:   /etc/xdg/lxsession/LXDE-pi/autostart
       regexp: '^/usr/bin/chromium-browser'
       line:   '/usr/bin/chromium-browser  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
   when:
-      lxde_present.stat.exists
+      lxde_present.stat.exists and not chromium_present.stat.exists
+
+- name:  Add a chromium-browser to autostart if session manager is LXDE
+  lineinfile:
+      path:   /etc/xdg/lxsession/LXDE-pi/autostart
+      regexp: '^/usr/bin/chromium-browser'
+      line:   '/usr/bin/chromium  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+  when:
+      lxde_present.stat.exists and chromium_present.stat.exists
 
 - debug:
     msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: (nginx_high_php_limits or moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled'

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -25,13 +25,13 @@
 
 - name: Make home page autostart on localhost (the server's console) if session manager is LXDE (rpi)
   stat:
-      path: /etc/lxsession/LXDE-pi/autostart
+      path: /etc/xdg/lxsession/LXDE-pi/autostart
   register: lxde_present
 
 - name:  Add a chromium-browser to autostart if session manager is LXDE
   lineinfile:
-      path:   /etc/lxsession/LXDE-pi/autostart
-      rexexp: '^/usr/bin/chromium-browser'
+      path:   /etc/xdg/lxsession/LXDE-pi/autostart
+      regexp: '^/usr/bin/chromium-browser'
       line:   '/usr/bin/chromium-browser  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
   when:
       lxde_present.stat.exists

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -23,6 +23,19 @@
   when: nginx_installed is defined
   #when: nginx_install
 
+- name: Make home page autostart on localhost (the server's console) if session manager is LXDE (rpi)
+  stat:
+      path: /etc/lxsession/LXDE-pi/autostart
+  register: lxde_present
+
+- name:  Add a chromium-browser to autostart if session manager is LXDE
+  lineinfile:
+      path:   /etc/lxsession/LXDE-pi/autostart
+      rexexp: '^/usr/bin/chromium-browser'
+      line:   '/usr/bin/chromium-browser  --ignore-certificate-errors --disable-restore-session-state http://box/home' 
+  when:
+      lxde_present.stat.exists
+
 - debug:
     msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: (nginx_high_php_limits or moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled'
 


### PR DESCRIPTION
In the absence of something more spiffy, the home page has links to online and offline documentation. The naive user should have a direct path cleared to getting started.