### PR TITLE
Update & tighten up .travis.yml from Trusty (Ubuntu 14.04) + Python 2.7 to Focal (Ubuntu 20.04) + Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,21 @@ addons:
     sources:
       - sourceline: ppa:ansible/ansible
     packages:
+#      - python-pip    # @arky had used this starting in 2018
       - ansible-base    # Install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
-#      - python-pip
+#      - python3-pymysql    # These 7-or-8 packages are not needed during this very rapid --syntax-check
+#      - python3-psycopg2
+#      - python3-passlib
+#      - python3-pip
+#      - python3-setuptools
+      - python3-packaging    # To avoid warning "packaging Python module unavailable; unable to validate collection..."
+#      - python3-venv
+#      - virtualenv
 
 install:
 #  - scripts/ansible    # See #2105: fails to install latest Ansible (& ~4 Ansible Collections from collections.yml) due to Travis VM's disk layout/perms being different
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
-#  - pip install ansible-base    # Install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
+#  - pip install ansible-base    # ALSO WORKS e.g. if the above addons: / apt: section is commented out.  To install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
   - ansible-galaxy collection install -r collections.yml    # Install ~4 Ansible Collections
   - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg, appending to https://github.com/iiab/iiab/blob/master/ansible.cfg
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 #  - pip install ansible-base    # ALSO WORKS e.g. if the above addons: / apt: section is commented out.  To install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
   - ansible-galaxy collection install -r collections.yml    # Install ~4 Ansible Collections
   - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg, appending to https://github.com/iiab/iiab/blob/master/ansible.cfg
-#  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
+#  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # 2021-02-24: suddenly no longer works, with the newer ansible-base install methods above (error arises due to '[defaults]' appearing twice)
 #  - cat ansible.cfg    # UNCOMMENT TO VERIFY!
   - apt -a list ansible-base    # VERIFY ansible-base VERSIONS OFFERED BY apt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,9 @@
----
 language: python
-python: "2.7"
-
-# Use the new container infrastructure
-dist: trusty
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-
-install:
-  # Install ansible
-  - pip install ansible
-
-  # Create ansible.cfg with correct roles_path and local_tmp
-  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
-
+python: "3.8"
+dist: focal
+#install:
+## Create ansible.cfg with correct roles_path and local_tmp
+#- "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
 script:
-  #  Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-
-#notifications:
-#  webhooks:  https://galaxy.ansible.com/api/v1/notifications/
+- /opt/iiab/iiab/scripts/ansible
+- ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ dist: focal
 #    packages:
 #    - python-pip
 install:
-#  - scripts/ansible    # Fails to install latest Ansible (& ~4 Ansible Collections from collections.yml)
+#  - scripts/ansible    # See #2105: fails to install latest Ansible (& ~4 Ansible Collections from collections.yml) due to Travis VM's disk layout/perms being different
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
   - pip install ansible-base    # Let's avoid all Ansible Collections for now (for Ansible syntax check!)
+  - ansible-galaxy collection install -r collections.yml
   - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
 #  - cat ansible.cfg    # UNCOMMENT TO VERIFY

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
-python: "3.8"
+python: 3.8    # "3.8" also works
 dist: focal
 
-#addons:
-#  apt:
-#    packages:
-#    - python-pip
+addons:
+  apt:
+    sources:
+      - sourceline: ppa:ansible/ansible
+    packages:
+      - ansible-base    # Install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
+#      - python-pip
 
 install:
 #  - scripts/ansible    # See #2105: fails to install latest Ansible (& ~4 Ansible Collections from collections.yml) due to Travis VM's disk layout/perms being different
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
-  - pip install ansible-base    # Install latest ansible-base 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
+#  - pip install ansible-base    # Install latest ansible-base e.g. 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
   - ansible-galaxy collection install -r collections.yml    # Install ~4 Ansible Collections
   - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg, appending to https://github.com/iiab/iiab/blob/master/ansible.cfg
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ dist: focal
 #  apt:
 #    packages:
 #    - python-pip
