### PR TITLE
Install apache2 + its 'rewrite' mod in freepbx_dependencies.yml -- so roles/httpd can be phased out

### DIFF
--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -3,7 +3,7 @@
     name: "{{ apache_service }}"    # apache2 or httpd, per /opt/iiab/iiab/vars/<OS>.yml
     state: stopped
   ignore_errors: yes
-  # 'when: apache_installed is defined' insuff b/c mysql's php installs apache2
+  # 'when: apache_installed is defined' insuff b/c mysql's php (etc) can install apache2
 
 - name: 'Install 5 packages for NGINX: libnginx-mod-http-subs-filter, nginx-extras, php{{ php_version }}-fpm, uwsgi, uwsgi-plugin-python3'
   package:
@@ -50,8 +50,8 @@
     - { src: 'server.conf.j2', dest: '/etc/nginx/server.conf' }
     - { src: 'nginx.conf.j2', dest: '/etc/nginx/nginx.conf' }
     - { src: 'mime.types.j2', dest: '/etc/nginx/mime.types' }
-    #- { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
-    #- { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml below
+    # - { src: 'ports.conf.j2', dest: '/etc/{{ apache_service }}/ports.conf' }    # Moved to enable-or-disable.yml
+    # - { src: 'iiab.conf.j2', dest: "{{ nginx_conf_dir }}/iiab.conf" }    # Moved into homepage.yml, invoked later by roles/www_options/tasks/main.yml (see below!)
 
 - debug:
     msg: roles/nginx/tasks/homepage.yml will run LATER (invoked by roles/www_options/tasks/main.yml) SO THAT NGINX CAN REDIRECT http://box TO http://box{{ iiab_home_url }} (based on var iiab_home_url)
@@ -61,7 +61,7 @@
   systemd:
     name: "php{{ php_version }}-fpm"
     state: restarted
-  #when: nginx_enabled
+  # when: nginx_enabled
 
 
 # RECORD NGINX AS INSTALLED

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -15,23 +15,27 @@
       - uwsgi-plugin-python3    # these 2 packages on demand (not every IIAB needs these).
     state: present
 
+
+# 2021-08-07: Legacy from roles/httpd/tasks/install.yml
+
+# - name: 'Create group: admin'
+#   group:
+#     name: admin
+
 # 2020-10-16: Removed per #2560
 # - name: Add user '{{ apache_user }}' to shadow group, so it can authenticate Admin Console
 #   user:
 #     name: "{{ apache_user }}"    # www-data or apache, per /opt/iiab/iiab/vars/<OS>.yml
 #     groups: shadow
 
-# - name: 'Create group: admin'
-#   group:
-#     name: admin
-
-# - name: Add user {{ apache_user }} (from variable apache_user) to groups shadow
+# - name: Add user {{ apache_user }} (from variable apache_user) to groups admin, shadow
 #   user:
 #     name: "{{ apache_user }}"    # www-data on Debuntu
 #     #groups: admin,shadow
 #     groups: shadow    # 2020-06-04: shadow nec for Admin Console login (this line had been clobbering user www-data's membership in group shadow, as set earlier by nginx/tasks/install.yml, SEE #2431)
 #     createhome: no
 #     append: yes
+
 
 - name: Remove NGINX default config /etc/nginx/sites-enabled/default
   file:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -16,10 +16,22 @@
     state: present
 
 # 2020-10-16: Removed per #2560
