### PR TITLE
scripts/ansible: try --force-with-deps with Ansible Collections

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -93,7 +93,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
-# upgrading all collections cleanly in future.  See links off PR iiab/iiab#2652
+# upgrading all collections cleanly in future.  See PR #2652 (links) & PR #2653
 echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
 ansible-galaxy collection install --force-with-deps community.general
 ansible-galaxy collection install --force-with-deps community.mysql

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -94,7 +94,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
 # upgrading all collections cleanly in future.  See links off PR iiab/iiab#2652
-echo -e "\n\nIIAB requires these 3 Ansible Collections: (we try to upgrade them if nec!)\n"
+echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
 ansible-galaxy collection install --force-with-deps community.general
 ansible-galaxy collection install --force-with-deps community.mysql
 ansible-galaxy collection install --force-with-deps ansible.posix # For 3 below

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -94,7 +94,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
 # upgrading all collections cleanly in future.  See links off PR iiab/iiab#2652
-echo -e "\n\nIIAB requires these 3 Ansible Collections: (with ansible-base 2.10.3+)\n"
+echo -e "\n\nIIAB requires these 3 Ansible Collections: (we try to upgrade them if nec!)\n"
 ansible-galaxy collection install --force-with-deps community.general
 ansible-galaxy collection install --force-with-deps community.mysql
 ansible-galaxy collection install --force-with-deps ansible.posix # For 3 below

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -91,10 +91,13 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
               python3-pymysql python3-psycopg2 python3-passlib python3-pip \
               python3-setuptools python3-packaging python3-venv virtualenv
 
+# (Re)running collection installs appears safe, with --force-with-deps to force
+# upgrade of collection and dependencies it pulls in.  Note Ansible may support
+# upgrading all collections cleanly in future.  See links off PR iiab/iiab#2652
 echo -e "\n\nIIAB requires these 3 Ansible Collections: (with ansible-base 2.10.3+)\n"
-ansible-galaxy collection install community.general    # Re-running collection
-ansible-galaxy collection install community.mysql      # installs appears safe!
-ansible-galaxy collection install ansible.posix    # 2020-11-27: For 3 below...
+ansible-galaxy collection install --force-with-deps community.general
+ansible-galaxy collection install --force-with-deps community.mysql
+ansible-galaxy collection install --force-with-deps ansible.posix # For 3 below
 # selinux WAS in /opt/iiab/iiab/roles/1-prep/tasks/main.yml
 # sysctl in      /opt/iiab/iiab/roles/2-common/tasks/main.yml
 # synchronize in /opt/iiab/iiab-admin-console/roles/js-menu/tasks/main.yml


### PR DESCRIPTION
Building on PRs #2518, #2648, #2651, #2652

In order to keep the longstanding spirit of script [scripts/ansible](https://github.com/iiab/iiab/blob/master/scripts/ansible.md) intact, which as a general rule tries to help folks upgrade Ansible to the latest release (of all things Ansible).

Briefly tested with:
`ansible collection install --force-with-deps <SOME NEW ANSIBLE COLLECTION>`