### PR TITLE
gitea/tasks/install.yml: timeout: 10 -> 200 (for get_url from dl.gitea.org)

### DIFF
--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -48,6 +48,7 @@
     url: "{{ gitea_download_url }}"
     dest: "{{ gitea_install_path }}"
     mode: '0775'
+    timeout: "{{ download_timeout }}"
   when: internet_available
 
 - name: Download Gitea GPG signature


### PR DESCRIPTION
Thanks @deldesir for surfacing this longstanding issue: https://github.com/iiab/iiab/issues/2610#issuecomment-734315053

When IIAB is installed in developing world countries, it's especially important that Ansible's download timeout default (10 seconds) be raised to a much higher number.

This PR brings that IIAB norm (200 seconds) to Gitea, in addition to the 23 other places where `timeout: "{{ download_timeout }}"` is already in use across IIAB code, thanks to https://github.com/iiab/iiab/blob/master/vars/default_vars.yml#L43-L44 &mdash; which is currently:

```
# Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
download_timeout: 200
```

CC: @aidan-fitz