### PR TITLE
Correctly record Ansible versions like "[core 2.11.0rc2]" (e.g. when installing pre-releases using 'pip3 install ansible-core')

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -89,9 +89,10 @@ CURR_ANSIBLE_VER=0
 #if [[ `which ansible` ]]; then            # "which" misses built-in commands like cd, and is RISKY per https://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script
 #if [[ `type -P ansible` ]]; then          # "type -P" isn't POSIX compliant; it misses built-in commands like "cd"
 if [[ `command -v ansible` ]]; then        # "command -v" is POSIX compliant; it catches built-in commands like "cd"
-    #CURR_ANSIBLE_VER=`ansible --version | head -1 | sed -e 's/.* //'`
-    #CURR_ANSIBLE_VER=`ansible --version | head -1 | cut -f 2 -d " "`
-    CURR_ANSIBLE_VER=`ansible --version | head -1 | awk '{print $2}'`    # to match scripts/ansible
+    CURR_ANSIBLE_VER=$(ansible --version | head -1 | cut -f 2- -d " ")
+    # Above works with 'ansible [core 2.11.0rc2]' -- these old ways do not:
+    #CURR_ANSIBLE_VER=$(ansible --version | head -1 | awk '{print $2}')
+    #CURR_ANSIBLE_VER=$(ansible --version | head -1 | sed -e 's/.* //')
     echo "Found Ansible ""$CURR_ANSIBLE_VER"
 fi
 if version_gt $MIN_ANSIBLE_VER $CURR_ANSIBLE_VER ; then

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -74,7 +74,10 @@ echo -e "IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)"
 echo -e "https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n"
 
 if [ $(command -v ansible) ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
-    CURR_VER=`ansible --version | head -1 | awk '{print $2}'`    # To match iiab-install.  Was: CURR_VER=`ansible --version | head -n 1 | cut -f 2 -d " "`
+    CURR_VER=$(ansible --version | head -1 | cut -f 2- -d " ")
+    # Above works with 'ansible [core 2.11.0rc2]' -- these old ways do not:
+    #CURR_VER=$(ansible --version | head -1 | awk '{print $2}')
+    #CURR_VER=$(ansible --version | head -1 | sed -e 's/.* //')
     echo -e "CURRENTLY INSTALLED ANSIBLE: $CURR_VER -- LET'S TRY TO UPGRADE IT!"
 else
     echo -e "ANSIBLE NOT FOUND ON THIS COMPUTER -- LET'S TRY TO INSTALL IT!"

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -89,7 +89,10 @@ tmp=$(cat /proc/device-tree/model) &&
     RPI_MODEL=$tmp
 
 tmp=$(ansible --version) &&
-    ANSIBLE_VERSION=$(echo "$tmp" | head -n 1 | cut -f 2 -d " ")
+    ANSIBLE_VERSION=$(echo "$tmp" | head -1 | cut -f 2- -d " ")
+    # Above works with 'ansible [core 2.11.0rc2]' -- these old ways do not:
+    #ANSIBLE_VERSION=$(echo "$tmp" | head -1 | awk '{print $2}')
+    #ANSIBLE_VERSION=$(echo "$tmp" | head -1 | sed -e 's/.* //')
 
 
 # THE LAST 3 BELOW ARE DIFFERENT as "systemctl is-enabled" unhelpfully returns


### PR DESCRIPTION
Tested on Ubuntu 20.04 with both of these Ansible versions:

- 2.10.8
- [core 2.11.0rc2]

More testing ongoing.

Ref: #2721