### PR TITLE
kiwix-tools 3.1.2-4 -> 3.1.2-5

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,9 +26,9 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-3.1.2-4
-kiwix_version_linux64: kiwix-tools_linux-x86_64-3.1.2-4
-kiwix_version_i686: kiwix-tools_linux-i586-3.1.2-4
+kiwix_version_armhf: kiwix-tools_linux-armhf-3.1.2-5
+kiwix_version_linux64: kiwix-tools_linux-x86_64-3.1.2-5
+kiwix_version_i686: kiwix-tools_linux-i586-3.1.2-5
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")


### PR DESCRIPTION
A major improvement, even if not the final word.  Replaces PR #2810.

Excellent Summary of the Situation: https://github.com/kiwix/libkiwix/issues/551#issuecomment-858422940 (thanks to @mgautierfr!)

FYI this fixes most-if-not-all of these issues:

- 'Clicking quickly many times on random crashes kiwix-serve for Windows' kiwix/libkiwix#512
- 'Kiwix Serve freezing on RPI with a lot of ZIM files' kiwix/libkiwix#513
- 'handle-search is getting stuck when using "containing..."' kiwix/libkiwix#515
- 'Larger .zim files not searchable with Kiwix-serve on RPI W' kiwix/libkiwix#542