### PR TITLE
kalite/defaults/main.yml: remove var kalite_repo_url (no longer in use)

### DIFF
--- a/roles/kalite/defaults/main.yml
+++ b/roles/kalite/defaults/main.yml
@@ -8,7 +8,6 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 kalite_version: 0.17.5
-kalite_repo_url: https://github.com/learningequality/ka-lite.git
 kalite_requirements: https://raw.githubusercontent.com/learningequality/ka-lite/master/requirements.txt
 
 kalite_venv: /usr/local/kalite/venv


### PR DESCRIPTION
Oops I missed this one, as part of PRs #2702 and #2709 pruning.