### PR TITLE
Another way to set /etc/usbmount/usbmount.conf so that Kolibri exports work

### DIFF
--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,12 +20,11 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 67 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L67>`_
 
+In March 2021, Kolibri exports were enabled, using ``umask=0000`` (also within /etc/usbmount/usbmount.conf) to override what was ``umask=0022`` by default: `PR #2715 <https://github.com/iiab/iiab/issues/2715>`_
+
 Official `usbmount <https://github.com/hfuchs/usbmount>`_ documentation, from 2010:
 
 * https://github.com/hfuchs/usbmount/blob/master/README
 * https://github.com/hfuchs/usbmount/blob/master/usbmount.conf
 
-In March 2021, Kolibri exports were enabled, using ``umask=0000`` (also within /etc/usbmount/usbmount.conf) to override what was ``umask=0022`` by default: `PR #2715 <https://github.com/iiab/iiab/issues/2715>`_
-
-Legacy: There is also a patch for problems with automount on Fedora 21+.
-Please Note that as of 4.1.8-200.fc22.x86_64 not all USB drives will mount, even with this patch.
+Legacy warning: There is also a patch for problems with automount on Fedora 21+.  Please note that as of 4.1.8-200.fc22.x86_64 not all USB drives will mount, even with this patch.

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 67 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L67>`_
 
-In March 2021, Kolibri exports were enabled, using ``umask=0000`` (also within /etc/usbmount/usbmount.conf) to override what was ``umask=0022`` by default: `PR #2715 <https://github.com/iiab/iiab/issues/2715>`_
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_
 
 Official `usbmount <https://github.com/hfuchs/usbmount>`_ documentation, from 2010:
 

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -18,14 +18,14 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 ...and if found, creates a symlink of the form /library/www/html/local_content/USBn pointing to /media/usbn.
 
-USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at /etc/usbmount/usbmount.conf
+USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 67 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L67>`_
 
 Official `usbmount <https://github.com/hfuchs/usbmount>`_ documentation, from 2010:
 
 * https://github.com/hfuchs/usbmount/blob/master/README
 * https://github.com/hfuchs/usbmount/blob/master/usbmount.conf
 
-As of March 2021, better Kolibri integration/support is being investigated: `#2713 <https://github.com/iiab/iiab/issues/2713>`_
+In March 2021, Kolibri exports were enabled, using ``umask=0000`` (also within /etc/usbmount/usbmount.conf) to override what was ``umask=0022`` by default: `PR #2715 <https://github.com/iiab/iiab/issues/2715>`_
 
 Legacy: There is also a patch for problems with automount on Fedora 21+.
 Please Note that as of 4.1.8-200.fc22.x86_64 not all USB drives will mount, even with this patch.

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 67 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L67>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ prior to installing IIAB.
 
 Official `usbmount <https://github.com/hfuchs/usbmount>`_ documentation, from 2010:
 

--- a/roles/usb_lib/defaults/main.yml
+++ b/roles/usb_lib/defaults/main.yml
@@ -4,5 +4,9 @@
 # Show entire contents of USB sticks/drives (at http://box/usb)
 # iiab_usb_lib_show_all: True
 
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+# usb_lib_umask0000_for_kolibri: True
+
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -67,8 +67,8 @@
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
     path: /etc/usbmount/usbmount.conf
 
-# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs} appears to accomplish the exact same thing:
-# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000"
+# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs, exfat} appears to accomplish the exact same thing:
+# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"
 - name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
   lineinfile:
     regexp: '^MOUNTOPTIONS=.*'

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -67,13 +67,18 @@
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
     path: /etc/usbmount/usbmount.conf
 
-# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs, exfat} appears to accomplish the exact same thing:
-# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"
-- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+- name: "Set 'umask=0000' for {FAT, VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
   lineinfile:
-    regexp: '^MOUNTOPTIONS=.*'
-    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
+    regexp: '^FS_MOUNTOPTIONS=.*'
+    line: 'FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
     path: /etc/usbmount/usbmount.conf
+
+# Setting 'umask=0000' for all filesystems: (accomplishes the same thing as above)
+#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+#  lineinfile:
+#    regexp: '^MOUNTOPTIONS=.*'
+#    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
+#    path: /etc/usbmount/usbmount.conf
 
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template
   template:

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -67,10 +67,10 @@
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
     path: /etc/usbmount/usbmount.conf
 
