### PR TITLE
Install bionic-or-focal version of ansible-base, depending on OS

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -6,17 +6,36 @@
 APT_PATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER="undefined"    # Ansible version you currently have installed
 GOOD_VER="2.10.6"    # Orig for 'yum install [rpm]' & XO laptops (pip install)
-# We install latest 'ansible-base' from PPA: (may be more recent than GOOD-VER)
-# https://launchpad.net/~ansible/+archive/ubuntu/ansible
-# https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.10
-# http://ppa.launchpad.net/ansible/ansible/ubuntu/pool/main/a/ansible-base/
-# https://github.com/ansible/ansible/commits/stable-2.10/changelogs/CHANGELOG-v2.10.rst
 
-# IIAB implementers might instead consider these 2 GENERAL TECHNIQUES below
+# We install the latest 'ansible-base' from PPA, using an OS 'CODENAME' below:
+# https://launchpad.net/~ansible/+archive/ubuntu/ansible
+
+# 'lsb_release -sc' gives Mint 20 codename 'ulyana' etc: (TOO FINE-GRAINED)
+if grep -q buster /etc/os-release /etc/debian_version; then
+    CODENAME=bionic    # Debian 10, RaspiOS 10 & Buster-like distros
+else
+    CODENAME=focal     # Debian 11+, RaspiOS 11+, Ubuntu 20.04+, Mint 20+ (ETC)
+fi
+
+# 'ansible-base' RELEASE LINKS FOR REFERENCE:
+# http://ppa.launchpad.net/ansible/ansible/ubuntu/pool/main/a/ansible-base/
+# https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.10
+# https://github.com/ansible/ansible/commits/stable-2.10/changelogs/CHANGELOG-v2.10.rst
+# https://github.com/ansible/ansible/releases
+# https://releases.ansible.com/ansible-base/
+
+# FYI .travis.yml installs ansible-base in a slightly different way (PR #2689).
+
+# IIAB implementers might instead consider these 3 GENERAL TECHNIQUES below
 # ("in an emergency!") e.g. if you must install an older version of Ansible:
 
-# TEMPORARILY USE ANSIBLE 2.9.17 (REMOVE IT WITH "pip uninstall ansible")
-#pip install ansible==2.9.17
+# TEMPORARILY USE ansible-base 2.10.6 (REMOVE W/ "pip3 uninstall ansible-base")
+#pip3 install ansible-base==2.10.6   # Start new shell, so /usr/local/bin works
+#ansible-galaxy collection install -r collections.yml
+
+# TEMPORARILY USE ANSIBLE 2.9.18 (REMOVE IT WITH "pip uninstall ansible")
+#apt install python-pip
+#pip install ansible==2.9.18
 
 # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. Details: iiab/iiab#669
 #echo "Install http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb"
@@ -61,7 +80,7 @@ fi
 echo -e "\napt update; install dirmngr; PPA to /etc/apt/sources.list.d/iiab-ansible.list\n"
 $APT_PATH/apt update
 $APT_PATH/apt -y install dirmngr
-echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
+echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu $CODENAME main" \
      > /etc/apt/sources.list.d/iiab-ansible.list
 # In future we might instead consider 'add-apt-repository ppa:ansible/ansible'
 # or 'apt-add-repository ppa:ansible/bionic/ansible' etc, e.g. for streamlined
@@ -78,7 +97,7 @@ echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
 
 echo -e '\nIF YOU FACE ERROR "signatures couldn'"'"'t be verified because the public key is not available" THEN REPEATEDLY RE-RUN "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367"\n'
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
-echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main"'
+echo -e 'PPA source "deb http://ppa.launchpad.net/ansible/ansible/ubuntu '$CODENAME' main"'
 echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
 echo -e "IF *OTHER* ANSIBLE SOURCES APPEAR BELOW, PLEASE MANUALLY REMOVE THEM TO"
 echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -112,11 +112,13 @@ $APT_PATH/apt -y --allow-downgrades install ansible-base \
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support
-# upgrading all collections cleanly in future.  See PRs #2647 #2652 #2653 #2655
+# explicit upgrading of collections (--upgrade / -U flag) in version "2.11"
+# with PR ansible/ansible#73336.  See also IIAB PRs #2647 #2652 #2653 #2655.
 echo -e "\n\nIIAB requires these ~4 Ansible Collections: (we upgrade them here if possible!)\n"
 ansible-galaxy collection install --force-with-deps \
                -r /opt/iiab/iiab/collections.yml \
                -p /usr/share/ansible/collections
+# 2021-02-24: Run 'ansible-galaxy collection list' to list those installed.
 # 2020-11-28: The ~3 Ansible Collections used by IIAB (~37MB) once lived here:
 #    /root/.ansible/collections/ansible_collections
 # But going forward they'll be stored herein:


### PR DESCRIPTION
Catches a few more OS/distro corner cases than PR #2521, tightens code, adds explanations/options for those wanting help uninstalling/installing Ansible (ansible-base) in other ways.

Refs: #2105, PR #2521, PR #2527, #2647, PR #2652, PR #2654, PR #2655, #2659, #2669, PR #2670, PR #2671, PR #2672, PR #2685, PR #2689.