### PR TITLE
MediaWiki 1.36.1 Security Release ETA 2021-06-23

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: 1.36    # "1.35" also works
-mediawiki_minor_version: 0
+mediawiki_minor_version: 1
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Will be released tomorrow:

https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/2WSJ5T2GJQIC45YEB26OGTJM6HKWHEP3/

Ref:

- PR #2806