### PR TITLE
runrole: auto-prompt to pass 'APP_install: True' to Ansible + properly validate 5 dependencies

### DIFF
--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -55,6 +55,8 @@
 # https://github.com/iiab/iiab/blob/master/roles/0-DEPRECATED-ROLES/
 # https://github.com/iiab/iiab/blob/master/tests/test.yml
 # https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml
+#
+# 2020-11-04: Fix validation of 5 core dependencies, for ./runrole etc
 
 - name: Set vars_checklist for 40 + 40 + up-to-40 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
@@ -69,7 +71,7 @@
       - openvpn
       - admin_console
       #- nginx              # MANDATORY
-      #- apache             # Dependency installed on demand by other apps/svcs
+      - apache              # Dependency - excluded from _installed check below
       #- mysql              # MANDATORY
       - squid
       - dansguardian
@@ -88,7 +90,7 @@
       - lokole
       - mediawiki
       - mosquitto
-      #- nodejs             # Dependency installed on demand by other apps/svcs
+      - nodejs              # Dependency - excluded from _installed check below
       - nodered
       - nextcloud
       - pbx
@@ -96,9 +98,9 @@
       - kalite
       - kolibri
       - kiwix
-      #- postgresql         # Dependency installed on demand by other apps/svcs
+      - postgresql          # Dependency - excluded from _installed check below
       - moodle
-      #- mongodb            # Dependency installed on demand by other apps/svcs
+      - mongodb             # Dependency - excluded from _installed check below
       - sugarizer
       - osm_vector_maps
       - transmission
@@ -107,7 +109,7 @@
       - munin
       - phpmyadmin
       - vnstat
-      #- yarn               # Dependency installed on demand by other apps/svcs
+      - yarn                # Dependency - excluded from _installed check below
       - internetarchive
       - captiveportal
       - minetest
@@ -154,4 +156,5 @@
     that: "{{ item }}_install or {{ item }}_installed is undefined"
     fail_msg: "DISALLOWED: '{{ item }}_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN '{{ item }}_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
     quiet: yes
+  when: item != 'apache' and item != 'nodejs' and item != 'postgresql' and item != 'mongodb' and item != 'yarn'    # Exclude auto-installed dependencies
   loop: "{{ vars_checklist }}"

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,4 +1,4 @@
-# SEE VAR nodejs_version: 12.x IN /opt/iiab/iiab/vars/default_vars.yml (FOR
+# SEE VAR nodejs_version: 14.x IN /opt/iiab/iiab/vars/default_vars.yml (FOR
 # NOW!) AND IF NEC OVERRIDE THIS IN /etc/iiab/local_vars.yml
 
 # Duplicate Node.js code unified by @jvonau.  Revised by @holta.  Used by:

--- a/runrole
+++ b/runrole
@@ -74,7 +74,7 @@ else
    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 fi
 
-ARGS="$ARGS\"role_to_run\":\"$1\"}"
+ARGS="$ARGS\"role_to_run\":\"$1\"}"    # $1 works like \"$1\" if str validated
 CMD="ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local $ARGS"
 echo -e "\e[1mbash will now run this, adding single quotes around the {...} curly braces:\e[0m\n\n$CMD\n"
 ansible -m setup -i $INVENTORY localhost --connection=local | grep python

