### PR TITLE
Allow './runrole usb_lib' post-install toggling betw umask=0000 and umask=0022 (in /etc/usbmount/usbmount.conf)

### DIFF
--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 76 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L76>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ prior to installing IIAB.
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ (preferably do this prior to installing IIAB).
 
 Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/releases>`_ documentation:
 

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -76,29 +76,6 @@
     line: 'FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus exfat fuseblk ntfs"'
     path: /etc/usbmount/usbmount.conf
 
-- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
-  lineinfile:
-    regexp: '^FS_MOUNTOPTIONS=.*'
-    line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
-    path: /etc/usbmount/usbmount.conf
-  when: usb_lib_umask0000_for_kolibri
-
-# Setting 'umask=0000' for all filesystems: (much the same thing as above, as
-# the mount command does not use this umask setting for filesystems like ext4)
-#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
-#  lineinfile:
-#    regexp: '^MOUNTOPTIONS=.*'
-#    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
-#    path: /etc/usbmount/usbmount.conf
-#  when: usb_lib_umask0000_for_kolibri
-
-- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
-  lineinfile:
-    regexp: '^FS_MOUNTOPTIONS=.*'
-    line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, if runrole forced
-    path: /etc/usbmount/usbmount.conf
-  when: not usb_lib_umask0000_for_kolibri
-
 # 2021-03-25: Consider removing this stanza & all of this role's Apache logic!
 - name: Install /etc/{{ apache_conf_dir }}/content_dir.conf from template
   template:

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -29,6 +29,9 @@
   include_tasks: install.yml
   when: usb_lib_installed is undefined
 
+
+# If setup.yml becomes the norm in future, put the 2-3 stanzas below in there:
+
 - name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
@@ -48,9 +51,10 @@
 - name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
-    line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, if runrole forced
+    line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, e.g. for runrole
     path: /etc/usbmount/usbmount.conf
   when: not usb_lib_umask0000_for_kolibri
+
 
 - name: Enable/Disable/Restart Apache if primary
   include_tasks: apache.yml

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -29,6 +29,28 @@
   include_tasks: install.yml
   when: usb_lib_installed is undefined
 
+- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+  lineinfile:
+    regexp: '^FS_MOUNTOPTIONS=.*'
+    line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
+    path: /etc/usbmount/usbmount.conf
+  when: usb_lib_umask0000_for_kolibri
+
+# Setting 'umask=0000' for all filesystems: (much the same thing as above, as
+# the mount command does not use this umask setting for filesystems like ext4)
+#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+#  lineinfile:
+#    regexp: '^MOUNTOPTIONS=.*'
+#    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
+#    path: /etc/usbmount/usbmount.conf
+#  when: usb_lib_umask0000_for_kolibri
+
+- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
+  lineinfile:
+    regexp: '^FS_MOUNTOPTIONS=.*'
+    line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, if runrole forced
+    path: /etc/usbmount/usbmount.conf
+  when: not usb_lib_umask0000_for_kolibri
 
 - name: Enable/Disable/Restart Apache if primary
   include_tasks: apache.yml
@@ -60,3 +82,5 @@
       value: "{{ usb_lib_install }}"
     - option: usb_lib_enabled
       value: "{{ usb_lib_enabled }}"
+    - option: usb_lib_umask0000_for_kolibri
+      value: "{{ usb_lib_umask0000_for_kolibri }}"


### PR DESCRIPTION
This is @jvonau's PR #2717 with documentation added.

Refs: #2713, PR #2715, http://FAQ.IIAB.IO > "4 Can teachers display their own content?"