### PR TITLE
Don't load legacy modules [iptables firewall] & New feature rapid changing of client internet access [iiab-internet-on, iiab-internet-off]

### DIFF
--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -141,6 +141,13 @@
     line: 'IIAB_LAN_DEVICE={{ iiab_lan_iface }}'
     state: present
 
+- name: Record 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}' in {{ iiab_env_file }}
+  lineinfile:
+    path: "{{ iiab_env_file }}"
+    regexp: '^IIAB_GATEWAY_ENABLED=*'
+    line: 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}'
+    state: present
+
 - name: Add 'computed_network' variable values to {{ iiab_ini_file }}
   ini_file:
     dest: "{{ iiab_ini_file }}"

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -205,6 +205,17 @@
     group: root
     mode: 0755
 
+- name: Install iiab-internet-on|off
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - { src: 'gateway/iiab-internet-on', dest: '/usr/bin/iiab-internet-on' }
+    - { src: 'gateway/iiab-internet-off', dest: '/usr/bin/iiab-internet-off' }
+
 - name: Add 'squid' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -53,11 +53,12 @@
     name: avahi-daemon
     state: restarted
 
-- name: Create gateway flag
-  shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway
-  args:
-    creates: /etc/sysconfig/olpc-scripts/setup.d/installed/gateway
-  when: iiab_network_mode == "Gateway"
+- name: Record 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}' in {{ iiab_env_file }}
+  lineinfile:
+    path: "{{ iiab_env_file }}"
+    regexp: '^IIAB_GATEWAY_ENABLED=*'
+    line: 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}'
+    state: present
 
 #netplan de-configures pre-created bridged interfaces 
 #- name: Reload netplan when Wifi is not gateway on Ubuntu 18+

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -53,13 +53,6 @@
     name: avahi-daemon
     state: restarted
 
-- name: Record 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}' in {{ iiab_env_file }}
-  lineinfile:
-    path: "{{ iiab_env_file }}"
-    regexp: '^IIAB_GATEWAY_ENABLED=*'
-    line: 'IIAB_GATEWAY_ENABLED={{ iiab_gateway_enabled }}'
-    state: present
-
 #netplan de-configures pre-created bridged interfaces 
 #- name: Reload netplan when Wifi is not gateway on Ubuntu 18+
 #  shell: netplan apply

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -86,14 +86,6 @@ elif [ "$ports_externally_visible" -lt 0 ] || [ "$ports_externally_visible" -gt 
     exit 1
 fi
 
-#if [ "$wan" != "none" ] && [ "$network_mode" != "Appliance" ]; then
-# Load iptables kernel modules
-/sbin/modprobe ip_tables
-/sbin/modprobe iptable_filter
-/sbin/modprobe ip_conntrack
-/sbin/modprobe iptable_nat
-#fi
-
 # Delete all existing firewall rules
 $IPTABLES -F
 $IPTABLES -t nat -F

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -37,6 +37,7 @@ IPTABLES_DATA=/etc/sysconfig/iptables
 source {{ iiab_env_file }}
 lan=$IIAB_LAN_DEVICE
 wan=$IIAB_WAN_DEVICE
+iiab_gateway_enabled=$IIAB_GATEWAY_ENABLED
 echo -e "\nLAN: $lan"
 echo -e "WAN: $wan\n"
 #network_mode=`grep iiab_network_mode_applied {{ iiab_ini_file }} | gawk '{print $3}'`
@@ -49,7 +50,6 @@ gw_block_https={{ gw_block_https }}
 sshd_port={{ sshd_port }}
 #gui_wan= [no longer needed]
 gui_port={{ gui_port }}
-iiab_gateway_enabled={{ iiab_gateway_enabled }}
 block_DNS={{ block_DNS }}
 
 azuracast_ports="{{ azuracast_port_range_prefix }}000:{{ azuracast_port_range_prefix }}100"

--- a/roles/network/templates/gateway/iiab-internet-off
+++ b/roles/network/templates/gateway/iiab-internet-off
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed -i -e "s/^IIAB_GATEWAY_ENABLED.*/IIAB_GATEWAY_ENABLED=False/" {{ iiab_env_file }}
+/usr/bin/iiab-gen-iptables

--- a/roles/network/templates/gateway/iiab-internet-on
+++ b/roles/network/templates/gateway/iiab-internet-on
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed -i -e "s/^IIAB_GATEWAY_ENABLED.*/IIAB_GATEWAY_ENABLED=True/" {{ iiab_env_file }}
+/usr/bin/iiab-gen-iptables


### PR DESCRIPTION
Eliminates this noted warning #2667 #2665
\# Warning: iptables-legacy tables present, use iptables-legacy to see them
