### PR TITLE
Revert 'RestartSec=3' in /etc/systemd/system/freepbx.service

### DIFF
--- a/roles/pbx/tasks/enable-or-disable.yml
+++ b/roles/pbx/tasks/enable-or-disable.yml
@@ -7,7 +7,8 @@
 # Yes /etc/systemd/system/freepbx.service is supposed to run 'fwconsole stop'
 # then 'fwconsole start' reliably, as many web posts recommend, But No Dice!
 #
-# Do we need something like 'RestartSec=3' in freepbx.service ??
+# Adding 'RestartSec=3' to freepbx.service is not the answer.  Discussion here:
+# https://github.com/iiab/iiab/pull/2908
 #
 #- name: Enable & (Re)start 'asterisk' systemd service (if pbx_enabled)
 #  systemd:

--- a/roles/pbx/templates/freepbx.service.j2
+++ b/roles/pbx/templates/freepbx.service.j2
@@ -7,9 +7,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/fwconsole start
 ExecStop=/usr/sbin/fwconsole stop
-# 2021-08-04: Does this help Asterisk (re)start reliably, as FreePBX install completes?
-# PR #2908: https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/enable-or-disable.yml
-RestartSec=3
+# 2021-08-04: Asterisk doesn't (re)start reliably, as FreePBX install completes:
+# https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/enable-or-disable.yml
+# RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It causes no harm, but far better to move forward towards a legit solution.

As discussed here:

- PR #2908

cc: @jvonau @lemueldsouza 