### PR TITLE
WordPress "Recommended" + "Optional" PHP Modules

### DIFF
--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -6,7 +6,7 @@
       - php{{ php_version }}-intl        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       #- php{{ php_version }}-json       # See stanza just below
       - php{{ php_version }}-mbstring    # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
-      - php{{ php_version }}-xml         # 2021-06-27 REQUIRED despite it being missing from MediaWiki's doc!  Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
+      - php{{ php_version }}-xml         # 2021-06-27: REQUIRED (AND ENFORCED) despite this being missing from MediaWiki's above requirements doc!  Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
     state: present
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,11 +1,22 @@
+# https://www.mediawiki.org/wiki/Manual:Installation_requirements#PHP
 - name: 'Install packages: php{{ php_version }}-intl, php{{ php_version }}-mbstring, php{{ php_version }}-xml'
   package:
     name:
       #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-intl        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
-      - php{{ php_version }}-mbstring    # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-xml         # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
+      - php{{ php_version }}-intl        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      #- php{{ php_version }}-json       # See stanza just below
+      - php{{ php_version }}-mbstring    # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-xml         # 2021-06-27 REQUIRED despite it being missing from MediaWiki's doc!  Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
     state: present
+
+# For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
+# For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
+#
+#- name: Install php{{ php_version }}-json if PHP < 8.0
+#  package:
+#    name: php{{ php_version }}-json
+#    state: present
+#  when: php_version is version('8.0', '<')
 
 - name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}
   get_url:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -43,21 +43,22 @@
     name: postgresql
 
 
-- name: Install libsodium23 + 7 PHP packages (run 'php -m' or 'php -i' to verify)
+# https://docs.moodle.org/19/en/PHP_settings_by_Moodle_version#PHP_Extensions_and_libraries
+- name: Install libsodium23 + 8 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:
-      - libsodium23                      # 2021-06-28: Likewise installed by nginx/tasks/install.yml via php{{ php_version }}-fpm AND httpd/tasks/install.yml via libapache2-mod-php{{ php_version }} -- it can ALSO be auto-installed by phpX.Y-cgi OR phpX.Y-cli as confirmed by 'apt rdepends libsodium23' -- Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
+      - libsodium23                      # 2021-06-28: Likewise installed in nginx/tasks/install.yml via php{{ php_version }}-fpm AND httpd/tasks/install.yml via libapache2-mod-php{{ php_version }} AND wordpress/tasks/install.yml -- it can ALSO be auto-installed by phpX.Y-cgi OR phpX.Y-cli as confirmed by 'apt rdepends libsodium23' -- Recommended by Moodle 3.11+ at https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium -- whereas https://www.php.net/manual/en/sodium.installation.php says it's always bundled with PHP 7.2+ -- VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
       #- php{{ php_version }}-common     # 2021-06-27: Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       #- php{{ php_version }}-cli        # 2021-06-27: Compare to php{{ php_version }}-common just above!  2020-06-15: In the past this included (below) mbstring?  However this is not true on Ubuntu Server 20.04 LTS.
-      - php{{ php_version }}-curl        # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-gd          # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-intl        # 2020-12-03: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- Required by Moodle 3.10+
-      - php{{ php_version }}-mbstring    # 2020-06-15: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- Required by Moodle 3.9+
+      - php{{ php_version }}-curl        # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-gd          # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-intl        # 2020-12-03: Required by Moodle 3.10+ -- Likewise installed in mediawiki/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-mbstring    # 2020-06-15: Required by Moodle 3.9+ -- Likewise installed in mediawiki/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-pgsql       # 2021-06-27: Required for PostgreSQL
       - php{{ php_version }}-soap        # 2020-12-03: Recommended by Moodle 3.10+
-      - php{{ php_version }}-xml         # 2021-06-28: Likewise installed by nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
+      - php{{ php_version }}-xml         # 2021-06-28: Likewise installed in mediawiki/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       #- php{{ php_version }}-xmlrpc     # 2021-06-27: Required per https://docs.moodle.org/19/en/PHP_settings_by_Moodle_version#PHP_Extensions_and_libraries BUT UNMAINTAINED FOR YEARS (POSSIBLE SECURITY RISK) SO MOVED TO PECL: https://php.watch/versions/8.0/xmlrpc
-      - php{{ php_version }}-zip         # 2021-06-27: Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
 - name: Does {{ moodle_base }}/config-dist.php exist? (indicating Moodle is/was installed)

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -11,7 +11,7 @@
       - mariadb-server
       - mariadb-client
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-mysql      # Likewise installed by nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-mysql      # Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
 # 2020-07-11:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -53,12 +53,13 @@
       - libxml2      # php-libxml requires libxml2 >= 2.7.0
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
       - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility" -- Likewise installed in pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
-      - php{{ php_version }}-bz2           # Optional (for extraction of apps)
+      - php{{ php_version }}-bz2           # OPTIONAL (for extraction of apps)
       #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl          # Likewise installed in moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      #- php{{ php_version }}-exif         # Optional (for image rotation in pictures app) but somehow already installed in our PHP core.
       - php{{ php_version }}-gd            # Likewise installed in moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-gmp           # Optional (for SFTP storage)
