### PR TITLE
Does something like 'RestartSec=3' in /etc/systemd/system/freepbx.service help Asterisk start reliably? (WIP)

### DIFF
--- a/roles/pbx/tasks/enable-or-disable.yml
+++ b/roles/pbx/tasks/enable-or-disable.yml
@@ -1,18 +1,29 @@
-- name: Enable & (Re)start 'asterisk' systemd service (if pbx_enabled)
-  systemd:
-    daemon_reload: yes
-    name: asterisk
-    enabled: yes
-    state: restarted
-  when: pbx_enabled
+# 2021-08-04: This stanza commonly causes systemd error "Asterisk is already
+# running.  /etc/init.d/asterisk will exit now" (initial installs especially?)
+#
+# Also 'systemctl restart freepbx' all alone during initial install -- is
+# likewise unreliable -- as confirmed on both Ubuntu 20.04 and Debian 11 :/
+#
+# Yes /etc/systemd/system/freepbx.service is supposed to run 'fwconsole stop'
+# then 'fwconsole start' reliably, as many web posts recommend, But No Dice :/
+#
+# Do we need something like 'RestartSec=3' in freepbx.service ??
+#
+#- name: Enable & (Re)start 'asterisk' systemd service (if pbx_enabled)
+#  systemd:
+#    daemon_reload: yes
+#    name: asterisk
+#    enabled: yes
+#    state: restarted
+#  when: pbx_enabled
 
-- name: Disable & Stop 'asterisk' systemd service (if not pbx_enabled)
-  systemd:
-    daemon_reload: yes
-    name: asterisk
-    enabled: no
-    state: stopped
-  when: not pbx_enabled
+#- name: Disable & Stop 'asterisk' systemd service (if not pbx_enabled)
+#  systemd:
+#    daemon_reload: yes
+#    name: asterisk
+#    enabled: no
+#    state: stopped
+#  when: not pbx_enabled
 
 
 - name: Enable & (Re)start 'freepbx' systemd service (if pbx_enabled)

--- a/roles/pbx/tasks/enable-or-disable.yml
+++ b/roles/pbx/tasks/enable-or-disable.yml
@@ -1,11 +1,11 @@
-# 2021-08-04: This stanza commonly causes systemd error "Asterisk is already
+# 2021-08-04: Stanza below commonly causes systemd error "Asterisk is already
 # running.  /etc/init.d/asterisk will exit now" (initial installs especially?)
 #
-# Also 'systemctl restart freepbx' all alone during initial install -- is
-# likewise unreliable -- as confirmed on both Ubuntu 20.04 and Debian 11 :/
+# But without this stanza, 'systemctl restart freepbx' all alone during initial
+# install ALSO fails to start Asterisk reliably, on Ubuntu 20.04 & Debian 11 :/
 #
 # Yes /etc/systemd/system/freepbx.service is supposed to run 'fwconsole stop'
-# then 'fwconsole start' reliably, as many web posts recommend, But No Dice :/
+# then 'fwconsole start' reliably, as many web posts recommend, But No Dice!
 #
 # Do we need something like 'RestartSec=3' in freepbx.service ??
 #

--- a/roles/pbx/templates/freepbx.service.j2
+++ b/roles/pbx/templates/freepbx.service.j2
@@ -7,6 +7,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/fwconsole start
 ExecStop=/usr/sbin/fwconsole stop
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I don't know yet!

But @lemueldsouza and @jvonau may be able to guide us towards a reliable outcome?

Asterisk 18.x should certainly be stable after almost 10 months (is it possible FreePBX 16.x Beta is not yet stable in this very basic way?)

Refs:

- PR #2905 
- PR #2906