### PR TITLE
freepbx.yml: 'ignore_errors: yes' for 'killall -9 safe_asterisk'

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -149,6 +149,8 @@
     # - fwconsole ma delete firewall
     # - fwconsole reload
     # - fwconsole restart
+  ignore_errors: yes    # 2021-08-08: For things like 'killall -9 safe_asterisk' that fail when process doesn't exist
+
 
 # 2021-08-06: This stanza works, but above is more graceful.  (FYI PRs #2908,
 # #2912, #2913 didn't quite work -- whereas this PR #2915 at least worked!)


### PR DESCRIPTION
Touchup needed for:

- PR #2920

Uncovered by additional testing back on VM OS's instead of Ubuntu Server 21.04 on RPi 4.