### PR TITLE
Test kiwix-tools 3.1.2-5 RC1 for armhf

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,7 +26,7 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-3.1.2-4
+kiwix_version_armhf: kiwix-tools_linux-armhf-3.1.2-5-rc1
 kiwix_version_linux64: kiwix-tools_linux-x86_64-3.1.2-4
 kiwix_version_i686: kiwix-tools_linux-i586-3.1.2-4
 

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -70,7 +70,7 @@
     dest: /tmp
 
 - name: Move /tmp/{{ kiwix_src_dir }}/* to permanent location {{ kiwix_path }}/bin
-  shell: "mv /tmp/{{ kiwix_src_dir }}/* {{ kiwix_path }}/bin/"    # /opt/iiab/kiwix
+  shell: "mv /tmp/kiwix-tools_linux-armhf-3.1.2-5/* {{ kiwix_path }}/bin/"    # /opt/iiab/kiwix
 
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU


### PR DESCRIPTION
@shanti-bhardwa please consider testing your latest ZIM files if you install IIAB today &mdash; installing this PR as part of your IIAB install as follows:

```
curl d.iiab.io/install.txt | sudo bash -s 2810
```

Background: this installs http://tmp.kiwix.org/kiwix-tools_3.1.2-5/ (Release Candidate 1, based on libzim 6.3.1) into `/opt/iiab/kiwix/bin` for armhf / Raspberry Pi, as is very likely to be released in coming days.