### PR TITLE
Stem zero

### DIFF
--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -26,7 +26,7 @@
     group: root
     #mode: ????
     remote_src: yes
-  when: ansible_machine == "armv7l" and stem_available is defined
+  when: (ansible_machine == "armv7l" or is_raspbian) and stem_available is defined
 
 - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar to / (rpi)
   unarchive:

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -132,6 +132,9 @@
 
   when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS.  COMPARE apache_allow_sudo conditionals below.
 
+- name: Install stem-php when requested
+  include: php-stem.yml
+  when: stem_installed is not defined and use_stem is defined
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'
 # gives more details here: http://FAQ.IIAB.IO

--- a/roles/www_options/tasks/php-stem.yml
+++ b/roles/www_options/tasks/php-stem.yml
@@ -61,3 +61,9 @@
 # Presumably fails on Debian 8 & 10?
 # Fails on Debian i686 as of 2018-08-07: https://github.com/iiab/iiab/issues/983
 # Fails on Ubuntu 18.04 as of 2018-07-28: https://github.com/iiab/iiab/issues/829
+
+- name: "Add 'stem_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^stem_installed'
+    line: 'stem_installed: True'


### PR DESCRIPTION
### Fixes bug:
Replaces #2799 corrects #2797
End users who are installing es-wikihow from 2016 #829 would be the only users requiring the workaround to be installed, in all other cases it's not needed to be installed. Want stem? Adding `use_stem: True` to your local_vars.yml file installs the option on the next ansible run. (runrole www_options, iiab-configure, admin-console or iiab-install prior to first run.) I see no point blocking new users for a workaround that the new users may not ever even need. This is a deployment level area when a custom local_vars would be required anyway, just add the variable and php-stem is installed.   