### PR TITLE
Initialize vars more meaningfully, for #2669 and #2670, thx to ansible-base 2.10.5's more strict checking [roles/network/defaults/main.yml]

### DIFF
--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -36,6 +36,11 @@
 # 2020-07-08 - Excellent analysis & summary by Jon Spriggs: "In Ansible,
 # determine the type of a value, and casting those values to other types"
 # https://jon.sprig.gs/blog/post/1801
+#
+# 2021-01-29 - ansible-base 2.10.5 (1) is more strict about empty string vars
+# (2) no longer supports "when: myvar is boolean", "is integer" & "is float"
+# (3) brings yet more "Ansible collection" dependency changes (undocumented!)
+# Details: https://github.com/iiab/iiab/pull/2672 (see also #2669)
 
 # 3. "How do i fail a task in Ansible if the variable contains a boolean value?
 # I want to perform input validation for Ansible playbooks"

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -39,7 +39,7 @@
 #
 # 2021-01-29 - ansible-base 2.10.5 (1) is more strict about empty string vars
 # (2) no longer supports "when: myvar is boolean", "is integer" & "is float"
-# (3) brings yet more "Ansible collection" dependency changes (undocumented!)
+# (3) brings yet more "Ansible Collections" dependency changes (undocumented!)
 # Details: https://github.com/iiab/iiab/pull/2672 (see also #2669)
 
 # 3. "How do i fail a task in Ansible if the variable contains a boolean value?

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # Wi-Fi - IF NECESSARY, CUSTOMIZE THESE 6 VARIABLES IN /etc/iiab/local_vars.yml
 # host_country_code: US
-# host_ssid: "Internet in a Box"
+# host_ssid: Internet in a Box
 # host_wifi_mode: g
 # host_channel: 6
 # hostapd_secure: False
@@ -53,28 +53,28 @@ wireless_lan_present: False
 strict_networking: False
 iiab_demo_mode: False
 gui_static_wan: False
-wan_cidr:
+wan_cidr: ""
 virtual_network_devices: "-e ap0 -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth"
 
 # Set defaults for discovery process as strings
 wifi1: "not found-1"
 wifi2: "not found-2"
-exclude_devices: "none"
-device_gw: "none"
-prior_gw_device: ""
+exclude_devices: none
+device_gw: none
+prior_gw_device: unset
 
-iiab_wan_iface: "none"
-iiab_lan_iface: "none"
-discovered_lan_iface: "none"
-discovered_wired_iface: "none"
-discovered_wireless_iface: "none"
+iiab_wan_iface: none
+iiab_lan_iface: none
+discovered_lan_iface: none
+discovered_wired_iface: none
+discovered_wireless_iface: none
 
 # Red Hat
 #iiab_wired_lan_iface: "none"
 #iiab_wireless_lan_iface: "none"
 has_WAN: False
-has_ifcfg_gw: "none"
-has_wifi_gw: "none"
+has_ifcfg_gw: none
+has_wifi_gw: none
 
 # Debian
 dhcpcd_result: ""
@@ -83,10 +83,10 @@ network_manager_active: False
 systemd_networkd_active: False
 
 # The values here are default local variables
-gui_wan_iface: "unset"
-gui_static_wan_ip: "unset"
-wondershaper_dspeed: "4096"
-wondershaper_upspeed: "1024"
+gui_wan_iface: unset
+gui_static_wan_ip: unset
+wondershaper_dspeed: 4096
+wondershaper_upspeed: 1024
 
 # netplan
 fix_dispatcher: True
@@ -105,7 +105,7 @@ fix_dispatcher: True
 # Above 2 vars set in /etc/iiab/local_vars.yml
 # captive_portal_port: "9090"
 # Above var set in /opt/iiab/iiab/vars/default_vars.yml
-py_captive_portal_port: "9090"
-py_captive_portal_username: "Admin"
-py_captive_portal_password: "changeme"
+py_captive_portal_port: 9090
+py_captive_portal_username: Admin
+py_captive_portal_password: changeme
 # In a pinch, disable it by running: systemctl disable captive-portal


### PR DESCRIPTION
Possible emergency fix, given ansible-base 2.10.5's changed behavior.

See ongoing discussion at PR #2670.  See also #2669 and PR #2671.