### PR TITLE
Comment out non-existent var {{ ansible_product_uuid }} [not quite enough: {{ prior_gateway_device }} has a similar issue]

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -137,7 +137,7 @@
       value: "{{ ansible_memtotal_mb }}"
     - option: swap_mb
       value: "{{ ansible_swaptotal_mb }}"
-    # 2021-01-28: Non-existent var, so fails with Ansible 2.10.5 (#2669)
+    # 2021-01-28: Non-existent var, so fails with ansible-base 2.10.5 (#2669)
     #- option: product_id
     #  value: "{{ ansible_product_uuid }}"
     - option: gw_active

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -137,7 +137,7 @@
       value: "{{ ansible_memtotal_mb }}"
     - option: swap_mb
       value: "{{ ansible_swaptotal_mb }}"
-    # 2021-01-28: Non-existent, so fails with Ansible 2.10.5 (#2669)
+    # 2021-01-28: Non-existent var, so fails with Ansible 2.10.5 (#2669)
     #- option: product_id
     #  value: "{{ ansible_product_uuid }}"
     - option: gw_active

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -137,8 +137,9 @@
       value: "{{ ansible_memtotal_mb }}"
     - option: swap_mb
       value: "{{ ansible_swaptotal_mb }}"
-    - option: product_id
-      value: "{{ ansible_product_uuid }}"
+    # 2021-01-28: Non-existent, so fails with Ansible 2.10.5 (#2669)
+    #- option: product_id
+    #  value: "{{ ansible_product_uuid }}"
     - option: gw_active
       value: "{{ gw_active }}"
     - option: internet_available


### PR DESCRIPTION
Proposed emergency fix for #2669