### PR TITLE
Lokole install blocked on RaspiOS, so add 'python_ver: 3.7' to vars/raspbian-10.yml

### DIFF
--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -26,6 +26,7 @@ sshd_service: ssh
 php_version: 7.3
 postgresql_version: 11
 systemd_location: /lib/systemd/system
+python_ver: 3.7
 
 # minetest for rpi
 minetest_server_bin: /library/games/minetest/bin/minetestserver


### PR DESCRIPTION
Patch for PR #2776.

Thanks @nzola for reporting the issue at https://github.com/ascoderu/lokole/issues/546#issuecomment-841871192

Thanks @adamsclafani @deldesir for all the ongoing testing.

Refs: #2767, PR #2778