### PR TITLE
Be a better Guest

### DIFF
--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -63,3 +63,4 @@
   - name: Network
     include_role:
       name: network
+    when: not is_guest

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -108,7 +108,7 @@
 
 - name: Set hostname if FQDN_changed
   include_tasks: hostname.yml
-  when: FQDN_changed
+  when: FQDN_changed and not is_guest
 
 - name: Add 'runtime' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -36,6 +36,13 @@
     state: present
   when: admin_console_install
 
+- name: start iiab-nginx on port {{ nginx_port }}
+  systemd:
+    daemon_reload: yes
+    name: iiab-nginx.service
+    state: restarted
+  when: nginx_port|int != 80 or nginx_dir != "/etc/nginx"
+
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     path: "{{ iiab_env_file }}"

--- a/roles/nginx/tasks/enable-or-disable.yml
+++ b/roles/nginx/tasks/enable-or-disable.yml
@@ -25,6 +25,12 @@
     enabled: true
   when: apache_installed is defined and apache_enabled    # or not nginx_enabled
 
+- name: Start iiab-nginx on port {{ nginx_port }}
+  systemd:
+    daemon_reload: yes
+    name: iiab-nginx.service
+    state: restarted
+  when: nginx_port|int != 80 or nginx_dir != "/etc/nginx"
 
 - name: Enable & (Re)Start 'nginx' systemd service, if nginx_enabled
   systemd:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -21,17 +21,6 @@
 #    name: "{{ apache_user }}"    # www-data or apache, per /opt/iiab/iiab/vars/<OS>.yml
 #    groups: shadow
 
-- name: Insure alternate nginx path is present
-  file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ nginx_conf_dir }}"
-    - "{{ nginx_dir }}/modules-available"
-    - "{{ nginx_dir }}/modules-enabled"
-    - "{{ nginx_dir }}/sites-available"
-    - "{{ nginx_dir }}/sites-enabled"
-
 - name: Remove NGINX default config /etc/nginx/sites-enabled/default
   file:
     path: /etc/nginx/sites-enabled/default
@@ -51,6 +40,21 @@
 
 # start block
 - block:
+  - name: Insure alternate nginx path is present
+    file:
+      path: "{{ item }}"
+      state: directory
+    with_items:
+      - "{{ nginx_conf_dir }}"
+      - "{{ nginx_dir }}/sites-available"
+      - "{{ nginx_dir }}/sites-enabled"
+
+  - name: Link {{ nginx_dir }}/modules-enabled
+    file:
+      src: /etc/nginx/modules-enabled
+      path: "{{ nginx_dir }}/modules-enabled"
+      state: link
+
   - name: Grab stock unit file
     copy:
       force: yes
@@ -58,7 +62,7 @@
       dest: /etc/systemd/system/iiab-nginx.service
 
   - name: shove {{ nginx_dir }}/nginx.conf into unit file
-    command: sed -i 's|/usr/sbin/nginx|/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf|' /etc/systemd/system/nginx.service
+    command: sed -i 's|/usr/sbin/nginx|/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf|' /etc/systemd/system/iiab-nginx.service
 #    lineinfile:
 #      path: /etc/systemd/system/nginx.service
 #      state: present
@@ -68,14 +72,14 @@
 #    - { regexp: '^ExecStartPre=/usr/sbin/nginx' , line: 'ExecStartPre=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf' }
 #    - { regexp: '^ExecStart=/usr/sbin/nginx', line: 'ExecStart=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf'  }
 #    - { regexp: '^ExecReload=/usr/sbin/nginx', line: 'ExecReload=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf' }
+
   - name: start iiab-nginx on port {{ nginx_port }}
     systemd:
       daemon_reload: yes
       name: iiab-nginx.service
       state: restarted
-
 # end block
-  when: is_guest or nginx_dir != "/etc/nginx"
+  when: nginx_port|int != 80 or nginx_dir != "/etc/nginx"
 
 - debug:
     msg: roles/nginx/tasks/homepage.yml will run LATER (invoked by roles/www_options/tasks/main.yml) SO THAT NGINX CAN REDIRECT http://box TO http://box{{ iiab_home_url }} (based on var iiab_home_url)

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -27,17 +27,6 @@
     state: absent
   when: not is_guest
 
