### PR TITLE
dhcpcd.conf.j2: denyinterfaces IF {{ iiab_wireless_lan_iface }} defined — for Raspberry Pi OS on PC/Mac

### DIFF
--- a/roles/network/templates/network/dhcpcd.conf.j2
+++ b/roles/network/templates/network/dhcpcd.conf.j2
@@ -38,7 +38,9 @@ require dhcp_server_identifier
 slaac private
 
 # IIAB
+{% if iiab_wireless_lan_iface is defined %}
 denyinterfaces {{ iiab_wireless_lan_iface }}
+{% endif %}
 
 # Setting iiab_wired_lan_iface would install the device as a slave under
 # br0 so we need to turn off the dhcp client in that network layout.


### PR DESCRIPTION
@jvonau can you review this PR?

To resolve Part 2 of #2148 for @deltacloud9.

(i.e. we're hoping this might permit IIAB to install onto Raspberry Pi OS on PC/Mac)