### PR TITLE
Don't softcode in local_vars.yml

### DIFF
--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -409,4 +409,4 @@ calibreweb_port: 8083       # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 calibreweb_url1: /books     # For SHORT URL http://box/books  (English)
 calibreweb_url2: /libros    # For SHORT URL http://box/libros (Spanish)
 calibreweb_url3: /livres    # For SHORT URL http://box/livres (French)
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
+calibreweb_home: /library/calibre-web    # default_vars.yml uses: "{{ content_base }}/calibre-web"

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -409,4 +409,4 @@ calibreweb_port: 8083       # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 calibreweb_url1: /books     # For SHORT URL http://box/books  (English)
 calibreweb_url2: /libros    # For SHORT URL http://box/libros (Spanish)
 calibreweb_url3: /livres    # For SHORT URL http://box/livres (French)
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
+calibreweb_home: /library/calibre-web    # default_vars.yml uses: "{{ content_base }}/calibre-web"

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -409,4 +409,4 @@ calibreweb_port: 8083       # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 calibreweb_url1: /books     # For SHORT URL http://box/books  (English)
 calibreweb_url2: /libros    # For SHORT URL http://box/libros (Spanish)
 calibreweb_url3: /livres    # For SHORT URL http://box/livres (French)
-calibreweb_home: "{{ content_base }}/calibre-web"    # /library/calibre-web
+calibreweb_home: /library/calibre-web    # default_vars.yml uses: "{{ content_base }}/calibre-web"


### PR DESCRIPTION
Avoiding softcoding within local_vars.yml is recommended by @tim-moody.

This seems like a good idea for several reasons:

- [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) is used by newcomers to survey and understand their IIAB options, and so keeping this self-contained within 1 file enhances understandability.
- This allows for easier automated parsing/processing of [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)

Just as clarification for this specific case: RaspiOS Desktop users/implementers sometimes want to align their install of Calibre-Web and/or Calibre with the OS's own install of Calibre (elsewhere in the filesystem) and so keeping this option prominent (on the last line of most local_vars.yml files, e.g. [MIN-sized, MEDIUM-sized and BIG-sized](https://github.com/iiab/iiab/tree/master/vars)) is a good thing.