### PR TITLE
kalite/defaults/main.yml: var kalite_root does not need to be defined twice (already defined in default_vars.yml)

### DIFF
--- a/roles/kalite/defaults/main.yml
+++ b/roles/kalite/defaults/main.yml
@@ -11,7 +11,6 @@ kalite_version: 0.17.5
 kalite_repo_url: https://github.com/learningequality/ka-lite.git
 kalite_requirements: https://raw.githubusercontent.com/learningequality/ka-lite/master/requirements.txt
 
-kalite_root: /library/ka-lite
 kalite_venv: /usr/local/kalite/venv
 kalite_program: "{{ kalite_venv }}/bin/kalite"
 


### PR DESCRIPTION
It's possible variable `kalite_root` should default to `/library/ka-lite-en` in future, to be more consistent with directories/instances in multilingual IIAB installations that contain:
- `/library/ka-lite-es`
- `/library/ka-lite-fr`
- etc

(Currently it defaults to `/library/ka-lite`)

Refs:
- PR #2702
- http://FAQ.IIAB.IO > "34 KA Lite Administration: What tips & tricks exist?"