### PR TITLE
Audit & Clean roles' PHP 7.x & 8.0 PHP module dependencies [MediaWiki, Moodle, MySQL, Nextcloud, NGINX, FreePBX]

### DIFF
--- a/roles/1-prep/README.rst
+++ b/roles/1-prep/README.rst
@@ -2,7 +2,14 @@
 1-prep README
 =============
 
-This 1st stage is primarily hardware-focused, prior to OS additions/mods.
+This 1st stage is primarily hardware-focused, prior to OS
+additions/mods, but also includes critical pieces sometimes needed for
+remote support:
 
-Traditionally it included preliminaries like hostname and things specific to a
-particular platform, such as the XO laptop, done before the bulk of the install.
+- SSH
+- Administrator security (username iiab-admin by default)
+- OpenVPN software if/as needed later for remote support
+
+Traditionally it included preliminaries like hostname and things
+specific to a particular platform, such as the XO laptop, done before
+the bulk of the install.

--- a/roles/1-prep/README.rst
+++ b/roles/1-prep/README.rst
@@ -2,14 +2,15 @@
 1-prep README
 =============
 
-This 1st stage is primarily hardware-focused, prior to OS
+This 1st stage (1-prep) is primarily hardware-focused, prior to OS
 additions/mods, but also includes critical pieces sometimes needed for
 remote support:
 
 - SSH
-- Administrator security (username iiab-admin by default)
+- `iiab-admin <https://github.com/iiab/iiab/tree/master/roles/iiab-admin>`_ username and group to log into Admin Console
 - OpenVPN software if/as needed later for remote support
 
-Traditionally it included preliminaries like hostname and things
-specific to a particular platform, such as the XO laptop, done before
-the bulk of the install.
+Traditionally 1-prep also included preliminaries like hostname and
+hardware-oriented things specific to a particular platform (such as
+One Laptop Per Child's XO laptop) i.e. critical setup prior to the
+bulk of IIAB's software install.

--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -4,10 +4,14 @@
 
 This 3rd stage installs base server infra that Internet-in-a-Box requires, including:
 
-- MySQL (the database underlying many/most user-facing apps)
+- MySQL (database underlying many/most user-facing apps)
 - NGINX web server (with Apache in some lingering cases)
-- *PHP core packages are installed by the above 2 roles e.g. ``php{{ php_version }}-common``, ``php{{ php_version }}-cli``, ``php{{ php_version }}-fpm``, ``php{{ php_version }}-mysql``*
+- *A few core PHP packages are also installed by the above 2 roles, e.g.*
+   - php{{ php_version }}-common
+   - php{{ php_version }}-cli
+   - php{{ php_version }}-fpm
+   - php{{ php_version }}-mysql
 
-4-server-options follows with more diverse/optional server infra functionality.
+As with 2-common, 4-server-options and 5-xo-services: this stage installs core server infra, that is not user-facing.
 
-As in the case of 2-common, 4-server-options and 5-xo-services: this stage installs core server infra, that is not user-facing.
+The next stage (4-server-options) brings more diverse/optional server infra functionality.

--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -5,7 +5,7 @@
 This 3rd stage installs base server infra that Internet-in-a-Box requires, including:
 
 - MySQL (database underlying many/most user-facing apps)
-- NGINX web server (with Apache in some lingering cases)
+- `NGINX <https://github.com/iiab/iiab/blob/master/roles/nginx/README.md>`_ web server (with Apache in some lingering cases)
 - *A few core PHP packages are also installed by the above 2 roles, e.g.*
    - php{{ php_version }}-common
    - php{{ php_version }}-cli

--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -4,9 +4,9 @@
 
 This 3rd stage installs base server infra that Internet-in-a-Box requires, including:
 
-- the web server (Apache for now, possibly NGINX in future)
-- administrator security (username iiab-admin by default)
 - MySQL (the database underlying many/most user-facing apps)
+- NGINX web server (with Apache in some lingering cases)
+- *PHP core packages are installed by the above 2 roles e.g. ``php{{ php_version }}-common``, ``php{{ php_version }}-cli``, ``php{{ php_version }}-fpm``, ``php{{ php_version }}-mysql``*
 
 4-server-options follows with more diverse/optional server infra functionality.
 

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: ...IS BEGINNING =====================================
   command: echo
 
-- name: MYSQL
+- name: MYSQL + PHP CORE
   include_role:
     name: mysql
   #when: mysql_install

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: ...IS BEGINNING =====================================
   command: echo
 
-- name: MYSQL + PHP CORE
+- name: MYSQL + CORE PHP
   include_role:
     name: mysql
   #when: mysql_install
@@ -19,7 +19,7 @@
 #
 # SEE ALSO: https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
 
-- name: NGINX
+- name: NGINX + CORE PHP
   include_role:
     name: nginx
   #when: nginx_install

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: "2021-06-27 TEMPORARY CODE TO INSTALL 'php-pear' UNTIL ADMIN CONSOLE DECLARES ITS OWN DEPENDENCY FOR: https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19"
   package:
-    name: php-pear    # WARNING: this also drags in 'php{{ php_version }}-xml' (affecting MediaWiki, Nextcloud, roles/pbx's FreePBX) AND 'php{{ php_version }}-cgi' (affecting roles/pbx's FreePBX)
+    name: php-pear    # WARNING: this also drags in 'php{{ php_version }}-xml' (also installed by MediaWiki, Nextcloud, roles/pbx's FreePBX) AND 'php{{ php_version }}-cgi' (also installed by roles/pbx's FreePBX)
     state: present
   when: admin_console_install
 

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -34,6 +34,7 @@
   package:
     name: php-pear    # WARNING: this also drags in 'php{{ php_version }}-xml' (affecting MediaWiki, Nextcloud, roles/pbx's FreePBX) AND 'php{{ php_version }}-cgi' (affecting roles/pbx's FreePBX)
     state: present
+  when: admin_console_install
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -30,6 +30,11 @@
     name: calibre-web
   when: calibreweb_install
 
+- name: "2021-06-27 TEMPORARY CODE TO INSTALL 'php-pear' UNTIL ADMIN CONSOLE DECLARES ITS OWN DEPENDENCY FOR: https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19"
+  package:
+    name: php-pear    # WARNING: this also drags in 'php{{ php_version }}-xml' (affecting MediaWiki, Nextcloud, roles/pbx's FreePBX) AND 'php{{ php_version }}-cgi' (affecting roles/pbx's FreePBX)
+    state: present
+
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     path: "{{ iiab_env_file }}"

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -1,14 +1,13 @@
-- name: 'Install 4 packages: apache2, libapache2-mod-php{{ php_version }}, php{{ php_version }}, php{{ php_version }}-curl'
+- name: 'Install 2 packages: {{ apache_service }}, libapache2-mod-php{{ php_version }}'
   package:
     #name: [u'apache2', u'php{{ php_version }}', u'php{{ php_version }}-curl']    # FAILS ('u' for Unicode strings)
     #name: ['apache2', 'php{{ php_version }}', 'php{{ php_version }}-curl']       # WORKS?
     name:
       - "{{ apache_service }}"    # apache2 on Debuntu
-      - "libapache2-mod-php{{ php_version }}"    # 2020-06-15: Required (e.g. for Elgg, Moodle & possibly others) now that mysql/tasks/install.yml installs "php{{ php_version }}-common" rather than the full "php{{ php_version }}"
+      - libapache2-mod-php{{ php_version }}    # 2020-06-15: Required (e.g. for Elgg, Moodle & possibly others) now that mysql/tasks/install.yml installs "php{{ php_version }}-common" rather than the full "php{{ php_version }}"
 #      - "php{{ php_version }}"
 #      - "php{{ php_version }}-curl"
     state: present
-  when: is_debuntu
 #  when: is_debian
 
 # - name: 'Install 2 packages: apache2, php (ubuntu)'

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -4,7 +4,7 @@
     #name: ['apache2', 'php{{ php_version }}', 'php{{ php_version }}-curl']       # WORKS?
     name:
       - "{{ apache_service }}"    # apache2 on Debuntu
-      - libapache2-mod-php{{ php_version }}    # 2020-06-15: Required (e.g. for Elgg, Moodle & possibly others) now that mysql/tasks/install.yml installs "php{{ php_version }}-common" rather than the full "php{{ php_version }}"
+      - libapache2-mod-php{{ php_version }}    # 2020-06-15: Required (e.g. for Elgg, Moodle & possibly others) now that mysql/tasks/install.yml installs "php{{ php_version }}-common" rather than the full "php{{ php_version }}" -- 2021-06-28 FYI: this also drags in libsodium23 (likewise installed via nginx/tasks/install.yml AND moodle/tasks/install.yml)
       #- "php{{ php_version }}"
       #- "php{{ php_version }}-curl"
     state: present

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -5,8 +5,8 @@
     name:
       - "{{ apache_service }}"    # apache2 on Debuntu
       - libapache2-mod-php{{ php_version }}    # 2020-06-15: Required (e.g. for Elgg, Moodle & possibly others) now that mysql/tasks/install.yml installs "php{{ php_version }}-common" rather than the full "php{{ php_version }}"
-#      - "php{{ php_version }}"
-#      - "php{{ php_version }}-curl"
+      #- "php{{ php_version }}"
+      #- "php{{ php_version }}-curl"
     state: present
 #  when: is_debian
 
@@ -38,29 +38,29 @@
 #  when: is_debuntu and (not is_debian_8) and (not is_ubuntu_16)
 #  #when: (is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18
 
-- name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'
-  package:
-    #name: [u'httpd', u'php', u'php-curl', u'mod_authnz_external']    # FAILS ('u' for Unicode strings)
-    #name: ['httpd', 'php', 'php-curl', 'mod_authnz_external']        # WORKS
-    name:
-      - httpd
-      - mod_authnz_external
-      - php
-      - php-curl
-    state: present
-  when: is_redhat
+#- name: 'Install 4 packages: httpd, mod_authnz_external, php, php-curl (redhat)'
+#  package:
+#    #name: [u'httpd', u'php', u'php-curl', u'mod_authnz_external']    # FAILS ('u' for Unicode strings)
+#    #name: ['httpd', 'php', 'php-curl', 'mod_authnz_external']        # WORKS
+#    name:
+#      - httpd
+#      - mod_authnz_external
+#      - php
+#      - php-curl
+#    state: present
+#  when: is_redhat
 
 # Remove symlinks for mpm_event, replace with mpm_prefork
-- name: Remove both mpm_event symlinks from /etc/apache2/mods-enabled (debuntu)
+- name: Remove both mpm_event symlinks from /etc/apache2/mods-enabled
   file:
     path: "/etc/apache2/mods-enabled/{{ item }}"
     state: absent
   with_items:
     - mpm_event.conf
     - mpm_event.load
-  when: is_debuntu
+  #when: is_debuntu
 
-- name: Create both mpm_prefork symlinks from /etc/apache2/mods-enabled to /etc/apache2/mods-available (debuntu)
+- name: Create both mpm_prefork symlinks from /etc/apache2/mods-enabled to /etc/apache2/mods-available
   file:
     src: "/etc/apache2/mods-available/{{ item }}"
     path: "/etc/apache2/mods-enabled/{{ item }}"
@@ -68,9 +68,9 @@
   with_items:
     - mpm_prefork.conf
     - mpm_prefork.load
-  when: is_debuntu
+  #when: is_debuntu
 
-- name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc--if debuntu)'
+- name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc)'
   apache2_module:
     name: "{{ item }}"
   with_items:
