### PR TITLE
Run 'systemctl restart freepbx' twice, so http://box:83/freepbx works right away on install, prior to reboot -- Re: "Unable to run Pre-Asterisk hooks, because Asterisk is already running"

### DIFF
--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -2,6 +2,9 @@
 #- name: Asterisk - Install dependencies
 #  include: asterisk_dependencies.yml
 
+# BEWARE: 'systemctl is-active asterix' falsely reports 'inactive' even when systemd
+# is compiled in below!  FWIW: /opt/iiab/asterisk/contrib/systemd/asterisk.service
+
 - name: Asterisk - Install package 'libsystemd-dev' so Asterisk compiles in imperfect-but-improving systemd support -- so '/* #undef HAVE_SYSTEMD */' becomes '#undef HAVE_SYSTEMD' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3 and https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
   package:
     name: libsystemd-dev

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,8 +1,8 @@
-# 2021-08-05: Asterisk's own install_prereq (below) handles most all of these
+# 2021-08-05: Asterisk's own install_prereq (below) handles essentially all of these
 #- name: Asterisk - Install dependencies
 #  include: asterisk_dependencies.yml
 
-- name: Install package 'libsystemd-dev' so Asterisk compiles in systemd support -- after '/* #undef HAVE_SYSTEMD */' becomes '#undef HAVE_SYSTEMD' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3 and https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
+- name: Asterisk - Install package 'libsystemd-dev' so Asterisk compiles in imperfect-but-improving systemd support -- so '/* #undef HAVE_SYSTEMD */' becomes '#undef HAVE_SYSTEMD' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3 and https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
   package:
     name: libsystemd-dev
     state: present
@@ -105,12 +105,6 @@
   command: ldconfig
   args:
     chdir: "{{ asterisk_src_dir }}"
-
-# - name: 2021-08-05 EXPERIMENTALLY RUN 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' as recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
-#   command: update-rc.d -f asterisk remove
-
-
-- pause:
 
 
 - name: Asterisk - Ensure group 'asterisk' exists

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -68,12 +68,6 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-# - name: Asterisk - Set '#define HAVE_SYSTEMD 1' in /opt/iiab/asterisk/include/asterisk/autoconfig.h
-#   lineinfile:
-#     path: /opt/iiab/asterisk/include/asterisk/autoconfig.h
-#     regexp: '#undef HAVE_SYSTEMD'
-#     line: '#define HAVE_SYSTEMD 1'
-
 - name: Asterisk - Run 'make menuselect.makeopts'
   command: make menuselect.makeopts
   args:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,6 +1,11 @@
-# 2021-08-03: Asterisk's own install_prereq (below) handles these?
+# 2021-08-05: Asterisk's own install_prereq (below) handles most all of these
 #- name: Asterisk - Install dependencies
 #  include: asterisk_dependencies.yml
+
+- name: Install package 'libsystemd-dev' so Asterisk compiles in systemd support -- after '/* #undef HAVE_SYSTEMD */' becomes '#undef HAVE_SYSTEMD' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3 and https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
+  package:
+    name: libsystemd-dev
+    state: present
 
 - name: Asterisk - Download {{ asterisk_url }}/{{ asterisk_src_file }} to {{ downloads_dir }}
   get_url:
@@ -74,7 +79,7 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - Run 'make' - CAN TAKE 30 MIN OR LONGER!
+- name: Asterisk - Run 'make' - CAN TAKE 8-30 MIN OR LONGER!
   command: make
   args:
     chdir: "{{ asterisk_src_dir }}"
@@ -97,9 +102,15 @@
     chdir: "{{ asterisk_src_dir }}"
 
 - name: Asterisk - Run 'ldconfig'
-  shell: ldconfig
+  command: ldconfig
   args:
     chdir: "{{ asterisk_src_dir }}"
+
+# - name: 2021-08-05 EXPERIMENTALLY RUN 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' as recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+#   command: update-rc.d -f asterisk remove
+
+
+- pause:
 
 
 - name: Asterisk - Ensure group 'asterisk' exists

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -3,9 +3,10 @@
 #  include: asterisk_dependencies.yml
 
 # BEWARE: 'systemctl is-active asterix' falsely reports 'inactive' even when systemd
