### PR TITLE
calibre-web/tasks/install.yml: small code cleanup

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -13,13 +13,13 @@
     line: '  <policy domain="coder" rights="read" pattern="PDF" />'
     state: present
 
-- name: "Create 3 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_venv_path }}, {{ calibreweb_config }} (all set to {{ calibreweb_user }}:{{ apache_user }}, '0755')"
+- name: "Create 3 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_venv_path }}, {{ calibreweb_config }} (all set to {{ calibreweb_user }}:{{ apache_user }})"
   file:
     state: directory
     path: "{{ item }}"
     owner: "{{ calibreweb_user }}"    # root
     group: "{{ apache_user }}"        # www-data on debuntu
-    mode: '0755'
+    #mode: '0755'
   with_items:
     - "{{ calibreweb_home }}"         # /library/calibre-web
     - "{{ calibreweb_config }}"       # /library/calibre-web/config
@@ -74,7 +74,7 @@
     dest: "{{ calibreweb_home }}"     # /library/calibre-web
     owner: "{{ calibreweb_user }}"    # root
     group: "{{ apache_user }}"        # www-data on debuntu
-    mode: '0644'
+    #mode: '0644'
     backup: yes
   with_items:
     - roles/calibre-web/files/metadata.db
@@ -88,7 +88,7 @@
     dest: "{{ calibreweb_config }}"    # /library/calibre-web/config
     owner: "{{ calibreweb_user }}"     # root
     group: "{{ apache_user }}"         # www-data on debuntu
-    mode: '0644'
+    #mode: '0644'
     backup: yes
   when: not metadatadb.stat.exists
   #when: calibreweb_provision


### PR DESCRIPTION
Tested on Raspberry Pi OS Lite on RPi 4: directories & files end up with identical permissions (before & after this change).

Replaces PR #2704