### PR TITLE
MediaWiki 1.36.0

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: 1.35    # "1.35" also works
-mediawiki_minor_version: 2
+mediawiki_major_version: 1.36    # "1.35" also works
+mediawiki_minor_version: 0
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
MediaWiki 1.36.0 release announcement was emailed, but mailing list archiving appears broken for now, so it's not (yet) readable here:

https://lists.wikimedia.org/pipermail/mediawiki-announce/

Refs: PR #2722, #2765