### PR TITLE
rpi_debian.yml: clone-wifi when: discovered_wireless_iface != "none" — for RaspiOS on PC

### DIFF
--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -60,6 +60,9 @@
   systemd:
     name: clone-wifi
     state: started
+  when: discovered_wireless_iface != "none"
+  # Whereas sysd-netd-debian.yml uses...
+  # when: wifi_up_down and discovered_wireless_iface != "none"
 
 - name: Restart the networking service if appropriate
   systemd:


### PR DESCRIPTION
@jvonau can you review quick?

Thanks to @deltacloud9.

Towards resolving:

- https://github.com/iiab/iiab/pull/2870#issuecomment-883781483

Ref:

- #2148