-#install:
+install:
+  - scripts/ansible    # Install latest Ansible & ~4 Ansible Collections (collections.yml)
 #  - pip install ansible
 #  # Create ansible.cfg with correct roles_path and local_tmp
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
 script:
-- /opt/iiab/iiab/scripts/ansible
-- ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 python: "3.8"
 dist: focal
+#addons:
+#  apt:
+#    packages:
+#    - python-pip
 #install:
-## Create ansible.cfg with correct roles_path and local_tmp
-#- "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
+#  - pip install ansible
+#  # Create ansible.cfg with correct roles_path and local_tmp
+#  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
 script:
 - /opt/iiab/iiab/scripts/ansible
 - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 #  - scripts/ansible    # Fails to install latest Ansible (& ~4 Ansible Collections from collections.yml)
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
   - pip install ansible-base    # Let's avoid all Ansible Collections for now (for Ansible syntax check!)
-#  # Create ansible.cfg with correct roles_path and local_tmp
-#  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
+  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
+  - cat ansible.cfg    # TEMP TESTING
 script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
 #  - scripts/ansible    # Fails to install latest Ansible (& ~4 Ansible Collections from collections.yml)
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
   - pip install ansible-base    # Let's avoid all Ansible Collections for now (for Ansible syntax check!)
-  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
-  - cat ansible.cfg    # TEMP TESTING
+  - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg
+#  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
+#  - cat ansible.cfg    # UNCOMMENT TO VERIFY
 script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg, appending to https://github.com/iiab/iiab/blob/master/ansible.cfg
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
 #  - cat ansible.cfg    # UNCOMMENT TO VERIFY!
+  - apt -a list ansible-base    # VERIFY ansible-base VERSIONS OFFERED BY apt
 
 script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: python
 python: "3.8"
 dist: focal
+
 #addons:
 #  apt:
 #    packages:
 #    - python-pip
+
 install:
 #  - scripts/ansible    # See #2105: fails to install latest Ansible (& ~4 Ansible Collections from collections.yml) due to Travis VM's disk layout/perms being different
 #  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
-  - pip install ansible-base    # Let's avoid all Ansible Collections for now (for Ansible syntax check!)
-  - ansible-galaxy collection install -r collections.yml
-  - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg
+  - pip install ansible-base    # Install latest ansible-base 2.10.6+, similar to https://github.com/iiab/iiab/blob/master/scripts/ansible
+  - ansible-galaxy collection install -r collections.yml    # Install ~4 Ansible Collections
+  - "{ echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Add correct roles_path to ansible.cfg, appending to https://github.com/iiab/iiab/blob/master/ansible.cfg
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"    # Create ansible.cfg with correct roles_path and local_tmp
-#  - cat ansible.cfg    # UNCOMMENT TO VERIFY
+#  - cat ansible.cfg    # UNCOMMENT TO VERIFY!
+
 script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ dist: focal
 #    packages:
 #    - python-pip
 install:
-  - scripts/ansible    # Install latest Ansible & ~4 Ansible Collections (collections.yml)
-#  - pip install ansible
+#  - scripts/ansible    # Fails to install latest Ansible (& ~4 Ansible Collections from collections.yml)
+#  - pip install ansible    # SLOW/OVERWEIGHT: installs Ansible 3.0.0+ with ~80 Ansible Collections
+  - pip install ansible-base    # Let's avoid all Ansible Collections for now (for Ansible syntax check!)
 #  # Create ansible.cfg with correct roles_path and local_tmp
 #  - "{ echo '[defaults]'; echo 'roles_path = ./roles/'; } >> ansible.cfg"
 script:


### PR DESCRIPTION
Tested.

Bonus it runs substantially faster than in recent months, now that it avoids installing all ~80 Ansible Collections!

Thanks to @jvonau offering suggestions at #2105.