### PR TITLE
Explain networking packages in 1-prep and 2-common -- and experimentally deprecate exfat-fuse, exfat-utils, ntfs-3g -- mandating 5.4+ kernels

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -22,7 +22,7 @@
     path: /boot/firmware/usercfg.txt
     line: "dtoverlay=i2c-rtc,{{ rtc_id }}=on"
     state: present
-  when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, staring in 2020 especially
+  when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, starting in 2020 especially
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -31,15 +31,21 @@
 #    line: 'include btcfg.txt'
 #  when: is_ubuntu
 
-- name: 'Ensure packages are installed: dphys-swapfile, fake-hwclock, iw, rfkill, wireless-tools'
+- name: '2021-07-27: SEE ALSO ~3 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
+  meta: noop
+
+- name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
+  meta: noop
+
+- name: 'Install packages: cloud-guest-utils, dphys-swapfile, fake-hwclock, iw, rfkill, wireless-tools'
   package:
     name:
-      - dphys-swapfile
-      - fake-hwclock
-      - iw
-      - rfkill
-      - wireless-tools
-      - cloud-guest-utils
+      - cloud-guest-utils    # Contains 'growpart' for resizing a partition during boot, which is normally done with the aid of cloud-init
+      - dphys-swapfile       # Autogenerate and use a swap file
+      - fake-hwclock         # Save/restore system clock on machines without working RTC hardware
+      - iw                # Configuring Linux wireless devices
+      - rfkill            # Enabling & disabling wireless devices
+      - wireless-tools    # Manipulating Linux Wireless Extensions
     state: present
 
 - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -22,7 +22,7 @@
     path: /boot/firmware/usercfg.txt
     line: "dtoverlay=i2c-rtc,{{ rtc_id }}=on"
     state: present
-  when: rtc_id is defined and rtc_id != "none" and is_ubuntu
+  when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, staring in 2020 especially
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -31,11 +31,18 @@
 #    line: 'include btcfg.txt'
 #  when: is_ubuntu
 
-- name: '2021-07-27: SEE ALSO ~3 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
+- name: '2021-07-27: SEE ALSO ~4 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
   meta: noop
 
 - name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
   meta: noop
+
+# 2021-07-27 explanation from @jvonau: The 3 BELOW (iw, rfkill, wireless-tools)
+# are provided by RaspiOS.  Ubuntu|Debian on the other hand are hit or miss:
+# desktops might have some/all 3 preinstalled, while servers tend not to have
+# these present at all, but are needed to be installed if you want to take full
+# advantage of WiFi on Ubuntu and friends -- but it's only enforced on RPi
+# hardware where we know in advance of the likelihood of WiFi being present.
 
 - name: 'Install packages: cloud-guest-utils, dphys-swapfile, fake-hwclock, iw, rfkill, wireless-tools'
   package:
@@ -43,7 +50,7 @@
       - cloud-guest-utils    # Contains 'growpart' for resizing a partition during boot, which is normally done with the aid of cloud-init
       - dphys-swapfile       # 2021-07-27: RaspiOS installs this regardless -- autogenerate and use a swap file
       - fake-hwclock         # 2021-07-27: RaspiOS installs this regardless -- save/restore system clock on machines without working RTC hardware
-      - iw                # 2021-07-27: RaspiOS installs this regardless -- configure Linux wireless devices
+      - iw                # 2021-07-27: RaspiOS installs this regardless -- configure Linux wireless devices -- hard dependence for ap0 creation, SEE https://github.com/iiab/iiab/blob/master/roles/network/templates/hostapd/clone-wifi.service.j2
       - rfkill            # 2021-07-27: RaspiOS installs this regardless -- enable & disable wireless devices
       - wireless-tools    # 2021-07-27: RaspiOS installs this regardless -- manipulate Linux Wireless Extensions
     state: present

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -41,11 +41,11 @@
   package:
     name:
       - cloud-guest-utils    # Contains 'growpart' for resizing a partition during boot, which is normally done with the aid of cloud-init
