### PR TITLE
Install 'make' package only when nec e.g. roles/pbx

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -40,7 +40,7 @@
       #- iproute2     # Installed by roles/2-common/tasks/network.yml
       - logrotate
       #- lynx         # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
-      #- make         # 2021-04-26: What roles (if any) truly still use this?
+      #- make         # 2021-07-27: Currently used by roles/pbx and no other roles
       - mlocate
       - net-tools     # 2021-04-26: @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - ntfs-3g       # Possibly no longer nec, similar to exfat packages above?

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -27,7 +27,7 @@
     state: present
   when: is_debuntu
 
-- name: "Install 19 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, make, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
+- name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:
     name:
       - acpid         # Daemon for ACPI (power mgmt) events
@@ -40,7 +40,7 @@
       #- iproute2     # Installed by roles/2-common/tasks/network.yml
       - logrotate
       #- lynx         # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
-      - make          # 2021-04-26: What roles (if any) truly still use this?
+      #- make         # 2021-04-26: What roles (if any) truly still use this?
       - mlocate
       - net-tools     # 2021-04-26: @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - ntfs-3g       # Possibly no longer nec, similar to exfat packages above?

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -1,3 +1,12 @@
+- debug:    # Crazy spacing below is tuned for 80-column screens
+    msg: >-
+      ####################################################################WARNING:
+      ONLY UBUNTU 18.04, DEBIAN 9 & RASPBIAN ARE SUPPORTED AS OF FEB 2019.   Please
+      assist Internet-in-a-Box communities worldwide if you can make
+      Asterisk  and FreePBX work on other OS's / distros, Thank
+      You!  http://FAQ.IIAB.IO        ###############################################################################
+
+
 - name: "Set 'nodejs_install: True' and 'nodejs_enabled: True'"
   set_fact:
     nodejs_install: True
@@ -17,6 +26,7 @@
 #    msg: "PBX install cannot proceed, as it currently requires Node.js 12.x, whereas nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml, /etc/iiab/local_vars.yml, /opt/iiab/iiab/roles/nodejs, etc."
 #  when: nodejs_version != "12.x"
 
+
 - name: "Set 'apache_install: True' and 'apache_enabled: True'"
   set_fact:
     apache_install: True
@@ -26,34 +36,33 @@
   include_role:
     name: httpd
 
+
+# 2021-07-27: taken care of by main.yml
 #- name: TODO: Check if asterisk and freepbx are already installed
+#
+#- name: Check if /etc/systemd/system/freepbx.service is already installed
+#  stat: 
+#    path: /etc/systemd/system/freepbx.service
+#  register: freepbx_installed
+#
+#- debug:
+#    msg: >-
+#      FreePBX already installed. Reinstall shall be skipped
+#  when: freepbx_installed.stat.exists
 
-- debug:    # Crazy spacing below is tuned for 80-column screens
-    msg: >-
-      ####################################################################WARNING:
-      ONLY UBUNTU 18.04, DEBIAN 9 & RASPBIAN ARE SUPPORTED AS OF FEB 2019.   Please
-      assist Internet-in-a-Box communities worldwide if you can make
-      Asterisk  and FreePBX work on other OS's / distros, Thank
-      You!  http://FAQ.IIAB.IO        ###############################################################################
+- name: Install 'make' package
+  package:
+    name: make
+    state: present
 
-- name: Check if /etc/systemd/system/freepbx.service is already installed
-  stat: 
-    path: /etc/systemd/system/freepbx.service
-  register: freepbx_installed
-
-- debug:
-    msg: >-
-      FreePBX already installed. Reinstall shall be skipped
-  when: freepbx_installed.stat.exists
-
-- name: Install Asterisk (debuntu)
+- name: Install Asterisk
   include_tasks: asterisk.yml
-  when: internet_available and pbx_install and (pbx_installed is undefined) and is_debuntu and (not freepbx_installed.stat.exists)
+  #when: internet_available and pbx_install and (pbx_installed is undefined) and is_debuntu and (not freepbx_installed.stat.exists)
   #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)
 
-- name: Install FreePBX (debuntu)
+- name: Install FreePBX
   include_tasks: freepbx.yml
-  when: internet_available and pbx_install and (pbx_installed is undefined) and is_debuntu and (not freepbx_installed.stat.exists)
+  #when: internet_available and pbx_install and (pbx_installed is undefined) and is_debuntu and (not freepbx_installed.stat.exists)
   #when: internet_available and pbx_install and (not pbx_installed) and ((is_debian and ansible_distribution_major_version == "9") or is_ubuntu_18)
 
 


### PR DESCRIPTION
@lemueldsouza this is just an interim/small step forward suggestion, as IIAB was declaring far too many 'pollution' packages across the board, that many schools/clinics will never need.

Refs:

- PR #2862
- #2875 
- PR #2877 
- PR #2878