### PR TITLE
WIP: /etc/usbmount/usbmount.conf setting so that Kolibri exports work

### DIFF
--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -67,8 +67,8 @@
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
     path: /etc/usbmount/usbmount.conf
 
-# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs} appears to accomplish the exact same thing:
-# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000"
+# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs, exfat} appears to accomplish the exact same thing:
+# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"
 - name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
   lineinfile:
     regexp: '^MOUNTOPTIONS=.*'

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -61,10 +61,18 @@
     - { src: 'iiab-usb_lib-show-all-off', dest: '/usr/bin/', mode: '0755' }
     - { src: 'iiab-clean-usb.sh', dest: '/usr/sbin/', mode: '0755' }
 
-- name: Enable exFAT and NTFS in /etc/usbmount/usbmount.conf
+- name: Add ' exfat fuseblk ntfs' to FILESYSTEMS var in /etc/usbmount/usbmount.conf
   lineinfile:
-    regexp: '^FILESYSTEMS.*'
+    regexp: '^FILESYSTEMS=.*'
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
+    path: /etc/usbmount/usbmount.conf
+
+# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs} appears to accomplish the exact same thing:
+# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000"
+- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+  lineinfile:
+    regexp: '^MOUNTOPTIONS=.*'
+    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
     path: /etc/usbmount/usbmount.conf
 
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template


### PR DESCRIPTION
Intended for @fisherbryan and the several others stuck with the inability to export Kolibri Channels to USB drives, as described in #2713.

In my testing of this PR (on RaspiOS Lite on RPi 4) Kolibri exports-to-USB and imports-from-USB both work fine.   (Imports probably work fine without this PR as well, though Bryan had some unspecified trouble yesterday, trying to import Kolibri Channels from his USB drive.)