### PR TITLE
Fix Freepbx CDR backend

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -216,6 +216,7 @@
     dest: /etc/systemd/system/
 
 
+# default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 2 MIN OR LONGER!
   command: fwconsole ma upgradeall
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -168,6 +168,11 @@
     create: yes
 
 
+- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+  template:
+    src: odbc.ini
+    dest: /etc/
+
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
@@ -204,11 +209,6 @@
 #     enabled: yes
 #     state: restarted
 
-
-- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
-  template:
-    src: odbc.ini
-    dest: /etc/
 
 - name: FreePBX - Install /etc/systemd/system/freepbx.service from template (root:root, 0644 by default)
   template:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -187,7 +187,7 @@
     creates: /usr/local/lib/mariadb/libmaodbc.so
 
 # http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
-- name: FreePBX - Install /etc/odbc.ini /etc/odbconit.ini from template (root:root, 0644 by default)
+- name: FreePBX - Install /etc/odbc.ini /etc/odbcinst.ini from template (root:root, 0644 by default)
   template:
     src: "{{ item }}"
     dest: /etc/

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -13,11 +13,11 @@
 # 2021-08-12: Let's try to track the "official" init.d / update-rc.d
 # instructions ('update-rc.d -f asterisk remove') but using systemd instead,
 # to be more future-proof?
-- name: "FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9"
+- name: FreePBX - Disable 'asterisk' service
   systemd:
     daemon_reload: yes
     name: asterisk
-    #state: stopped
+    state: stopped
     enabled: no
 
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -135,9 +135,9 @@
     name: "{{ asterisk_db_dbname }}"    # asterisk
     encoding: utf8
     collation: utf8_general_ci
-    # login_host: "{{ asterisk_db_host }}"
-    # login_user: root
-    # login_password: "{{ mysql_root_password }}"
+    login_host: "{{ asterisk_db_host }}"
+    login_user: "{{ asterisk_db_user  }}"
+    login_password: "{{ asterisk_db_password }}"
     state: present
 
 - name: FreePBX - Add cdr MySQL db ({{ asterisk_db_cdrdbname }})
@@ -147,6 +147,9 @@
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
     state: present
+    login_host: "{{ asterisk_db_host }}"
+    login_user: "{{ asterisk_db_user  }}"
+    login_password: "{{ asterisk_db_password }}"
 
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:
@@ -193,6 +196,13 @@
   - odbc.ini
   - odbcinst.ini
 
+- name: FreePBX - Create /etc/asterisk/cdr_mysql.conf
+  template:
+    src: "{{ item }}"
+    dest: /etc/asterisk/
+  with_items:
+    - cdr_mysql.conf
+
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
@@ -200,14 +210,14 @@
     creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
 
 - name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
   command: "{{ item }}"
   with_items:
+    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     - fwconsole stop
     - killall -9 safe_asterisk        # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
-    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     # - killall -9 asterisk       # 2021-08-05: Also from @jvonau's PR #2912, to brute force this.  In the end, above 'fwconsole stop' works more gracefully.
     # - ./start_asterisk stop     # Buggy!
     # - /usr/sbin/asterisk -rx "core stop gracefully"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -48,6 +48,11 @@
       - php{{ php_version }}-snmp
       - php{{ php_version }}-xml         # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       - php{{ php_version }}-zip         # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      - cmake
+      - make
+      - gcc
+      - libssl-dev
+      - unixodbc-dev
     state: latest
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
@@ -143,7 +148,6 @@
     login_host: "{{ asterisk_db_host }}"
     state: present
 
-
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:
     path: /var/lib/php/asterisk_sessions/
@@ -167,11 +171,27 @@
     group: asterisk
     create: yes
 
+- name: Freepbx -  Clone mariadb-connector-odbc
+  git:
+    repo: https://github.com/mariadb-corporation/mariadb-connector-odbc
+    dest: /usr/src/mariadb-connector-odbc
+    version: master
+    force: yes
+    depth: 1
 
-- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+- name: FreePBX - Build mariadb-connector-odbc
+  command: "{{ iiab_dir }}/scripts/mk-odbc-connector"
+  args:
+    creates: /usr/local/lib/mariadb/libmaodbc.so
+
+# http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
+- name: FreePBX - Install /etc/odbc.ini /etc/odbconit.ini from template (root:root, 0644 by default)
   template:
-    src: odbc.ini
+    src: "{{ item }}"
     dest: /etc/
+  with_items:
+  - odbc.ini
+  - odbcinst.ini
 
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -146,10 +146,9 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-    state: present
-    login_host: "{{ asterisk_db_host }}"
     login_user: "{{ asterisk_db_user  }}"
     login_password: "{{ asterisk_db_password }}"
+    state: present
 
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:

--- a/roles/pbx/templates/cdr_mysql.conf
+++ b/roles/pbx/templates/cdr_mysql.conf
@@ -1,0 +1,6 @@
+[global]
+hostname = localhost
+dbname = asteriskcdrdb
+user = asterisk
+password = asterisk
+userfield=1

--- a/roles/pbx/templates/odbcinst.ini
+++ b/roles/pbx/templates/odbcinst.ini
@@ -1,0 +1,4 @@
+[MySQL]
+Description = ODBC for MySQL (MariaDB)
+Driver = /usr/local/lib/mariadb/libmaodbc.so
+FileUsage = 1

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -1,0 +1,10 @@
+#!/bin/bash
+mkdir /usr/src/mariadb-connector-odbc/build
+cd /usr/src/mariadb-connector-odbc/build
+if [ -f /etc/rpi-issue ]; then
+    DM_DIR=/usr/lib/arm-linux-gnueabihf cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb -L/usr/lib"
+else
+    DM_DIR=/usr/lib/aarch64-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
+fi
+make
+make install

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -9,3 +9,9 @@ else
 fi
 make
 make install
+
+cat << EOF > /etc/ld.so.conf.d/99-iiab.conf
+/usr/local/lib/mariadb/
+EOF
+
+ldconfig

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -1,10 +1,11 @@
 #!/bin/bash
+ARCH=$(uname -m)
 mkdir /usr/src/mariadb-connector-odbc/build
 cd /usr/src/mariadb-connector-odbc/build
 if [ -f /etc/rpi-issue ]; then
     DM_DIR=/usr/lib/arm-linux-gnueabihf cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb -L/usr/lib"
 else
-    DM_DIR=/usr/lib/aarch64-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
+    DM_DIR=/usr/lib/$ARCH-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
 fi
 make
 make install


### PR DESCRIPTION
### Fixes bug:
https://github.com/iiab/iiab/pull/2938#issuecomment-898693126
### Description of changes proposed in this pull request:
Somewhere in the muck I got the CDR backends to showup
```
ubuntu@box:/opt/iiab/freepbx$ sudo asterisk -rvvv 
[sudo] password for ubuntu: 
Asterisk 18.5.1, Copyright (C) 1999 - 2021, Sangoma Technologies Corporation and others.
Created by Mark Spencer <markster@digium.com>
Asterisk comes with ABSOLUTELY NO WARRANTY; type 'core show warranty' for details.
This is free software, with components licensed under the GNU General Public
License version 2 and other licenses; you are welcome to redistribute it under
certain conditions. Type 'core show license' for details.
=========================================================================
Connected to Asterisk 18.5.1 currently running on box (pid = 274978)
box*CLI> cdr show status

Call Detail Record (CDR) settings
----------------------------------
  Logging:                    Enabled
  Mode:                       Simple
  Log unanswered calls:       No
  Log congestion:             No

* Registered Backends
  -------------------
    cdr_manager (suspended) 
    cdr-custom
    csv
    Adaptive ODBC

box*CLI> exit
Asterisk cleanly ending (0).
Executing last minute cleanups

```
Needs full clean testing