@@ -79,16 +79,16 @@
     - proxy_html
     - proxy_http
     - rewrite
-  when: is_debuntu
+  #when: is_debuntu
 
-- name: Remove 000-default.conf from /etc/apache2 and /etc/apache2/sites-enabled (debuntu)
+- name: Remove 000-default.conf from /etc/apache2 and /etc/apache2/sites-enabled
   file:
     path: "{{ item }}"
     state: absent
   with_items:
     - /etc/apache2/000-default.conf    # Not nec on Raspbian.  Is this really still needed elsewhere?
     - /etc/apache2/sites-enabled/000-default.conf
-  when: is_debuntu
+  #when: is_debuntu
 
 - name: Create Apache's pid dir /var/run/{{ apache_user }}
   file:

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,8 +1,10 @@
 - name: 'Install packages: php{{ php_version }}-intl, php{{ php_version }}-mbstring'
   package:
     name:
-      - "php{{ php_version }}-intl"
-      - "php{{ php_version }}-mbstring"
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      - php{{ php_version }}-intl
+      - php{{ php_version }}-mbstring
+      - php{{ php_version }}-xml    # 
     state: present
 
 - name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -4,7 +4,7 @@
       #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-intl        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-mbstring    # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-xml         # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-xml         # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
     state: present
 
 - name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,7 +1,7 @@
 - name: 'Install packages: php{{ php_version }}-intl, php{{ php_version }}-mbstring, php{{ php_version }}-xml'
   package:
     name:
-      #- php{{ php_version }}-common     # Auto-installed as an apt dependency
+      #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-intl        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-mbstring    # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-xml         # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -4,7 +4,7 @@
       #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-intl        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-mbstring    # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-xml         # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
+      - php{{ php_version }}-xml         # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
     state: present
 
 - name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,10 +1,10 @@
-- name: 'Install packages: php{{ php_version }}-intl, php{{ php_version }}-mbstring'
+- name: 'Install packages: php{{ php_version }}-intl, php{{ php_version }}-mbstring, php{{ php_version }}-xml'
   package:
     name:
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
-      - php{{ php_version }}-intl
-      - php{{ php_version }}-mbstring
-      - php{{ php_version }}-xml    # 
+      #- php{{ php_version }}-common     # Auto-installed as an apt dependency
+      - php{{ php_version }}-intl        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-mbstring    # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-xml         # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
     state: present
 
 - name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -29,8 +29,8 @@
   package:
     name:
       - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
-      #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      #- php{{ php_version }}-cli        # 2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common.  REGARDLESS: this is installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      #- php{{ php_version }}-common     # 2021-06-27: Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      #- php{{ php_version }}-cli        # 2021-06-27: Compare to php{{ php_version }}-common just above!  2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.
       - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-intl        # 2020-12-03: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- Required by Moodle 3.10+

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -29,12 +29,12 @@
   package:
     name:
       - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
-      #- php{{ php_version }}-common     # Auto-installed as an apt dependency
-      #- php{{ php_version }}-cli        # 2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
+      #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      #- php{{ php_version }}-cli        # 2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common.  REGARDLESS: this is installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-intl        # 2020-12-03: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- required by Moodle 3.10+
-      - php{{ php_version }}-mbstring    # 2020-06-15: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- required by Moodle 3.9+
+      - php{{ php_version }}-intl        # 2020-12-03: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- Required by Moodle 3.10+
+      - php{{ php_version }}-mbstring    # 2020-06-15: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- Required by Moodle 3.9+
       - php{{ php_version }}-pgsql       # 2021-06-27: Required for PostgreSQL
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
       #- php{{ php_version }}-xmlrpc     # 2021-06-27: Required per https://docs.moodle.org/19/en/PHP_settings_by_Moodle_version#PHP_Extensions_and_libraries BUT UNMAINTAINED FOR YEARS (POSSIBLE SECURITY RISK) SO MOVED TO PECL: https://php.watch/versions/8.0/xmlrpc

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,15 +25,15 @@
     name: postgresql
 
 
