### PR TITLE
Mandate nginx_high_php_limits in www_options/tasks/main.yml if moodle_install (as required by Moodle 3.11 w/ PHP 8). For /etc/php/{{ php_version }}/fpm/php.ini

### DIFF
--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -1,3 +1,10 @@
+# 2021-05-22: FYI nginx_high_php_limits is effectively now auto-enabled by
+# www_options/tasks/main.yml#L81-L94 (as required by Moodle 3.11 with PHP 8) IF
+# 'moodle_install: True'. Happens at the end of 4-server-options/tasks/main.yml
+# See the 6 settings in /etc/php/{{ php_version }}/fpm/php.ini -- which Moodle
+# should take advantage of soon, as it transitions from Apache to Moodle: #2785
+
+
 - name: "Set 'apache_install: True' and 'apache_enabled: True'"
   set_fact:
     apache_install: True

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -56,7 +56,7 @@
 
   # FYI roles/nginx has already installed package php-fpm, in 3-base-server
 
-  - name: Raise 2+2 PHP default values in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/Moodle/PBX (allow photos/docs up to 100MB, 100s timeouts, but preserve PHP's 128MB RAM limit)
+  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, BUT preserve 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
       path: "/etc/php/{{ php_version }}/fpm/php.ini"
       #path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
@@ -69,7 +69,7 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: not nginx_high_php_limits    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
 
   # 2020-03-08: IIAB does not support uninstalling apps, so a 3rd clause
   # (to reset/restore PHP's defaults) is not necessary at this time.
@@ -77,8 +77,8 @@
   # COMPARE apache_allow_sudo further below.
 
   # WARNING: This might cause excess use of RAM/disk or other resources!
-  # The 5 values below were chosen by @ericnitschke and @kananigit in ~2018.
-  - name: Enact nginx_high_php_limits in /etc/php/{{ php_version }}/fpm/php.ini for schools that use WordPress/Nextcloud/Moodle/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, 512MB RAM limit)
+  # The 5 first values below were chosen by @ericnitschke and @kananigit in ~2018.
+  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for schools that use WordPress/Moodle/Nextcloud/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
     lineinfile:
       path: "/etc/php/{{ php_version }}/fpm/php.ini"
       #path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
@@ -91,7 +91,7 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: nginx_high_php_limits    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
     systemd:

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -56,7 +56,7 @@
 
   # FYI roles/nginx has already installed package php-fpm, in 3-base-server
 
-  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, BUT preserve 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
       path: "/etc/php/{{ php_version }}/fpm/php.ini"
       #path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -50,7 +50,7 @@
       lxde_present.stat.exists and chromium_present.stat.exists
 
 - debug:
-    msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled'
+    msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: moodle_install or nextcloud_install or pbx_install or wordpress_install'
 
 - block:    # 3-STANZA BLOCK BEGINS
 
@@ -69,7 +69,7 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   # 2020-03-08: IIAB does not support uninstalling apps, so a 3rd clause
   # (to reset/restore PHP's defaults) is not necessary at this time.
@@ -91,14 +91,14 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
     systemd:
       name: "php{{ php_version }}-fpm"
       state: restarted
 
-  when: (moodle_install or nextcloud_install or pbx_install or wordpress_install) and nginx_enabled    # 3-STANZA BLOCK ENDS
+  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 3-STANZA BLOCK ENDS
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -264,8 +264,9 @@ nginx_log_dir: /var/log/nginx
 #
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
+# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
+# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -267,7 +267,7 @@ nginx_high_php_limits: False
 # FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # Make this False to disable http://box/common/services/power_off.php button:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -266,7 +266,7 @@ nginx_log_dir: /var/log/nginx
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L52-L66
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # Make this False to disable http://box/common/services/power_off.php button:

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -169,7 +169,7 @@ pi_swap_file_size: 1024
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L52-L66
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -170,7 +170,7 @@ nginx_high_php_limits: False
 # FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -167,8 +167,9 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
+# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
+# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -169,7 +169,7 @@ pi_swap_file_size: 1024
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L52-L66
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -170,7 +170,7 @@ nginx_high_php_limits: False
 # FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -167,8 +167,9 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
+# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
+# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -169,7 +169,7 @@ pi_swap_file_size: 1024
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L52-L66
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -170,7 +170,7 @@ nginx_high_php_limits: False
 # FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -167,8 +167,9 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
+# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 5 SETTINGS...
+# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L72
 # ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
 


### PR DESCRIPTION
In preparation for #2785 etc.

Refs: PR #2784, #2796