### PR TITLE
Gitea 1.13.4 -> 1.13 (installs latest point-release from branch release/v1.13 w/o hassling us so often)

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -9,7 +9,7 @@
 
 # Info needed to install Gitea:
 
-gitea_version: 1.13.4
+gitea_version: 1.13    # 2021-03-07: Had been fine-grained, e.g. 1.13.4
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
So the latest security/bug fix releases of Gitea are installed automatically, e.g. during fresh installs of BIG-sized IIAB.

Tested on RaspiOS Lite on RPi 4.