### PR TITLE
2-common: Annotate 6 lesser-maintained sections

### DIFF
--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -6,15 +6,19 @@
 - name: Create IIAB directory structure ("file layout")
   include_tasks: fl.yml
 
+# UNMAINTAINED
 - include_tasks: centos.yml
   when: ansible_distribution == "CentOS"
 
+# UNMAINTAINED
 - include_tasks: fedora.yml
   when: ansible_distribution == "Fedora"
 
+# UNMAINTAINED
 - include_tasks: prep.yml
   when: not is_debuntu
 
+# UNMAINTAINED
 - include_tasks: xo.yml
   when: xo_model != "none" or osbuilder is defined
 
@@ -38,11 +42,13 @@
     #- { name: 'net.ipv6.conf.default.disable_ipv6', value: '1' }    # AUTO-SET
     #- { name: 'net.ipv6.conf.lo.disable_ipv6', value: '1' }         # BY ABOVE
 
+# UNMAINTAINED
 - name: Install /etc/profile.d/zzz_iiab.sh from template, to add sbin dirs to unprivileged users' $PATH
   template:
     dest: /etc/profile.d/zzz_iiab.sh
     src: zzz_iiab.sh
 
+# UNMAINTAINED
 - include_tasks: net_mods.yml
   when: not is_debuntu and not is_F18
 


### PR DESCRIPTION
For code readability and possible future deprecating of things like:

- centos.yml
- fedora.yml
- prep.yml
- xo.yml
- /etc/profile.d/zzz_iiab.sh
- net_mods.yml

No functional changes for now.

Ref:

- #2875
- PR #2877