### PR TITLE
Force NGINX to allow HTTP/1.1 byte-range, so proxied Kolibri videos play on Apple devices

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -82,6 +82,8 @@ http {
     # 2021-06-22: Enables HTTP/1.1 byte-range, so Kolibri videos play on Apple
     # and LG devices: https://github.com/learningequality/kolibri/issues/8164
     # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_force_ranges
+    # This should help all roles!  RECAP: when unproxied, Kolibri videos worked
+    # (http://box:8009/kolibri/) but not when proxied (http://box/kolibri/).
     proxy_force_ranges on;
 
     ##

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -1,6 +1,6 @@
 # IIAB notes:
-# /etc/nginx/sites-enabled is for server declarations
-# /etc/nginx/conf.d is for location declarations within the main server block
+# /etc/nginx/conf.d/* are included by /etc/nginx/server.conf
+# /etc/nginx/sites-enabled/*.conf includes other sites
 
 user www-data;
 worker_processes auto;
@@ -78,6 +78,11 @@ http {
         default upgrade;
         ''      close;
     }
+
+    # 2021-06-22: Enables HTTP/1.1 byte-range, so Kolibri videos play on Apple
+    # and LG devices: https://github.com/learningequality/kolibri/issues/8164
+    # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_force_ranges
+    proxy_force_ranges on;
 
     ##
     # Virtual Host Configs

--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -1,35 +1,35 @@
 server {
-      root {{ doc_root }};
-      server_name {{ iiab_hostname }};
-      listen 80;
- 
-      index  index.php index.html index.htm;
+    root {{ doc_root }};
+    server_name {{ iiab_hostname }};
+    listen 80;
 
-      # let individual services drop location blocks in conf.d
-      include {{ nginx_conf_dir }}/*;
- 
-      location ~ .*\.php$ {
-          proxy_set_header X-Real-IP  $remote_addr;
-          proxy_set_header X-Forwarded-For $remote_addr;
-          proxy_set_header Host $host;
-          fastcgi_pass php;
-          fastcgi_index index.php;
-          fastcgi_split_path_info ^(.+\.php)(/.+)$;
-          fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
-          fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
-          include fastcgi_params;
-       }
- 
-      location /cgi-bin {
-         root /usr/lib;
-      }
+    index index.php index.html index.htm;
 
-       # if you don't like seeing all the errors for missing favicon.ico in root
-       location = /favicon.ico { access_log off; log_not_found off; }
+    # let individual services drop location blocks in conf.d
+    include {{ nginx_conf_dir }}/*;
+
+    location ~ .*\.php$ {
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+        fastcgi_pass php;
+        fastcgi_index index.php;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        include fastcgi_params;
+    }
  
-       # if you don't like seeing errors for a missing robots.txt in root
-       location = /robots.txt { access_log off; log_not_found off; }
- 
-       # this will prevent files like .htaccess .htpassword .secret etc from being served
-       location ~ /\. { deny all; }
+    location /cgi-bin {
+        root /usr/lib;
+    }
+
+    # if you don't like seeing all the errors for missing favicon.ico in root
+    location = /favicon.ico { access_log off; log_not_found off; }
+
+    # if you don't like seeing errors for a missing robots.txt in root
+    location = /robots.txt { access_log off; log_not_found off; }
+
+    # this will prevent files like .htaccess .htpassword .secret etc from being served
+    location ~ /\. { deny all; }
 }

--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -19,7 +19,7 @@ server {
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         include fastcgi_params;
     }
- 
+
     location /cgi-bin {
         root /usr/lib;
     }


### PR DESCRIPTION
For https://github.com/learningequality/kolibri/issues/8164.  This should also fix videos on LG devices, according to @nzola.

Tested on RaspiOS with desktop on RPi 4, which confirms that only 100 bytes (rather than the entire file!) are transmitted when running:

```
curl --range 0-99 http://localhost/kolibri/static/kolibri.core.default_frontend/kolibri-logo.svg -o /dev/null
```

_Huge thanks to @jvonau who traced this down._

Ref: #2762 "Notes: Stalled progress on nginx front"