### PR TITLE
ansible.posix collection for 2-common sysctl & js-menu synchronize (formerly needed by 1-prep's selinux)

### DIFF
--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -27,7 +27,7 @@
     name: "{{ item.name }}"
     value: "{{ item.value }}"
   with_items:
-    - { name: 'net.ipv4.ip_forward', value: '1' }
+    - { name: 'net.ipv4.ip_forward', value: '1' }  # Masquerading LAN->Internet
     - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }
     - { name: 'net.ipv4.conf.default.accept_source_route', value: '0' }
     #- { name: 'kernel.sysrq', value: '1' }             # OS values differ, Ok?

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -30,9 +30,9 @@
     - { name: 'net.ipv4.ip_forward', value: '1' }
     - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }
     - { name: 'net.ipv4.conf.default.accept_source_route', value: '0' }
-    #- { name: 'kernel.sysrq', value: '1' }    # Already set by most Linux OS's
+    #- { name: 'kernel.sysrq', value: '1' }             # OS values differ, Ok?
     - { name: 'kernel.core_uses_pid', value: '1' }
-    #- { name: 'net.ipv4.tcp_syncookies', value: '1' }    # Should be set by OS
+    #- { name: 'net.ipv4.tcp_syncookies', value: '1' }  # Very standard in 2020
     #- { name: 'kernel.shmmax', value: '268435456' }    # OS values differ, Ok?
     - { name: 'net.ipv6.conf.all.disable_ipv6', value: '1' }    # IPv6 disabled
     #- { name: 'net.ipv6.conf.default.disable_ipv6', value: '1' }    # AUTO-SET

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -21,25 +21,22 @@
 - include_tasks: packages.yml
 - include_tasks: iptables.yml
 
-# 2020-11-27 emergency patch+experiment til this is answered more methodically:
-# https://github.com/iiab/iiab/issues/2650
-# https://github.com/iiab/iiab/pull/2651
-#
-#- name: Use 'sysctl' to set 10 network/kernel settings, turning off IPv6 if possible
-#  sysctl:
-#    name: "{{ item.name }}"
-#    value: "{{ item.value }}"
-#  with_items:
-#    - { name: 'net.ipv4.ip_forward', value: '1' }
-#    - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }
-#    - { name: 'net.ipv4.conf.default.accept_source_route', value: '0' }
-#    - { name: 'kernel.sysrq', value: '1' }
-#    - { name: 'kernel.core_uses_pid', value: '1' }
-#    - { name: 'net.ipv4.tcp_syncookies', value: '1' }
-#    - { name: 'kernel.shmmax', value: '268435456' }
-#    - { name: 'net.ipv6.conf.all.disable_ipv6', value: '1' }    # IPv6 disabled
-#    - { name: 'net.ipv6.conf.default.disable_ipv6', value: '1' }
-#    - { name: 'net.ipv6.conf.lo.disable_ipv6', value: '1' }
+# 2020-11-27 ongoing rework arising from ansible.posix collection changes:
+- name: Use 'sysctl' to set 5 network/kernel settings, turning off IPv6 if possible
+  sysctl:    # Places these settings in /etc/sysctl.conf, to survive reboot
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { name: 'net.ipv4.ip_forward', value: '1' }
+    - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }
+    - { name: 'net.ipv4.conf.default.accept_source_route', value: '0' }
+    #- { name: 'kernel.sysrq', value: '1' }    # Already set by most Linux OS's
+    - { name: 'kernel.core_uses_pid', value: '1' }
+    #- { name: 'net.ipv4.tcp_syncookies', value: '1' }    # Should be set by OS
+    #- { name: 'kernel.shmmax', value: '268435456' }    # OS values differ, Ok?
+    - { name: 'net.ipv6.conf.all.disable_ipv6', value: '1' }    # IPv6 disabled
+    #- { name: 'net.ipv6.conf.default.disable_ipv6', value: '1' }    # AUTO-SET
+    #- { name: 'net.ipv6.conf.lo.disable_ipv6', value: '1' }         # BY ABOVE
 
 - name: Install /etc/profile.d/zzz_iiab.sh from template, to add sbin dirs to unprivileged users' $PATH
   template:

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -21,7 +21,7 @@
 - include_tasks: packages.yml
 - include_tasks: iptables.yml
 
