### PR TITLE
pbx/defaults/main.yml: Asterisk 16.x -> 18.x

### DIFF
--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -17,7 +17,7 @@
 #pbx_installed: False
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/
-asterisk_src_file: asterisk-16-current.tar.gz
+asterisk_src_file: asterisk-18-current.tar.gz
 asterisk_src_dir: /opt/iiab/asterisk
 
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/


### PR DESCRIPTION
Verification is ongoing with @lemueldsouza for RPi etc, but long story short Asterisk 18.5.1 installed with FreePBX 15.0.17.37 on Ubuntu Server 20.04 with Node.js 16.6.0 seems to better support modern testing:

```
root@box:~# asterisk -r
Asterisk 18.5.1, Copyright (C) 1999 - 2021, Sangoma Technologies Corporation and others.
```

```
root@box:~# amportal a ma list | grep framework
| framework        | 15.0.17.37 | Enabled                           | GPLv2+  |
```

Asterisk 17.x is also possible, if anybody strongly prefers that for any reason in coming weeks ?

But for now, v18 seem would seem to be best, to harmonize IIAB community testing among all.