-# is compiled in below!  FWIW: /opt/iiab/asterisk/contrib/systemd/asterisk.service
+# is compiled in below!   FWIW: /opt/iiab/asterisk/contrib/systemd/asterisk.service
+# https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
 
-- name: Asterisk - Install package 'libsystemd-dev' so Asterisk compiles in imperfect-but-improving systemd support -- so '/* #undef HAVE_SYSTEMD */' becomes '#undef HAVE_SYSTEMD' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3 and https://github.com/asterisk/asterisk/blob/master/contrib/systemd/asterisk.service
+- name: Asterisk - Install package 'libsystemd-dev' so Asterisk compiles in imperfect-but-improving systemd support -- if ./configure below places '#define HAVE_SYSTEMD 1' in /opt/iiab/asterisk/include/asterisk/autoconfig.h -- please later confirm with 'ldd /usr/sbin/asterisk | grep systemd' -- per https://community.asterisk.org/t/systemctl-start-asterisk-is-fail-with-timeout/81123/3
   package:
     name: libsystemd-dev
     state: present
@@ -66,6 +67,12 @@
   command: ./configure --with-jansson-bundled
   args:
     chdir: "{{ asterisk_src_dir }}"
+
+# - name: Asterisk - Set '#define HAVE_SYSTEMD 1' in /opt/iiab/asterisk/include/asterisk/autoconfig.h
+#   lineinfile:
+#     path: /opt/iiab/asterisk/include/asterisk/autoconfig.h
+#     regexp: '#undef HAVE_SYSTEMD'
+#     line: '#define HAVE_SYSTEMD 1'
 
 - name: Asterisk - Run 'make menuselect.makeopts'
   command: make menuselect.makeopts

--- a/roles/pbx/tasks/asterisk_dependencies.yml.unused
+++ b/roles/pbx/tasks/asterisk_dependencies.yml.unused
@@ -1,12 +1,12 @@
 - name: Asterisk - Install dependencies
   package:
     name:
-      - git                # Not visible in install_prereq
-      - curl               # Not visible in install_prereq
+      - git                # 2021-08-05: Not in Asterisk's install_prereq
+      - curl               # 2021-08-05: Not in Asterisk's install_prereq
       - wget
       - libnewt-dev
       - libssl-dev
-      - libncurses5-dev    # Not visible in install_prereq
+      - libncurses5-dev    # 2021-08-05: Not in Asterisk's install_prereq
       - subversion
       - libsqlite3-dev
       - build-essential

--- a/roles/pbx/tasks/asterisk_dependencies.yml.unused
+++ b/roles/pbx/tasks/asterisk_dependencies.yml.unused
@@ -1,12 +1,12 @@
 - name: Asterisk - Install dependencies
   package:
     name:
-      - git
-      - curl
+      - git                # Not visible in install_prereq
+      - curl               # Not visible in install_prereq
       - wget
       - libnewt-dev
       - libssl-dev
-      - libncurses5-dev
+      - libncurses5-dev    # Not visible in install_prereq
       - subversion
       - libsqlite3-dev
       - build-essential

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -1,6 +1,7 @@
 # https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
 # https://computingforgeeks.com/how-to-install-asterisk-16-with-freepbx-15-on-ubuntu-debian/
 # RPi: http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
+# 2012-2017: http://www.raspberry-asterisk.org
 
 - name: FreePBX - Install dependencies
   include: freepbx_dependencies.yml
@@ -56,6 +57,14 @@
 #     name: asterisk
 #     enabled: no
 #     state: stopped
+
+# 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
+# Imperfect (even when compiled in, see the top of asterisk.tml) so let's
+# follow the official instructions for now:
+
+- name: FreePBX - Run 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' giving FreePBX full control during boot - not strictly required but recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+  command: update-rc.d -f asterisk remove
+
 
 - name: FreePBX - Add MySQL user ({{ asterisk_db_user }})
   mysql_user:
@@ -124,11 +133,10 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - /usr/sbin/asterisk -rx "core stop gracefully"    # 2021-08-05: For 1st run of enable-or-disable.yml, so 'systemctl status freepbx' doesn't show "Unable to run Pre-Asterisk hooks, because Asterisk is already running" -- allowing http://box:83/freepbx to connect to Asterix reliably/immediately -- even prior to the 1st reboot
     # - ./start_asterisk stop
-    #- killall -9 safe_asterisk    # 2021-08-05: Thanks to @jvonau's PR $2912, these 2 lines attempt a (brute force for now, not enough?!) workaround to intermittent
-    #- killall -9 asterisk         # #2908 install issue of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
-
-- pause:
+    # - killall -9 safe_asterisk    # 2021-08-05: Thanks to @jvonau's PR $2912, these 2 lines attempt a (brute force for now, not enough?!) workaround to intermittent
+    # - killall -9 asterisk         # #2908 install issue of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
 
 # - name: 'FreePBX - fix file permissions for NGINX: /etc/freepbx.conf (0644), /var/log/asterisk/freepbx.log (0666)'
 #   file:
@@ -172,6 +180,3 @@
     path: /etc/apache2/ports.conf
     line: "Listen {{ pbx_http_port }}"
     # insertafter: Listen 80
-
-
-- pause:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -116,7 +116,7 @@
 #     dest: "{{ freepbx_install_dir }}/admin/libraries/view.functions.php"
 
 
-- name: FreePBX - 4-step install (just run once) - CAN TAKE 12 MIN OR LONGER!
+- name: FreePBX - 4-step install (just run once) - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
@@ -124,9 +124,11 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
-    # - ./start_asterisk stop    
-    - killall -9 safe_asterisk    # 2021-08-05: Thanks to @jvonau's PR $2912, these 2 lines are a (brute force for now!) workaround to the intermittent #2908
-    - killall -9 asterisk         # install issue of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+    # - ./start_asterisk stop
+    #- killall -9 safe_asterisk    # 2021-08-05: Thanks to @jvonau's PR $2912, these 2 lines attempt a (brute force for now, not enough?!) workaround to intermittent
+    #- killall -9 asterisk         # #2908 install issue of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+
+- pause:
 
 # - name: 'FreePBX - fix file permissions for NGINX: /etc/freepbx.conf (0644), /var/log/asterisk/freepbx.log (0666)'
 #   file:
@@ -147,7 +149,7 @@
 #     # - /var/www/html/freepbx/admin/assets/less/cache
 #     - /var/spool/asterisk/cache
 
-- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default)
+- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
   template:
     src: odbc.ini
     dest: /etc/
@@ -170,3 +172,6 @@
     path: /etc/apache2/ports.conf
     line: "Listen {{ pbx_http_port }}"
     # insertafter: Listen 80
+
+
+- pause:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -59,8 +59,8 @@
 #     state: stopped
 
 # 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
-# Imperfect (even when compiled in, see the top of asterisk.tml) so let's
-# follow the official instructions for now:
+# Imperfect (even when compiled in, as a result of package 'libsystemd-dev' at
+# top of asterisk.tml) so let's follow the official instructions for now:
 
 - name: FreePBX - Run 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' giving FreePBX full control during boot - not strictly required but recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
   command: update-rc.d -f asterisk remove

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -125,7 +125,7 @@
 #     dest: "{{ freepbx_install_dir }}/admin/libraries/view.functions.php"
 
 
-- name: FreePBX - 4-step install (just run once) - CAN TAKE 3-12 MIN OR LONGER!
+- name: FreePBX - 2-step install (just run once) - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
@@ -133,10 +133,10 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
-    - /usr/sbin/asterisk -rx "core stop gracefully"    # 2021-08-05: For 1st run of enable-or-disable.yml, so 'systemctl status freepbx' doesn't show "Unable to run Pre-Asterisk hooks, because Asterisk is already running" -- allowing http://box:83/freepbx to connect to Asterix reliably/immediately -- even prior to the 1st reboot
     # - ./start_asterisk stop
