### PR TITLE
OPWEN_SETTINGS

### DIFF
--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -24,7 +24,8 @@ lokole_user: lokole
 lokole_url: /lokole
 lokole_uid: "2000"
 lokole_run_directory: /home/{{ lokole_user }}/state
-lokole_domain_socket: "/run/lokole_gunicorn.sock"
+lokole_log_directory: /home/{{ lokole_user }}/log
+lokole_domain_socket: "{{ lokole_run_directory }}/lokole_gunicorn.sock"
 lokole_sim_type: LocalOnly
 
 lokole_full_url: "http://{{ iiab_hostname }}.{{ iiab_domain }}{{ lokole_url }}"    # http://box.lan/lokole

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -85,7 +85,7 @@
     path: "{{ lokole_run_directory }}"
     group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
-    mode: u+rw
+    mode: g+rw
 
 - name: mkdir /{{ lokole_user }}/log
   file:
@@ -93,12 +93,15 @@
     path: "{{ lokole_log_directory }}"
     group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
-    mode: u+rw
+    mode: g+rw
 
 - name: Install {{ lokole_run_directory }}/settings.env
   template:
     src: settings.env.j2
     dest: "{{ lokole_run_directory }}/settings.env"
+    group: "{{ lokole_user }}"
+    owner: "{{ lokole_user }}"
+    mode: a+rw
 
 - name: Install {{ lokole_run_directory }}/webapp_secrets.sh from template, to configure Lokole
   template:
@@ -110,10 +113,9 @@
   template:
     src: webapp.sh.j2
     dest: "{{ lokole_run_directory }}/webapp.sh"
-    mode: a+x
     group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
-    mode: u+rw
+    mode: a+x
 
 - name: Create Lokole admin user with password, for http://box{{ lokole_url }}    # http://box/lokole
   shell: |

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -83,21 +83,19 @@
   file:
     state: directory
     path: "{{ lokole_run_directory }}"
-    #mode: a+x    # Not nec, given above 'state: directory'
+    group: "{{ lokole_user }}"
+    owner: "{{ lokole_user }}"
+    mode: u+rw
 
-# lets try to catch settings.env creation at registration time
-# can't tell if the routine doesn't like settings.env being missing
-- name: mkdir /{{ lokole_user }}/state for registration testing
+- name: mkdir /{{ lokole_user }}/log
   file:
     state: directory
-    path: /{{ lokole_user }}/state
+    path: "{{ lokole_log_directory }}"
+    group: "{{ lokole_user }}"
+    owner: "{{ lokole_user }}"
+    mode: u+rw
 
-- name: Install dummy target for registration testing fake
-  template:
-    src: settings.env.j2
-    dest: "/{{ lokole_user }}/state/settings.env"
-
-- name: Install dummy target for registration testing run
+- name: Install {{ lokole_run_directory }}/settings.env
   template:
     src: settings.env.j2
     dest: "{{ lokole_run_directory }}/settings.env"
@@ -113,6 +111,9 @@
     src: webapp.sh.j2
     dest: "{{ lokole_run_directory }}/webapp.sh"
     mode: a+x
+    group: "{{ lokole_user }}"
+    owner: "{{ lokole_user }}"
+    mode: u+rw
 
 - name: Create Lokole admin user with password, for http://box{{ lokole_url }}    # http://box/lokole
   shell: |

--- a/roles/lokole/templates/celery.service.j2
+++ b/roles/lokole/templates/celery.service.j2
@@ -6,6 +6,7 @@ Before=celerybeat.service
 
 [Service]
 Type=simple
+EnvironmentFile={{ lokole_run_directory }}/settings.env
 ExecStart={{ lokole_venv }}/bin/celery --uid={{ lokole_uid }} --gid={{ lokole_uid }} --app=opwen_email_client.webapp.tasks worker --loglevel=info --concurrency=2
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill TERM $MAINPID

--- a/roles/lokole/templates/celerybeat.service.j2
+++ b/roles/lokole/templates/celerybeat.service.j2
@@ -6,6 +6,7 @@ Before=lokole_restarter.service
 
 [Service]
 Type=simple
+EnvironmentFile={{ lokole_run_directory }}/settings.env
 ExecStart={{ lokole_venv }}/bin/celery --app=opwen_email_client.webapp.tasks beat --loglevel=info
 
 [Install]

--- a/roles/lokole/templates/lokole.service.j2
+++ b/roles/lokole/templates/lokole.service.j2
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile={{ lokole_run_directory }}/settings.env
 ExecStart=/bin/bash {{ lokole_run_directory }}/webapp.sh
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/roles/lokole/templates/lokole_restarter.service.j2
+++ b/roles/lokole/templates/lokole_restarter.service.j2
@@ -5,6 +5,7 @@ After=celerybeat.service
 
 [Service]
 Type=simple
+EnvironmentFile={{ lokole_run_directory }}/settings.env
 WorkingDirectory={{ lokole_run_directory }}
 ExecStart={{ lokole_venv }}/bin/manage.py restarter --directory={{ lokole_run_directory }}
 

--- a/roles/lokole/templates/settings.env.j2
+++ b/roles/lokole/templates/settings.env.j2
@@ -1,7 +1,8 @@
-OPWEN_SIM_TYPE='{{ lokole_sim_type }}'
+OPWEN_SETTINGS='{{ lokole_run_directory }}/settings.env'
 OPWEN_STATE_DIRECTORY='{{ lokole_run_directory }}'
 OPWEN_APP_ROOT='{{ lokole_url }}/'
 OPWEN_MAX_UPLOAD_SIZE_MB=10
 OPWEN_SYNC_SCHEDULE='1,16,31,46 * * * *'
 OPWEN_SESSION_KEY='{{ lookup('password', '/dev/null chars=ascii_letters,digits,_ length=32') }}'
 OPWEN_PASSWORD_SALT='{{ lookup('password', '/dev/null chars=ascii_letters,digits,_ length=16') }}'
+OPWEN_SIM_TYPE='{{ lokole_sim_type }}'

--- a/roles/lokole/templates/webapp_secrets.sh.j2
+++ b/roles/lokole/templates/webapp_secrets.sh.j2
@@ -1,3 +1,4 @@
+export OPWEN_SETTINGS='{{ lokole_run_directory }}/settings.env'
 export OPWEN_SIM_TYPE='{{ lokole_sim_type }}'
 export OPWEN_STATE_DIRECTORY='{{ lokole_run_directory }}'
 export OPWEN_APP_ROOT='{{ lokole_url }}/'


### PR DESCRIPTION
From an install.py machine where supervisord is used this value is passed
pi@jv-rpi-stock:~ $ cat /etc/supervisor/conf.d/lokole_gunicorn.conf
[program:lokole_gunicorn]
command="/lokole/venv/bin/gunicorn" --bind="unix:/lokole/state/lokole_gunicorn.sock" --timeout=300 --workers=3 --log-level=error opwen_email_client.webapp:app
autostart=true
autorestart=true
startretries=3
stopasgroup=true
stderr_logfile=/lokole/logs/lokole_gunicorn.stderr.log
stdout_logfile=/lokole/logs/lokole_gunicorn.stdout.log
user=root
environment=OPWEN_SETTINGS=/lokole/state/settings.env