-# 2020-11-27 ongoing rework arising from ansible.posix collection changes:
+# Ongoing rework (e.g. PR #2652) arising from ansible.posix collection changes:
 - name: Use 'sysctl' to set 5 network/kernel settings, turning off IPv6 if possible
   sysctl:    # Places these settings in /etc/sysctl.conf, to survive reboot
     name: "{{ item.name }}"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -97,7 +97,7 @@ ansible-galaxy collection install community.mysql      # installs appears safe!
 ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...
 # selinux WAS in /opt/iiab/iiab/roles/1-prep/tasks/main.yml
 # sysctl in      /opt/iiab/iiab/roles/2-common/tasks/main.yml
-# synchronize in /opt/iiab/iiab-admin-console/roles/2-common/tasks/main.yml
+# synchronize in /opt/iiab/iiab-admin-console/roles/js-menu/tasks/main.yml
 
 echo -e "\n\nCreating/verifying directory /etc/ansible & installing /etc/ansible/hosts\n"
 mkdir -p /etc/ansible

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -91,7 +91,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
               python3-pymysql python3-psycopg2 python3-passlib python3-pip \
               python3-setuptools python3-packaging python3-venv virtualenv
 
-echo -e "\n\nIIAB requires these 3 Ansible Collections: (w/ ansible-base 2.10.3+)\n"
+echo -e "\n\nIIAB requires these 3 Ansible Collections: (with ansible-base 2.10.3+)\n"
 ansible-galaxy collection install community.general    # Re-running collection
 ansible-galaxy collection install community.mysql      # installs appears safe!
 ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -91,7 +91,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
               python3-pymysql python3-psycopg2 python3-passlib python3-pip \
               python3-setuptools python3-packaging python3-venv virtualenv
 
-echo -e "\n\nIIAB requires these 2 Ansible Collections: (w/ ansible-base 2.10.0 or higher)\n"
+echo -e "\n\nIIAB requires these 3 Ansible Collections: (w/ ansible-base 2.10.0 or higher)\n"
 ansible-galaxy collection install community.general    # Re-running collection
 ansible-galaxy collection install community.mysql      # installs appears safe!
 ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -92,9 +92,12 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
               python3-setuptools python3-packaging python3-venv virtualenv
 
 echo -e "\n\nIIAB requires these 2 Ansible Collections: (w/ ansible-base 2.10.0 or higher)\n"
-ansible-galaxy collection install community.general    # Re-running these
-ansible-galaxy collection install community.mysql      # appears to be safe!?
-#ansible-galaxy collection install ansible.posix       # 2020-11-27: See roles/1-prep/tasks/main.yml & PR #2647, PR #2648, #2650, PR #2651
+ansible-galaxy collection install community.general    # Re-running collection
+ansible-galaxy collection install community.mysql      # installs appears safe!
+ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...
+# selinux WAS in /opt/iiab/iiab/roles/1-prep/tasks/main.yml
+# sysctl in      /opt/iiab/iiab/roles/2-common/tasks/main.yml
+# synchronize in /opt/iiab/iiab-admin-console/roles/2-common/tasks/main.yml
 
 echo -e "\n\nCreating/verifying directory /etc/ansible & installing /etc/ansible/hosts\n"
 mkdir -p /etc/ansible

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -91,7 +91,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
               python3-pymysql python3-psycopg2 python3-passlib python3-pip \
               python3-setuptools python3-packaging python3-venv virtualenv
 
-echo -e "\n\nIIAB requires these 3 Ansible Collections: (w/ ansible-base 2.10.0 or higher)\n"
+echo -e "\n\nIIAB requires these 3 Ansible Collections: (w/ ansible-base 2.10.3+)\n"
 ansible-galaxy collection install community.general    # Re-running collection
 ansible-galaxy collection install community.mysql      # installs appears safe!
 ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...


### PR DESCRIPTION
Currently IIAB and Admin Console do not install properly.

This is a 1st stab cleaner resolution of issues arising from the sudden upstream changes in Ansible Collections &mdash; including things like PR #2647, PR #2648, #2650, PR #2651 &mdash; and also the install of Admin Console's js-menu which is currently (silently) failing at: https://github.com/iiab/iiab-admin-console/blob/master/roles/js-menu/tasks/main.yml#L77-L80

This is sure to evolve over time, but is tested on RaspiOS Lite & Ubuntu Server 20.04.1 to get us back on track.

Ref: PR #2518 "Begin transition to Ansible 2.10 (now that ansible-base 2.10.1 is released & appears solid!)"