### PR TITLE
Fix outdated explanations/order in Stages 3 & 4 of local_vars.yml, default_vars.yml

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -217,7 +217,8 @@ openvpn_server_virtual_ip: 10.8.0.1
 openvpn_server_port: 1194
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
-# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
+# e.g. iiab_admin_user, iiab_admin_user_install, iiab_admin_can_sudo,
+# iiab_admin_published_pwd, admin_console_group
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -241,7 +242,6 @@ mysql_enabled: True
 
 # 2020-09-24: NGINX is MANDATORY but still evolving - please see:
 # https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
-# https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml
 # THESE 2 LEGACY VARS ARE PRESERVED BUT HAVE NO EFFECT:
 nginx_install: True
 nginx_enabled: True
@@ -249,17 +249,9 @@ nginx_port: 80
 nginx_interface: 0.0.0.0
 nginx_conf_dir: /etc/nginx/conf.d
 nginx_log_dir: /var/log/nginx
-#
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
-nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
-# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
+# SEE BELOW: nginx_high_php_limits, apache_allow_sudo
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# roles/www_base runs here (mandatory)
 
 
 # 4-SERVER-OPTIONS
@@ -279,6 +271,15 @@ squid_enabled: False
 dansguardian_install: False
 dansguardian_enabled: False
 
+# USB_LIB
+usb_lib_install: True
+usb_lib_enabled: True
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
+
 # Common UNIX Printing System (CUPS)
 cups_install: False
 cups_enabled: False
@@ -291,14 +292,18 @@ samba_udp_ports: 137:138
 samba_tcp_mports: 139,445
 shared_dir : "{{ content_base }}/public"    # /library/public
 
-# USB_LIB
-usb_lib_install: True
-usb_lib_enabled: True
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# roles/www_options HANDLES THE 3 VARS BELOW:
+
+# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+nginx_high_php_limits: False
+# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
+# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
+# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
+# ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
+
+# Make this False to disable http://box/common/services/power_off.php button:
+apache_allow_sudo: True
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -120,7 +120,7 @@ openvpn_enabled: False
 openvpn_handle: BIG-sized - Put Your Name Here
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
-# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
+# e.g. iiab_admin_user, iiab_admin_user_install, iiab_admin_can_sudo
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -136,6 +136,34 @@ pi_swap_file_size: 1024
 # 3-BASE-SERVER
 
 # roles/mysql runs here (mandatory)
+# roles/nginx runs here (mandatory)
+# roles/www_base runs here (mandatory)
+
+# SEE BELOW: nginx_high_php_limits, apache_allow_sudo
+
+
+# 4-SERVER-OPTIONS
+
+# SSHD runs here & also above in 1-PREP
+
+# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
+# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
+
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
+
+# Common UNIX Printing System (CUPS)
+cups_install: True
+cups_enabled: True
+
+# At Your Own Risk: take a security audit seriously before deploying this
+samba_install: True
+samba_enabled: False
+
+# roles/www_options HANDLES THE 3 VARS BELOW:
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
@@ -148,27 +176,8 @@ nginx_high_php_limits: False
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 
-
-# 4-SERVER-OPTIONS
-
-# SSHD runs here & also above in 1-PREP
-
-# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
-# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
-
-# Common UNIX Printing System (CUPS)
-cups_install: True
-cups_enabled: True
-
-# At Your Own Risk: take a security audit seriously before deploying this
-samba_install: True
-samba_enabled: False
-
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
+nodocs: False
 
 
 # 5-XO-SERVICES

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -120,7 +120,7 @@ openvpn_enabled: False
 openvpn_handle: MEDIUM-sized - Put Your Name Here
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
-# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
+# e.g. iiab_admin_user, iiab_admin_user_install, iiab_admin_can_sudo
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -136,6 +136,34 @@ pi_swap_file_size: 1024
 # 3-BASE-SERVER
 
 # roles/mysql runs here (mandatory)
