### PR TITLE
Enable php-stem installation for armv6l machine type

### DIFF
--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -26,7 +26,7 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: ansible_machine == "armv7l" and stem_available is defined
+  when: (ansible_machine == "armv7l" or ansible_machine == "armv6l") and stem_available is defined
 
 - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar to / (rpi)
   unarchive:


### PR DESCRIPTION
This allows the installation to continue on additional ARM devices, such as the original Raspberry Pi 1.

### Fixes bug:

https://github.com/iiab/iiab/issues/2835

### Description of changes proposed in this pull request:

Just an additional machine type added to the condition, which makes sure that this step is not accidentally skipped on Raspberry Pi 1 (and other machines with the same architecture).

### Smoke-tested on which OS or OS's:

Tested on the Raspberry Pi that is linked in the original issue. It got past stage 9 at this point, after which I ran into networking-related issues (probably due to the Pi not having native WiFi and me using an USB adapter), which are a separate topic to handle.

### Mention a team member @username e.g. to help with code review:
@holta 