-- name: 'Install 3 (of 5) files from template: /etc/nginx/server.conf, /etc/nginx/nginx.conf, /etc/nginx/mime.types'
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-  with_items:
-    - { src: 'server.conf.j2', dest: '{{ nginx_dir }}/server.conf' }
-    - { src: 'nginx.conf.j2', dest: '{{ nginx_dir }}/nginx.conf' }
-    - { src: 'mime.types.j2', dest: '{{ nginx_dir }}/mime.types' }
-    #- { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
-    #- { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml below
-
 # start block
 - block:
   - name: Insure alternate nginx path is present
@@ -49,11 +38,23 @@
       - "{{ nginx_dir }}/sites-available"
       - "{{ nginx_dir }}/sites-enabled"
 
-  - name: Link {{ nginx_dir }}/modules-enabled
+  - name: Link {{ nginx_dir }}/ files
     file:
-      src: /etc/nginx/modules-enabled
-      path: "{{ nginx_dir }}/modules-enabled"
+      src: /etc/nginx/{{ item }}
+      path: "{{ nginx_dir }}/{{ item }}"
       state: link
+    with_items:
+      - modules-available
+      - modules-enabled
+      - snippets
+      - fastcgi.conf
+      - fastcgi_params
+      - koi-win
+      - koi-utf
+      - proxy_params
+      - scgi_params
+      - uwsgi_params
+      - win-utf
 
   - name: Grab stock unit file
     copy:
@@ -73,13 +74,19 @@
 #    - { regexp: '^ExecStart=/usr/sbin/nginx', line: 'ExecStart=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf'  }
 #    - { regexp: '^ExecReload=/usr/sbin/nginx', line: 'ExecReload=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf' }
 
-  - name: start iiab-nginx on port {{ nginx_port }}
-    systemd:
-      daemon_reload: yes
-      name: iiab-nginx.service
-      state: restarted
 # end block
   when: nginx_port|int != 80 or nginx_dir != "/etc/nginx"
+
+- name: 'Install 3 (of 5) files from template: /etc/nginx/server.conf, /etc/nginx/nginx.conf, /etc/nginx/mime.types'
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { src: 'server.conf.j2', dest: '{{ nginx_dir }}/server.conf' }
+    - { src: 'nginx.conf.j2', dest: '{{ nginx_dir }}/nginx.conf' }
+    - { src: 'mime.types.j2', dest: '{{ nginx_dir }}/mime.types' }
+    #- { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
+    #- { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml below
 
 - debug:
     msg: roles/nginx/tasks/homepage.yml will run LATER (invoked by roles/www_options/tasks/main.yml) SO THAT NGINX CAN REDIRECT http://box TO http://box{{ iiab_home_url }} (based on var iiab_home_url)

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -23,8 +23,14 @@
 
 - name: Insure alternate nginx path is present
   file:
+    path: "{{ item }}"
     state: directory
-    path: "{{ nginx_conf_dir }}"
+  with_items:
+    - "{{ nginx_conf_dir }}"
+    - "{{ nginx_dir }}/modules-available"
+    - "{{ nginx_dir }}/modules-enabled"
+    - "{{ nginx_dir }}/sites-available"
+    - "{{ nginx_dir }}/sites-enabled"
 
 - name: Remove NGINX default config /etc/nginx/sites-enabled/default
   file:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -30,6 +30,7 @@
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
+  when: not is_guest
 
 - name: 'Install 3 (of 5) files from template: /etc/nginx/server.conf, /etc/nginx/nginx.conf, /etc/nginx/mime.types'
   template:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -21,6 +21,11 @@
 #    name: "{{ apache_user }}"    # www-data or apache, per /opt/iiab/iiab/vars/<OS>.yml
 #    groups: shadow
 
+- name: Insure alternate nginx path is present
+  file:
+    state: directory
+    path: "{{ nginx_conf_dir }}"
+
 - name: Remove NGINX default config /etc/nginx/sites-enabled/default
   file:
     path: /etc/nginx/sites-enabled/default
@@ -31,9 +36,9 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { src: 'server.conf.j2', dest: '/etc/nginx/server.conf' }
-    - { src: 'nginx.conf.j2', dest: '/etc/nginx/nginx.conf' }
-    - { src: 'mime.types.j2', dest: '/etc/nginx/mime.types' }
+    - { src: 'server.conf.j2', dest: '{{ nginx_dir }}/server.conf' }
+    - { src: 'nginx.conf.j2', dest: '{{ nginx_dir }}/nginx.conf' }
+    - { src: 'mime.types.j2', dest: '{{ nginx_dir }}/mime.types' }
     #- { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
     #- { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml below
 

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -49,6 +49,34 @@
     #- { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
     #- { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml below
 
