### PR TITLE
Prepare for Ubuntu 21.04 (Hirsute Hippo)

### DIFF
--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -89,7 +89,8 @@
   systemd:
     name: "{{ dhcp_service2 }}"
     state: restarted
-  when: (not no_net_restart or (is_ubuntu_20 and wifi_up_down)) or (iiab_stage|int == 9)
+  when: (not no_net_restart or (is_ubuntu and wifi_up_down)) or (iiab_stage|int == 9)
+  #when: (not no_net_restart or (is_ubuntu_20 and wifi_up_down)) or (iiab_stage|int == 9)
   #when: (not no_net_restart or (is_ubuntu_20 and wifi_up_down))
   #when: (iiab_network_mode != "Appliance")    # Sufficient b/c br0 exists thanks to /etc/network/interfaces.d/iiab
   #when: iiab_network_mode != "Appliance" and iiab_wan_iface != discovered_wireless_iface

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -60,10 +60,14 @@ OS_VER=$OS-$VERSION_ID
 # 2020-10-21: Debian 11 (Bullseye) not yet supported but adding this line to
 # its /etc/os-release can help testing this unreleased OS: VERSION_ID="11"
 
+# 2020-11-14: Ubuntu 21.04 (Hirsute Hippo) not yet supported but this
+# unreleased OS can help testing.
+
 case $OS_VER in
     "debian-10"    | \
     "debian-11"    | \
     "ubuntu-20"    | \
+    "ubuntu-21"    | \
     "linuxmint-20" | \
     "raspbian-10")
        ;;

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -688,6 +688,7 @@ calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)
 
 is_ubuntu: False    # Covers: Ubuntu, Linux Mint
+is_ubuntu_21: False
 is_ubuntu_20: False
 is_ubuntu_19: False
 is_ubuntu_18: False

--- a/vars/ubuntu-21.yml
+++ b/vars/ubuntu-21.yml
@@ -1,0 +1,28 @@
+is_debuntu: True
+is_ubuntu: True
+is_ubuntu_21: True
+
+# 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dns_user: bind
+dhcp_service: isc-dhcp-server
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_user: www-data
+apache_conf_dir: apache2/sites-available
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+# issue raised 
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: 7.4
+# "postgresql_version: 11.2" failed (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 19.04)
+postgresql_version: 12
+systemd_location: /lib/systemd/system

--- a/vars/ubuntu-21.yml
+++ b/vars/ubuntu-21.yml
@@ -22,7 +22,7 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.4
+php_version: 7.4    # 2020-11-14: Change to 8.0 very soon?
 # "postgresql_version: 11.2" failed (too detailed for /etc/systemd/system/postgresql-iiab.service on Ubuntu 19.04)
-postgresql_version: 12
+postgresql_version: 12    # 2020-11-14: Change to 13 very soon?
 systemd_location: /lib/systemd/system


### PR DESCRIPTION
Ubuntu Server 21.04 (Hirsute Hippo) Daily Builds:
https://cdimage.ubuntu.com/ubuntu-server/daily-live/current/
https://cdimage.ubuntu.com/ubuntu-server/daily-live/pending/

Ubuntu Desktop 21.04 (Hirsute Hippo) Daily Builds:
https://cdimage.ubuntu.com/daily-live/current/
https://cdimage.ubuntu.com/daily-live/pending/

Ref:

- PR #2582 "Overseas request for immediate testing of IIAB on Debian 11 Bullseye + similarly clean out long-deprecated apache_config_dir from high-level <OS>.yml vars files [ASIDE: dnsmasq & dhclient issues? host_country_code MUST match PC/HW, or hostapd won't start]"
- #2585 "Testing the new Ubuntu Desktop 20.10 for RPi 4 (rumor confirmed!) [Bluetooth, MongoDB, NetworkManager]"
- #2610 "Who can help test on Ubuntu 20.10 (Server &/or Desktop version!) on x86_64 / amd64, VM or PC?"
- #2624 "Who can help test IIAB on Ubuntu Server 20.04.1 & 20.10 on RPi 4 ? Can WiFi firmware 7.45.18.0 work reliably?"