### PR TITLE
(1) create /opt/iiab/iiab/collections.yml (2) move Ansible Collections from /root/.ansible to /usr/share/ansible

### DIFF
--- a/collections.yml
+++ b/collections.yml
@@ -1,0 +1,13 @@
+# IIAB requires the Ansible Collections listed below.  Explanations here:
+# http://FAQ.IIAB.IO > "What is Ansible and what version should I use?"
+# https://github.com/iiab/iiab/blob/master/scripts/ansible.md
+
+---
+collections:
+  - name: community.general
+  - name: community.mysql
+  - name: ansible.posix    # 2020-11-28: For ~3 modules below...
+
+# selinux WAS in /opt/iiab/iiab/roles/1-prep/tasks/main.yml
+# sysctl      in /opt/iiab/iiab/roles/2-common/tasks/main.yml
+# synchronize in /opt/iiab/iiab-admin-console/roles/js-menu/tasks/main.yml

--- a/iiab-install
+++ b/iiab-install
@@ -8,7 +8,7 @@ INVENTORY=ansible_hosts
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
 ARGS=""
 CWD=`pwd`
-OS=`grep ^ID= /etc/*release|cut -d= -f2`
+OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}
 MIN_RPI_KERN=4.19.97       # If using Raspbian, 'rpi-update' should no longer be nec -- please use Raspbian 2020-02-13 or higher: https://github.com/iiab/iiab/issues/1993
 MIN_ANSIBLE_VER=2.8.11     # Ansible 2.8.3 and 2.8.6 have serious bugs, preventing their use with IIAB.

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -15,8 +15,8 @@ GOOD_VER="2.10.3"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # IIAB implementers might instead consider these 2 GENERAL TECHNIQUES below
 # ("in an emergency!") e.g. if you must install an older version of Ansible:
 
-# TEMPORARILY USE ANSIBLE 2.9.13 (REMOVE IT WITH "pip uninstall ansible")
-#pip install ansible==2.9.13
+# TEMPORARILY USE ANSIBLE 2.9.15 (REMOVE IT WITH "pip uninstall ansible")
+#pip install ansible==2.9.15
 
 # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. Details: iiab/iiab#669
 #echo "Install http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb"
@@ -95,7 +95,9 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
 # upgrading all collections cleanly in future.  See PRs #2647 #2652 #2653 #2655
 echo -e "\n\nIIAB requires these ~3 Ansible Collections: (we upgrade them here if possible!)\n"
-ansible-galaxy collection install --force-with-deps -r /opt/iiab/iiab/collections.yml -p /usr/share/ansible/collections
+ansible-galaxy collection install --force-with-deps \
+               -r /opt/iiab/iiab/collections.yml \
+               -p /usr/share/ansible/collections
 # 2020-11-28: The ~3 Ansible Collections used by IIAB (~37MB) once lived here:
 #    /root/.ansible/collections/ansible_collections
 # But going forward they'll be stored herein:

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -93,12 +93,12 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
-# upgrading all collections cleanly in future.  See PR #2652 (links) & PR #2653
-echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
+# upgrading all collections cleanly in future.  See PRs #2647 #2652 #2653 #2655
+echo -e "\n\nIIAB requires these ~3 Ansible Collections: (we upgrade them here if possible!)\n"
 ansible-galaxy collection install --force-with-deps -r /opt/iiab/iiab/collections.yml -p /usr/share/ansible/collections
-# 2020-11-28: The ~3 Ansible Collections (~37MB) used by IIAB used to be here:
+# 2020-11-28: The ~3 Ansible Collections used by IIAB (~37MB) once lived here:
 #    /root/.ansible/collections/ansible_collections
-# But going forward they'll be stored here:
+# But going forward they'll be stored herein:
 #    /usr/share/ansible/collections/ansible_collections
 
 echo -e "\n\nCreating/verifying directory /etc/ansible & installing /etc/ansible/hosts\n"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -95,12 +95,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
 # upgrading all collections cleanly in future.  See PR #2652 (links) & PR #2653
 echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
-ansible-galaxy collection install --force-with-deps community.general
-ansible-galaxy collection install --force-with-deps community.mysql
-ansible-galaxy collection install --force-with-deps ansible.posix # For 3 below
-# selinux WAS in /opt/iiab/iiab/roles/1-prep/tasks/main.yml
-# sysctl in      /opt/iiab/iiab/roles/2-common/tasks/main.yml
-# synchronize in /opt/iiab/iiab-admin-console/roles/js-menu/tasks/main.yml
+ansible-galaxy collection install --force-with-deps -r collections.yml -p /usr/share/ansible/collections
 
 echo -e "\n\nCreating/verifying directory /etc/ansible & installing /etc/ansible/hosts\n"
 mkdir -p /etc/ansible

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -96,6 +96,10 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # upgrading all collections cleanly in future.  See PR #2652 (links) & PR #2653
 echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
 ansible-galaxy collection install --force-with-deps -r collections.yml -p /usr/share/ansible/collections
+# 2020-11-28: The ~3 Ansible Collections (~37MB) used by IIAB used to be here:
+#    /root/.ansible/collections/ansible_collections
+# But going forward they'll be stored here:
+#    /usr/share/ansible/collections/ansible_collections
 
 echo -e "\n\nCreating/verifying directory /etc/ansible & installing /etc/ansible/hosts\n"
 mkdir -p /etc/ansible

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -95,7 +95,7 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
 # upgrading all collections cleanly in future.  See PR #2652 (links) & PR #2653
 echo -e "\n\nIIAB requires these 3 Ansible Collections: (we upgrade them here if possible!)\n"
-ansible-galaxy collection install --force-with-deps -r collections.yml -p /usr/share/ansible/collections
+ansible-galaxy collection install --force-with-deps -r /opt/iiab/iiab/collections.yml -p /usr/share/ansible/collections
 # 2020-11-28: The ~3 Ansible Collections (~37MB) used by IIAB used to be here:
 #    /root/.ansible/collections/ansible_collections
 # But going forward they'll be stored here:


### PR DESCRIPTION
Inspired by PR #2647 (see discussion on ticket) and https://github.com/iiab/iiab/pull/2652#issuecomment-735234059, with thanks to @jvonau for the careful research of Ansible Collections.

This approach is similar but upgrades all Ansible Collections whenever `/opt/iiab/iiab/scripts/ansible` is run, keeping with the established norm of scripts/ansible, to purposefully guide and help the implementer in bringing all-things-Ansible up the very latest.

**RECAP: do not run /opt/iiab/iiab/scripts/ansible if you do not want to upgrade Ansible Collections.**

The internals are what are slightly changing &mdash; going forward as follows:

- Separate file `/opt/iiab/iiab/collections.yml` will list the Ansible Collections that IIAB requires
- IIAB's Ansible Collections storage area (requests 3 Collections, but with dependencies ends up holding 6 Collections for now, or about 37 MB) will change from `/root/.ansible/collections/ansible_collections` to `/usr/share/ansible/collections/ansible_collections`

Tested on VM 196-u21-srv-BIG = 10.8.0.22

Further testing to follow with a fresh install on VM 195-mint20-MIN.

Refs PRs: #2518, #2647, #2648, #2651, #2652, #2653.