### PR TITLE
cups - drop apache

### DIFF
--- a/roles/cups/tasks/enable-or-disable.yml
+++ b/roles/cups/tasks/enable-or-disable.yml
@@ -1,11 +1,3 @@
-- name: Enable http://box/cups via Apache (MIGHT NOT WORK?)
-  command: a2ensite cups.conf
-  when: cups_enabled
-
-- name: Disable http://box/cups via Apache
-  command: a2dissite cups.conf
-  when: not cups_enabled
-
 - name: systemd daemon-reload
   systemd:
     daemon_reload: yes

--- a/roles/cups/tasks/install.yml
+++ b/roles/cups/tasks/install.yml
@@ -1,13 +1,3 @@
-- name: "Set 'apache_install: True' and 'apache_enabled: True'"
-  set_fact:
-    apache_install: True
-    apache_enabled: True
-
-- name: APACHE - run 'httpd' role
-  include_role:
-    name: httpd
-
-
 - name: Install 'cups' package
   package:
     name: cups
@@ -17,12 +7,6 @@
   template:
     src: cupsd.conf
     dest: /etc/cups/cupsd.conf
-
-- name: Install /etc/{{ apache_conf_dir }}/cups.conf from template
-  template:
-    src: cups.conf
-    dest: "/etc/{{ apache_conf_dir }}/"
-
 
 # RECORD CUPS AS INSTALLED
 

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -34,7 +34,6 @@
       * wordpress
 
    3. These support Apache but ***NOT*** "Native" NGINX.  They use a "Shim" to [proxy_pass](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) from NGINX to Apache on port 8090.  See [roles/3-base-server/tasks/main.yml#L11](../3-base-server/tasks/main.yml#L11) for a list of IIAB Apps/Services that auto-enable Apache.
-      * cups [*, shim not yet in place.]
       * elgg
       * lokole
       * moodle
@@ -43,6 +42,7 @@
    4. These each run their own web server or non-web / backend services, e.g. off of their own [unique port(s)](https://github.com/iiab/iiab/wiki/IIAB-Networking#list-of-ports--services) (IIAB home pages link directly to these destinations).  In future we'd like mnemonic URL's for all of these: (e.g. http://box/calibre, http://box/archive, http://box/kalite)
       * bluetooth
       * calibre (menu goes directly to port 8080)
+      * cups [(available on port 631) * shim not yet in place.]
       * internetarchive (menu goes directly to port 4244, [PR #2120](https://github.com/iiab/iiab/pull/2120)) [*]
       * kalite (menu goes directly to ports 8006-8008)
       * minetest


### PR DESCRIPTION
The port is open anyway, just lose the /cups redirect, not worth dragging apache in. Still
missing the nginx config to make apache work, nginx should really just use nginx directly.

### Fixes bug:
Incomplete nginx port
### Description of changes proposed in this pull request:
Just access via box:631vs box/cups, should /cups be wanted a nginx file could be crafted but to date there is no interest in doing so.