### PR TITLE
Update roles/pbx/README.rst, announcing Asterisk 16.x -> 18.x but also warning about PHP 7.4 etc! [Announce transition to FreePBX 16 Beta is now underway, moving away from PHP 7.3]

### DIFF
--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -6,9 +6,9 @@ This "pbx" playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https
 
 The initial release (for IIAB 6.7 in February 2019) supported Ubuntu 18.04, Debian 9 "Stretch" — and experimentally, Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
 
-*2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x to 18.x* (`docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_).
+*2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x (released 2018-10-09) to 18.x (released 2020-10-20*, `docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_).
 
-*2021-08-02 BAD NEWS: The latest versions of Ubuntu (20.04, 20.10, 21.04), Debian 11 "Bullseye" and the imminent Raspberry Pi OS 11 "Bullseye" all include PHP 7.4 — which does not work with FreePBX 15 — so we could use some help looking into 2021-06-21's FreePBX 16.0 Beta:* `#2897 <https://github.com/iiab/iiab/issues/2897#issuecomment-891371536>`_
+*2021-08-02 BAD NEWS: The latest versions of Ubuntu (20.04, 20.10, 21.04), Debian 11 "Bullseye" and the imminent Raspberry Pi OS 11 "Bullseye" all include PHP 7.4 — which does not work with FreePBX 15 — so we could use some help looking into 2021-06-21's FreePBX 16 Beta:* `#2897 <https://github.com/iiab/iiab/issues/2897#issuecomment-891371536>`_
 
 What Asterisk & FreePBX Do
 --------------------------

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -4,7 +4,11 @@ PBX README
 
 This 'pbx' playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality e.g. for rural telephony.
 
