### PR TITLE
NGINX Security Risk: Remove /cgi-bin access to /usr/lib ?

### DIFF
--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -20,9 +20,10 @@ server {
         include fastcgi_params;
     }
 
-    location /cgi-bin {
-        root /usr/lib;
-    }
+    # 2021-07-30: Security risk identified by @tim-moody
+    #location /cgi-bin {
+    #    root /usr/lib;
+    #}
 
     # if you don't like seeing all the errors for missing favicon.ico in root
     location = /favicon.ico { access_log off; log_not_found off; }


### PR DESCRIPTION
Many thanks to @tim-moody for having identified this potentially serious hazard.

Needs testing to establish that most/all IIAB apps continue to work with this patch.