### PR TITLE
Raspberry Pi OS 11 is imminent, expected before Debian 11's own ETA "2021-07-31"

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -60,7 +60,7 @@ OS_VER=$OS-$VERSION_ID
 # 2020-10-21: Debian 11 (Bullseye) not yet supported but adding this line to
 # its /etc/os-release can help testing this unreleased OS: VERSION_ID="11"
 
-# 2020-11-14: Ubuntu 21.04 (Hirsute Hippo) not yet supported but this
+# 2021-06-19: Ubuntu 21.10 (Impish Indri) not yet supported but this
 # unreleased OS can help testing.
 
 case $OS_VER in
@@ -69,7 +69,8 @@ case $OS_VER in
     "ubuntu-20"    | \
     "ubuntu-21"    | \
     "linuxmint-20" | \
-    "raspbian-10")
+    "raspbian-10"  | \
+    "raspbian-11")
        ;;
     *) OS_VER="OS_not_supported"
        ;;

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -62,7 +62,7 @@ OS_VER=$OS-$VERSION_ID
 
 # 2021-06-19: Ubuntu 21.10 (Impish Indri) not yet supported but this
 # unreleased OS can help testing.  For now this means MANUALLY changing
-# php_version: 7.4 to 8.0 in vars/ubuntu-21.yml
+# php_version: 7.4 to 8.0 in /opt/iiab/iiab/vars/ubuntu-21.yml
 
 case $OS_VER in
     "debian-10"    | \

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -61,7 +61,8 @@ OS_VER=$OS-$VERSION_ID
 # its /etc/os-release can help testing this unreleased OS: VERSION_ID="11"
 
 # 2021-06-19: Ubuntu 21.10 (Impish Indri) not yet supported but this
-# unreleased OS can help testing.
+# unreleased OS can help testing.  For now this means MANUALLY changing
+# php_version: 7.4 to 8.0 in vars/ubuntu-21.yml
 
 case $OS_VER in
     "debian-10"    | \

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -1,0 +1,38 @@
+is_debuntu: True
+is_debian: True
+is_debian_11: True
+is_raspbian: True
+is_raspbian_11: True
+
+# 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dns_user: bind
+dhcp_service: isc-dhcp-server
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_conf_dir: apache2/sites-available
+apache_user: www-data
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: ssh
+sshd_service: ssh
+php_version: 7.4
+postgresql_version: 13
+systemd_location: /lib/systemd/system
+python_ver: 3.9
+
+# minetest for rpi
+minetest_server_bin: /library/games/minetest/bin/minetestserver
+minetest_working_dir: /library/games/minetest
+minetest_game_dir: /library/games/minetest/games/minetest_game
+minetest_rpi_src_tar: minetest.5.1.1.tar.gz
+#minetest_rpi_src_url: "http://www.nathansalapat.com/downloads/{{ minetest_rpi_src_tar }}"
+minetest_rpi_src_url: "http://d.iiab.io/packages/{{ minetest_rpi_src_tar }}"
+minetest_rpi_src_untarred: Minetest

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -28,7 +28,7 @@ postgresql_version: 13
 systemd_location: /lib/systemd/system
 python_ver: 3.9
 
-# minetest for rpi
+# Minetest for RPi
 minetest_server_bin: /library/games/minetest/bin/minetestserver
 minetest_working_dir: /library/games/minetest
 minetest_game_dir: /library/games/minetest/games/minetest_game


### PR DESCRIPTION
Raspberry Pi OS 11 was announced as something that would be released in the coming 10 days.

Also known as RaspiOS 11, or Raspbian 11.

In any case, whether the Raspberry Pi Foundation meets their own deadline or not, let's be prepared for it.

Refs:

- #2749 "Testing IIAB on the new Debian 11 "Bullseye" Release Candidate(s) [and Haiti content discussion]"
- #2818 "Test IIAB on Ubuntu 21.10 pre-releases (RPi+PC) x (Server+Desktop). Does RPi WiFi firmware 7.45.18.0 work well?"