-This initial release (for IIAB 6.7 in February 2019) supports Ubuntu 18.04, Debian 9 "Stretch" — and experimentally supports Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
+The initial release (for IIAB 6.7 in February 2019) supported Ubuntu 18.04, Debian 9 "Stretch" — and experimentally supported Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
+
+*2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x to 18.x* (`docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_).
+
+*2021-08-02 BAD NEWS: The latest versions of Ubuntu (20.04, 20.10, 21.04), Debian 11 "Bullseye" and the imminent Raspberry Pi OS 11 "Bullseye" all include PHP 7.4 — which does not work with FreePBX 15 — so we could use some help looking into 2021-06-21's FreePBX 16.0 Beta:* `#2897 <https://github.com/iiab/iiab/issues/2897#issuecomment-891371536>`_
 
 What Asterisk & FreePBX Do
 --------------------------
@@ -34,7 +38,7 @@ You can monitor the FreePBX service with command::
 Raspberry Pi Known Issue
 ------------------------
 
-As of 2019-02-14, "systemctl restart freepbx" fails more than 50% of the time when run on a `BIG-sized <http://wiki.laptop.org/go/IIAB/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation.3F>`_ install of IIAB 6.7 on RPi 3 or RPi 3 B+.
+As of 2019-02-14, "systemctl restart freepbx" failed more than 50% of the time when run on a `BIG-sized <http://wiki.laptop.org/go/IIAB/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation.3F>`_ install of IIAB 6.7 on RPi 3 or RPi 3 B+.
 
 It is possible that FreePBX restarts much more reliably when run on a MIN-sized install of IIAB?  Please `contact us <http://wiki.laptop.org/go/IIAB/FAQ#What_are_the_best_places_for_community_support.3F>`_ if you can assist here in any way: `#1493 <https://github.com/iiab/iiab/issues/1493>`_
 

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -2,9 +2,9 @@
 PBX README
 ==========
 
-This 'pbx' playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality e.g. for rural telephony.
+This "pbx" playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https://freepbx.org/>`_ to Internet-in-a-Box (IIAB) for VoIP and SIP functionality e.g. for rural telephony.
 
-The initial release (for IIAB 6.7 in February 2019) supported Ubuntu 18.04, Debian 9 "Stretch" — and experimentally supported Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
+The initial release (for IIAB 6.7 in February 2019) supported Ubuntu 18.04, Debian 9 "Stretch" — and experimentally, Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
 
 *2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x to 18.x* (`docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_).
 
@@ -47,7 +47,9 @@ Raspberry Pi Zero W Warning
 
 Node.js applications like Asterisk/FreePBX, Node-RED and Sugarizer won't work on Raspberry Pi Zero W (ARMv6) if you installed Node.js while on RPi 3, 3 B+ (ARMv7) or RPi 4 (ARMv8).  If necessary, run ``apt remove nodejs`` or ``apt purge nodejs`` then ``rm /etc/apt/sources.list.d/nodesource.list; apt update`` then (`attempt! <https://nodered.org/docs/hardware/raspberrypi#swapping-sd-cards>`_) to `install Node.js <https://github.com/iiab/iiab/blob/master/roles/nodejs/tasks/main.yml>`_ *on the Raspberry Pi Zero W itself* (a better approach than "cd /opt/iiab/iiab; ./runrole nodejs" is to try ``apt install nodejs`` or try installing the tar file mentioned at `#2082 <https://github.com/iiab/iiab/issues/2082#issuecomment-569344617>`_).  You might also need ``apt install npm``.  Whatever versions of Node.js and npm you install, make sure ``/etc/iiab/iiab_state.yml`` contains the line ``nodejs_installed: True`` (add it if nec!)  Finally, proceed to install Asterisk/FreePBX, Node-RED and/or Sugarizer.  `#1799 <https://github.com/iiab/iiab/issues/1799>`_
 
+Please also check the "Known Issues" at the bottom of `IIAB's latest release notes <https://github.com/iiab/iiab/wiki#our-evolution>`_.
+
 Attribution
 -----------
 
-This 'pbx' playbook was heavily inspired by Yannik Sembritzki's `Asterisk <https://github.com/Yannik/ansible-role-asterisk>`_ and `FreePBX <https://github.com/Yannik/ansible-role-freepbx>`_ Ansible work, Thank You!
+This "pbx" playbook was heavily inspired by Yannik Sembritzki's `Asterisk <https://github.com/Yannik/ansible-role-asterisk>`_ and `FreePBX <https://github.com/Yannik/ansible-role-freepbx>`_ Ansible work, Thank You!

--- a/roles/pbx/README.rst
+++ b/roles/pbx/README.rst
@@ -6,9 +6,9 @@ This "pbx" playbook adds `Asterisk <https://asterisk.org/>`_ and `FreePBX <https
 
 The initial release (for IIAB 6.7 in February 2019) supported Ubuntu 18.04, Debian 9 "Stretch" — and experimentally, Raspberry Pi: `#1467 <https://github.com/iiab/iiab/issues/1467>`_
 
-*2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x (released 2018-10-09) to 18.x (released 2020-10-20*, `docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_).
+*2021-08-02 GOOD NEWS: IIAB has upgraded from Asterisk 16.x (released 2018-10-09) to 18.x (released 2020-10-20*, `docs <https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation>`_): `PR #2896 <https://github.com/iiab/iiab/pull/2896>`_
 
-*2021-08-02 BAD NEWS: The latest versions of Ubuntu (20.04, 20.10, 21.04), Debian 11 "Bullseye" and the imminent Raspberry Pi OS 11 "Bullseye" all include PHP 7.4 — which does not work with FreePBX 15 — so we could use some help looking into 2021-06-21's FreePBX 16 Beta:* `#2897 <https://github.com/iiab/iiab/issues/2897#issuecomment-891371536>`_
+*2021-08-02 WORK IN PROGRESS: The latest versions of Ubuntu (20.04, 20.10, 21.04), Debian 11 "Bullseye" and the imminent Raspberry Pi OS 11 "Bullseye" all include PHP 7.4 — which does not work with FreePBX 15 — so we're now making the transition to FreePBX 16 who Beta emerged on 2021-06-21:* `#2897 <https://github.com/iiab/iiab/issues/2897#issuecomment-891371536>`_, `PR #2899 <https://github.com/iiab/iiab/pull/2899>`_
 
 What Asterisk & FreePBX Do
 --------------------------


### PR DESCRIPTION
@lemueldsouza can you help refine this 1st pass?

(What else should be added/removed/clarified !)

Refs:

- #1467
  - #1493
- PR #1761
  - https://github.com/FreePBX/framework/pull/71#issuecomment-494390926
- PR #2896 
- #2897
  - PR #2899