-#- name: Add user '{{ apache_user }}' to shadow group, so it can authenticate Admin Console
-#  user:
-#    name: "{{ apache_user }}"    # www-data or apache, per /opt/iiab/iiab/vars/<OS>.yml
-#    groups: shadow
+# - name: Add user '{{ apache_user }}' to shadow group, so it can authenticate Admin Console
+#   user:
+#     name: "{{ apache_user }}"    # www-data or apache, per /opt/iiab/iiab/vars/<OS>.yml
+#     groups: shadow
+
+# - name: 'Create group: admin'
+#   group:
+#     name: admin
+
+# - name: Add user {{ apache_user }} (from variable apache_user) to groups shadow
+#   user:
+#     name: "{{ apache_user }}"    # www-data on Debuntu
+#     #groups: admin,shadow
+#     groups: shadow    # 2020-06-04: shadow nec for Admin Console login (this line had been clobbering user www-data's membership in group shadow, as set earlier by nginx/tasks/install.yml, SEE #2431)
+#     createhome: no
+#     append: yes
 
 - name: Remove NGINX default config /etc/nginx/sites-enabled/default
   file:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -128,15 +128,15 @@
     name: asterisk
     # group: asterisk            # 2021-08-06: Implicit
     # groups: audio,dialout      # 2021-08-06: No longer mainline
-    # home: /var/lib/asterisk    # 2021-08-06: No longer mainline
-    # system: yes                # 2021-08-06: No longer mainline (and does nothing to pre-existing users)
+    home: /var/lib/asterisk      # 2021-08-07: /home/asterisk (default) ok too
+    # system: yes                # 2021-08-06: No longer mainline (and Ansible doesn't change pre-existing users)
     # append: yes                # 2021-08-06: Only relevant if adding groups later
 
 - name: Asterisk - Add user 'www-data' to group 'asterisk'
   user:
     name: www-data
     groups: asterisk
-    # system: yes                # 2021-08-06: Does nothing to pre-existing users
+    # system: yes                # 2021-08-06: Ansible doesn't change pre-existing users)
     append: yes
 
 - name: Asterisk - Set ownership for 6 directories (asterisk:asterisk, recurse)

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -136,7 +136,7 @@
   user:
     name: www-data
     groups: asterisk
-    # system: yes                # 2021-08-06: Ansible doesn't change pre-existing users)
+    # system: yes                # 2021-08-06: Ansible doesn't change pre-existing users
     append: yes
   when: pbx_try_nginx
 

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -127,9 +127,9 @@
   user:
     name: asterisk
     # group: asterisk            # 2021-08-06: Implicit
-    # groups: audio,dialout      # 2021-08-06: No longer mainline
+    groups: audio,dialout        # 2021-08-08: Plausibly might help?
     home: /var/lib/asterisk      # 2021-08-07: /home/asterisk (default) ok too
-    # system: yes                # 2021-08-06: No longer mainline (and Ansible doesn't change pre-existing users)
+    system: yes                  # 2021-08-08: No evidence this is needed. Hopefully it doesn't cause harm? (FYI Ansible doesn't change pre-existing users)
     # append: yes                # 2021-08-06: Only relevant if adding groups later
 
 - name: Asterisk - Add user 'www-data' to group 'asterisk'

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,6 +1,6 @@
 # 2021-08-05: Asterisk's own install_prereq (below) handles essentially all of these
-#- name: Asterisk - Install dependencies
-#  include: asterisk_dependencies.yml
+# - name: Asterisk - Install dependencies
+#   include: asterisk_dependencies.yml
 
 # BEWARE: 'systemctl is-active asterix' falsely reports 'inactive' even when systemd
 # is compiled in below!   FWIW: /opt/iiab/asterisk/contrib/systemd/asterisk.service
@@ -47,10 +47,10 @@
 # 'aptitude' regardless, within handle_debian() here:
 # https://github.com/asterisk/asterisk/blob/master/contrib/scripts/install_prereq#L262-L271
 #
-#- name: Asterisk - Install aptitude (otherwise install_prereq fails?)
-#  package:
-#    name: aptitude
-#    state: latest
+# - name: Asterisk - Install aptitude (otherwise install_prereq fails?)
+#   package:
+#     name: aptitude
+#     state: latest
 
 - name: Asterisk - Run 'install_prereq install' for dependencies - CAN TAKE 5 MIN OR LONGER!
   shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -138,6 +138,7 @@
     groups: asterisk
     # system: yes                # 2021-08-06: Ansible doesn't change pre-existing users)
     append: yes
+  when: pbx_try_nginx
 
 - name: Asterisk - Set ownership for 6 directories (asterisk:asterisk, recurse)
   file:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -150,9 +150,8 @@
     # - fwconsole reload
     # - fwconsole restart
 
-# 2021-08-06: This stanza might be removed in future, if Asterix/FreePBX fix
-# this install glitch in a future release?  FYI #2908, #2912, #2913 attempts
-# didn't work.  This workaround helps: https://github.com/iiab/iiab/pull/2915
+# 2021-08-06: This stanza works, but above is more graceful.  (FYI PRs #2908,
+# #2912, #2913 didn't quite work -- whereas this PR #2915 at least worked!)
 # - name: FreePBX - Run 'systemctl restart freepbx' TWICE (THIS IS 1 OF 2) to get past 'systemctl status freepbx' glitch "Unable to run Pre-Asterisk hooks, because Asterisk is already running"
 #   systemd:
 #     daemon_reload: yes
@@ -189,15 +188,18 @@
     src: freepbx.service
     dest: /etc/systemd/system/
 
-# FreePBX's initial page (Admin user registration) tries to set up a cron job and
-# fails: "Exception: Trying to edit user asterisk, when I'm running as www-data"
-# DETAILS: https://github.com/iiab/iiab/pull/2916#issuecomment-894585322
-# FWIW hacking /etc/freepbx.conf in this way does not help in the end...
+
+# For 'pbx_try_nginx: True' -- FreePBX's initial page (Admin user registration)
+# tries to set up a cron job but fails:
+#   "Exception: Trying to edit user asterisk, when I'm running as www-data"
+# #2916 DETAILS: https://github.com/iiab/iiab/pull/2916#issuecomment-894585322
+# FWIW hacking /etc/freepbx.conf (lineinfile or manually) did not solve it...
 # - name: "2021-08-06: Try \"$amp_conf['AMPASTERISKWEBUSER'] = 'www-data';\" in /etc/freepbx.conf for #2916 registration cron fix ?'"
 #   lineinfile:
 #     path: /etc/freepbx.conf
 #     insertafter: '^<\?php$'    # Match exact line '<?php'
 #     line: "$amp_conf['AMPASTERISKWEBUSER'] = 'www-data';"
+#   when: pbx_try_nginx
 
 
 - block:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -135,7 +135,7 @@
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
 - name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
-  command:
+  command: "{{ item }}"
   with_items:
     - fwconsole stop
     - killall -9 safe_asterisk    # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -134,22 +134,21 @@
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
-- name: "Run 'fwconsole stop' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
-  command: fwconsole stop
-  # command: "{{ item }}"
-  # with_items:
-  #   # - ./start_asterisk stop
-  #   # - killall -9 safe_asterisk    # 2021-08-05: These 2 lines from PR #2912 brute force a workaround for #2908 #2913 #2915
-  #   # - killall -9 asterisk         # glitches on 1st install.  In the end, above 'fwconsole stop' does the job more gracefully.
-  #   # - /usr/sbin/asterisk -rx "core stop gracefully"
-  #   # - fwconsole reload
-  #   - fwconsole stop
-  #   # - fwconsole restart
-  #   # - fwconsole ma disablerepo commercial
-  #   # - fwconsole ma installall
-  #   # - fwconsole ma delete firewall
-  #   # - fwconsole reload
-  #   # - fwconsole restart
+- name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
+  command:
+  with_items:
+    - fwconsole stop
+    - killall -9 safe_asterisk    # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
+    # - killall -9 asterisk       # 2021-08-05: Also from @jvonau's PR #2912, to brute force this.  In the end, above 'fwconsole stop' works more gracefully.
+    # - ./start_asterisk stop     # Buggy!
+    # - /usr/sbin/asterisk -rx "core stop gracefully"
+    # - fwconsole reload
+    # - fwconsole restart
+    # - fwconsole ma disablerepo commercial
+    # - fwconsole ma installall
+    # - fwconsole ma delete firewall
+    # - fwconsole reload
+    # - fwconsole restart
 
 # 2021-08-06: This stanza might be removed in future, if Asterix/FreePBX fix
 # this install glitch in a future release?  FYI #2908, #2912, #2913 attempts

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -125,9 +125,6 @@
 #     dest: "{{ freepbx_install_dir }}/admin/libraries/view.functions.php"
 
 
