### PR TITLE
Use '*_install: True' with on demand roles for runrole(s)

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -1,10 +1,5 @@
 # 1. INSTALL 3 PREREQS
 
-- name: "Set 'nodejs_install: True' and 'nodejs_enabled: True'"
-  set_fact:
-    nodejs_install: True
-    nodejs_enabled: True
-
 - name: NODEJS - run 'nodejs' role (attempt to install & enable Node.js)
   include_role:
     name: nodejs
@@ -13,11 +8,6 @@
   fail:
     msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x or 12.x or 14.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
   when: (nodejs_version != "10.x") and (nodejs_version != "12.x") and (nodejs_version != "14.x")
-
-- name: "Set 'yarn_install: True' and 'yarn_enabled: True'"
-  set_fact:
-    yarn_install: True
-    yarn_enabled: True
 
 - name: YARN - run 'yarn' role (attempt to install & enable Yarn package manager)
   include_role:

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -11,11 +11,6 @@
 # 2019-01-16: @jvonau's PR #1403 moved installation of Node.js (8.x for now) &
 # npm to roles/nodejs/tasks/main.yml
 
-- name: "Set 'nodejs_install: True' and 'nodejs_enabled: True'"
-  set_fact:
-    nodejs_install: True
-    nodejs_enabled: True
-
 # 2020-01-04 no longer triggered by roles/nodered/meta/main.yml
 - name: NODEJS - run 'nodejs' role (attempt to install & enable Node.js)
   include_role:

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -6,11 +6,6 @@
 
 # 1. INSTALL/ASSERT PREREQ #2: Node.js
 
-- name: "Set 'nodejs_install: True' and 'nodejs_enabled: True'"
-  set_fact:
-    nodejs_install: True
-    nodejs_enabled: True
-
 - name: NODEJS - run 'nodejs' role (attempt to install & enable Node.js)
   include_role:
     name: nodejs

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -22,10 +22,6 @@
 # 3 stanzas moved up from install.yml, so Debian-or-any-OS-where-MongoDB-fails
 # still finish their "BIG-sized" IIAB install: (WITH LOUD RED WARNINGS!)
 
-- name: "Set 'mongodb_install: True'"
-  set_fact:
-    mongodb_install: True
-
 - name: 'CAUTION: IF ''mongodb.service'' IS STOPPED FOR ANY REASON, IT WILL IMMEDIATELY CAUSE SUGARIZER TO FAIL ("502 Bad Gateway") !'
   debug:
     msg: "/etc/systemd/system/sugarizer.service Line 4 'Requires=mongodb.service' tries to auto-start MongoDB every time Sugarizer starts.  IIAB (roles/mongodb/tasks/enable-or-disable.yml) tries its best to keep Ansible var 'mongodb_enabled' in sync with its systemd equivalent, i.e. the output of 'systemctl is-enabled mongodb' (as of 2020-10-29 both are typically disabled, unless other apps/services/operators choose to use MongoDB)."

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -393,7 +393,6 @@ mosquitto_port: 1883
 # as a dependency -- by Node-RED, Sugarizer &/or Internet Archive
 # 2020-11-04: True required for runrole without user adding to local_vars.yml
 nodejs_install: True
-nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)
 nodejs_version: 14.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29
@@ -570,7 +569,6 @@ vnstat_enabled: False
 # dependency -- by Internet Archive
 # 2020-11-04: True required for runrole without user adding to local_vars.yml
 yarn_install: True
-yarn_enabled: False
 
 # Internet Archive Offline / Decentralized Web - create your own offline
 # version (http://box:4244 or later http://box/archive?) arising from digital

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -276,7 +276,8 @@ apache_allow_sudo: True
 #
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Apache is installed on demand as
 # a dependency -- by CUPS, Elgg, Lokole, Moodle, Node-RED, PBX &/or phpMyAdmin
-apache_install: False
+# 2020-11-04: True required for runrole without user adding to local_vars.yml
+apache_install: True
 apache_enabled: False
 #
 # NGINX proxies to Apache for legacy IIAB services, using:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -391,7 +391,8 @@ mosquitto_port: 1883
 
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Node.js is installed on demand
 # as a dependency -- by Node-RED, Sugarizer &/or Internet Archive
-nodejs_install: False
+# 2020-11-04: True required for runrole without user adding to local_vars.yml
+nodejs_install: True
 nodejs_enabled: False
 # Node.js version used by roles/nodejs/tasks/main.yml for 3 roles:
 # nodered (Node-RED), pbx (Asterix, FreePBX) & sugarizer (Sugarizer)
@@ -458,7 +459,8 @@ kiwix_apk_src: https://download.kiwix.org/release/kiwix-android/kiwix.apk
 
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as PostgreSQL is installed on
 # demand as a dependency -- by Moodle &/or Pathagar
-postgresql_install: False
+# 2020-11-04: True required for runrole without user adding to local_vars.yml
+postgresql_install: True
 postgresql_enabled: False
 
 moodle_install: False
@@ -479,7 +481,9 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 #
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as MongoDB is installed on demand
 # as a dependency -- by Sugarizer
-mongodb_install: False
+# 2020-11-04: True required for runrole without user adding to local_vars.yml
+mongodb_install: True
+
 # 'mongodb_enabled: False' MAY work when Sugarizer is disabled.  Required by
 # mongodb/tasks/enable.yml to shut down the service and log status, but that is
 # misleading as Sugarizer starts mongodb's systemd service on its own, due to
@@ -564,7 +568,8 @@ vnstat_enabled: False
 
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as Yarn is installed on demand as a
 # dependency -- by Internet Archive
-yarn_install: False
+# 2020-11-04: True required for runrole without user adding to local_vars.yml
+yarn_install: True
 yarn_enabled: False
 
 # Internet Archive Offline / Decentralized Web - create your own offline


### PR DESCRIPTION
  remove set_facts as default_vars now has the *_install value set to True with the *_enabled part being ignored anyway with nodejs & yarn apt repos
### Fixes bug:
restores runrole --reinstall functionality for the on demand roles:  nodejs, yarn, postgresql, mongodb
### Description of changes proposed in this pull request:
toggle the default *_install and remove unnecessary set_facts from the roles. 
### Smoke-tested on which OS or OS's:
lightly tested with ./runrole 
### Mention a team member @username e.g. to help with code review:
