### PR TITLE
Nextcloud 21 recommends php{{ php_version }}-bcmath

### DIFF
--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -48,8 +48,9 @@
       - ffmpeg       # Optional (for preview generation)
       - libxml2      # php-libxml requires libxml2 >= 2.7.0
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
+      - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
-      - php{{ php_version }}-cli           # Like optional?  @jvonau says this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
+      - php{{ php_version }}-cli           # Likely optional?  @jvonau says this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
       - php{{ php_version }}-curl
       - php{{ php_version }}-gd
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)


### PR DESCRIPTION
As recommended in the "Security & setup warnings" shown when visiting from http://box/nextcloud > Settings (top-right) > Overview:

> There are some errors regarding your setup.
The PHP memory limit is below the recommended value of 512MB.
You are accessing your instance over a secure connection, however your instance is generating insecure URLs. This most likely means that you are behind a reverse proxy and the overwrite config variables are not set correctly. Please read [the documentation page about this](https://docs.nextcloud.com/server/21/go.php?to=admin-reverse-proxy).
Accessing site insecurely via HTTP. You are strongly advised to set up your server to require HTTPS instead, as described in the [security tips ↗](https://docs.nextcloud.com/server/21/go.php?to=admin-security).
Your web server is not properly set up to resolve "/.well-known/webfinger". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).
Your web server is not properly set up to resolve "/.well-known/nodeinfo". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).
Your web server is not properly set up to resolve "/.well-known/caldav". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).
Your web server is not properly set up to resolve "/.well-known/carddav". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).
Your installation has no default phone region set. This is required to validate phone numbers in the profile settings without a country code. To allow numbers without a country code, please add "default_phone_region" with the respective [ISO 3166-1 code ↗](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) of the region to your config file.
No memory cache has been configured. To enhance performance, please configure a memcache, if available. Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-performance).
This instance is missing some recommended PHP modules. For improved performance and better compatibility it is highly recommended to install them.
bcmath
The "Referrer-Policy" HTTP header is not set to "no-referrer", "no-referrer-when-downgrade", "strict-origin", "strict-origin-when-cross-origin" or "same-origin". This can leak referer information. See the [W3C Recommendation ↗](https://www.w3.org/TR/referrer-policy/).
Please double check the [installation guides ↗](https://docs.nextcloud.com/server/21/go.php?to=admin-install), and check for any errors or warnings in the log.
>
> Check the security of your Nextcloud over our [security scan ↗](https://scan.nextcloud.com/).

Ref: PR #2683