### PR TITLE
Bump ansible-base recommendation: 2.10.2 -> 2.10.3

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -5,7 +5,7 @@
 
 APT_PATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER="undefined"    # Ansible version you currently have installed
-GOOD_VER="2.10.2"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
+GOOD_VER="2.10.3"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # We install latest 'ansible-base' from PPA: (may be more recent than GOOD-VER)
 # https://launchpad.net/~ansible/+archive/ubuntu/ansible
 # https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.10


### PR DESCRIPTION
2.10.3 has been tested as part of many IIAB installs for half a week now.