-- name: "Set 'umask=0000' for {FAT, VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
-    line: 'FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
+    line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
     path: /etc/usbmount/usbmount.conf
 
 # Setting 'umask=0000' for all filesystems: (accomplishes the same thing as above)

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -61,6 +61,9 @@
     - { src: 'iiab-usb_lib-show-all-off', dest: '/usr/bin/', mode: '0755' }
     - { src: 'iiab-clean-usb.sh', dest: '/usr/sbin/', mode: '0755' }
 
+# 2021-03-21: If usbmount is repackaged by apt as a result of Linux kernel 5.4+
+# supporting exFAT, the stanza below (might) in future no longer be needed...
+# SEE ALSO: https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml#L22-L23
 - name: Add ' exfat fuseblk ntfs' to FILESYSTEMS var in /etc/usbmount/usbmount.conf
   lineinfile:
     regexp: '^FILESYSTEMS=.*'

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -93,7 +93,7 @@
     path: /etc/usbmount/usbmount.conf
   when: not usb_lib_umask0000_for_kolibri
 
-# 2020-03-25: Consider removing this stanza & all of this role's Apache logic!
+# 2021-03-25: Consider removing this stanza & all of this role's Apache logic!
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template
   template:
     src: content_dir.conf

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -75,6 +75,7 @@
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
     path: /etc/usbmount/usbmount.conf
+  when: usb_lib_umask0000_for_kolibri
 
 # Setting 'umask=0000' for all filesystems: (accomplishes the same thing as above)
 #- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -77,13 +77,23 @@
     path: /etc/usbmount/usbmount.conf
   when: usb_lib_umask0000_for_kolibri
 
-# Setting 'umask=0000' for all filesystems: (accomplishes the same thing as above)
+# Setting 'umask=0000' for all filesystems: (much the same thing as above, as
+# the mount command does not use this umask setting for filesystems like ext4)
 #- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
 #  lineinfile:
 #    regexp: '^MOUNTOPTIONS=.*'
 #    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
 #    path: /etc/usbmount/usbmount.conf
+#  when: usb_lib_umask0000_for_kolibri
 
+- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
+  lineinfile:
+    regexp: '^FS_MOUNTOPTIONS=.*'
+    line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, if runrole forced
+    path: /etc/usbmount/usbmount.conf
+  when: not usb_lib_umask0000_for_kolibri
+
+# 2020-03-25: Consider removing this stanza & all of this role's Apache logic!
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template
   template:
     src: content_dir.conf

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -61,10 +61,18 @@
     - { src: 'iiab-usb_lib-show-all-off', dest: '/usr/bin/', mode: '0755' }
     - { src: 'iiab-clean-usb.sh', dest: '/usr/sbin/', mode: '0755' }
 
-- name: Enable exFAT and NTFS in /etc/usbmount/usbmount.conf
+- name: Add ' exfat fuseblk ntfs' to FILESYSTEMS var in /etc/usbmount/usbmount.conf
   lineinfile:
-    regexp: '^FILESYSTEMS.*'
+    regexp: '^FILESYSTEMS=.*'
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
+    path: /etc/usbmount/usbmount.conf
+
+# Setting 'umask=0000' for partic filesystems e.g. {fat, vfat, ntfs} appears to accomplish the exact same thing:
+# FS_MOUNTOPTIONS="-fstype=fat,umask=0000 -fstype=vfat,umask=0000 -fstype=ntfs,umask=0000"
+- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+  lineinfile:
+    regexp: '^MOUNTOPTIONS=.*'
+    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
     path: /etc/usbmount/usbmount.conf
 
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -316,6 +316,9 @@ usb_lib_install: True
 usb_lib_enabled: True
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -203,6 +203,9 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
 
 
 # 5-XO-SERVICES

--- a/vars/local_vars_medical.yml
+++ b/vars/local_vars_medical.yml
@@ -13,6 +13,7 @@ munin_enabled: True
 vnstat_install: True
 vnstat_enabled: True
 openvpn_handle: "Medical IIAB - Put Your Name Here"
+usb_lib_umask0000_for_kolibri: False
 # By default
 # kiwix
 # awstats

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -203,6 +203,9 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
 
 
 # 5-XO-SERVICES

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -203,6 +203,9 @@ samba_enabled: False
 
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
 
 
 # 5-XO-SERVICES


### PR DESCRIPTION
Another alternative, more complex than PR #2714 but possibly a tiny bit safer.

Refs:

- #2713 "Let's provide a less confusing way for Kolibri communities to save [export Channels] to USB drives"
- http://FAQ.IIAB.IO > "4 Can teachers display their own content?"
- https://github.com/iiab/iiab/wiki/IIAB-Installation#external-usbdrive-content
- https://github.com/iiab/iiab/blob/master/roles/usb_lib/README.rst