-# - pause:
-
-
 - name: FreePBX - 2-step install (just run once) - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
@@ -206,16 +203,16 @@
 
 - block:
 
-  - name: FreePBX - Install /etc/apache2/sites-available/freepbx.conf from template ({{ apache_user }}:{{ apache_user }}, 0644 by default)
+  - name: FreePBX - Install /etc/{{ apache_service }}/sites-available/freepbx.conf from template ({{ apache_user }}:{{ apache_user }}, 0644 by default)
     template:
       src: freepbx.conf.j2
-      dest: /etc/apache2/sites-available/freepbx.conf
+      dest: /etc/{{ apache_service }}/sites-available/freepbx.conf    # apache2
       owner: "{{ apache_user }}"    # www-data
       group: "{{ apache_user }}"
 
-  - name: FreePBX - Add directive "Listen {{ pbx_http_port }}" to /etc/apache2/ports.conf
+  - name: FreePBX - Add directive "Listen {{ pbx_http_port }}" to /etc/{{ apache_service }}/ports.conf
     lineinfile:
-      path: /etc/apache2/ports.conf
+      path: /etc/{{ apache_service }}/ports.conf
       line: "Listen {{ pbx_http_port }}"
       # insertafter: Listen 80
 

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -1,13 +1,13 @@
-- name: FreePBX - Install ~19 dependencies (run 'php -m' or 'php -i' to verify PHP modules)
+- name: FreePBX - Install wget, git, unixodbc, sudo, net-tools, cron, sox + ~12 PHP dependencies (run 'php -m' or 'php -i' to verify PHP modules)
   package:
     name:
       - wget
       - git
-      - unixodbc     # for Asterisk CDR (Call Detail Records)
-      - sudo         # required by FreePBX install script
-      - net-tools    # required by FWConsole (command-line utility, that controls FreePBX)
-      - cron         # required by FreePBX UCP package (User Control Panel)
-      - sox          # required for CDR web-playback
+      - unixodbc     # For Asterisk CDR (Call Detail Records)
+      - sudo         # Required by FreePBX install script
+      - net-tools    # Required by FWConsole (command-line utility, that controls FreePBX)
+      - cron         # Required by FreePBX UCP package (User Control Panel)
+      - sox          # Required for CDR web-playback
       #- php{{ php_version }}            # Basically drags in phpX.Y-cgi (already below!)
       - php{{ php_version }}-bcmath      # Likewise installed in nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-cgi
@@ -27,13 +27,6 @@
       #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
     state: latest
 
-- name: "FreePBX - Install packages: libapache2-mod-php, libapache2-mpm-itk - if not pbx_try_nginx"
-  package:
-    name:
-      - libapache2-mod-php    # NOTE duplication: roles/httpd/tasks.install.yml installs libapache2-mod-php{{ php_version }} ostensibly for "Elgg, Moodle, etc"
-      - libapache2-mpm-itk    # To serve FreePBX through a VirtualHost as asterisk user (#2914: Is this possible via NGINX?)
-  when: not pbx_try_nginx
-
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
 # For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
 #
@@ -42,3 +35,21 @@
 #    name: php{{ php_version }}-json
 #    state: present
 #  when: php_version is version('8.0', '<')
+
+- name: "FreePBX - Install Apache packages: {{ apache_service }}, libapache2-mod-php, libapache2-mpm-itk - if not pbx_try_nginx"
+  package:
+    name:
+      - "{{ apache_service }}"    # 2021-08-07: Install apache2 directly, as we prepare to deprecate roles/httpd
+      - libapache2-mod-php        # NOTE duplication: roles/httpd/tasks.install.yml installed libapache2-mod-php{{ php_version }} ostensibly for "Elgg, Moodle, etc"
+      - libapache2-mpm-itk        # To serve FreePBX through a VirtualHost as asterisk user (#2914: Is this possible via NGINX?)
+  when: not pbx_try_nginx
+
+# - name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc)'
+#   apache2_module:
+#     name: "{{ item }}"
+#   with_items:
+#     - headers
+#     - proxy
+#     - proxy_html
+#     - proxy_http
+#     - rewrite

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -8,33 +8,33 @@
       - net-tools    # Required by FWConsole (command-line utility, that controls FreePBX)
       - cron         # Required by FreePBX UCP package (User Control Panel)
       - sox          # Required for CDR web-playback
