### PR TITLE
little heavy handed but it works [workaround for FreePBX's "Unable to run Pre-Asterisk hooks, because Asterisk is already running"]

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -113,6 +113,8 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - killall -9 safe_asterisk
+    - killall -9 asterisk
 
 # 2021-08-04: FreePBX 16 no longer needs this FreePBX 15 patch
 # - name: FreePBX - Patch FreePBX source - disable get_magic_quotes_gpc()


### PR DESCRIPTION
`./start_asterisk stop` does nothing
`./start_asterisk kill` spits out an error
just undoes what `./start_asterisk start` did
allows the freepbx service to start cleanly to run the hooks

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
