### PR TITLE
Illegal tab character in captiveportal/tasks/main.yml (ansible-core 2.11 requires legal .yml's)

### DIFF
--- a/roles/captiveportal/tasks/main.yml
+++ b/roles/captiveportal/tasks/main.yml
@@ -24,7 +24,7 @@
   when: captiveportal_installed is undefined
 
 
-- name: Enable or Disable Captive Portal	
+- name: Enable or Disable Captive Portal
   include_tasks: enable-or-disable.yml
 
 


### PR DESCRIPTION
Bug surfaced during a MEDIUM-sized IIAB install using `pip3 install ansible-core` on RaspiOS Lite on RPi 4.

Ref: #2721