### PR TITLE
Desupport Debian 10 + lay groundwork for Debian 12 (Bookworm)

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -52,6 +52,7 @@ OS_VER=$OS-$VERSION_ID
     #"fedora-22"    | \
     #"debian-8"     | \
     #"debian-9"     | \
+    #"debian-10"    | \
     #"ubuntu-16"    | \
     #"ubuntu-17"    | \
     #"ubuntu-18"    | \
@@ -60,16 +61,16 @@ OS_VER=$OS-$VERSION_ID
     #"raspbian-8"   | \
     #"raspbian-9"   | \
 
-# 2020-10-21: Debian 11 (Bullseye) not yet supported but adding this line to
-# its /etc/os-release can help testing this unreleased OS: VERSION_ID="11"
-
 # 2021-06-19: Ubuntu 21.10 (Impish Indri) not yet supported but this
 # unreleased OS can help testing.  For now this means MANUALLY changing
 # php_version: 7.4 to 8.0 in /opt/iiab/iiab/vars/ubuntu-21.yml
 
+# 2020-07-31: Debian 12 (Bookworm) not yet supported but adding this line
+# to its /etc/os-release can help testing this upcoming OS: VERSION_ID="12"
+
 case $OS_VER in
-    "debian-10"    | \
     "debian-11"    | \
+    "debian-12"    | \
     "ubuntu-20"    | \
     "ubuntu-21"    | \
     "linuxmint-20" | \

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,0 +1,29 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_debian: True    # Opposite of is_ubuntu for now
+is_debian_12: True
+
+# 2019-01-31: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dhcp_service: isc-dhcp-server
+dns_user: bind
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_conf_dir: apache2/sites-available
+apache_user: www-data
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: 8.0
+postgresql_version: 13
+systemd_location: /lib/systemd/system
+python_ver: 3.9

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -716,6 +716,7 @@ is_linuxmint: False    # Subset of is_ubuntu
 is_linuxmint_20: False
 
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
+is_debian_12: False
 is_debian_11: False
 is_debian_10: False
 is_debian_9: False


### PR DESCRIPTION
Arguably this should have been done 6 months ago, when the bulk of the Debian community moved from Debian 10 (Buster) to Debian 11 (Bullseye).

Not without reason nodesource.com began supporting Debian 11 last year in 2020.

In any case, IIAB should not and will not support nostalgia OS's from years ago.

CLARIFICATION 1: Those who insist on running nostalgia OS's can of course attempt that At Their Own Risk &mdash; by following the instructions under section 3. here: https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems

CLARIFICATION 2: IIAB will continue to support Raspberry Pi OS 10 for a few more weeks, until Raspberry Pi OS 11 is mainlined shortly at https://www.raspberrypi.org/software/operating-systems/ &mdash; _and confirmed to be good enough (:_

Ref:

- #1737
- #2658
- PR #2885