### PR TITLE
WARN implementers that hotspot passwords may FAIL, especially if firmware customized with 'wifi_hotspot_capacity_rpi_fix: True' ?

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -115,8 +115,8 @@ host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False
-hostapd_password: changeme
+hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
 hostapd_install: True    # 2020-01-21: this var MIGHT be implemented in future.
 hostapd_enabled: True
 wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -63,8 +63,8 @@ host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False
-hostapd_password: changeme
+hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
 wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
 # WiFi hotspots to service 30-to-32 client devices.  Background explanation:
 # https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -63,8 +63,8 @@ host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False
-hostapd_password: changeme
+hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
 wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
 # WiFi hotspots to service 30-to-32 client devices.  Background explanation:
 # https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -63,8 +63,8 @@ host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False
-hostapd_password: changeme
+hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
 wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
 # WiFi hotspots to service 30-to-32 client devices.  Background explanation:
 # https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.


### PR DESCRIPTION
We don't know that the situation is much better with 'wifi_hotspot_capacity_rpi_fix: False'

But the warning is left intentionally broad for now, to warn IIAB implementers about hotspot passwords in general.

See #2696 for many more and hopefully ongoing details, as we and others progressively learn more here.