-- name: Install 8 php packages (debuntu)
+- name: Install 7 PHP packages (debuntu)
   package:
     name:
       - php{{ php_version }}-pgsql
       - php{{ php_version }}-curl
       - php{{ php_version }}-zip
-      - php{{ php_version }}-gd
+      #- php{{ php_version }}-gd         # 2021-06-25: Already installed by www_base/tasks/main.yml
       - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
-      - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.
+      - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
       - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
       #- php-sodium                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium AND ALREADY PRE-ENABLED BY PHP 7.2+ https://www.php.net/manual/en/sodium.installation.php AS CONFIRMED BY 'php -i | grep sodium' AND 'apt list "*sodium*"'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,7 +25,7 @@
     name: postgresql
 
 
-- name: Install 7 PHP packages (debuntu)
+- name: Install 7 PHP packages (run 'php -m' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql
@@ -38,7 +38,6 @@
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
       #- php-sodium                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium AND ALREADY PRE-ENABLED BY PHP 7.2+ https://www.php.net/manual/en/sodium.installation.php AS CONFIRMED BY 'php -i | grep sodium' AND 'apt list "*sodium*"'
     state: present
-  when: is_debuntu
 
 - name: Does {{ moodle_base }}/config-dist.php exist? (indicating Moodle is/was installed)
   stat:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,7 +25,7 @@
     name: postgresql
 
 
-- name: Install 6 PHP packages (run 'php -m' to verify)
+- name: Install 6 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -28,7 +28,7 @@
 - name: Install libsodium23 + 7 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
-      - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
+      - libsodium23                      # 2021-06-28: Likewise installed by nginx/tasks/install.yml via php{{ php_version }}-fpm AND httpd/tasks/install.yml via libapache2-mod-php{{ php_version }} -- it can ALSO be auto-installed by phpX.Y-cgi OR phpX.Y-cli as confirmed by 'apt rdepends libsodium23' -- Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
       #- php{{ php_version }}-common     # 2021-06-27: Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       #- php{{ php_version }}-cli        # 2021-06-27: Compare to php{{ php_version }}-common just above!  2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.
       - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,18 +25,19 @@
     name: postgresql
 
 
-- name: Install 6 PHP packages (run 'php -m' or 'php -i' to verify)
+- name: Install libsodium23 + 7 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
-      - php{{ php_version }}-pgsql
-      #- php{{ php_version }}-curl       # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
-      - php{{ php_version }}-zip
-      #- php{{ php_version }}-gd         # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
-      - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
-      - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
+      #- php{{ php_version }}-common     # Auto-installed as an apt dependency
+      #- php{{ php_version }}-cli        # 2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
+      - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
+      - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
       - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+
+      - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
+      - php{{ php_version }}-pgsql
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
-      #- php-sodium                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium AND ALREADY PRE-ENABLED BY PHP 7.2+ https://www.php.net/manual/en/sodium.installation.php AS CONFIRMED BY 'php -i | grep sodium' AND 'apt list "*sodium*"'
+      - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
+      - php{{ php_version }}-zip         # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
     state: present
 
 - name: Does {{ moodle_base }}/config-dist.php exist? (indicating Moodle is/was installed)

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -37,6 +37,7 @@
       - php{{ php_version }}-mbstring    # 2020-06-15: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- Required by Moodle 3.9+
       - php{{ php_version }}-pgsql       # 2021-06-27: Required for PostgreSQL
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
+      - php{{ php_version }}-xml         # 2021-06-28: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
       #- php{{ php_version }}-xmlrpc     # 2021-06-27: Required per https://docs.moodle.org/19/en/PHP_settings_by_Moodle_version#PHP_Extensions_and_libraries BUT UNMAINTAINED FOR YEARS (POSSIBLE SECURITY RISK) SO MOVED TO PECL: https://php.watch/versions/8.0/xmlrpc
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
     state: present
@@ -138,9 +139,13 @@
     path: "{{ moodle_base }}/config.php"
   register: config
 
+- pause:
+
 - name: Execute {{ moodle_base }}/moodle_installer
   shell: "{{ moodle_base }}/moodle_installer"
   when: config.stat.exists is defined and not config.stat.exists
+
+- pause:
 
 # 2021-02-01: Let's stick with Moodle's default (640)
 #- name: Make {{ moodle_base }}/config.php readable, with permission '0644'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -25,13 +25,13 @@
     name: postgresql
 
 
-- name: Install 7 PHP packages (run 'php -m' to verify)
+- name: Install 6 PHP packages (run 'php -m' to verify)
   package:
     name:
       - php{{ php_version }}-pgsql
-      - php{{ php_version }}-curl
+      #- php{{ php_version }}-curl       # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-zip
-      #- php{{ php_version }}-gd         # 2021-06-25: Already installed by www_base/tasks/main.yml
+      #- php{{ php_version }}-gd         # 2021-06-25: ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
       - php{{ php_version }}-cli         # 2020-06-15: In the past this included (above) mbstring? However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
       - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -139,13 +139,9 @@
     path: "{{ moodle_base }}/config.php"
   register: config
 
-- pause:
-
 - name: Execute {{ moodle_base }}/moodle_installer
   shell: "{{ moodle_base }}/moodle_installer"
   when: config.stat.exists is defined and not config.stat.exists
-
-- pause:
 
 # 2021-02-01: Let's stick with Moodle's default (640)
 #- name: Make {{ moodle_base }}/config.php readable, with permission '0644'

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -28,16 +28,17 @@
 - name: Install libsodium23 + 7 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
+      - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
       #- php{{ php_version }}-common     # Auto-installed as an apt dependency
       #- php{{ php_version }}-cli        # 2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.  FYI php{{ php_version }}-cli is a superset of php{{ php_version }}-common
-      - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
-      - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
-      - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+
-      - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+
-      - php{{ php_version }}-pgsql
+      - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-intl        # 2020-12-03: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- required by Moodle 3.10+
+      - php{{ php_version }}-mbstring    # 2020-06-15: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- required by Moodle 3.9+
+      - php{{ php_version }}-pgsql       # 2021-06-27: Required for PostgreSQL
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
-      - libsodium23                      # 2021-05-17: Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- this can be auto-installed by phpX.Y-fpm or phpX.Y-cgi or phpX.Y-cli, according to 'apt rdepends libsodium23 | grep php' -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- GIVEN THE AMBIGUITY, PLEASE VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
-      - php{{ php_version }}-zip         # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml
+      #- php{{ php_version }}-xmlrpc     # 2021-06-27: Required per https://docs.moodle.org/19/en/PHP_settings_by_Moodle_version#PHP_Extensions_and_libraries BUT UNMAINTAINED FOR YEARS (POSSIBLE SECURITY RISK) SO MOVED TO PECL: https://php.watch/versions/8.0/xmlrpc
+      - php{{ php_version }}-zip         # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
     state: present
 
 - name: Does {{ moodle_base }}/config-dist.php exist? (indicating Moodle is/was installed)

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -1,9 +1,12 @@
 # 2021-05-22: FYI nginx_high_php_limits is effectively now auto-enabled by
-# www_options/tasks/main.yml#L81-L94 (as required by Moodle 3.11 with PHP 8) IF
+# www_options/tasks/main.yml#L100-L112 (as required by Moodle 3.11 w/ PHP 8) IF
 # 'moodle_install: True'. Happens at the end of 4-server-options/tasks/main.yml
 # See the 6 settings in /etc/php/{{ php_version }}/fpm/php.ini -- which Moodle
 # should take advantage of soon, as it transitions from Apache to Moodle: #2785
 
+# 2021-06-28: This ALSO now happens in /etc/php/{{ php_version }}/cli/php.ini
+# (as required by Moodle's CLI installer) AND THIRDLY below (for now, until
+# Moodle's ported to NGINX!) in /etc/php/{{ php_version }}/apache2/php.ini
 
 - name: "Set 'apache_install: True' and 'apache_enabled: True'"
   set_fact:
@@ -13,6 +16,21 @@
 - name: APACHE - run 'httpd' role
   include_role:
     name: httpd
+
+- name: "Enact the equivalent of 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/{{ apache_service }}/php.ini for Moodle 3.11+"
+  lineinfile:
+    path: /etc/php/{{ php_version }}/{{ apache_service }}/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/cli/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
+    - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
+    - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
+    - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
+    - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
+    - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+
+# Apache's restarted prior to moodle_installer below, so no need right here!
 
 
 - name: "Set 'postgresql_install: True' and 'postgresql_enabled: True'"
@@ -139,7 +157,7 @@
     path: "{{ moodle_base }}/config.php"
   register: config
 
-- name: Execute {{ moodle_base }}/moodle_installer
+- name: Execute {{ moodle_base }}/moodle_installer -- REQUIRES 'max_input_vars = 5000' (or higher) in /etc/php/{{ php_version }}/cli/php.ini with PHP 8+ (as set up by www_options/tasks/main.yml) -- WHEREAS Moodle uses /etc/php/{{ php_version }}/{{ apache_service }}/php.ini or /etc/php/{{ php_version }}/fpm/php.ini during regular operation
   shell: "{{ moodle_base }}/moodle_installer"
   when: config.stat.exists is defined and not config.stat.exists
 

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -11,7 +11,7 @@
       - mariadb-server
       - mariadb-client
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-mysql
+      - php{{ php_version }}-mysql      # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
     state: present
 
 # 2020-07-11:

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -10,7 +10,7 @@
     name:
       - mariadb-server
       - mariadb-client
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-mysql
     state: present
 

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -5,13 +5,14 @@
 # - 7 DB config
 # - 2 record as installed
 
-- name: 'Install MySQL packages: mariadb-server, mariadb-client (debuntu)'
+- name: 'Install MySQL packages: mariadb-server, mariadb-client, php{{ php_version }}-mysql'
   package:
     name:
       - mariadb-server
       - mariadb-client
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      - php{{ php_version }}-mysql
     state: present
-  when: is_debuntu
 
 # 2020-07-11:
 # 10 PHP package installs moved to roles/www_base/tasks/main.yml

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -58,7 +58,7 @@
       - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
-      - php-imagick                        # Optional (for preview generation).  Drags in many deps (apt depends php-imagick).  FYI php{{ php_version }}-imagick appears flawed: (1) 'apt depends php7.4-imagick' yields incomplete output; (2) Version-in-name package not available according to: apt list "php*imagick"
+      - php-imagick                        # Optional (for preview generation).  BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.
       - php{{ php_version }}-intl          # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml -- Optional (increases language translation performance and fixes sorting of non-ASCII characters)
       #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -39,7 +39,7 @@
 # - debug:
 #     var: php_new
 
-
+# February 2020: See @m-anish's PR #2119 and follow-up PR #2258.
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-06-27: Use this after Nextcloud 22 is released "2021-07-06" :
@@ -53,7 +53,7 @@
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
-      #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  @jvonau said php{{ php_version }}-cli drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
+      #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -69,7 +69,7 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- Nextcloud's official requirements include {SimpleXML, XMLReader, XMLWriter} as confirmed by 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
+      - php{{ php_version }}-xml           # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- Nextcloud's official requirements include {SimpleXML, XMLReader, XMLWriter} as confirmed by 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove, as explained in moodle/tasks/install.yml
       - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -40,10 +40,11 @@
 #     var: php_new
 
 
-# https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' or 'php -i' to verify)
+# 2021-06-27: Use this after Nextcloud 22 is released "2021-07-06" :
+# https://docs.nextcloud.com/server/22/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+- name: Install ffmpeg + libxml2 + 11 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud
@@ -52,13 +53,13 @@
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
-      #- php{{ php_version }}-cli          # Likely optional: @jvonau said this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258 ?  Certainly php{{ php_version }}-common is already installed by www_base/tasks/main.yml
-      #- php{{ php_version }}-curl         # ALREADY INSTALLED by www_base/tasks/main.yml
-      #- php{{ php_version }}-gd           # ALREADY INSTALLED by www_base/tasks/main.yml
+      #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  @jvonau said php{{ php_version }}-cli drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
+      - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml
+      - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
-      - php{{ php_version }}-imagick       # Optional (for preview generation)
+      - php-imagick                        # Optional (for preview generation).  Drags in many deps (apt depends php-imagick).  FYI php{{ php_version }}-imagick appears flawed: (1) 'apt depends php7.4-imagick' yields incomplete output; (2) Version-in-name package not available according to 'apt list "php*imagick"'
       - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
-      #- php{{ php_version }}-json         # Part of PHP 8.0+ core, so MOVED to stanza just below.
+      #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
       - php{{ php_version }}-mbstring
       - php{{ php_version }}-mysql
@@ -67,16 +68,20 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      #- php{{ php_version }}-xml          # ALREADY INSTALLED by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml -- NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove
       - php{{ php_version }}-zip
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
 
-- name: Install php{{ php_version }}-json if PHP < 8.0
-  package:
-    name: php{{ php_version }}-json
-    state: present
-  when: php_version is version('8.0', '<')
+# For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
+# For PHP <  8.0: Auto-installed by phpX.Y-fpm AND phpX.Y-cli in roles/3-base-server, as confirmed by: apt rdepends phpX.Y-json
+#
+#- name: Install php{{ php_version }}-json if PHP < 8.0
+#  package:
+#    name: php{{ php_version }}-json
+#    state: present
+#  when: php_version is version('8.0', '<')
 
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 #- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 9 PHP packages (run 'php -m' to verify)
+- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud
@@ -53,8 +53,8 @@
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
       #- php{{ php_version }}-cli          # Likely optional: @jvonau said this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258 ?  Certainly php{{ php_version }}-common is already installed by www_base/tasks/main.yml
-      - php{{ php_version }}-curl
-      #- php{{ php_version }}-gd           # Already installed by www_base/tasks/main.yml
+      #- php{{ php_version }}-curl         # ALREADY INSTALLED by www_base/tasks/main.yml
+      #- php{{ php_version }}-gd           # ALREADY INSTALLED by www_base/tasks/main.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
       - php{{ php_version }}-imagick       # Optional (for preview generation)
       - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
@@ -67,7 +67,7 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      #- php{{ php_version }}-xml          # Already installed by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-xml          # ALREADY INSTALLED by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       - php{{ php_version }}-zip
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -76,7 +76,7 @@
     state: present
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
-# For PHP <  8.0: Auto-installed by phpX.Y-fpm AND phpX.Y-cli in roles/3-base-server, as confirmed by: apt rdepends phpX.Y-json
+# For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
 #
 #- name: Install php{{ php_version }}-json if PHP < 8.0
 #  package:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -39,6 +39,7 @@
 # - debug:
 #     var: php_new
 
+
 # February 2020: See @m-anish's PR #2119 and follow-up PR #2258.
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
@@ -57,7 +58,7 @@
       - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
-      - php-imagick                        # Optional (for preview generation).  Drags in many deps (apt depends php-imagick).  FYI php{{ php_version }}-imagick appears flawed: (1) 'apt depends php7.4-imagick' yields incomplete output; (2) Version-in-name package not available according to 'apt list "php*imagick"'
+      - php-imagick                        # Optional (for preview generation).  Drags in many deps (apt depends php-imagick).  FYI php{{ php_version }}-imagick appears flawed: (1) 'apt depends php7.4-imagick' yields incomplete output; (2) Version-in-name package not available according to: apt list "php*imagick"
       - php{{ php_version }}-intl          # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml -- Optional (increases language translation performance and fixes sorting of non-ASCII characters)
       #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -54,23 +54,23 @@
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
       #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  @jvonau said php{{ php_version }}-cli drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
-      - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml
-      - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml
+      - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
       - php-imagick                        # Optional (for preview generation).  Drags in many deps (apt depends php-imagick).  FYI php{{ php_version }}-imagick appears flawed: (1) 'apt depends php7.4-imagick' yields incomplete output; (2) Version-in-name package not available according to 'apt list "php*imagick"'
-      - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
+      - php{{ php_version }}-intl          # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml -- Optional (increases language translation performance and fixes sorting of non-ASCII characters)
       #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
-      - php{{ php_version }}-mbstring
-      - php{{ php_version }}-mysql
+      - php{{ php_version }}-mbstring      # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-mysql         # Likewise installed by mysql/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-openssl      # NOT INSTALLABLE: ENABLED BY DEFAULT?
-      #- php{{ php_version }}-pdo_mysql    # NOT INSTALLABLE: php-mysql handles this on all OS's?
+      #- php{{ php_version }}-pdo_mysql    # NOT INSTALLABLE: php{{ php_version }}-mysql handles this on all OS's?
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml -- NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove
-      - php{{ php_version }}-zip
+      - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
 

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -69,7 +69,7 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- Nextcloud' official requirements include {SimpleXML, XMLReader, XMLWriter} -- on Raspbian 'php -m | grep -i xml' in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
+      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- Nextcloud's official requirements include {SimpleXML, XMLReader, XMLWriter} as confirmed by 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove, as explained in moodle/tasks/install.yml
       - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -69,7 +69,7 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- Nextcloud' official requirements include {SimpleXML, XMLReader, XMLWriter} -- on Raspbian 'php -m | grep -i xml' in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove, as explained in moodle/tasks/install.yml
       - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' to verify)
+- name: Install ffmpeg + libxml2 + 8 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # 2021-04-11: If you're running Nextcloud 21+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-- name: Install ffmpeg + libxml2 + 13 php packages
+- name: Install ffmpeg + libxml2 + 9 PHP packages (run 'php -m' to verify)
   package:
     name:
       #- dnsutils    # NOT REQUESTED by Nextcloud
@@ -52,13 +52,13 @@
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
-      - php{{ php_version }}-cli           # Likely optional?  @jvonau says this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258
+      #- php{{ php_version }}-cli          # Likely optional: @jvonau said this drags in php{{ php_version }}-common as @m-anish wanted in PR #2119 / #2258 ?  Certainly php{{ php_version }}-common is already installed by www_base/tasks/main.yml
       - php{{ php_version }}-curl
-      - php{{ php_version }}-gd
+      #- php{{ php_version }}-gd           # Already installed by www_base/tasks/main.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
       - php{{ php_version }}-imagick       # Optional (for preview generation)
       - php{{ php_version }}-intl          # Optional (increases language translation performance and fixes sorting of non-ASCII characters)
-      - php{{ php_version }}-json
+      #- php{{ php_version }}-json         # Part of PHP 8.0+ core, so MOVED to stanza just below.
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
       - php{{ php_version }}-mbstring
       - php{{ php_version }}-mysql
@@ -67,10 +67,16 @@
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
+      #- php{{ php_version }}-xml          # Already installed by www_base/tasks/main.yml.  NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
       - php{{ php_version }}-zip
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
+
+- name: Install php{{ php_version }}-json if PHP < 8.0
+  package:
+    name: php{{ php_version }}-json
+    state: present
+  when: php_version is version('8.0', '<')
 
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 #- name: Install 9 additional php packages, if OS is not Raspbian (these are not available on Raspbian on RPi, as of Feb 2020)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -69,7 +69,7 @@
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
       - php{{ php_version }}-xml           # Likewise installed by mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- NOT FORMALLY REQUESTED by Nextcloud (BUT hopefully delivers php-simplexml if not {php-xmlreader, php-xmlwriter} on Raspbian?)
-      #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove
+      #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove, as explained in moodle/tasks/install.yml
       - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present

--- a/roles/nextcloud/tasks/nginx.yml
+++ b/roles/nextcloud/tasks/nginx.yml
@@ -16,4 +16,4 @@
     state: restarted
   with_items:
     - nginx
-    - "php{{ php_version }}-fpm"
+    - php{{ php_version }}-fpm

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -5,12 +5,14 @@
   ignore_errors: yes
   # 'when: apache_installed is defined' insuff b/c mysql's php installs apache2
 
-- name: 'Install 5 packages for NGINX: libnginx-mod-http-subs-filter, nginx-extras, php-fpm, uwsgi, uwsgi-plugin-python3'
+- name: 'Install 5 packages for NGINX: libnginx-mod-http-subs-filter, nginx-extras, php{{ php_version }}-fpm, uwsgi, uwsgi-plugin-python3 -- TEMPORARILY ALSO php-pear UNTIL ADMIN CONSOLE DECLARES ITS OWN DEPENDENCY FOR: https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19'
   package:
     name:
       - libnginx-mod-http-subs-filter
       - nginx-extras
-      - php-fpm
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      - php{{ php_version }}-fpm    # Drags in php{{ php_version }}-cli
+      - php-pear    # 2021-06-27: TEMPORARY, SEE 7 LINES ABOVE!
       - uwsgi
       - uwsgi-plugin-python3
     state: present

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -11,8 +11,8 @@
       - libnginx-mod-http-subs-filter
       - nginx-extras
       - php{{ php_version }}-fpm    # Drags in [1] php{{ php_version }}-cli (superset of php{{ php_version }}-common) [2] libsodium23 (likewise installed by moodle/tasks/install.yml) [3] php{{ php_version }}-json if PHP < 8.0 (NEEDED FOR nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml)
-      - uwsgi
-      - uwsgi-plugin-python3
+      - uwsgi                   # Admin Console & roles/captiveportal should really install
+      - uwsgi-plugin-python3    # these 2 packages on demand (not every IIAB needs these).
     state: present
 
 # 2020-10-16: Removed per #2560

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -5,14 +5,12 @@
   ignore_errors: yes
   # 'when: apache_installed is defined' insuff b/c mysql's php installs apache2
 
-- name: 'Install 5 packages for NGINX: libnginx-mod-http-subs-filter, nginx-extras, php{{ php_version }}-fpm, uwsgi, uwsgi-plugin-python3 -- TEMPORARILY ALSO php-pear UNTIL ADMIN CONSOLE DECLARES ITS OWN DEPENDENCY FOR: https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19'
+- name: 'Install 5 packages for NGINX: libnginx-mod-http-subs-filter, nginx-extras, php{{ php_version }}-fpm, uwsgi, uwsgi-plugin-python3'
   package:
     name:
       - libnginx-mod-http-subs-filter
       - nginx-extras
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm just below.
-      - php{{ php_version }}-fpm        # Drags in php{{ php_version }}-cli
-      - php-pear                        # 2021-06-27: TEMPORARY, SEE 7 LINES ABOVE!
+      - php{{ php_version }}-fpm    # Drags in [1] php{{ php_version }}-cli (superset of php{{ php_version }}-common) [2] libsodium23 (likewise installed by moodle/tasks/install.yml) [3] php{{ php_version }}-json if PHP < 8.0 (NEEDED FOR nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml)
       - uwsgi
       - uwsgi-plugin-python3
     state: present

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -10,9 +10,9 @@
     name:
       - libnginx-mod-http-subs-filter
       - nginx-extras
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
-      - php{{ php_version }}-fpm    # Drags in php{{ php_version }}-cli
-      - php-pear    # 2021-06-27: TEMPORARY, SEE 7 LINES ABOVE!
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm just below.
+      - php{{ php_version }}-fpm        # Drags in php{{ php_version }}-cli
+      - php-pear                        # 2021-06-27: TEMPORARY, SEE 7 LINES ABOVE!
       - uwsgi
       - uwsgi-plugin-python3
     state: present

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -175,7 +175,8 @@
     state: present
     name:
       - python3-wget
-      - "php{{ php_version }}-sqlite3"
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      - php{{ php_version }}-sqlite3
       - python3-geojson
       - python3-pil
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -175,7 +175,7 @@
     state: present
     name:
       - python3-wget
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-sqlite3
       - python3-geojson
       - python3-pil

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -14,10 +14,10 @@
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-fpm        # Likewise installed by nginx/tasks/install.yml
+      #- php{{ php_version }}-gettext
       - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-imap
       #- php{{ php_version }}-json      # See stanza just below
-      #- php{{ php_version }}-gettext
       - php{{ php_version }}-mbstring   # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
       - php{{ php_version }}-mysql      # Likewise installed by mysql/tasks/install.yml AND nextcloud/tasks/install.yml
       - php-pear                        # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
@@ -30,7 +30,7 @@
     state: latest
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
-# For PHP <  8.0: Auto-installed by phpX.Y-fpm AND phpX.Y-cli in roles/3-base-server, as confirmed by: apt rdepends phpX.Y-json
+# For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
 #
 #- name: Install php{{ php_version }}-json if PHP < 8.0
 #  package:

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -22,7 +22,7 @@
       - php{{ php_version }}-mysql      # Likewise installed by mysql/tasks/install.yml AND nextcloud/tasks/install.yml
       - php-pear                        # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
       - php{{ php_version }}-snmp
-      - php{{ php_version }}-xml        # Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
+      - php{{ php_version }}-xml        # Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
       - php{{ php_version }}-zip        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - libapache2-mod-php
       #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -1,4 +1,4 @@
-- name: FreePBX - Install dependencies
+- name: FreePBX - Install dependencies (run 'php -m' or 'php -i' to verify PHP modules)
   package:
     name:
       - wget

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -12,17 +12,17 @@
       - php{{ php_version }}-bcmath
       - php{{ php_version }}-cgi
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-fpm        # Likewise installed by nginx/tasks/install.yml
       #- php{{ php_version }}-gettext
-      - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-imap
       #- php{{ php_version }}-json      # See stanza just below
-      - php{{ php_version }}-mbstring   # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
+      - php{{ php_version }}-mbstring   # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
       - php{{ php_version }}-mysql      # Likewise installed by mysql/tasks/install.yml AND nextcloud/tasks/install.yml
       - php-pear                        # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
       - php{{ php_version }}-snmp
-      - php{{ php_version }}-xml        # Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
+      - php{{ php_version }}-xml        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
       - php{{ php_version }}-zip        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - libapache2-mod-php
       #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -2,28 +2,28 @@
   package:
     name:
       - wget
-      - git 
+      - git
       - unixodbc     # for Asterisk CDR (Call Detail Records)
       - sudo         # required by FreePBX install script
       - net-tools    # required by FWConsole (command-line utility, that controls FreePBX)
       - cron         # required by FreePBX UCP package (User Control Panel)
       - sox          # required for CDR web-playback
-      #- php{{ php_version }}    # Drags in phpX.Y-cgi (already below!)
+      #- php{{ php_version }}           # Basically drags in phpX.Y-cgi (already below!)
       - php{{ php_version }}-bcmath
       - php{{ php_version }}-cgi
       #- php{{ php_version }}-common    # Auto-installed as a dependency
-      - php{{ php_version }}-curl
-      - php{{ php_version }}-fpm
-      - php{{ php_version }}-gd
+      - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-fpm        # Likewise installed by nginx/tasks/install.yml
+      - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-imap
-      #- php{{ php_version }}-json    # See stanza just below
+      #- php{{ php_version }}-json      # See stanza just below
       #- php{{ php_version }}-gettext
-      - php{{ php_version }}-mbstring
-      - php{{ php_version }}-mysql
-      - php-pear
-      - php{{ php_version }}-snmp 
-      - php{{ php_version }}-xml
-      - php{{ php_version }}-zip
+      - php{{ php_version }}-mbstring   # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
+      - php{{ php_version }}-mysql      # Likewise installed by mysql/tasks/install.yml AND nextcloud/tasks/install.yml
+      - php-pear                        # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
+      - php{{ php_version }}-snmp
+      - php{{ php_version }}-xml        # Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
+      - php{{ php_version }}-zip        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
       - libapache2-mod-php
       #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
       - libapache2-mpm-itk    # To serve FreePBX through a VirtualHost as asterisk user

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -8,23 +8,32 @@
       - net-tools    # required by FWConsole (command-line utility, that controls FreePBX)
       - cron         # required by FreePBX UCP package (User Control Panel)
       - sox          # required for CDR web-playback
-      - php 
+      #- php{{ php_version }}    # Drags in phpX.Y-cgi (already below!)
+      - php{{ php_version }}-bcmath
+      - php{{ php_version }}-cgi
+      #- php{{ php_version }}-common    # Auto-installed as a dependency
+      - php{{ php_version }}-curl
+      - php{{ php_version }}-fpm
+      - php{{ php_version }}-gd
+      - php{{ php_version }}-imap
+      #- php{{ php_version }}-json    # See stanza just below
+      #- php{{ php_version }}-gettext
+      - php{{ php_version }}-mbstring
+      - php{{ php_version }}-mysql
       - php-pear
-      - php-cgi
-      - php-common
-      - php-curl
-      - php-mbstring
-      - php-gd
-      - php-mysql
-#      - php-gettext
-      - php-bcmath
-      - php-zip
-      - php-xml
-      - php-imap
-      - php-json
-      - php-snmp 
-      - php-fpm
+      - php{{ php_version }}-snmp 
+      - php{{ php_version }}-xml
+      - php{{ php_version }}-zip
       - libapache2-mod-php
-#      - python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
+      #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
       - libapache2-mpm-itk    # To serve FreePBX through a VirtualHost as asterisk user
     state: latest
+
+# For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
+# For PHP <  8.0: Auto-installed by phpX.Y-fpm AND phpX.Y-cli in roles/3-base-server, as confirmed by: apt rdepends phpX.Y-json
+#
+#- name: Install php{{ php_version }}-json if PHP < 8.0
+#  package:
+#    name: php{{ php_version }}-json
+#    state: present
+#  when: php_version is version('8.0', '<')

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -11,7 +11,7 @@
       #- php{{ php_version }}           # Basically drags in phpX.Y-cgi (already below!)
       - php{{ php_version }}-bcmath
       - php{{ php_version }}-cgi
-      #- php{{ php_version }}-common    # Auto-installed as a dependency
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml
       - php{{ php_version }}-fpm        # Likewise installed by nginx/tasks/install.yml
       - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/main.yml AND nextcloud/tasks/install.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -9,7 +9,7 @@
 #  package:
 #    name:
 #      - php{{ php_version }}           # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
-#      - php{{ php_version }}-common    # 2021-06-27: Experimentally remove.  2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli that nginx/tasks/install.yml is installing anyways :/
+#      - php{{ php_version }}-common    # 2021-06-27: @jvonau suggested this (2020-05-21) to avoid Apache packages dragged in above.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
 #      - php{{ php_version }}-curl      # 2021-06-27: Installed by nextcloud/tasks/install.yml AND moodle/tasks/main.yml
 #      - php{{ php_version }}-gd        # 2021-06-27: Installed by nextcloud/tasks/install.yml AND moodle/tasks/main.yml
 #      - php{{ php_version }}-imap      # 2021-06-27: Installed by pbx/tasks/freepbx_dependencies.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: Install 9 PHP packages
+- name: Install 9 PHP packages (run 'php -m' to verify)
   package:
     name:
       # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: Install 9 PHP packages (run 'php -m' to verify)
+- name: Install 9 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -5,16 +5,16 @@
   package:
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
-      - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      - php{{ php_version }}-curl      # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
-      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli if absolutely nec?
+      - php{{ php_version }}-curl      # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-gd        # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql
       - php{{ php_version }}-odbc
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      - php{{ php_version }}-xml          # nextcloud/tasks/install.yml needs this!
+      - php{{ php_version }}-xml          # 2021-06-25: nextcloud/tasks/install.yml used to install this (and might still benefit!)
       #- php{{ php_version }}-xmlrpc      # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
 

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -8,18 +8,18 @@
 #- name: Install 10 PHP packages (run 'php -m' or 'php -i' to verify)
 #  package:
 #    name:
-      # - php{{ php_version }}          # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
-      #- php{{ php_version }}-common    # 2021-06-27: Experimentally remove.  2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      #- php{{ php_version }}-curl      # 2021-06-27: Installed by nextcloud/tasks/install.yml & moodle/tasks/main.yml
-      #- php{{ php_version }}-gd        # 2021-06-27: Installed by nextcloud/tasks/install.yml & moodle/tasks/main.yml
-      #- php{{ php_version }}-imap      # 2021-06-27: Experimentally remove
-      #- php{{ php_version }}-ldap      # 2021-06-27: Experimentally remove
-      #- php{{ php_version }}-mysql     # 2021-06-27: Experimentally remove
-      #- php{{ php_version }}-odbc      # 2021-06-27: Experimentally remove
-      #- php-pear                       # 2021-06-27: Experimentally remove
-      # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      #- php{{ php_version }}-xml       # 2021-06-27: Installed by nextcloud/tasks/install.yml
-      #- php{{ php_version }}-xmlrpc    # 2021-06-27: Experimentally remove
+#      - php{{ php_version }}           # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
+#      - php{{ php_version }}-common    # 2021-06-27: Experimentally remove.  2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli that nginx/tasks/install.yml is installing anyways :/
+#      - php{{ php_version }}-curl      # 2021-06-27: Installed by nextcloud/tasks/install.yml AND moodle/tasks/main.yml
+#      - php{{ php_version }}-gd        # 2021-06-27: Installed by nextcloud/tasks/install.yml AND moodle/tasks/main.yml
+#      - php{{ php_version }}-imap      # 2021-06-27: Installed by pbx/tasks/freepbx_dependencies.yml
+#      - php{{ php_version }}-ldap      # 2021-06-27: Experimentally remove
+#      - php{{ php_version }}-mysql     # 2021-06-27: Installed by mysql/tasks/install.yml
+#      - php{{ php_version }}-odbc      # 2021-06-27: Experimentally remove
+#      - php-pear                       # 2021-06-27: REQUIRED BY ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
+#      - php{{ php_version }}-sqlite3   # 2020-07-10: Installed by osm-vector-maps/tasks/install.yml as part of OSM fix PR #2464 for #2461
+#      - php{{ php_version }}-xml       # 2021-06-27: Installed by nextcloud/tasks/install.yml AND mediawiki/tasks/main.yml
+#      - php{{ php_version }}-xmlrpc    # 2021-06-27: Experimentally remove -- SEE EXPLANATION IN moodle/tasks/main.yml
 #    state: present
 
 - name: Using html.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -6,8 +6,8 @@
     name:
       # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
       - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      - php{{ php_version }}-curl
-      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml needs this!
+      - php{{ php_version }}-curl      # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
+      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,7 +1,7 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: 'Install ~10 PHP packages (debuntu)'
+- name: Install 9 PHP packages
   package:
     name:
       # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
@@ -15,9 +15,14 @@
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
       - php{{ php_version }}-xml    # Was below
-      - php{{ php_version }}-xmlrpc
+      #- php{{ php_version }}-xmlrpc    # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
-  when: is_debuntu
+
+- name: Install php{{ php_version }}-xmlrpc if PHP < 8.0
+  package:
+    name: php{{ php_version }}-xmlrpc
+    state: present
+  when: php_version is version('8.0', '<')
 
 - name: Using html.yml
   include_tasks: html.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -1,28 +1,26 @@
 # Role "www_base" runs here, probably in 3-BASE-SERVER.
 # Role "www_options" runs later, likely in 4-SERVER-OPTIONS.
 
-- name: Install 9 PHP packages (run 'php -m' or 'php -i' to verify)
-  package:
-    name:
-      # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
-      - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli if absolutely nec?
-      - php{{ php_version }}-curl      # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
-      - php{{ php_version }}-gd        # 2021-06-25: nextcloud/tasks/install.yml & moodle/tasks/main.yml need this!
-      - php{{ php_version }}-imap
-      - php{{ php_version }}-ldap
-      - php{{ php_version }}-mysql
-      - php{{ php_version }}-odbc
-      - php-pear
+# 2021-06-27: Antifragile roles can become less brittle by fully declaring
+# their own dependencies (i.e. modularity, separation-of-concerns,
+# encapsulation, compartmentalization, scope sanity, etc).
+#
+#- name: Install 10 PHP packages (run 'php -m' or 'php -i' to verify)
+#  package:
+#    name:
+      # - php{{ php_version }}          # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
+      #- php{{ php_version }}-common    # 2021-06-27: Experimentally remove.  2020-05-21: @jvonau suggests this to avoid Apache that was above.  Or its superset php{{ php_version }}-cli if absolutely nec?
+      #- php{{ php_version }}-curl      # 2021-06-27: Installed by nextcloud/tasks/install.yml & moodle/tasks/main.yml
+      #- php{{ php_version }}-gd        # 2021-06-27: Installed by nextcloud/tasks/install.yml & moodle/tasks/main.yml
+      #- php{{ php_version }}-imap      # 2021-06-27: Experimentally remove
+      #- php{{ php_version }}-ldap      # 2021-06-27: Experimentally remove
+      #- php{{ php_version }}-mysql     # 2021-06-27: Experimentally remove
+      #- php{{ php_version }}-odbc      # 2021-06-27: Experimentally remove
+      #- php-pear                       # 2021-06-27: Experimentally remove
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      - php{{ php_version }}-xml          # 2021-06-25: nextcloud/tasks/install.yml used to install this (and might still benefit!)
-      #- php{{ php_version }}-xmlrpc      # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
-    state: present
-
-- name: Install php{{ php_version }}-xmlrpc if PHP < 8.0
-  package:
-    name: php{{ php_version }}-xmlrpc
-    state: present
-  when: php_version is version('8.0', '<')
+      #- php{{ php_version }}-xml       # 2021-06-27: Installed by nextcloud/tasks/install.yml
+      #- php{{ php_version }}-xmlrpc    # 2021-06-27: Experimentally remove
+#    state: present
 
 - name: Using html.yml
   include_tasks: html.yml

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -4,18 +4,18 @@
 - name: Install 9 PHP packages (run 'php -m' to verify)
   package:
     name:
-      # - php{{ php_version }}    # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
+      # - php{{ php_version }}         # On Ubuntu 20.04 (and prob other OS's) this forces the install of: apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php{{ php_version }} ETC
       - php{{ php_version }}-common    # 2020-05-21: @jvonau suggests this to avoid Apache above.  Or its superset php{{ php_version }}-cli if absolutely nec?
       - php{{ php_version }}-curl
-      - php{{ php_version }}-gd
+      - php{{ php_version }}-gd        # nextcloud/tasks/install.yml needs this!
       - php{{ php_version }}-imap
       - php{{ php_version }}-ldap
       - php{{ php_version }}-mysql
       - php{{ php_version }}-odbc
       - php-pear
       # - php{{ php_version }}-sqlite3    # 2020-07-10: Experimentally install this within roles/osm-vector-maps/tasks/install.yml only, as part of OSM fix PR #2464 for #2461.
-      - php{{ php_version }}-xml    # Was below
-      #- php{{ php_version }}-xmlrpc    # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
+      - php{{ php_version }}-xml          # nextcloud/tasks/install.yml needs this!
+      #- php{{ php_version }}-xmlrpc      # 2021-06-25: Experimentally moved just below, to figure out if/where IIAB still needs this with PHP 8.0+
     state: present
 
 - name: Install php{{ php_version }}-xmlrpc if PHP < 8.0

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - block:    # 3-STANZA BLOCK BEGINS
 
-  # FYI roles/nginx has already installed package php-fpm, in 3-base-server
+  # roles/nginx has installed pkg 'php{{ php_version }}-fpm' in 3-base-server
 
   - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
@@ -95,7 +95,7 @@
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
     systemd:
-      name: "php{{ php_version }}-fpm"
+      name: php{{ php_version }}-fpm
       state: restarted
 
   when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 3-STANZA BLOCK ENDS

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -50,9 +50,9 @@
       lxde_present.stat.exists and chromium_present.stat.exists
 
 - debug:
-    msg: 'THE 3 ANSIBLE STANZAS BELOW ONLY RUN... when: moodle_install or nextcloud_install or pbx_install or wordpress_install'
+    msg: 'THE 5 ANSIBLE STANZAS BELOW ONLY RUN... when: moodle_install or nextcloud_install or pbx_install or wordpress_install'
 
-- block:    # 3-STANZA BLOCK BEGINS
+- block:    # 5-STANZA BLOCK BEGINS
 
   # roles/nginx has installed pkg 'php{{ php_version }}-fpm' in 3-base-server
 
@@ -69,7 +69,7 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   # 2020-03-08: IIAB does not support uninstalling apps, so a 3rd clause
   # (to reset/restore PHP's defaults) is not necessary at this time.
@@ -91,14 +91,35 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 3-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
     systemd:
       name: php{{ php_version }}-fpm
       state: restarted
 
-  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 3-STANZA BLOCK ENDS
+  - name: "Enact the equivalent of 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/{{ apache_service }}/php.ini for Moodle 3.11+"
+    lineinfile:
+      #path: "/etc/php/{{ php_version }}/fpm/php.ini"
+      path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+      - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
+      - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
+      - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
+      - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
+      - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
+      - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
+    when: moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+
+  - name: Restart {{ apache_service }} systemd service
+    systemd:
+      name: "{{ apache_service }}"
+      state: restarted
+    when: moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+
+  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -49,6 +49,7 @@
   when:
       lxde_present.stat.exists and chromium_present.stat.exists
 
+
 - debug:
     msg: 'THE 5 ANSIBLE STANZAS BELOW ONLY RUN... when: moodle_install or nextcloud_install or pbx_install or wordpress_install'
 
@@ -58,8 +59,7 @@
 
   - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
-      path: "/etc/php/{{ php_version }}/fpm/php.ini"
-      #path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
+      path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
     with_items:
@@ -68,20 +68,38 @@
       - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
-      - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requests 5000' }
+      - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
     when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
-  # 2020-03-08: IIAB does not support uninstalling apps, so a 3rd clause
-  # (to reset/restore PHP's defaults) is not necessary at this time.
+  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/cli/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+    lineinfile:
+      path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+      - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
+      - { regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
+      - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
+      - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
+      - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
+      - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
-  # COMPARE apache_allow_sudo further below.
+  # 2020-03-08: IIAB DOES NOT SUPPORT UNINSTALLING APPS, so additional
+  # clauses (to reset/restore PHP's defaults) are not necessary at this time.
+
+  # 2021-06-28: WITH PHP 8, MOODLE'S CLI INSTALLER UNFORTUNATELY *REQUIRES*
+  # editing /etc/php/{{ php_version }}/cli/php.ini (below) -- even though during
+  # regular operation it instead uses .../apache2/php.ini or .../fpm/php.ini
+  #
+  # SEE ALSO roles/moodle/tasks/install.yml WHERE SIMILAR SURGERY'S DONE TO
+  # /etc/php/{{ php_version }}/apache2/php.ini UNTIL MOODLE'S PORTED TO NGINX!
 
   # WARNING: This might cause excess use of RAM/disk or other resources!
   # The 5 first values below were chosen by @ericnitschke and @kananigit in ~2018.
   - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for schools that use WordPress/Moodle/Nextcloud/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
     lineinfile:
-      path: "/etc/php/{{ php_version }}/fpm/php.ini"
-      #path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
+      path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
     with_items:
@@ -90,7 +108,21 @@
       - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
-      - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
+      - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+
+  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for schools that use WordPress/Moodle/Nextcloud/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+    lineinfile:
+      path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+      - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
+      - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
+      - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
+      - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
+      - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
+      - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
     when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
@@ -98,28 +130,7 @@
       name: php{{ php_version }}-fpm
       state: restarted
 
-  - name: "Enact the equivalent of 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/{{ apache_service }}/php.ini for Moodle 3.11+"
-    lineinfile:
-      #path: "/etc/php/{{ php_version }}/fpm/php.ini"
-      path: "/etc/php/{{ php_version }}/{{ apache_service }}/php.ini"
-      regexp: "{{ item.regexp }}"
-      line: "{{ item.line }}"
-    with_items:
-      - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 500M    ; default is 2M' }
-      - { regexp: '^post_max_size', line: 'post_max_size = 500M    ; default is 8M' }
-      - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
-      - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
-      - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
-      - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requests 5000' }
-    when: moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
-
-  - name: Restart {{ apache_service }} systemd service
-    systemd:
-      name: "{{ apache_service }}"
-      state: restarted
-    when: moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
-
-  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS
+  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS.  COMPARE apache_allow_sudo conditionals below.
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -264,11 +264,11 @@ nginx_log_dir: /var/log/nginx
 #
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
-# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
-# ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
+# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
+# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
+# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -167,11 +167,11 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
-# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
-# ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
+# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
+# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
+# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file
 #

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -167,11 +167,11 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
-# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
-# ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
+# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
+# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
+# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file
 #

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -167,11 +167,11 @@ pi_swap_file_size: 1024
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
-# FYI: roles/www_options auto-sets these high limits if 'moodle_install: True'
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# SO AFTER INSTALLING IIAB, VERIFY THAT THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L59-L94
-# ...ARE SUITABLE FOR YOUR HARDWARE, for: /etc/php/<VERSION>/fpm/php.ini
+# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
+# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
+# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
 # See also Apache vars {default_language, language_priority} @ top of this file
 #


### PR DESCRIPTION
Tested on 32-bit RaspiOS Lite (PHP 7.3), Ubuntu Server 21.04 (PHP 7.4) and Ubuntu Server 21.10 pre-release (PHP 8.0).

Explanations are added to push role authors to be aware of AND declare their own evolving PHP dependencies &mdash; instead of blindly assuming things that were installed MANY years ago for "God knows what reason" (!) but too often nobody seems to remember why.

Forcing apps/services to live on their own 2 feet helps IIAB implementers installing diverse and unexpected sets of apps/services, rather than the proverbial kitchen sink (BIG-sized) which might make for really great "Get to Know" demos &mdash; but is just not appropriate in the field.

PHP modules that had no good reason to be there were removed.  As we all have enough security/complexity nightmares in our lives as it stands.

Further testing is ongoing for the heck of it.

FYI this PR includes and supersedes PR #2830 to accommodate PHP 8.0's minor changes.

ASIDE: Admin Console should declare its own dependency on `php-pear` for Line 19 of https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#19 (likely by installing apt package php-pear in the stanza just above that).  An interim patch is included until that happens: https://github.com/holta/iiab/blob/php7-and-php8-cleanup/roles/nginx/tasks/install.yml#L15 (LATER MOVED TO https://github.com/holta/iiab/blob/php7-and-php8-cleanup/roles/9-local-addons/tasks/main.yml#L33-L36)

Somewhat Related:

- PR #2119
- PR #2258
- PR #2684
- #2814
- #2818
- #2829