### PR TITLE
Better explain is_<OS>.yml files

### DIFF
--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: True
-is_ubuntu: False
+is_debian: True    # Opposite of is_ubuntu for now
 is_debian_10: True
 
 # 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: True
-is_ubuntu: False
+is_debian: True    # Opposite of is_ubuntu for now
 is_debian_11: True
 
 # 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -722,6 +722,7 @@ is_debian_9: False
 is_debian_8: False
 
 is_raspbian: False    # Covers both: RPi HW + non-RPi HW versions of Raspberry Pi OS (Raspbian)
+is_raspbian_11: False
 is_raspbian_10: False
 is_raspbian_9: False
 is_raspbian_8: False

--- a/vars/linuxmint-20.yml
+++ b/vars/linuxmint-20.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: False
-is_ubuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_20: True
 is_linuxmint: True
 is_linuxmint_20: True

--- a/vars/raspbian-10.yml
+++ b/vars/raspbian-10.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: True
-is_ubuntu: False
+is_debian: True    # Opposite of is_ubuntu for now
 is_debian_10: True
 is_raspbian: True
 is_raspbian_10: True

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: True
-is_ubuntu: False
+is_debian: True    # Opposite of is_ubuntu for now
 is_debian_11: True
 is_raspbian: True
 is_raspbian_11: True

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: False
-is_ubuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_20: True
 
 # 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True

--- a/vars/ubuntu-21.yml
+++ b/vars/ubuntu-21.yml
@@ -1,6 +1,7 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_debian: False
-is_ubuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_21: True
 
 # 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True


### PR DESCRIPTION
Ever-evolving as different Linux distributions are supported or fall out of use.

Also fixes PR #2819 in support of the imminent Raspberry Pi OS 11.

Refs: #2749, #2818, #2820, PR #2821