### PR TITLE
ansible - install dependencies before pip

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -152,12 +152,11 @@ grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | gre
 echo -e "\napt update; apt install ansible-core and python3 dependencies explained at:"
 echo -e "https://github.com/iiab/iiab/blob/master/scripts/ansible.md\n"
 $APT_PATH/apt update
-$APT_PATH/apt -y install python3-pip
-pip3 install ansible-core
 #$APT_PATH/apt -y --allow-downgrades install ansible-core \
 $APT_PATH/apt -y --allow-downgrades install \
               python3-pymysql python3-psycopg2 python3-passlib python3-pip \
               python3-setuptools python3-packaging python3-venv virtualenv
+pip3 install ansible-core
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support


### PR DESCRIPTION
pip will install the same packages but in /local/lib if the dependency
is not already in the system path, fill the system path with all the
dependencies before doing the local pip install. Helps avoid
overlapping of apt vs pip managed files.

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
