### PR TITLE
iiab-diagnostics: redact commented passwords

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -39,11 +39,11 @@ function cat_file_raw() {    # $1 = path/filename; $2 = # of lines, for tail
         elif [ $# -eq 1 ]; then
             echo >> $outfile
             # Redact most passwords from /etc/iiab/local_vars.yml, /etc/hostapd/hostapd.conf, /etc/wpa_supplicant/wpa_supplicant.conf, /etc/netplan/*, /etc/network/interfaces, /etc/network/interfaces.d/* ETC -- not much to worry about in /etc/iiab/iiab.ini (' = ')
-            cat "$1" | sed 's/^\(\s*[[:alnum:]_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            cat "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
         else    # e.g. last 100 lines, maximum
             echo "                        ...ITS LAST $2 LINES FOLLOW..." >> $outfile
             echo >> $outfile
-            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
         fi
         echo >> $outfile
     elif [ -h "$1" ]; then


### PR DESCRIPTION
Thanks to those who brought this to light:

This patch helps [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md) redact passwords more comprehensively from files like `/etc/wpa_supplicant/wpa_supplicant.conf` -- where WiFi passwords are often auto-published (in cleartext!) to comments that begin with a hash -- that I had not seen in earlier years, but have definitely become a problem.

This patch was tested on RaspiOS.