### PR TITLE
mongo port - use the KISS method - revert from the mistaken use of 27018 to 27017

### DIFF
--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -15,7 +15,6 @@
 
 # mongodb_enabled: False
 
-# mongodb_port: 27017
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -15,7 +15,7 @@
 
 # mongodb_enabled: False
 
-# mongodb_port: 27018
+# mongodb_port: 27017
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -114,13 +114,6 @@
         - mongodb-org-server
       state: present
 
-#  - name: Change {{ mongodb_conf }} port to {{ mongodb_port }} -- takes effect on next (re)start of the service -- via enable-or-disable.yml or via sugarizer.service auto-starting MongoDB on demand
-#    lineinfile:
-#      path: "{{ mongodb_conf }}"
-#      regexp: "port: 27017"
-#      backrefs: yes
-#      line: "  port: {{ mongodb_port }}"    # 27018
-
   # end block
   when: (ansible_architecture == "aarch64") or (ansible_architecture == "x86_64")
 

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -49,7 +49,7 @@
 
   - name: Install {{ mongodb_conf }} from template (aarch32)
     template:
-      src: mongod.conf.j2
+      src: mongod.conf
       dest: "{{ mongodb_conf }}"    # /etc/mongod.conf
       #owner: root
       #group: root

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -114,12 +114,12 @@
         - mongodb-org-server
       state: present
 
-  - name: Change {{ mongodb_conf }} port to {{ mongodb_port }} -- takes effect on next (re)start of the service -- via enable-or-disable.yml or via sugarizer.service auto-starting MongoDB on demand
-    lineinfile:
-      path: "{{ mongodb_conf }}"
-      regexp: "port: 27017"
-      backrefs: yes
-      line: "  port: {{ mongodb_port }}"    # 27018
+#  - name: Change {{ mongodb_conf }} port to {{ mongodb_port }} -- takes effect on next (re)start of the service -- via enable-or-disable.yml or via sugarizer.service auto-starting MongoDB on demand
+#    lineinfile:
+#      path: "{{ mongodb_conf }}"
+#      regexp: "port: 27017"
+#      backrefs: yes
+#      line: "  port: {{ mongodb_port }}"    # 27018
 
   # end block
   when: (ansible_architecture == "aarch64") or (ansible_architecture == "x86_64")

--- a/roles/mongodb/templates/mongod.conf
+++ b/roles/mongodb/templates/mongod.conf
@@ -6,7 +6,7 @@
 bind_ip = 127.0.0.1
 
 # Specify port number (27017 by default...but typically 27018 for IIAB)
-port = {{ mongodb_port }}
+port = 27017
 
 # Fork server process (false by default)
 # fork = true

--- a/roles/mongodb/templates/mongod.conf
+++ b/roles/mongodb/templates/mongod.conf
@@ -5,8 +5,8 @@
 # Comma separated list of ip addresses to listen on (all local ips by default)
 bind_ip = 127.0.0.1
 
-# Specify port number (27017 by default...but typically 27018 for IIAB)
-port = 27017
+# Specify port number (27017 by default)
+#port = 27017
 
 # Fork server process (false by default)
 # fork = true

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -198,11 +198,11 @@
 
 # mongodb_port is set to 27018 in /opt/iiab/iiab/vars/default_vars.yml
 # If you need to change this, edit /etc/iiab/local_vars.yml prior to installing
-- name: Set MongoDB port to {{ mongodb_port }} in /opt/iiab/sugarizer-server/env/sugarizer.ini
-  lineinfile:
-    path: "{{ iiab_base }}/sugarizer-server/env/sugarizer.ini"
-    regexp: "^port = 27017$"
-    line: "port = {{ mongodb_port }}"
+#- name: Set MongoDB port to {{ mongodb_port }} in /opt/iiab/sugarizer-server/env/sugarizer.ini
+#  lineinfile:
+#    path: "{{ iiab_base }}/sugarizer-server/env/sugarizer.ini"
+#    regexp: "^port = 27017$"
+#    line: "port = {{ mongodb_port }}"
 
 # 2-LINE FIX FOR sugarizer.js BY @georgejhunt FOR http://box/sugarizer
 # SEE ~61 LINES ABOVE, as this is REQUIRED: 'npm install --allow-root --unsafe-perm=true path-prefix-proxy'

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -196,14 +196,6 @@
 #    regexp: "^server = localhost$"
 #    line: "server = 127.0.0.1"
 
-# mongodb_port is set to 27018 in /opt/iiab/iiab/vars/default_vars.yml
-# If you need to change this, edit /etc/iiab/local_vars.yml prior to installing
-#- name: Set MongoDB port to {{ mongodb_port }} in /opt/iiab/sugarizer-server/env/sugarizer.ini
-#  lineinfile:
-#    path: "{{ iiab_base }}/sugarizer-server/env/sugarizer.ini"
-#    regexp: "^port = 27017$"
-#    line: "port = {{ mongodb_port }}"
-
 # 2-LINE FIX FOR sugarizer.js BY @georgejhunt FOR http://box/sugarizer
 # SEE ~61 LINES ABOVE, as this is REQUIRED: 'npm install --allow-root --unsafe-perm=true path-prefix-proxy'
 # OR YOU GET ERRORS: "status=255" within "systemctl status sugarizer"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -485,7 +485,7 @@ mongodb_install: False
 # misleading as Sugarizer starts mongodb's systemd service on its own, due to
 # 'Requires=mongodb.service' within /etc/systemd/system/sugarizer.service
 mongodb_enabled: False
-mongodb_port: 27018
+mongodb_port: 27017
 
 # roles/sugarizer/meta/main.yml auto-invokes 2 above prereqs: mongodb & nodejs
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -485,7 +485,6 @@ mongodb_install: False
 # misleading as Sugarizer starts mongodb's systemd service on its own, due to
 # 'Requires=mongodb.service' within /etc/systemd/system/sugarizer.service
 mongodb_enabled: False
-mongodb_port: 27017
 
 # roles/sugarizer/meta/main.yml auto-invokes 2 above prereqs: mongodb & nodejs
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879


### PR DESCRIPTION
### Fixes bug:
non-stock port usage of mongoDB
### Description of changes proposed in this pull request:
return to the "factory defaults"
### Smoke-tested on which OS or OS's:
RaspOS 32bit
#2604