### PR TITLE
Update freepbx.yml

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -116,7 +116,7 @@
 - name: FreePBX - Patch FreePBX source - disable get_magic_quotes_gpc()
   patch:
     src: "roles/pbx/templates/pbx2.patch"
-    dest: "{{ freepbx_install_dir }}/freepbx/admin/libraries/view.functions.php"
+    dest: "{{ freepbx_install_dir }}/admin/libraries/view.functions.php"
 
 - name: FreePBX - Create /etc/odbc.ini
   template:


### PR DESCRIPTION
Fixes #2856, pbx installation succeeded on latest raspberry pi os (raspbian-10)

### Fixes bug:
#2856 

### Description of changes proposed in this pull request:
File: iiab/roles/pbx/tasks/freepbx.yml
'dest' path has been updated to get rid of additional 'freepbx' included in the path

### Smoke-tested on which OS or OS's:
freepbx installation succeeded on latest Raspberry Pi OS (raspbian-10)

### Mention a team member @username e.g. to help with code review:
@holta, please review