-      - php-imagick                        # Optional (for preview generation).  BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.  Likewise installed in wordpress/tasks/install.yml
+      - php{{ php_version }}-gmp           # OPTIONAL (for SFTP storage)
+      - php-imagick                        # OPTIONAL (for preview generation).  BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.  Likewise installed in wordpress/tasks/install.yml
       - php{{ php_version }}-intl          # OPTIONAL (increases language translation performance and fixes sorting of non-ASCII characters): Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, wordpress/tasks/install.yml
       #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -52,26 +52,26 @@
       - ffmpeg       # Optional (for preview generation)
       - libxml2      # php-libxml requires libxml2 >= 2.7.0
       #- libapache2-mod-php    # 2020-02-15: NO LONGER NEEDED?
-      - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility"
+      - php{{ php_version }}-bcmath        # Highly recommended by Nextcloud 21 for "improved performance and better compatibility" -- Likewise installed in pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-bz2           # Optional (for extraction of apps)
       #- php{{ php_version }}-common       # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-curl          # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-gd            # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-curl          # Likewise installed in moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-gd            # Likewise installed in moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-gmp           # Optional (for SFTP storage)
-      - php-imagick                        # Optional (for preview generation).  BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.
-      - php{{ php_version }}-intl          # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml -- Optional (increases language translation performance and fixes sorting of non-ASCII characters)
+      - php-imagick                        # Optional (for preview generation).  BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.  Likewise installed in wordpress/tasks/install.yml
+      - php{{ php_version }}-intl          # OPTIONAL (increases language translation performance and fixes sorting of non-ASCII characters): Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, wordpress/tasks/install.yml
       #- php{{ php_version }}-json         # See stanza just below
       #- php{{ php_version }}-libxml       # NOT INSTALLABLE: ENABLED BY DEFAULT (https://www.php.net/manual/en/libxml.installation.php)
-      - php{{ php_version }}-mbstring      # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
-      - php{{ php_version }}-mysql         # Likewise installed by mysql/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-mbstring      # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-mysql         # Likewise installed in mysql/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       #- php{{ php_version }}-openssl      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-pdo_mysql    # NOT INSTALLABLE: php{{ php_version }}-mysql handles this on all OS's?
       #- php{{ php_version }}-redis        # @m-anish future work?
       #- php{{ php_version }}-session      # NOT INSTALLABLE: ENABLED BY DEFAULT?
       #- php{{ php_version }}-smbclient    # Optional (SMB/CIFS integration)
-      - php{{ php_version }}-xml           # Likewise installed by moodle/tasks/install.yml AND mediawiki/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- Nextcloud's official requirements include {SimpleXML, XMLReader, XMLWriter} as confirmed by 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
+      - php{{ php_version }}-xml           # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- Nextcloud's official requirements include {SimpleXML, XMLReader, XMLWriter} as confirmed by 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       #- php{{ php_version }}-xmlrpc       # 2021-06-27: Experimentally remove, as explained in moodle/tasks/install.yml
-      - php{{ php_version }}-zip           # Likewise installed by moodle/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-zip           # Likewise installed in moodle/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       #- php{{ php_version }}-zlib         # NOT INSTALLABLE: ENABLED BY DEFAULT?
     state: present
 

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -10,7 +10,7 @@
     name:
       - libnginx-mod-http-subs-filter
       - nginx-extras
-      - php{{ php_version }}-fpm    # Drags in [1] php{{ php_version }}-cli (superset of php{{ php_version }}-common) [2] libsodium23 (likewise installed by moodle/tasks/install.yml) [3] php{{ php_version }}-json if PHP < 8.0 (NEEDED FOR nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml)
+      - php{{ php_version }}-fpm    # Drags in [1] php{{ php_version }}-cli (superset of php{{ php_version }}-common) [2] libsodium23 (likewise installed in moodle/tasks/install.yml AND wordpress/tasks/install.yml) [3] php{{ php_version }}-json if PHP < 8.0 (NEEDED FOR nextcloud/tasks/install.yml AND pbx/tasks/freepbx_dependencies.yml)
       - uwsgi                   # Admin Console & roles/captiveportal should really install
       - uwsgi-plugin-python3    # these 2 packages on demand (not every IIAB needs these).
     state: present

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -9,21 +9,21 @@
       - cron         # required by FreePBX UCP package (User Control Panel)
       - sox          # required for CDR web-playback
       #- php{{ php_version }}           # Basically drags in phpX.Y-cgi (already below!)
-      - php{{ php_version }}-bcmath
+      - php{{ php_version }}-bcmath     # Likewise installed by pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-cgi
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-curl       # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
-      - php{{ php_version }}-fpm        # Likewise installed by nginx/tasks/install.yml
+      - php{{ php_version }}-curl       # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-fpm        # Likewise installed in nginx/tasks/install.yml
       #- php{{ php_version }}-gettext
-      - php{{ php_version }}-gd         # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-gd         # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml
       - php{{ php_version }}-imap
       #- php{{ php_version }}-json      # See stanza just below