-      #- php{{ php_version }}            # Basically drags in phpX.Y-cgi (already below!)
+      # - php{{ php_version }}            # Basically drags in phpX.Y-cgi (already below!)
       - php{{ php_version }}-bcmath      # Likewise installed in nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-cgi
-      #- php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      # - php{{ php_version }}-common     # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-curl        # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-fpm         # Likewise installed in nginx/tasks/install.yml
-      #- php{{ php_version }}-gettext
+      # - php{{ php_version }}-gettext
       - php{{ php_version }}-gd          # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml
       - php{{ php_version }}-imap
-      #- php{{ php_version }}-json       # See stanza just below
+      # - php{{ php_version }}-json       # See stanza just below
       - php{{ php_version }}-mbstring    # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php{{ php_version }}-mysql       # Likewise installed in mysql/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
       - php-pear                         # Likewise installed for ADMIN CONSOLE https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/tasks/main.yml#L19
       - php{{ php_version }}-snmp
       - php{{ php_version }}-xml         # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       - php{{ php_version }}-zip         # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
-      #- python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
+      # - python-mysqldb        # https://github.com/Yannik/ansible-role-freepbx/blob/master/tasks/freepbx.yml#L33
     state: latest
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
 # For PHP <  8.0: phpX.Y-json auto-installed by phpX.Y-fpm AND phpX.Y-cli in 3-base-server's nginx/tasks/install.yml, as confirmed by: apt rdepends phpX.Y-json
 #
-#- name: Install php{{ php_version }}-json if PHP < 8.0
-#  package:
-#    name: php{{ php_version }}-json
-#    state: present
-#  when: php_version is version('8.0', '<')
+# - name: Install php{{ php_version }}-json if PHP < 8.0
+#   package:
+#     name: php{{ php_version }}-json
+#     state: present
+#   when: php_version is version('8.0', '<')
 
 
 - block:

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -60,4 +60,9 @@
   #     - proxy_http
   #     - rewrite
 
+  # 2021-08-08: Security risks?  But official install doc recommends this:
+  # https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+  - name: Run "sed -i 's/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf"
+    command: sed -i 's/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
   when: not pbx_try_nginx

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -37,7 +37,7 @@
 #  when: php_version is version('8.0', '<')
 
 
-block:
+- block:
 
   - name: "FreePBX - Install Apache packages: {{ apache_service }}, libapache2-mod-php, libapache2-mpm-itk - if not pbx_try_nginx"
     package:

--- a/roles/pbx/tasks/freepbx_dependencies.yml
+++ b/roles/pbx/tasks/freepbx_dependencies.yml
@@ -36,20 +36,28 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
-- name: "FreePBX - Install Apache packages: {{ apache_service }}, libapache2-mod-php, libapache2-mpm-itk - if not pbx_try_nginx"
-  package:
-    name:
-      - "{{ apache_service }}"    # 2021-08-07: Install apache2 directly, as we prepare to deprecate roles/httpd
-      - libapache2-mod-php        # NOTE duplication: roles/httpd/tasks.install.yml installed libapache2-mod-php{{ php_version }} ostensibly for "Elgg, Moodle, etc"
-      - libapache2-mpm-itk        # To serve FreePBX through a VirtualHost as asterisk user (#2914: Is this possible via NGINX?)
-  when: not pbx_try_nginx
 
