### PR TITLE
Specify is_debian & is_ubuntu for all supported OS's

### DIFF
--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_ubuntu: False
 is_debian_10: True
 
 # 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_ubuntu: False
 is_debian_11: True
 
 # 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True

--- a/vars/linuxmint-20.yml
+++ b/vars/linuxmint-20.yml
@@ -1,4 +1,5 @@
 is_debuntu: True
+is_debian: False
 is_ubuntu: True
 is_ubuntu_20: True
 is_linuxmint: True

--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_ubuntu: False
 is_debian_10: True
 is_raspbian: True
 is_raspbian_10: True

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -1,5 +1,6 @@
 is_debuntu: True
 is_debian: True
+is_ubuntu: False
 is_debian_11: True
 is_raspbian: True
 is_raspbian_11: True

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -1,4 +1,5 @@
 is_debuntu: True
+is_debian: False
 is_ubuntu: True
 is_ubuntu_20: True
 

--- a/vars/ubuntu-21.yml
+++ b/vars/ubuntu-21.yml
@@ -1,4 +1,5 @@
 is_debuntu: True
+is_debian: False
 is_ubuntu: True
 is_ubuntu_21: True
 


### PR DESCRIPTION
There's no magical solution.  Legacy norms leave us with:

- Theoretically one variable should have sufficed (https://en.wikipedia.org/wiki/Single_source_of_truth) as `is_debian` is currently always the opposite of `is_ubuntu`
- Nevertheless both above variables are already in very common use, so it's better to give them accurate values across the board, avoiding a flood of long-winded and error-prone `is_<OS> is defined` tests (increasing software maintenance costs) all over the place.
- Currently `is_debuntu` is a useless variable, as it's always true.  So be it for now.
  - In future that might possibly change — whether other Linux distributions become supported or not!

Refs: #2749, #2818, PR #2819, #2820