### PR TITLE
freepbx.yml: Ansible comment error + typo

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -9,11 +9,11 @@
 # Not Active at this point.
 # 2021-08-05: Asterisk's systemd / systemctl support is getting there but Very
 # Imperfect (even when compiled in, as a result of package 'libsystemd-dev' at
-# the top of asterisk.tml).
+# the top of asterisk.yml).
 # 2021-08-12: Let's try to track the "official" init.d / update-rc.d
 # instructions ('update-rc.d -f asterisk remove') but using systemd instead,
 # to be more future-proof?
-- name: FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
+- name: "'FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9"
   systemd:
     daemon_reload: yes
     name: asterisk


### PR DESCRIPTION
Resolves #2939.

Thanks @m-anish!