### PR TITLE
Update Kolibri supported languages from 16 to 25

### DIFF
--- a/roles/kolibri/README.rst
+++ b/roles/kolibri/README.rst
@@ -27,8 +27,8 @@ Automatic Device Provisioning
 When kolibri_provision is enabled (e.g. in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_) the installation will set up the following defaults::
 
   kolibri_facility: Kolibri-in-a-Box   
-  kolibri_language: en     # Options: see KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
-  kolibri_preset: formal   # Options: formal, nonformal, informal
+  kolibri_language: en      # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
+  kolibri_preset: formal    # formal, nonformal, informal
   kolibri_admin_user: Admin
   kolibri_admin_password: changeme
 

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -1,7 +1,7 @@
 # kolibri_install: False
 # kolibri_enabled: False
 
-# kolibri_language: en    # Options: see KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
+# kolibri_language: en    # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 
 # kolibri_http_port: 8009
 

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -1,7 +1,7 @@
 # kolibri_install: False
 # kolibri_enabled: False
 
-# kolibri_language: en    # ar,bn-bd,en,es-es,fa,fr-fr,hi-in,mr,nyn,pt-br,sw-tz,ta,te,ur-pk,yo,zu
+# kolibri_language: en    # Options: see KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 
 # kolibri_http_port: 8009
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -458,7 +458,7 @@ kalite_root: "{{ content_base }}/ka-lite"    # /library/ka-lite
 
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # Options: see KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
+kolibri_language: en    # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 kolibri_http_port: 8009
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -458,7 +458,7 @@ kalite_root: "{{ content_base }}/ka-lite"    # /library/ka-lite
 
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bn-bd,en,es-es,fa,fr-fr,hi-in,mr,nyn,pt-br,sw-tz,ta,te,ur-pk,yo,zu
+kolibri_language: en    # Options: see KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 kolibri_http_port: 8009
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -309,7 +309,7 @@ kalite_enabled: True
 
 kolibri_install: True
 kolibri_enabled: True
-kolibri_language: en    # ar,bn-bd,en,es-es,fa,fr-fr,hi-in,mr,nyn,pt-br,sw-tz,ta,te,ur-pk,yo,zu
+kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -309,7 +309,7 @@ kalite_enabled: True
 
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bn-bd,en,es-es,fa,fr-fr,hi-in,mr,nyn,pt-br,sw-tz,ta,te,ur-pk,yo,zu
+kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -309,7 +309,7 @@ kalite_enabled: True
 
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bn-bd,en,es-es,fa,fr-fr,hi-in,mr,nyn,pt-br,sw-tz,ta,te,ur-pk,yo,zu
+kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True


### PR DESCRIPTION
2 languages have been dropped and 11 added.

Which brings the total number of supported languages up from 16 to 25.

In conjunction with https://github.com/iiab/iiab/blob/master/roles/kolibri/README.rst which has been improved in recent days.

Ref: learningequality/kolibri#8164