-# - name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc)'
-#   apache2_module:
-#     name: "{{ item }}"
-#   with_items:
-#     - headers
-#     - proxy
-#     - proxy_html
-#     - proxy_http
-#     - rewrite
+block:
+
+  - name: "FreePBX - Install Apache packages: {{ apache_service }}, libapache2-mod-php, libapache2-mpm-itk - if not pbx_try_nginx"
+    package:
+      name:
+        - "{{ apache_service }}"    # 2021-08-07: Install apache2 directly, as we prepare to deprecate roles/httpd
+        - libapache2-mod-php        # NOTE duplication: roles/httpd/tasks.install.yml installed libapache2-mod-php{{ php_version }} ostensibly for "Elgg, Moodle, etc"
+        - libapache2-mpm-itk        # To serve FreePBX through a VirtualHost as asterisk user (#2914: Is this possible via NGINX?)
+
+  - name: 'Enable Apache module, as with "a2enmod" command: rewrite'
+    apache2_module:
+      name: rewrite
+
+  # - name: 'Enable 5 Apache modules, as with "a2enmod" command: headers, proxy, proxy_html, proxy_http, rewrite (for http://box/kiwix, http://box/kolibri, http://box/nodered, etc)'
+  #   apache2_module:
+  #     name: "{{ item }}"
+  #   with_items:
+  #     - headers
+  #     - proxy
+  #     - proxy_html
+  #     - proxy_http
+  #     - rewrite
+
+  when: not pbx_try_nginx

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -34,8 +34,8 @@
 #     name: httpd
 
 
-#- name: Install Asterisk
-#  include_tasks: asterisk.yml
+- name: Install Asterisk
+  include_tasks: asterisk.yml
 
 - name: Install FreePBX
   include_tasks: freepbx.yml

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -22,18 +22,16 @@
 #  when: nodejs_version != "12.x"
 
 
-- block:
+# 2021-08-07: Moved to roles/pbx/tasks/freepbx_dependencies.yml
 
-  - name: "Set 'apache_install: True' and 'apache_enabled: True'"
-    set_fact:
-      apache_install: True
-      apache_enabled: True
+# - name: "Set 'apache_install: True' and 'apache_enabled: True'"
+#   set_fact:
+#     apache_install: True
+#     apache_enabled: True
 
-  - name: APACHE - run 'httpd' role
-    include_role:
-      name: httpd
-
-  when: not pbx_try_nginx
+# - name: APACHE - run 'httpd' role
+#   include_role:
+#     name: httpd
 
 
 - name: Install Asterisk

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -16,10 +16,10 @@
     msg: "PBX install cannot proceed, as Node.js is not installed."
   when: nodejs_installed is undefined
 
-#- name: FAIL (STOP THE INSTALL) IF 'nodejs_version != "12.x"'
-#  fail:
-#    msg: "PBX install cannot proceed, as it currently requires Node.js 12.x, whereas nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml, /etc/iiab/local_vars.yml, /opt/iiab/iiab/roles/nodejs, etc."
-#  when: nodejs_version != "12.x"
+# - name: FAIL (STOP THE INSTALL) IF 'nodejs_version != "12.x"'
+#   fail:
+#     msg: "PBX install cannot proceed, as it currently requires Node.js 12.x, whereas nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml, /etc/iiab/local_vars.yml, /opt/iiab/iiab/roles/nodejs, etc."
+#   when: nodejs_version != "12.x"
 
 
 # 2021-08-07: Moved to roles/pbx/tasks/freepbx_dependencies.yml

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -34,8 +34,8 @@
 #     name: httpd
 
 
-- name: Install Asterisk
-  include_tasks: asterisk.yml
+#- name: Install Asterisk
+#  include_tasks: asterisk.yml
 
 - name: Install FreePBX
   include_tasks: freepbx.yml


### PR DESCRIPTION
Tested on Ubuntu Server 20.04 VM.  So that we're covered either way[*] &mdash; in preparation for:

- #2762
- PR #2850
- PR #2905

[*] Whether folks use `pbx_try_nginx: True` or `pbx_try_nginx: False` !  As outlined and implemented by:

- #2914
- PR #2916 
- PR #2917