### PR TITLE
Modernize (speed up) iiab-support so that it only installs OpenVPN when truly nec

### DIFF
--- a/iiab-support
+++ b/iiab-support
@@ -46,7 +46,7 @@ else
     echo -e "\n\e[1mWARNING: openvpn_handle remains unchanged in both above files.\e[0m\n"
 fi
 
-if grep -q '^openvpn_install: True' /etc/iiab/local_vars.yml; then
+if grep -q '^openvpn_installed: True' /etc/iiab/iiab_state.yml; then
     echo -e "Your IIAB installation appears normal, with OpenVPN already installed...\n"
 else
     echo -e "Plz wait a few minutes as sshd, iiab-admin & OpenVPN are confirmed/installed...\n"

--- a/iiab-support
+++ b/iiab-support
@@ -58,8 +58,6 @@ else
 
     if [ -d /opt/iiab/iiab ]; then
         cd /opt/iiab/iiab
-        #CWD=`pwd`
-        #export ANSIBLE_LOG_PATH="$CWD/iiab-install.log"
         export ANSIBLE_LOG_PATH="/opt/iiab/iiab/iiab-install.log"
         ansible -m setup -i $INVENTORY localhost --connection=local | grep python
         ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local

--- a/iiab-support
+++ b/iiab-support
@@ -46,7 +46,7 @@ else
     echo -e "\n\e[1mWARNING: openvpn_handle remains unchanged in both above files.\e[0m\n"
 fi
 
-if grep -q '^openvpn_installed: True' /etc/iiab/iiab_state.yml; then
+if grep -q '^openvpn_installed: True\b' /etc/iiab/iiab_state.yml; then
     echo -e "Your IIAB installation appears normal, with OpenVPN already installed...\n"
 else
     echo -e "Plz wait a few minutes as sshd, iiab-admin & OpenVPN are confirmed/installed...\n"


### PR DESCRIPTION
`iiab-support` should now run a lot faster (about 15 seconds instead of several minutes) in cases where `openvpn_installed: True` is in `/etc/iiab/iiab_state.yml` but not in `/etc/iiab/local_vars.yml`

Thanks @nzola & @jvonau for catching this.