### PR TITLE
sugarizer/tasks/install.yml: Clarify git clone d/l sizes

### DIFF
--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -29,7 +29,7 @@
 
 # 2. DOWNLOAD+LINK /opt/iiab/sugarizer
 
-- name: Clone llaske/sugarizer ({{ sugarizer_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_dir_version }} (DOWNLOADS ~469 MB)
+- name: Clone llaske/sugarizer ({{ sugarizer_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_dir_version }} (DOWNLOADS ~717 MB)
   git:
     repo: https://github.com/llaske/sugarizer
     dest: "{{ iiab_base }}/{{ sugarizer_dir_version }}"
@@ -62,7 +62,7 @@
 # CLARIF: during repeat runs of "./runrole sugarizer", this git sync shows
 # "changed" (whereas above git sync shows "ok").  Reason: "npm install"
 # (below) modifies /opt/iiab/sugarizer-server/node_modules
-- name: Clone llaske/sugarizer-server ({{ sugarizer_server_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_server_dir_version }}
+- name: Clone llaske/sugarizer-server ({{ sugarizer_server_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_server_dir_version }} (DOWNLOADS ~9 MB)
   git:
     repo: https://github.com/llaske/sugarizer-server
     dest: "{{ iiab_base }}/{{ sugarizer_server_dir_version }}"


### PR DESCRIPTION
Here's the straggler commit that unfortunately didn't make it into PR #2847 in time.