-    # - killall -9 safe_asterisk    # 2021-08-05: Thanks to @jvonau's PR $2912, these 2 lines attempt a (brute force for now, not enough?!) workaround to intermittent
-    # - killall -9 asterisk         # #2908 install issue of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+    # - killall -9 safe_asterisk    # 2021-08-05: These 2 lines from PR #2912 attempted a (brute force, not enough?!) workaround to frequent #2908 install
+    # - killall -9 asterisk         # annoyance 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+    # - /usr/sbin/asterisk -rx "core stop gracefully"
 
 # - name: 'FreePBX - fix file permissions for NGINX: /etc/freepbx.conf (0644), /var/log/asterisk/freepbx.log (0666)'
 #   file:
@@ -174,6 +174,13 @@
     dest: /etc/apache2/sites-available/freepbx.conf
     owner: "{{ apache_user }}"    # www-data
     group: "{{ apache_user }}"
+
+- name: FreePBX - Run 'systemctl restart freepbx' TWICE (THIS IS #1 OF 2) to get past 'systemctl status freepbx' glitch "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: yes
+    state: restarted
 
 - name: FreePBX - Add directive "Listen {{ pbx_http_port }}" to /etc/apache2/ports.conf
   lineinfile:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -60,7 +60,7 @@
 
 # 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
 # Imperfect (even when compiled in, as a result of package 'libsystemd-dev' at
-# top of asterisk.tml) so let's follow the official instructions for now:
+# top of asterisk.tml) so let's follow these "official" instructions for now:
 
 - name: FreePBX - Run 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' giving FreePBX full control during boot - not strictly required but recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
   command: update-rc.d -f asterisk remove
@@ -134,8 +134,8 @@
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
     # - ./start_asterisk stop
-    # - killall -9 safe_asterisk    # 2021-08-05: These 2 lines from PR #2912 attempted a (brute force, not enough?!) workaround to frequent #2908 install
-    # - killall -9 asterisk         # annoyance 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+    # - killall -9 safe_asterisk    # 2021-08-05: These 2 lines from PR #2912 attempted a brute force (not enough!) workaround for the #2908 annoyance on 1st
+    # - killall -9 asterisk         # install, of 'systemctl status freepbx' showing "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
     # - /usr/sbin/asterisk -rx "core stop gracefully"
 
 # - name: 'FreePBX - fix file permissions for NGINX: /etc/freepbx.conf (0644), /var/log/asterisk/freepbx.log (0666)'
@@ -167,6 +167,13 @@
     src: freepbx.service
     dest: /etc/systemd/system/
 
+- name: FreePBX - Run 'systemctl restart freepbx' TWICE (THIS IS #1 OF 2) to get past 'systemctl status freepbx' glitch "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
+  systemd:
+    daemon_reload: yes
+    name: freepbx
+    enabled: yes
+    state: restarted
+
 
 - name: FreePBX - Install /etc/apache2/sites-available/freepbx.conf from template ({{ apache_user }}:{{ apache_user }}, 0644 by default)
   template:
@@ -174,13 +181,6 @@
     dest: /etc/apache2/sites-available/freepbx.conf
     owner: "{{ apache_user }}"    # www-data
     group: "{{ apache_user }}"
-
-- name: FreePBX - Run 'systemctl restart freepbx' TWICE (THIS IS #1 OF 2) to get past 'systemctl status freepbx' glitch "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
-  systemd:
-    daemon_reload: yes
-    name: freepbx
-    enabled: yes
-    state: restarted
 
 - name: FreePBX - Add directive "Listen {{ pbx_http_port }}" to /etc/apache2/ports.conf
   lineinfile:


### PR DESCRIPTION
After many false leads, let's hope this solution is reliable!

Tested on a Debian 11 (server) VM.  Refs:

- PR #2905
- PR #2908
- PR #2910
- PR #2911
- PR #2912 
- PR #2913 
- PR #2914

With thanks to @jvonau & @lemueldsouza.