### PR TITLE
Contextualize {AzuraCast, MediaWiki, Kolibri, AWStats, Monit, Munin, vnStat} in local_vars.yml / default_vars.yml

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -328,6 +328,7 @@ idmgr_enabled: False    # 2020-01-23: UNUSED
 
 # 6-GENERIC-APPS
 
+# Simple, Self-Hosted Web Radio - from AzuraCast.com
 azuracast_install: False
 azuracast_enabled: False    # This var is currently IGNORED
 azuracast_http_port: 10080
@@ -374,6 +375,7 @@ lokole_enabled: False
 lokole_sim_type: LocalOnly
 lokole_client_id: None
 
+# Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: False
 mediawiki_enabled: False
 
@@ -424,6 +426,7 @@ kalite_enabled: True
 kalite_server_port: 8008
 kalite_root: "{{ content_base }}/ka-lite"    # /library/ka-lite
 
+# Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
 kolibri_language: en    # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
@@ -520,9 +523,11 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+# AWStats, originally known as Advanced Web Statistics - from https://awstats.sourceforge.io
 awstats_install: True
 awstats_enabled: True
 
+# Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849
 monit_install: False
 monit_enabled: False
@@ -534,6 +539,7 @@ watchdog:
   - postgresql
   #- squid
 
+# Networked resource monitoring/graphing tool - from munin-monitoring.org
 munin_install: False
 munin_enabled: False
 
@@ -542,6 +548,7 @@ munin_enabled: False
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
+# Network traffic monitor - from https://humdi.net/vnstat/
 vnstat_install: False
 vnstat_enabled: False
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -179,6 +179,7 @@ usb_lib_umask0000_for_kolibri: True
 
 # 6-GENERIC-APPS
 
+# Simple, Self-Hosted Web Radio - from AzuraCast.com
 azuracast_install: False
 azuracast_enabled: False    # This var is currently IGNORED.
 
@@ -194,6 +195,7 @@ jupyterhub_enabled: True
 lokole_install: True
 lokole_enabled: True
 
+# Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: True
 mediawiki_enabled: True
 
@@ -232,6 +234,7 @@ wordpress_enabled: True
 kalite_install: True
 kalite_enabled: True
 
+# Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True
 kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
@@ -282,13 +285,16 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+# AWStats, originally known as Advanced Web Statistics - from https://awstats.sourceforge.io
 awstats_install: True
 awstats_enabled: True
 
+# Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849
 monit_install: False
 monit_enabled: False
 
+# Networked resource monitoring/graphing tool - from munin-monitoring.org
 munin_install: True
 munin_enabled: True
 
@@ -297,6 +303,7 @@ munin_enabled: True
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
+# Network traffic monitor - from https://humdi.net/vnstat/
 vnstat_install: True
 vnstat_enabled: True
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -179,6 +179,7 @@ usb_lib_umask0000_for_kolibri: True
 
 # 6-GENERIC-APPS
 
+# Simple, Self-Hosted Web Radio - from AzuraCast.com
 azuracast_install: False
 azuracast_enabled: False    # This var is currently IGNORED.
 
@@ -194,6 +195,7 @@ jupyterhub_enabled: False
 lokole_install: False
 lokole_enabled: False
 
+# Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: False
 mediawiki_enabled: False
 
@@ -232,6 +234,7 @@ wordpress_enabled: True
 kalite_install: True
 kalite_enabled: True
 
+# Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
 kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
@@ -282,13 +285,16 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+# AWStats, originally known as Advanced Web Statistics - from https://awstats.sourceforge.io
 awstats_install: True
 awstats_enabled: True
 
+# Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849
 monit_install: False
 monit_enabled: False
 
+# Networked resource monitoring/graphing tool - from munin-monitoring.org
 munin_install: False
 munin_enabled: False
 
@@ -297,6 +303,7 @@ munin_enabled: False
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
+# Network traffic monitor - from https://humdi.net/vnstat/
 vnstat_install: False
 vnstat_enabled: False
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -179,6 +179,7 @@ usb_lib_umask0000_for_kolibri: True
 
 # 6-GENERIC-APPS
 
+# Simple, Self-Hosted Web Radio - from AzuraCast.com
 azuracast_install: False
 azuracast_enabled: False    # This var is currently IGNORED.
 
@@ -194,6 +195,7 @@ jupyterhub_enabled: False
 lokole_install: False
 lokole_enabled: False
 
+# Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: False
 mediawiki_enabled: False
 
@@ -232,6 +234,7 @@ wordpress_enabled: False
 kalite_install: True
 kalite_enabled: True
 
+# Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
 kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
@@ -282,13 +285,16 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+# AWStats, originally known as Advanced Web Statistics - from https://awstats.sourceforge.io
 awstats_install: True
 awstats_enabled: True
 
+# Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849
 monit_install: False
 monit_enabled: False
 
+# Networked resource monitoring/graphing tool - from munin-monitoring.org
 munin_install: False
 munin_enabled: False
 
@@ -297,6 +303,7 @@ munin_enabled: False
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
+# Network traffic monitor - from https://humdi.net/vnstat/
 vnstat_install: False
 vnstat_enabled: False
 

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -179,6 +179,7 @@ usb_lib_umask0000_for_kolibri: True
 
 # 6-GENERIC-APPS
 
+# Simple, Self-Hosted Web Radio - from AzuraCast.com
 azuracast_install: False
 azuracast_enabled: False    # This var is currently IGNORED.
 
@@ -194,6 +195,7 @@ jupyterhub_enabled: False
 lokole_install: False
 lokole_enabled: False
 
+# Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: False
 mediawiki_enabled: False
 
@@ -232,6 +234,7 @@ wordpress_enabled: False
 kalite_install: False
 kalite_enabled: False
 
+# Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
 kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
@@ -282,13 +285,16 @@ transmission_kalite_languages:
 #    then click "Scan content folder for videos" (can take many minutes!)
 # E. READ "KA Lite Administration: What tips & tricks exist?" AT http://FAQ.IIAB.IO
 
+# AWStats, originally known as Advanced Web Statistics - from https://awstats.sourceforge.io
 awstats_install: False
 awstats_enabled: False
 
+# Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849
 monit_install: False
 monit_enabled: False
 
+# Networked resource monitoring/graphing tool - from munin-monitoring.org
 munin_install: False
 munin_enabled: False
 
@@ -297,6 +303,7 @@ munin_enabled: False
 phpmyadmin_install: False
 phpmyadmin_enabled: False
 
+# Network traffic monitor - from https://humdi.net/vnstat/
 vnstat_install: False
 vnstat_enabled: False
 


### PR DESCRIPTION
So people who are new to https://internet-in-a-box.org better understand their options.

When they're choosing among IIAB Apps / services using [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)

In conjuntion with http://FAQ.IIAB.IO > "9 What services (IIAB apps) are suggested during installation?"

Somewhat Related:

- #2943