--- a/runrole
+++ b/runrole
@@ -26,6 +26,22 @@ if [ $# -eq 0 ] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ]; then
     exit 0
 fi
 
+# 2020-08-05: yes /etc/iiab/iiab_state.yml is necessary, but we DON'T
+# want to encourage sloppy operators to delete/touch this file.
+#
+# (The iiab_state.yml file should always be created by ./iiab-install,
+# for IIAB's Ansible roles that then auto-populate this file.)
+#
+# FYI ./iiab-network and ./iiab-configure likewise warn operators (IN RED!)
+# if they try to run without the existence of /etc/iiab/iiab_state.yml :
+#
+# ERROR! vars file /etc/iiab/iiab_state.yml was not found
+#
+# Needed for Stages 1-3 if not installed yet
+#if [ ! -f $IIAB_STATE_FILE ]; then
+#    touch $IIAB_STATE_FILE
+#fi
+
 if [ "$1" == "--reinstall" ]; then
     ARGS="$ARGS\"reinstall\":True," # Needs boolean not string so use JSON list
     REINSTALL=true

--- a/runrole
+++ b/runrole
@@ -68,6 +68,17 @@ if $REINSTALL; then   # Add '_' so '--reinstall calibre' doesn't zap calibreweb
 	echo -e "Try again without the '--reinstall' flag?\n"
 	exit 1
     fi
+else
+    if grep -q "^${ROLE_VAR}_" $IIAB_STATE_FILE; then
+        echo -e "\e[1mWARNING: $IIAB_STATE_FILE already has this/these line(s):\e[0m\n"
+	grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
+        echo -e "To reinstall it, run: ./runrole --reinstall $1\n"
+	echo -n "Or continue, e.g. to enable/disable it based on var '${ROLE_VAR}_enabled' ? [Y/n] "
+	read ans < /dev/tty
+	echo
+	[ "$ans" = "n" ] || [ "$ans" = "N" ] &&
+            exit 1
+    fi
 fi
 
 grep -q "^${ROLE_VAR}_install:\s\+[Tt]rue\b" $DEFAULT_VARS_FILE && INSTALL=true

--- a/runrole
+++ b/runrole
@@ -60,23 +60,23 @@ fi
 echo
 if $REINSTALL; then   # Add '_' so '--reinstall calibre' doesn't zap calibreweb
     if grep -q "^${ROLE_VAR}_" $IIAB_STATE_FILE; then
-	echo -e "\e[1mThese line(s) in $IIAB_STATE_FILE are now being deleted:\e[0m\n"
-	grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
-	sed -i "/^${ROLE_VAR}_/d" $IIAB_STATE_FILE
+        echo -e "\e[1mThese line(s) in $IIAB_STATE_FILE are now being deleted:\e[0m\n"
+        grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
+        sed -i "/^${ROLE_VAR}_/d" $IIAB_STATE_FILE
     else
-	echo -e "\e[1mERROR: $IIAB_STATE_FILE has no lines that begin with '${ROLE_VAR}_'\e[0m\n"
-	echo -e "Try again without the '--reinstall' flag?\n"
-	exit 1
+        echo -e "\e[1mERROR: $IIAB_STATE_FILE has no lines that begin with '${ROLE_VAR}_'\e[0m\n"
+        echo -e "Try again without the '--reinstall' flag?\n"
+        exit 1
     fi
 else
     if grep -q "^${ROLE_VAR}_" $IIAB_STATE_FILE; then
         echo -e "\e[1mWARNING: $IIAB_STATE_FILE already has this/these line(s):\e[0m\n"
-	grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
+        grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
         echo -e "To reinstall it, run: ./runrole --reinstall $1\n"
-	echo -n "Or continue, e.g. to enable/disable it based on var '${ROLE_VAR}_enabled' ? [Y/n] "
-	read ans < /dev/tty
-	echo
-	[ "$ans" = "n" ] || [ "$ans" = "N" ] &&
+        echo -n "Or continue, e.g. to enable/disable it based on var '${ROLE_VAR}_enabled' ? [Y/n] "
+        read ans < /dev/tty
+        echo
+        [ "$ans" = "n" ] || [ "$ans" = "N" ] &&
             exit 1
     fi
 fi

--- a/runrole
+++ b/runrole
@@ -75,7 +75,7 @@ grep -q "^${ROLE_VAR}_install:\s\+[Ff]alse\b" $LOCAL_VARS_FILE && INSTALL=false
 grep -q "^${ROLE_VAR}_install:\s\+[Tt]rue\b" $LOCAL_VARS_FILE && INSTALL=true
 if ! $INSTALL; then
     echo -e "\e[1m'${ROLE_VAR}_install: True' MUST BE SET!\e[0m\n"
-    echo -e "Usually it's best to set this in: $LOCAL_VARS_FILE\n"
+    echo -e "Usually it's best to set variables in: $LOCAL_VARS_FILE\n"
     echo -n "Just for now, pass '${ROLE_VAR}_install: True' directly to Ansible? [Y/n] "
     read ans < /dev/tty
     echo

--- a/runrole
+++ b/runrole
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+DEFAULT_VARS_FILE=/opt/iiab/iiab/vars/default_vars.yml
+LOCAL_VARS_FILE=/etc/iiab/local_vars.yml
+IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
+ROLE_VAR=""
+INSTALL=false
+REINSTALL=false
+CWD=`pwd`
+ARGS="--extra-vars {"    # bash forces {...} to '{...}' for Ansible, SEE BOTTOM
 INVENTORY=ansible_hosts
 PLAYBOOK=run-one-role.yml
-ARGS=""
-REINSTALL=0
-CWD=`pwd`
-IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
-LOCAL_VARS_FILE=/etc/iiab/local_vars.yml
 
 if [ ! -f $PLAYBOOK ]; then
     echo "Exiting: IIAB Playbook not found."
@@ -14,7 +17,7 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-if [[ $# -eq 0 ]] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ] ; then
+if [ $# -eq 0 ] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ]; then
     echo "Usage: ./runrole <name of role>"
     echo "Usage: ./runrole --reinstall <name of role>"
     echo
@@ -24,64 +27,45 @@ if [[ $# -eq 0 ]] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ] ; th
 fi
 
 if [ "$1" == "--reinstall" ]; then
-    ARGS="$ARGS -e reinstall=True"
-    REINSTALL=1
-    shift 1
+    ARGS="$ARGS\"reinstall\":True," # Needs boolean not string so use JSON list
+    REINSTALL=true
+    shift
 fi
 
-#if ! grep -q "^""$1""_install: True" $LOCAL_VARS_FILE; then
-#    echo "ERROR: $LOCAL_VARS_FILE must contain '""$1""_install: True'"
-#    exit 1
-#fi
+ROLE_VAR=$1    # Ansible role name & var name sometimes differ :/
+if [ $1 == "calibre-web" ]; then 
+    ROLE_VAR=calibreweb
+elif [ $1 == "httpd" ]; then
+    ROLE_VAR=apache
+elif [ $1 == "osm-vector-maps" ]; then
+    ROLE_VAR=osm_vector_maps
+fi
 
-# 2020-08-05: yes /etc/iiab/iiab_state.yml is necessary, but we DON'T
-# want to encourage sloppy operators to delete/touch this file.
-#
-# (The iiab_state.yml file should always be created by ./iiab-install,
-# for IIAB's Ansible roles that then auto-populate this file.)
-#
-# FYI ./iiab-network and ./iiab-configure likewise warn operators (IN RED!)
-# if they try to run without the existence of /etc/iiab/iiab_state.yml :
-#
-# ERROR! vars file /etc/iiab/iiab_state.yml was not found
-#
-# Needed for Stages 1-3 if not installed yet
-#if [ ! -f $IIAB_STATE_FILE ]; then
-#    touch $IIAB_STATE_FILE
-#fi
-
-#if ! grep -q $1_install $LOCAL_VARS_FILE; then
-#    echo " $1_install: not found in $VARS"
-#    echo " Please review $VARS and edit as required"
-#    exit 1
-#elif grep $1_install $LOCAL_VARS_FILE | grep -q --exclude "#" False; then
-#    echo " $1_install: set to False found in $VARS"
-#    echo " Please review $VARS and edit as required"
-#    exit 1
-#elif grep $1_install $LOCAL_VARS_FILE | grep -q "#"; then
-#    echo " $1_install: commented out (#) in $VARS"
-#    echo " Please review $VARS and edit as required"
-#    exit 1
-#else
-#    if grep $1_install $LOCAL_VARS_FILE | grep -q --exclude "#" True; then
-#        echo " $1_install: set to True found in $VARS"
-#        echo " continuing...."
-#    else
-#        echo "somthing went wrong to get here"
-#        exit 1
-#    fi
-#fi
-
-if [ "$REINSTALL" == "1" ]; then
-    if [ $1 == "calibre-web" ]; then # role directory & installed marker differ
-        sed -i -e '/^calibreweb/d' $IIAB_STATE_FILE
-    elif [ $1 == "httpd" ]; then # role directory & installed marker differ
-        sed -i -e '/^apache/d' $IIAB_STATE_FILE
-    elif [ $1 == "osm-vector-maps" ]; then # role directory & installed marker differ
-        sed -i -e '/^osm_vector_maps/d' $IIAB_STATE_FILE
+echo
+if $REINSTALL; then   # Add '_' so '--reinstall calibre' doesn't zap calibreweb
+    if grep -q "^${ROLE_VAR}_" $IIAB_STATE_FILE; then
+	echo -e "\e[1mThese line(s) in $IIAB_STATE_FILE are now being deleted:\e[0m\n"
+	grep "^${ROLE_VAR}_" $IIAB_STATE_FILE; echo
+	sed -i "/^${ROLE_VAR}_/d" $IIAB_STATE_FILE
     else
-        sed -i -e "/^$1/d" $IIAB_STATE_FILE
+	echo -e "\e[1mERROR: $IIAB_STATE_FILE has no lines that begin with '${ROLE_VAR}_'\e[0m\n"
+	echo -e "Try again without the '--reinstall' flag?\n"
+	exit 1
     fi
+fi
+
+grep -q "^${ROLE_VAR}_install:\s\+[Tt]rue\b" $DEFAULT_VARS_FILE && INSTALL=true
+grep -q "^${ROLE_VAR}_install:\s\+[Ff]alse\b" $LOCAL_VARS_FILE && INSTALL=false
+grep -q "^${ROLE_VAR}_install:\s\+[Tt]rue\b" $LOCAL_VARS_FILE && INSTALL=true
+if ! $INSTALL; then
+    echo -e "\e[1m'${ROLE_VAR}_install: True' MUST BE SET!\e[0m\n"
+    echo -e "Usually it's best to set this in: $LOCAL_VARS_FILE\n"
+    echo -n "Just for now, pass '${ROLE_VAR}_install: True' directly to Ansible? [Y/n] "
+    read ans < /dev/tty
+    echo
+    [ "$ans" = "n" ] || [ "$ans" = "N" ] &&
+        exit 1
+    ARGS="$ARGS\"${ROLE_VAR}_install\":True,"
 fi
 
 if [ $# -eq 2 ]; then
@@ -90,5 +74,19 @@ else
    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 fi
 
-ansible -m setup -i $INVENTORY localhost ${ARGS} --connection=local | grep python
-ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local -e "role_to_run=$1"
+ARGS="$ARGS\"role_to_run\":\"$1\"}"
+CMD="ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local $ARGS"
+echo -e "\e[1mbash will now run this, adding single quotes around the {...} curly braces:\e[0m\n\n$CMD\n"
+ansible -m setup -i $INVENTORY localhost --connection=local | grep python
+$CMD
+
+# bash forces (NECESSARY) single quotes around {} at runtime (if $ARGS contains
+# curly braces).  If you also add single quotes *within* $ARGS, Ansible will
+# FAIL as you will end up with 2-not-1 single-quotes on each side of the {}.
+# https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#json-string-format
+#
+# Change the top line of this file to 'bash -x' to see this happen live.  Or,
+# if you prefer the single quotes in the $ARGS var itself, run it this way:
+#
+# echo $CMD > /tmp/runrole-ansible-cmd
+# bash /tmp/runrole-ansible-cmd


### PR DESCRIPTION
Alternative to @jvonau's PR #2616 with interactive explanations so testers know exactly what's happening.

This streamlines testing by cleaning up ad hoc installation of IIAB's 5 auto-installed dependencies {apache, nodejs, postgresql, mongodb, yarn}, allowing `./runrole <APP>` and `./runrole --reinstall <APP>` to work gracefully for most all of IIAB's Ansible [roles](https://github.com/iiab/iiab/tree/master/roles), in most all situations.

It does this by automatically prompting implementers/testers/you e.g. if you forgot to set APP_install: True in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) &mdash; allowing you to quickly (A) pass variable `APP_install: True` directly to Ansible, by hitting [Enter] at the prompt &mdash; or (B) exit to the command-line to edit `/etc/iiab/local_vars.yml` if you prefer that instead.

Also var validation of IIAB's 5 core dependencies is fixed.  With blue-on-green Ansible output when [0-init](https://github.com/iiab/iiab/tree/master/roles/0-init) runs, making clear which validations the 5 dependencies are bypassing.

Background: PR https://github.com/iiab/iiab/pull/2613#issuecomment-721329979

This PR has been heavily tested on Ubuntu Server 20.04.1