### PR TITLE
Transmission (BitTorrent): change group root to debian-transmission

### DIFF
--- a/roles/transmission/defaults/main.yml
+++ b/roles/transmission/defaults/main.yml
@@ -7,7 +7,7 @@
 # Transmission download directory & general owner/group
 # transmission_download_dir: "{{ content_base }}/transmission/"    # /library/transmission/
 # transmission_user: debian-transmission
-# transmission_group: root
+# transmission_group: debian-transmission
 
 # Monitor downloads at http://box:9091 or http://box:9091/transmission using Admin/changeme
 # transmission_http_port: 9091

--- a/roles/transmission/tasks/enable-or-disable.yml
+++ b/roles/transmission/tasks/enable-or-disable.yml
@@ -13,7 +13,7 @@
     -n {{ transmission_username }}:{{ transmission_password }}
     -a http://pantry.learningequality.org/downloads/ka-lite/{{ transmission_kalite_version }}/content/ka-lite-0.17-resized-videos-{{ item }}.torrent
   with_items: "{{ transmission_kalite_languages }}"
-  when: transmission_enabled and transmission_provision and transmission_kalite_languages is defined and transmission_kalite_languages is not none
+  when: transmission_enabled and transmission_provision and transmission_kalite_languages is defined and transmission_kalite_languages is not none    # '!= None' also works (i.e. to avoid var value 'null', with type 'NoneType')
   ignore_errors: yes
 
 - name: Disable & Stop 'transmission-daemon' service, if not transmission_enabled

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -507,11 +507,11 @@ transmission_password: changeme
 # Transmission download directory & general owner/group
 transmission_download_dir: "{{ content_base }}/transmission/"    # /library/transmission/
 transmission_user: debian-transmission
-transmission_group: root
+transmission_group: debian-transmission
 
 # Monitor downloads at http://box:9091 or http://box:9091/transmission using Admin/changeme
 transmission_http_port: 9091
-transmission_url : /transmission/
+transmission_url: /transmission/
 transmission_peer_port: 51413
 
 # Provision Transmission with torrent(s) from http://pantry.learningequality.org/downloads/ka-lite/0.17/content/


### PR DESCRIPTION
Towards making it more secure, per @arky's earlier recommendation at https://github.com/iiab/iiab/tree/master/roles/transmission#known-issues

Tested on RaspiOS on RPi 4.

Refs: #884, PR #1044, #1078