+# roles/nginx runs here (mandatory)
+# roles/www_base runs here (mandatory)
+
+# SEE BELOW: nginx_high_php_limits, apache_allow_sudo
+
+
+# 4-SERVER-OPTIONS
+
+# SSHD runs here & also above in 1-PREP
+
+# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
+# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
+
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
+
+# Common UNIX Printing System (CUPS)
+cups_install: False
+cups_enabled: False
+
+# At Your Own Risk: take a security audit seriously before deploying this
+samba_install: False
+samba_enabled: False
+
+# roles/www_options HANDLES THE 3 VARS BELOW:
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
@@ -148,27 +176,8 @@ nginx_high_php_limits: False
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 
-
-# 4-SERVER-OPTIONS
-
-# SSHD runs here & also above in 1-PREP
-
-# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
-# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
-
-# Common UNIX Printing System (CUPS)
-cups_install: False
-cups_enabled: False
-
-# At Your Own Risk: take a security audit seriously before deploying this
-samba_install: False
-samba_enabled: False
-
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
+nodocs: False
 
 
 # 5-XO-SERVICES

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -120,7 +120,7 @@ openvpn_enabled: False
 openvpn_handle: MIN-sized - Put Your Name Here
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
-# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
+# e.g. iiab_admin_user, iiab_admin_user_install, iiab_admin_can_sudo
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -136,6 +136,34 @@ pi_swap_file_size: 1024
 # 3-BASE-SERVER
 
 # roles/mysql runs here (mandatory)
+# roles/nginx runs here (mandatory)
+# roles/www_base runs here (mandatory)
+
+# SEE BELOW: nginx_high_php_limits, apache_allow_sudo
+
+
+# 4-SERVER-OPTIONS
+
+# SSHD runs here & also above in 1-PREP
+
+# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
+# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
+
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
+
+# Common UNIX Printing System (CUPS)
+cups_install: False
+cups_enabled: False
+
+# At Your Own Risk: take a security audit seriously before deploying this
+samba_install: False
+samba_enabled: False
+
+# roles/www_options HANDLES THE 3 VARS BELOW:
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
@@ -148,27 +176,8 @@ nginx_high_php_limits: False
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 
-
-# 4-SERVER-OPTIONS
-
-# SSHD runs here & also above in 1-PREP
-
-# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
-# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
-
-# Common UNIX Printing System (CUPS)
-cups_install: False
-cups_enabled: False
-
-# At Your Own Risk: take a security audit seriously before deploying this
-samba_install: False
-samba_enabled: False
-
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
+nodocs: False
 
 
 # 5-XO-SERVICES

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -120,7 +120,7 @@ openvpn_enabled: True
 openvpn_handle: unittest - Put Your Name Here
 
 # IIAB-ADMIN runs here - see its vars near top of this file:
-# e.g. iiab_admin_user_install, iiab_admin_user, iiab_admin_pwd_hash
+# e.g. iiab_admin_user, iiab_admin_user_install, iiab_admin_can_sudo
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
@@ -136,6 +136,34 @@ pi_swap_file_size: 1024
 # 3-BASE-SERVER
 
 # roles/mysql runs here (mandatory)
+# roles/nginx runs here (mandatory)
+# roles/www_base runs here (mandatory)
+
+# SEE BELOW: nginx_high_php_limits, apache_allow_sudo
+
+
+# 4-SERVER-OPTIONS
+
+# SSHD runs here & also above in 1-PREP
+
+# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
+# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
+
+# Show entire contents of USB sticks/drives (at http://box/usb)
+iiab_usb_lib_show_all: True
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
+# Kolibri can export & import channels to USB sticks/drive:
+usb_lib_umask0000_for_kolibri: True
+
+# Common UNIX Printing System (CUPS)
+cups_install: False
+cups_enabled: False
+
+# At Your Own Risk: take a security audit seriously before deploying this
+samba_install: False
+samba_enabled: False
+
+# roles/www_options HANDLES THE 3 VARS BELOW:
 
 # For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
 nginx_high_php_limits: False
@@ -148,27 +176,8 @@ nginx_high_php_limits: False
 # Make this False to disable http://box/common/services/power_off.php button:
 apache_allow_sudo: True
 
-
-# 4-SERVER-OPTIONS
-
-# SSHD runs here & also above in 1-PREP
-
-# DNS prep (dnsmasq, named &/or dhcpd) run here.  The full network stage runs
-# after 9-LOCAL-ADDONS (or manually run "cd /opt/iiab/iiab; ./iiab-network")
-
-# Common UNIX Printing System (CUPS)
-cups_install: False
-cups_enabled: False
-
-# At Your Own Risk: take a security audit seriously before deploying this
-samba_install: False
-samba_enabled: False
-
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
+nodocs: False
 
 
 # 5-XO-SERVICES


### PR DESCRIPTION
Ordering & explanations were quite out-of-date.

This at least is a major improvement.

Somewhat related:

- PR #2944