+# start block
+- block:
+  - name: Grab stock unit file
+    copy:
+      force: yes
+      src: /lib/systemd/system/nginx.service
+      dest: /etc/systemd/system/iiab-nginx.service
+
+  - name: shove {{ nginx_dir }}/nginx.conf into unit file
+    command: sed -i 's|/usr/sbin/nginx|/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf|' /etc/systemd/system/nginx.service
+#    lineinfile:
+#      path: /etc/systemd/system/nginx.service
+#      state: present
+#      regexp: "{{ item.regexp }}"
+#      line: "{{ item.line }}"
+#    with_items:
+#    - { regexp: '^ExecStartPre=/usr/sbin/nginx' , line: 'ExecStartPre=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf' }
+#    - { regexp: '^ExecStart=/usr/sbin/nginx', line: 'ExecStart=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf'  }
+#    - { regexp: '^ExecReload=/usr/sbin/nginx', line: 'ExecReload=/usr/sbin/nginx -c {{ nginx_dir }}/nginx.conf' }
+  - name: start iiab-nginx on port {{ nginx_port }}
+    systemd:
+      daemon_reload: yes
+      name: iiab-nginx.service
+      state: restarted
+
+# end block
+  when: is_guest or nginx_dir != "/etc/nginx"
+
 - debug:
     msg: roles/nginx/tasks/homepage.yml will run LATER (invoked by roles/www_options/tasks/main.yml) SO THAT NGINX CAN REDIRECT http://box TO http://box{{ iiab_home_url }} (based on var iiab_home_url)
 # - include_tasks: roles/nginx/tasks/homepage.yml

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -5,7 +5,7 @@
 user www-data;
 worker_processes auto;
 pid /run/nginx.pid;
-include /etc/nginx/modules-enabled/*.conf;
+include {{ nginx_dir }}/modules-enabled/*.conf;
 
 events {
     worker_connections 768;
@@ -29,7 +29,7 @@ http {
     server_names_hash_bucket_size 64;
     # server_name_in_redirect off;
 
-    include /etc/nginx/mime.types;
+    include {{ nginx_dir }}/mime.types;
     default_type text/html;
 
     ##
@@ -91,10 +91,10 @@ http {
     ##
 
     # include a server file which in turn includes conf.d/*
-    include /etc/nginx/server.conf;
+    include {{ nginx_dir }}/server.conf;
 
     # include other sites
-    include /etc/nginx/sites-enabled/*.conf;
+    include {{ nginx_dir }}/sites-enabled/*.conf;
 
     # define the upstream backend fastcgi for php
     upstream php {

--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -1,7 +1,7 @@
 server {
     root {{ doc_root }};
     server_name {{ iiab_hostname }};
-    listen 80;
+    listen {{ nginx_port }};
 
     index index.php index.html index.htm;
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -259,7 +259,8 @@ nginx_install: True
 nginx_enabled: True
 nginx_port: 80
 nginx_interface: 0.0.0.0
-nginx_conf_dir: /etc/nginx/conf.d
+nginx_dir: /etc/nginx
+nginx_conf_dir: "{{ nginx_dir }}/conf.d"
 nginx_log_dir: /var/log/nginx
 #
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
@@ -733,6 +734,8 @@ is_centos_7: False
 is_fedora: False
 is_fedora_22: False
 is_fedora_18: False
+
+is_guest: False
 
 # How This Works:
 #


### PR DESCRIPTION
### Fixes bug:
Ability to install on other closed-black-box-curl-like-installations that are floating around. 
Partial fix toward evaluation of #2831

### Description of changes proposed in this pull request:
New feature: ability to turn off automatic changes to hostname and networking. (be a good guest)
Further soft-code nginx variables to be able to run as a second instance of nginx on a foreign/unknown platform.
Exposes new variable nginx_dir for alternate location use. 
Supplies custom systemd file for use with nginx_dir is a non-stock location.
Allows further evaluation of the new platform with nginx on a different port   

### Smoke-tested on which OS or OS's:
lightly tested on Ubuntu 20.10 adding to local_vars
>is_guest: True
nginx_port: 2080
nginx_dir: /etc/iiab-nginx
 
### Mention a team member @username e.g. to help with code review:
