### PR TITLE
Advisories in local_vars.yml: role 'pbx' is untested for several years

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -434,7 +434,8 @@ nextcloud_enabled: False
 # nextcloud_dl_url: http://d.iiab.io/packages/latest.tar.bz2
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# Works on Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi 3.
+# Untested since Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi.
+# If using PBX intensively, set nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False
@@ -475,6 +476,7 @@ kiwix_apk_src: https://download.kiwix.org/release/kiwix-android/kiwix.apk
 postgresql_install: False
 postgresql_enabled: False
 
+# Warning: Moodle is a serious LMS, that takes a while to install.
 moodle_install: False
 moodle_enabled: False
 # If using Moodle intensively, set nginx_high_php_limits further above.

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -290,7 +290,8 @@ nextcloud_enabled: True
 # nextcloud_dl_url: http://d.iiab.io/packages/latest.tar.bz2
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# Works on Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi 3.
+# Untested since Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi.
+# If using PBX intensively, set nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -290,7 +290,8 @@ nextcloud_enabled: True
 # nextcloud_dl_url: http://d.iiab.io/packages/latest.tar.bz2
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# Works on Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi 3.
+# Untested since Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi.
+# If using PBX intensively, set nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -290,7 +290,8 @@ nextcloud_enabled: False
 # nextcloud_dl_url: http://d.iiab.io/packages/latest.tar.bz2
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# Works on Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi 3.
+# Untested since Ubuntu 18.04, Debian 9 w/ Node.js 10.x.  Experimental on RPi.
+# If using PBX intensively, set nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False
 asterisk_chan_dongle: False


### PR DESCRIPTION
For those wanting to try out and test the [pbx](https://github.com/iiab/iiab/tree/master/roles/pbx) role (at their own risk!) we also advise that `nginx_high_php_limits: True` be set in:

[/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) 