### PR TITLE
freepbx.yml: Run 'fwconsole ma upgradeall' on installed FreePBX modules [e.g. 16 default modules, of about 70 total modules available] + try systemd version of 'update-rc.d -f asterisk remove'

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -215,6 +215,9 @@
     dest: /etc/systemd/system/
 
 
+- name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 2 MIN OR LONGER!
+  command: fwconsole ma upgradeall
+
 - name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) - if pbx_try_nginx - so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec
   command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
   when: pbx_try_nginx

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -8,13 +8,14 @@
 # 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
 # Imperfect (even when compiled in, as a result of package 'libsystemd-dev' at
 # top of asterisk.tml).
-# 2021-08-12: Let's track the "official" init.d / update-rc.d instructions...
-- name: FreePBX - Disable & Stop 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+# 2021-08-12: Let's try to track the "official" init.d / update-rc.d
+# instructions, but using systemd instead, to be more future-proof?
+- name: FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
   systemd:
     daemon_reload: yes
     name: asterisk
+    #state: stopped
     enabled: no
-    state: stopped
 
 
 - name: FreePBX - Install wget, git, unixodbc, sudo, net-tools, cron, sox + ~12 PHP dependencies (run 'php -m' or 'php -i' to verify PHP modules)

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -4,20 +4,17 @@
 # 2012-2017: http://www.raspberry-asterisk.org
 
 
-# 2021-08-04: systemd service 'asterisk' is Enabled but Not Active at this point -- LET'S EXPERIMENT
-# - name: FreePBX - Disable & Stop 'asterisk' systemd service
-#   systemd:
-#     daemon_reload: yes
-#     name: asterisk
-#     enabled: no
-#     state: stopped
-
+# 2021-08-04: systemd service 'asterisk' is Enabled but Not Active at this point.
 # 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
 # Imperfect (even when compiled in, as a result of package 'libsystemd-dev' at
-# top of asterisk.tml) so let's follow these "official" instructions for now:
-
-- name: FreePBX - Run 'update-rc.d -f asterisk remove' similar to 'systemctl disable asterisk' giving FreePBX full control during boot - not strictly required but recommended by https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
-  command: update-rc.d -f asterisk remove
+# top of asterisk.tml).
+# 2021-08-12: Let's track the "official" init.d / update-rc.d instructions...
+- name: FreePBX - Disable & Stop 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+  systemd:
+    daemon_reload: yes
+    name: asterisk
+    enabled: no
+    state: stopped
 
 
 - name: FreePBX - Install wget, git, unixodbc, sudo, net-tools, cron, sox + ~12 PHP dependencies (run 'php -m' or 'php -i' to verify PHP modules)


### PR DESCRIPTION
Suggestion from @jvonau

cc: @lemueldsouza

Somewhat related:

- PR #2937