-      - php{{ php_version }}-mbstring   # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml
-      - php{{ php_version }}-mysql      # Likewise installed by mysql/tasks/install.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-mbstring   # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-mysql      # Likewise installed in mysql/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php-pear                        # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
       - php{{ php_version }}-snmp
-      - php{{ php_version }}-xml        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml AND mediawiki/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml
-      - php{{ php_version }}-zip        # Likewise installed by moodle/tasks/install.yml AND nextcloud/tasks/install.yml
+      - php{{ php_version }}-xml        # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
+      - php{{ php_version }}-zip        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - libapache2-mod-php
       #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
       - libapache2-mpm-itk    # To serve FreePBX through a VirtualHost as asterisk user

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -9,7 +9,7 @@
       - cron         # required by FreePBX UCP package (User Control Panel)
       - sox          # required for CDR web-playback
       #- php{{ php_version }}           # Basically drags in phpX.Y-cgi (already below!)
-      - php{{ php_version }}-bcmath     # Likewise installed in pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-bcmath     # Likewise installed in nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-cgi
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl       # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -9,7 +9,7 @@
       - cron         # required by FreePBX UCP package (User Control Panel)
       - sox          # required for CDR web-playback
       #- php{{ php_version }}           # Basically drags in phpX.Y-cgi (already below!)
-      - php{{ php_version }}-bcmath     # Likewise installed by pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
+      - php{{ php_version }}-bcmath     # Likewise installed in pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-cgi
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl       # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -11,6 +11,33 @@
 # and security enhancements using timestamps under /library/wordpress, as these
 # can arise without warning when WordPress is online, since WordPress ~4.8
 
+# 2021-06-29: PHP modules, covering "RECOMMENDED" and "OPTIONAL" sections here:
+# https://make.wordpress.org/hosting/handbook/server-environment/
+- name: Install libsodium23 + 8 PHP packages (run 'php -m' or 'php -i' to verify)
+  package:
+    name:
+      - libsodium23                      # Likewise installed in nginx/tasks/install.yml via php{{ php_version }}-fpm AND httpd/tasks/install.yml via libapache2-mod-php{{ php_version }} AND moodle/tasks/install.yml -- it can ALSO be auto-installed by phpX.Y-cgi OR phpX.Y-cli as confirmed by 'apt rdepends libsodium23' -- VERIFY USING 'php -i | grep sodium' AND 'apt list "*sodium*"'
+      - php{{ php_version }}-bcmath      # OPTIONAL: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+      #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      - php{{ php_version }}-curl        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+      - php-imagick                      # BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.  Likewise installed in nextcloud/tasks/install.yml
+      - php{{ php_version }}-intl        # OPTIONAL: Likewise installed by mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml
+      #- php{{ php_version }}-json       # See stanza just below
+      - php{{ php_version }}-mbstring    # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-mysql       # Likewise installed in mysql/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+      - php{{ php_version }}-xml         # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
+      - php{{ php_version }}-zip         # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
+    state: present
+
+# For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
+# For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
+#
+#- name: Install php{{ php_version }}-json if PHP < 8.0
+#  package:
+#    name: php{{ php_version }}-json
+#    state: present
+#  when: php_version is version('8.0', '<')
+
 - name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}
   get_url:
     url: "{{ wordpress_download_base_url }}/{{ wordpress_src }}"

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -21,7 +21,7 @@
       #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
       - php-imagick                      # BUT drags in Apache's libapache2-mod-phpX.Y etc, as confirmed by 'apt depends php-imagick' -- while php{{ php_version }}-imagick installs (despite not being shown within 'apt list "php*imagick"') it's no better -- and 'apt depends phpX.Y-imagick' mysteriously does NOT show its deps.  Likewise installed in nextcloud/tasks/install.yml
-      - php{{ php_version }}-intl        # OPTIONAL: Likewise installed by mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml
+      - php{{ php_version }}-intl        # OPTIONAL: Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml
       #- php{{ php_version }}-json       # See stanza just below
       - php{{ php_version }}-mbstring    # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml
       - php{{ php_version }}-mysql       # Likewise installed in mysql/tasks/install.yml, nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml


### PR DESCRIPTION
A more honest assessment of the PHP modules ("recommended" and "optional/desired") that IIAB-with-WordPress implementers might generally prefer, per https://make.wordpress.org/hosting/handbook/server-environment/

Towards keeping sanity (especially among those installing individual IIAB Apps, without the whole kitchen sink, and caring about rationalized dependencies helping us all keep an eye on security/bloat).

For [/opt/iiab/iiab/roles/wordpress/tasks/install.yml](https://github.com/iiab/iiab/blob/master/roles/wordpress/tasks/install.yml)

FYI WordPress works as is, but thanks go to @jvonau for [pushing](https://github.com/iiab/iiab/pull/2832#issuecomment-870558387) to make this selection of WordPress PHP modules/extensions far less arbitrary, far more coherent.  For IIAB field communities especially!

Building off: PR #2832