### PR TITLE
PHP 8.0 brings a couple changes—slightly affecting Moodle, Nextcloud etc: (1) php8.0-xmlrpc moved to PECL (2) php8.0-json is now baked into PHP itself

### DIFF
--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,15 +25,15 @@
     name: postgresql
 
 
-- name: Install 8 php packages (debuntu)
+- name: Install 7 PHP packages (debuntu)
   package:
     name:
       - php{{ php_version }}-pgsql
       - php{{ php_version }}-curl
       - php{{ php_version }}-zip
-      - php{{ php_version }}-gd
+      #- php{{ php_version }}-gd         # 2021-06-25: Already installed by www_base/tasks/main.yml
       - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
-      - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.
+      - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
       - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
       #- php-sodium                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium AND ALREADY PRE-ENABLED BY PHP 7.2+ https://www.php.net/manual/en/sodium.installation.php AS CONFIRMED BY 'php -i | grep sodium' AND 'apt list "*sodium*"'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,7 +25,7 @@
     name: postgresql
 
 
-- name: Install 7 PHP packages (debuntu)
+- name: Install 7 PHP packages (run 'php -m' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql
@@ -38,7 +38,6 @@
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
       #- php-sodium                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium AND ALREADY PRE-ENABLED BY PHP 7.2+ https://www.php.net/manual/en/sodium.installation.php AS CONFIRMED BY 'php -i | grep sodium' AND 'apt list "*sodium*"'
     state: present
-  when: is_debuntu
 
 - name: Does {{ moodle_base }}/config-dist.php exist? (indicating Moodle is/was installed)
   stat:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,7 +25,7 @@
     name: postgresql
 
 
-- name: Install 6 PHP packages (run 'php -m' to verify)
+- name: Install 6 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,13 +25,13 @@
     name: postgresql
 
 
-- name: Install 7 PHP packages (run 'php -m' to verify)
+- name: Install 6 PHP packages (run 'php -m' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql
-      - php{{ php_version }}-curl
+      #- php{{ php_version }}-curl       # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-zip
-      #- php{{ php_version }}-gd         # 2021-06-25: Already installed by www_base/tasks/main.yml
+      #- php{{ php_version }}-gd         # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
       - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
       - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 9 PHP packages (run 'php -m' to verify)
+- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud
@@ -53,8 +53,8 @@
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
       #- php{{ php_version }}-cli          # Likely optional: @jvonau said this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258 ?  Certainly php{{ php_version }}-common is already installed by www_base/tasks/main.yml
-      - php{{ php_version }}-curl
-      #- php{{ php_version }}-gd           # Already installed by www_base/tasks/main.yml
+      #- php{{ php_version }}-curl         # ALREADY INSTALLED by www_base/tasks/main.yml
+      #- php{{ php_version }}-gd           # ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
       - php{{ php_version }}-imagick       # Optional (for preview generation)
       - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
@@ -67,7 +67,7 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      #- php{{ php_version }}-xml          # Already installed by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-xml          # ALREADY INSTALLED by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       - php{{ php_version }}-zip
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' to verify)
+- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 13 php packages
+- name: Install ffmpeg + libxml2 + 9 PHP packages (run 'php -m' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud
@@ -52,13 +52,13 @@
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
-      - php{{ php_version }}-cli           # Likely optional?  @jvonau says this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
+      #- php{{ php_version }}-cli          # Likely optional: @jvonau said this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258 ?  Certainly php{{ php_version }}-common is already installed by www_base/tasks/main.yml
       - php{{ php_version }}-curl
-      - php{{ php_version }}-gd
+      #- php{{ php_version }}-gd           # Already installed by www_base/tasks/main.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
       - php{{ php_version }}-imagick       # Optional (for preview generation)
       - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
-      - php{{ php_version }}-json
+      #- php{{ php_version }}-json         # Part of PHP 8.0+ core, so MOVED to stanza just below.
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
       - php{{ php_version }}-mbstring
       - php{{ php_version }}-mysql
@@ -67,10 +67,16 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-xml          # Already installed by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       - php{{ php_version }}-zip
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
+
+- name: Install php{{ php_version }}-json if PHP < 8.0
+  package:
+    name: php{{ php_version }}-json
+    state: present
+  when: php_version is version('8.0', '<')
 
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 #- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: Install 9 PHP packages
+- name: Install 9 PHP packages (run 'php -m' to verify)
   package:
     name:
       # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: Install 9 PHP packages (run 'php -m' to verify)
+- name: Install 9 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -5,16 +5,16 @@
   package:
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
-      - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      - php{{ php_version }}-curl      # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
-      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli if absolutely nec?
+      - php{{ php_version }}-curl      # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-gd        # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql
       - php{{ php_version }}-odbc
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      - php{{ php_version }}-xml          # nextcloud/tasks/install.yml needs this!
+      - php{{ php_version }}-xml          # 2021-06-25: nextcloud/tasks/install.yml used to install this (and might still benefit!)
       #- php{{ php_version }}-xmlrpc      # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
 

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -6,8 +6,8 @@
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
       - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      - php{{ php_version }}-curl
-      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml needs this!
+      - php{{ php_version }}-curl      # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: 'Install ~10 PHP packages (debuntu)'
+- name: Install 9 PHP packages
   package:
     name:
       # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
@@ -15,9 +15,14 @@
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
       - php{{ php_version }}-xml    # Was below
-      - php{{ php_version }}-xmlrpc
+      #- php{{ php_version }}-xmlrpc    # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
-  when: is_debuntu
+
+- name: Install php{{ php_version }}-xmlrpc if PHP < 8.0
+  package:
+    name: php{{ php_version }}-xmlrpc
+    state: present
+  when: php_version is version('8.0', '<')
 
 - name: Using html.yml
   include_tasks: html.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -4,18 +4,18 @@
 - name: Install 9 PHP packages (run 'php -m' to verify)
   package:
     name:
-      # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
+      # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
       - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
       - php{{ php_version }}-curl
-      - php{{ php_version }}-gd
+      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml needs this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql
       - php{{ php_version }}-odbc
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      - php{{ php_version }}-xml    # Was below
-      #- php{{ php_version }}-xmlrpc    # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
+      - php{{ php_version }}-xml          # nextcloud/tasks/install.yml needs this!
+      #- php{{ php_version }}-xmlrpc      # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
 
 - name: Install php{{ php_version }}-xmlrpc if PHP < 8.0


### PR DESCRIPTION
WIP for #2814 (PHP 8) and #2818 (Ubuntu 21.10).

This PR will be re-tested on Ubuntu Server 21.10 pre-release and other OS's.