-      - dphys-swapfile       # Autogenerate and use a swap file
-      - fake-hwclock         # Save/restore system clock on machines without working RTC hardware
-      - iw                # Configuring Linux wireless devices
-      - rfkill            # Enabling & disabling wireless devices
-      - wireless-tools    # Manipulating Linux Wireless Extensions
+      - dphys-swapfile       # 2021-07-27: RaspiOS installs this regardless -- autogenerate and use a swap file
+      - fake-hwclock         # 2021-07-27: RaspiOS installs this regardless -- save/restore system clock on machines without working RTC hardware
+      - iw                # 2021-07-27: RaspiOS installs this regardless -- configure Linux wireless devices
+      - rfkill            # 2021-07-27: RaspiOS installs this regardless -- enable & disable wireless devices
+      - wireless-tools    # 2021-07-27: RaspiOS installs this regardless -- manipulate Linux Wireless Extensions
     state: present
 
 - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails

--- a/roles/2-common/tasks/network.yml
+++ b/roles/2-common/tasks/network.yml
@@ -1,22 +1,22 @@
 - name: '2021-07-27: SEE ALSO ~3 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml'
   meta: noop
 
-- name: '2021-07-27: SEE ALSO ~3 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
+- name: '2021-07-27: SEE ALSO ~4 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
   meta: noop
 
 - name: Install package networkd-dispatcher (OS's other than RaspiOS)
   package:
-    name: networkd-dispatcher
+    name: networkd-dispatcher    # Dispatcher service for systemd-networkd connection status changes
     state: present
   when: not is_raspbian
 
-- name: 'Install network packages: hostapd, iproute2, iptables-persistent, netmask (debuntu) -- later used by https://github.com/iiab/iiab/tree/master/roles/network'
+- name: 'Install network packages: hostapd, iproute2, iptables-persistent, netmask -- later used by https://github.com/iiab/iiab/tree/master/roles/network'
   package:
     name:
-      - iproute2
-      - iptables-persistent
-      - hostapd
-      - netmask
+      - hostapd                # IEEE 802.11 AP and IEEE 802.1X/WPA/WPA2/EAP Authenticator -- has its service masked out of the box, and only used when IIAB's network roles detects the presence of WiFi and an AP is desired
+      - iproute2               # 2021-07-27: RaspiOS installs this regardless -- the new networking and traffic control tools, meant to replace net-tools
+      - iptables-persistent    # Boot-time loader for netfilter rules, iptables (firewall) plugin -- however 'netfilter' is ever moving forward so keep an eye on it!
+      - netmask                # Handy utility -- helps determine network masks
     state: present
 
 - name: Install /etc/network/if-pre-up.d/iptables from template (0755, debuntu)

--- a/roles/2-common/tasks/network.yml
+++ b/roles/2-common/tasks/network.yml
@@ -1,11 +1,16 @@
+- name: '2021-07-27: SEE ALSO ~3 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml'
+  meta: noop
+
+- name: '2021-07-27: SEE ALSO ~3 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/packages.yml'
+  meta: noop
+
 - name: Install package networkd-dispatcher (OS's other than RaspiOS)
   package:
     name: networkd-dispatcher
     state: present
   when: not is_raspbian
 
-# used in the network role
-- name: 'Install network packages: hostapd, iproute2, iptables-persistent, netmask (debuntu)'
+- name: 'Install network packages: hostapd, iproute2, iptables-persistent, netmask (debuntu) -- later used by https://github.com/iiab/iiab/tree/master/roles/network'
   package:
     name:
       - iproute2
@@ -13,11 +18,9 @@
       - hostapd
       - netmask
     state: present
-  when: is_debuntu
 
 - name: Install /etc/network/if-pre-up.d/iptables from template (0755, debuntu)
   template:
     src: iptables
     dest: /etc/network/if-pre-up.d/iptables
     mode: '0755'
-  when: is_debuntu

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -14,6 +14,12 @@
 #    state: present
 #  when: is_redhat
 
+- name: '2021-07-27: SEE ALSO ~3 networking packages EARLIER installed by https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml'
+  meta: noop
+
+- name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
+  meta: noop
+
 - name: "Install 4 deb/apt packages: exfat-fuse, exfat-utils, libnss-mdns, wpasupplicant"
   package:
     name:
@@ -25,12 +31,6 @@
       - libnss-mdns      # 2021-07-27: Client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
       - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
     state: present
-
-- name: '2021-07-27: SEE ALSO ~3 networking packages earlier installed by https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml'
-  meta: noop
-
-- name: '2021-07-27: SEE ALSO ~4 networking packages later installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
-  meta: noop
 
 - name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -14,16 +14,16 @@
 #    state: present
 #  when: is_redhat
 
-- name: "Install 6 deb/apt packages: avahi-daemon, exfat-fuse, exfat-utils, inetutils-syslogd, libnss-mdns, wpasupplicant"
+- name: "Install 4 deb/apt packages: exfat-fuse, exfat-utils, libnss-mdns, wpasupplicant"
   package:
     name:
-      #- avahi-discover
-      - avahi-daemon
-      - exfat-fuse     # Should no longer be nec with 5.4+ kernels
-      - exfat-utils    # Likewise!
-      - inetutils-syslogd    # Error logging facility
-      - libnss-mdns    # Provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
-      - wpasupplicant
+      #- avahi-discover  # 2021-07-27: Commented out long ago
+      #- avahi-daemon    # 2021-07-27: Holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
+      - exfat-fuse       # Should no longer be nec with 5.4+ kernels
+      - exfat-utils      # Likewise!
+      #- inetutils-syslogd    # 2021-07-27: Error logging facility -- holdover from the XO days, journalctl has replaced this in newer distros
+      - libnss-mdns      # 2021-07-27: Client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
+      - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
     state: present
   #when: is_debuntu
 

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -25,7 +25,12 @@
       - libnss-mdns      # 2021-07-27: Client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
       - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
     state: present
-  #when: is_debuntu
+
+# 2021-07-27: SEE ALSO 3 networking packages installed by
+# https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml
+
+# 2021-07-27: SEE ALSO 4 networking packages installed by
+# https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml
 
 - name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -26,11 +26,11 @@
       - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
     state: present
 
-# 2021-07-27: SEE ALSO ~3 networking packages earlier installed by
-# https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml
+- name: '2021-07-27: SEE ALSO ~3 networking packages earlier installed by https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml'
+  meta: noop
 
-# 2021-07-27: SEE ALSO ~4 networking packages later installed by
-# https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml
+- name: '2021-07-27: SEE ALSO ~4 networking packages later installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
+  meta: noop
 
 - name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -20,7 +20,7 @@
 - name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
   meta: noop
 
-- name: "Install 21 common packages: acpid, avahi-daemon, bzip2, curl, gawk, htop, i2c-tools, libnss-mdns, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget, wpasupplicant"
+- name: "Install 20 common packages: acpid, avahi-daemon, bzip2, curl, gawk, htop, i2c-tools, libnss-mdns, logrotate, mlocate, net-tools, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget, wpasupplicant"
   package:
     name:
       - acpid              # Daemon for ACPI (power mgmt) events
@@ -30,7 +30,7 @@
       - curl               # Used to install roles/nodejs and roles/nodered
       #- etckeeper         # "nobody is really using etckeeper and it's bloating the filesystem every time apt runs" per @jvonau at https://github.com/iiab/iiab/issues/1146
       #- exfat-fuse        # 2021-07-27: Should no longer be nec with 5.4+ kernels, so let's try commenting it out
-      #- exfat-utils       # Ditto!
+      #- exfat-utils       # Ditto!  See also 'ntfs-3g' below
       - gawk
       - htop
       - i2c-tools          # Low-level bus/chip/register/EEPROM tools e.g. for RTC
@@ -42,7 +42,7 @@
       #- make              # 2021-07-27: Currently used by roles/pbx and no other roles
       - mlocate
       - net-tools          # 2021-04-26: @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
-      - ntfs-3g            # Possibly no longer nec, similar to exfat packages above?
+      #- ntfs-3g           # 2021-07-27: Should no longer be nec, similar to exfat packages above -- but see this symlink warning: https://superuser.com/questions/1050544/mount-with-kernel-ntfs-and-not-ntfs-3g
       #- openssh-server    # ssh (Raspbian) or openssh-server (other OS's) already installed by 1-prep's roles/sshd/tasks/main.yml
       - pandoc             # For /usr/bin/iiab-refresh-wiki-docs
       - pastebinit         # For /usr/bin/iiab-diagnostics

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -26,10 +26,10 @@
       - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
     state: present
 
-# 2021-07-27: SEE ALSO 3 networking packages installed by
+# 2021-07-27: SEE ALSO ~3 networking packages earlier installed by
 # https://github.com/iiab/iiab/blob/master/roles/1-prep/tasks/raspberry_pi.yml
 
-# 2021-07-27: SEE ALSO 4 networking packages installed by
+# 2021-07-27: SEE ALSO ~4 networking packages later installed by
 # https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml
 
 - name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -20,16 +20,16 @@
 - name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
   meta: noop
 
-- name: "Install 4 deb/apt packages: exfat-fuse, exfat-utils, libnss-mdns, wpasupplicant"
+- name: "Install 5 deb/apt packages: exfat-fuse, exfat-utils, libnss-mdns, wpasupplicant"
   package:
     name:
       #- avahi-discover  # 2021-07-27: Commented out long ago
-      #- avahi-daemon    # 2021-07-27: Holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
+      - avahi-daemon     # 2021-07-27: RaspiOS (and package libnss-mnds, below) install this regardless -- holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
       - exfat-fuse       # Should no longer be nec with 5.4+ kernels
       - exfat-utils      # Likewise!
       #- inetutils-syslogd    # 2021-07-27: Error logging facility -- holdover from the XO days, journalctl has replaced this in newer distros
-      - libnss-mdns      # 2021-07-27: Client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
-      - wpasupplicant    # 2021-07-27: Client library for connections to a WiFi AP
+      - libnss-mdns      # 2021-07-27: RaspiOS (and package avahi-daemon, above) install this regardless -- client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
+      - wpasupplicant    # 2021-07-27: RaspiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
 
 - name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -20,45 +20,40 @@
 - name: '2021-07-27: SEE ALSO 4-5 networking packages LATER installed by https://github.com/iiab/iiab/blob/master/roles/2-common/tasks/network.yml'
   meta: noop
 
-- name: "Install 5 deb/apt packages: exfat-fuse, exfat-utils, libnss-mdns, wpasupplicant"
+- name: "Install 21 common packages: acpid, avahi-daemon, bzip2, curl, gawk, htop, i2c-tools, libnss-mdns, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget, wpasupplicant"
   package:
     name:
-      #- avahi-discover  # 2021-07-27: Commented out long ago
-      - avahi-daemon     # 2021-07-27: RaspiOS (and package libnss-mnds, below) install this regardless -- holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
-      - exfat-fuse       # Should no longer be nec with 5.4+ kernels
-      - exfat-utils      # Likewise!
-      #- inetutils-syslogd    # 2021-07-27: Error logging facility -- holdover from the XO days, journalctl has replaced this in newer distros
-      - libnss-mdns      # 2021-07-27: RaspiOS (and package avahi-daemon, above) install this regardless -- client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
-      - wpasupplicant    # 2021-07-27: RaspiOS installs this regardless -- client library for connections to a WiFi AP
-    state: present
-
-- name: "Install 18 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, mlocate, net-tools, ntfs-3g, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
-  package:
-    name:
-      - acpid         # Daemon for ACPI (power mgmt) events
-      - bzip2         # 2021-04-26: Prob not used, but can't hurt?
-      - curl          # Used to install roles/nodejs and roles/nodered
-      #- etckeeper    # "nobody is really using etckeeper and it's bloating the filesystem every time apt runs" per @jvonau at https://github.com/iiab/iiab/issues/1146
+      - acpid              # Daemon for ACPI (power mgmt) events
+      #- avahi-discover    # 2021-07-27: Commented out long ago
+      - avahi-daemon       # 2021-07-27: RaspiOS (and package libnss-mnds, below) install this regardless -- holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
+      - bzip2              # 2021-04-26: Prob not used, but can't hurt?
+      - curl               # Used to install roles/nodejs and roles/nodered
+      #- etckeeper         # "nobody is really using etckeeper and it's bloating the filesystem every time apt runs" per @jvonau at https://github.com/iiab/iiab/issues/1146
+      #- exfat-fuse        # 2021-07-27: Should no longer be nec with 5.4+ kernels, so let's try commenting it out
+      #- exfat-utils       # Ditto!
       - gawk
       - htop
-      - i2c-tools     # Low-level bus/chip/register/EEPROM tools e.g. for RTC
-      #- iproute2     # Installed by roles/2-common/tasks/network.yml
+      - i2c-tools          # Low-level bus/chip/register/EEPROM tools e.g. for RTC
+      #- inetutils-syslogd # 2021-07-27: Error logging facility -- holdover from the XO days, journalctl has replaced this in newer distros
+      #- iproute2          # Installed by roles/2-common/tasks/network.yml
       - logrotate
-      #- lynx         # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
-      #- make         # 2021-07-27: Currently used by roles/pbx and no other roles
+      - libnss-mdns        # 2021-07-27: RaspiOS (and package avahi-daemon, above) install this regardless -- client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
+      #- lynx              # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
+      #- make              # 2021-07-27: Currently used by roles/pbx and no other roles
       - mlocate
-      - net-tools     # 2021-04-26: @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
-      - ntfs-3g       # Possibly no longer nec, similar to exfat packages above?
+      - net-tools          # 2021-04-26: @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
+      - ntfs-3g            # Possibly no longer nec, similar to exfat packages above?
       #- openssh-server    # ssh (Raspbian) or openssh-server (other OS's) already installed by 1-prep's roles/sshd/tasks/main.yml
-      - pandoc        # For /usr/bin/iiab-refresh-wiki-docs
-      - pastebinit    # For /usr/bin/iiab-diagnostics
+      - pandoc             # For /usr/bin/iiab-refresh-wiki-docs
+      - pastebinit         # For /usr/bin/iiab-diagnostics
       - rsync
-      #- screen       # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
+      #- screen            # Installed by 1-prep's roles/iiab-admin/tasks/access.yml
       - sqlite3
-      #- sudo         # Installed by 1-prep's roles/iiab-admin/tasks/sudo-prereqs.yml
+      #- sudo              # Installed by 1-prep's roles/iiab-admin/tasks/sudo-prereqs.yml
       - tar
       - unzip
-      #- usbmount     # Moved to roles/usb_lib/tasks/install.yml
-      - usbutils      # 2021-04-26: Also move to roles/usb_lib/tasks/install.yml ?
+      #- usbmount          # Moved to roles/usb_lib/tasks/install.yml
+      - usbutils           # 2021-07-27: RaspiOS installs this regardless -- move to roles/usb_lib/tasks/install.yml ?
       - wget
+      - wpasupplicant      # 2021-07-27: RaspiOS installs this regardless -- client library for connections to a WiFi AP
     state: present

--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -24,8 +24,8 @@
   package:
     name:
       - acpid              # Daemon for ACPI (power mgmt) events
-      #- avahi-discover    # 2021-07-27: Commented out long ago
       - avahi-daemon       # 2021-07-27: RaspiOS (and package libnss-mnds, below) install this regardless -- holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon
+      #- avahi-discover    # 2021-07-27: Commented out long ago
       - bzip2              # 2021-04-26: Prob not used, but can't hurt?
       - curl               # Used to install roles/nodejs and roles/nodered
       #- etckeeper         # "nobody is really using etckeeper and it's bloating the filesystem every time apt runs" per @jvonau at https://github.com/iiab/iiab/issues/1146


### PR DESCRIPTION
Thanks to @jvonau's very helpful contextualizing at https://github.com/iiab/iiab/pull/2876#issuecomment-887668201