### PR TITLE
freepbx.yml: 'fwconsole set CHECKREFERER 0' (false) if pbx_try_nginx

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -216,7 +216,7 @@
 
 
 - name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings - if pbx_try_nginx -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can override individual settings (variable values) in FreePBX's internal db if nec
-  command: fwconsole set CHECKREFERER 0    # Run 'fwconsole set CHECKREFERER 1' to restore FreePBX's default strict checking.
+  command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
   when: pbx_try_nginx
 
 # - name: Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -215,7 +215,7 @@
     dest: /etc/systemd/system/
 
 
-- name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings - if pbx_try_nginx -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can override individual settings (variable values) in FreePBX's internal db if nec
+- name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings - if pbx_try_nginx -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec
   command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
   when: pbx_try_nginx
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -215,12 +215,16 @@
     dest: /etc/systemd/system/
 
 
-- name: Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
-  lineinfile:
-    path: /etc/freepbx.conf
-    insertbefore: '^\?>$'    # Match exact line '?>' -- BOTTOM OF FILE NEC!
-    line: "$amp_conf['CHECKREFERER'] = false;"
+- name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings - if pbx_try_nginx -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can override individual settings (variable values) in FreePBX's internal db if nec
+  command: fwconsole set CHECKREFERER 0    # Run 'fwconsole set CHECKREFERER 1' to restore FreePBX's default strict checking.
   when: pbx_try_nginx
+
+# - name: Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
+#   lineinfile:
+#     path: /etc/freepbx.conf
+#     insertbefore: '^\?>$'    # Match exact line '?>' -- BOTTOM OF FILE NEC!
+#     line: "$amp_conf['CHECKREFERER'] = false;"
+#   when: pbx_try_nginx
 
 # - name: 'FreePBX - fix file permissions for NGINX: /etc/freepbx.conf (0644), /var/log/asterisk/freepbx.log (0666)'
 #   file:


### PR DESCRIPTION
Allows implementers / operators to more easily[*] restore FreePBX's default strict checking of HTTP_REFERER from http://box/freepbx >> Settings >> Admin Settings if they so choose.

[*] Without having to fuss with `/etc/freepbx.conf` overrides of FreePBX's internal settings.

Background:

- https://github.com/iiab/iiab/pull/2931#issuecomment-897622458