### PR TITLE
@jvonau's ODBC compiling for FreePBX CDR on NGINX + linting, explanations & small mods

### DIFF
--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -20,11 +20,11 @@
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk
 asterisk_src_file: asterisk-18-current.tar.gz
-asterisk_src_dir: {{ iiab_base }}/asterisk    # /opt/iiab
+asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/7.4
 freepbx_src_file: freepbx-16.0-latest.tgz    # Beta as of 2021-06-21 but looking great!  Does NOT support PHP < 7.4 (you've been warned!)  Please review https://github.com/iiab/iiab/blob/master/roles/pbx/README.rst
-freepbx_src_dir: {{ iiab_base }}/freepbx
+freepbx_src_dir: "{{ iiab_base }}/freepbx"
 freepbx_install_dir: /var/www/html/freepbx
 
 asterisk_db_host: localhost
@@ -35,4 +35,4 @@ asterisk_db_cdrdbname: asteriskcdrdb
 
 chan_dongle_url: https://github.com/wdoekes/asterisk-chan-dongle/archive
 chan_dongle_src_file: master.zip
-chan_dongle_src_dir: {{ iiab_base }}/chan_dongle
+chan_dongle_src_dir: "{{ iiab_base }}/chan_dongle"

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -20,11 +20,11 @@
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk
 asterisk_src_file: asterisk-18-current.tar.gz
-asterisk_src_dir: /opt/iiab/asterisk
+asterisk_src_dir: {{ iiab_base }}/asterisk    # /opt/iiab
 
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/7.4
 freepbx_src_file: freepbx-16.0-latest.tgz    # Beta as of 2021-06-21 but looking great!  Does NOT support PHP < 7.4 (you've been warned!)  Please review https://github.com/iiab/iiab/blob/master/roles/pbx/README.rst
-freepbx_src_dir: /opt/iiab/freepbx
+freepbx_src_dir: {{ iiab_base }}/freepbx
 freepbx_install_dir: /var/www/html/freepbx
 
 asterisk_db_host: localhost
@@ -35,4 +35,4 @@ asterisk_db_cdrdbname: asteriskcdrdb
 
 chan_dongle_url: https://github.com/wdoekes/asterisk-chan-dongle/archive
 chan_dongle_src_file: master.zip
-chan_dongle_src_dir: /opt/iiab/chan_dongle
+chan_dongle_src_dir: {{ iiab_base }}/chan_dongle

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,3 +1,7 @@
+# 2021-08-16 README.adoc, with screenshots:
+# https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+
+
 # 2021-08-05: Asterisk's own install_prereq (below) handles essentially all of these
 # - name: Asterisk - Install dependencies
 #   include_tasks: asterisk_dependencies.yml

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -216,6 +216,7 @@
     dest: /etc/systemd/system/
 
 
+# default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 2 MIN OR LONGER!
   command: fwconsole ma upgradeall
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -191,16 +191,16 @@
 # http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
 - name: FreePBX - Install /etc/odbc.ini, /etc/odbcinst.ini from template (root:root, 0644 by default)
   template:
-    src: "{{ item }}"
-    dest: /etc/
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
   with_items:
-    - odbc.ini
-    - odbcinst.ini
+    - { src: odbc.ini.j2, dest: /etc/odbc.ini }
+    - { src: odbcinst.ini, dest: /etc/odbcinst.ini }
 
 - name: FreePBX - Install /etc/asterisk/cdr_mysql.conf from template (root:root, 0644 by default)
   template:
-    src: cdr_mysql.conf
-    dest: /etc/asterisk/
+    src: cdr_mysql.conf.j2
+    dest: /etc/asterisk/cdr_mysql.conf
 
 
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -168,6 +168,11 @@
     create: yes
 
 
+- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+  template:
+    src: odbc.ini
+    dest: /etc/
+
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
@@ -204,11 +209,6 @@
 #     enabled: yes
 #     state: restarted
 
-
-- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
-  template:
-    src: odbc.ini
-    dest: /etc/
 
 - name: FreePBX - Install /etc/systemd/system/freepbx.service from template (root:root, 0644 by default)
   template:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -187,7 +187,7 @@
     creates: /usr/local/lib/mariadb/libmaodbc.so
 
 # http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
-- name: FreePBX - Install /etc/odbc.ini /etc/odbconit.ini from template (root:root, 0644 by default)
+- name: FreePBX - Install /etc/odbc.ini /etc/odbcinst.ini from template (root:root, 0644 by default)
   template:
     src: "{{ item }}"
     dest: /etc/

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -1,7 +1,5 @@
-# "Official" recipe: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9
-# Comprehensive & recent recipe for RPi: http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
-# Quirky but still useful for comparison: https://computingforgeeks.com/how-to-install-asterisk-16-with-freepbx-15-on-ubuntu-debian/
-# 2012-2017: http://www.raspberry-asterisk.org
+# 2021-08-16 README.adoc, with screenshots:
+# https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
 
 
 # 2021-08-04: Non-native systemd service 'asterisk.service' (redirects via
@@ -13,15 +11,15 @@
 # 2021-08-12: Let's try to track the "official" init.d / update-rc.d
 # instructions ('update-rc.d -f asterisk remove') but using systemd instead,
 # to be more future-proof?
-- name: FreePBX - Disable 'asterisk' service
+- name: "FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9"
   systemd:
     daemon_reload: yes
     name: asterisk
-    state: stopped
+    #state: stopped
     enabled: no
 
 
-- name: FreePBX - Install wget, git, unixodbc, sudo, net-tools, cron, sox + ~12 PHP dependencies (run 'php -m' or 'php -i' to verify PHP modules)
+- name: FreePBX - Install 24 packages = 7 (wget, git, unixodbc, sudo, net-tools, cron, sox) + 12 PHP dependencies (run 'php -m' or 'php -i' to verify PHP modules) + 5 for CDR ODBC (cmake, make, gcc, libssl-dev, unixodbc-dev)
   package:
     name:
       - wget
@@ -136,19 +134,22 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-    login_user: "{{ asterisk_db_user  }}"
+    login_user: "{{ asterisk_db_user }}"
     login_password: "{{ asterisk_db_password }}"
     state: present
 
-- name: FreePBX - Add cdr MySQL db ({{ asterisk_db_cdrdbname }})
+- name: FreePBX - Add CDR MySQL db ({{ asterisk_db_cdrdbname }})
   mysql_db:
     name: "{{ asterisk_db_cdrdbname }}"    # asteriskcdrdb
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-    login_user: "{{ asterisk_db_user  }}"
+    login_user: "{{ asterisk_db_user }}"
     login_password: "{{ asterisk_db_password }}"
     state: present
+
+
+# 2021-08-16: DOES NGINX NEED THE NEXT 2 STANZAS?  (If not, should 'when: not pbx_try_nginx' be added?)
 
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:
@@ -173,7 +174,8 @@
     group: asterisk
     create: yes
 
-- name: Freepbx -  Clone mariadb-connector-odbc
+
+- name: FreePBX - git clone https://github.com/mariadb-corporation/mariadb-connector-odbc to /usr/src/mariadb-connector-odbc
   git:
     repo: https://github.com/mariadb-corporation/mariadb-connector-odbc
     dest: /usr/src/mariadb-connector-odbc
@@ -181,26 +183,25 @@
     force: yes
     depth: 1
 
-- name: FreePBX - Build mariadb-connector-odbc
+- name: FreePBX - Run scripts/mk-odbc-connector to build mariadb-connector-odbc, creating /usr/local/lib/mariadb/libmaodbc.so
   command: "{{ iiab_dir }}/scripts/mk-odbc-connector"
   args:
     creates: /usr/local/lib/mariadb/libmaodbc.so
 
 # http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
-- name: FreePBX - Install /etc/odbc.ini /etc/odbcinst.ini from template (root:root, 0644 by default)
+- name: FreePBX - Install /etc/odbc.ini, /etc/odbcinst.ini from template (root:root, 0644 by default)
   template:
     src: "{{ item }}"
     dest: /etc/
   with_items:
-  - odbc.ini
-  - odbcinst.ini
+    - odbc.ini
+    - odbcinst.ini
 
-- name: FreePBX - Create /etc/asterisk/cdr_mysql.conf
+- name: FreePBX - Install /etc/asterisk/cdr_mysql.conf from template (root:root, 0644 by default)
   template:
-    src: "{{ item }}"
+    src: cdr_mysql.conf
     dest: /etc/asterisk/
-  with_items:
-    - cdr_mysql.conf
+
 
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
@@ -210,13 +211,14 @@
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
+    # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
 - name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
   command: "{{ item }}"
   with_items:
-    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     - fwconsole stop
     - killall -9 safe_asterisk        # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
+    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     # - killall -9 asterisk       # 2021-08-05: Also from @jvonau's PR #2912, to brute force this.  In the end, above 'fwconsole stop' works more gracefully.
     # - ./start_asterisk stop     # Buggy!
     # - /usr/sbin/asterisk -rx "core stop gracefully"
@@ -244,14 +246,14 @@
     src: freepbx.service
     dest: /etc/systemd/system/
 
-
-# default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
+# Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 2 MIN OR LONGER!
   command: fwconsole ma upgradeall
 
 - name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) - if pbx_try_nginx - so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec
   command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
   when: pbx_try_nginx
+
 
 # - name: Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
 #   lineinfile:
@@ -284,8 +286,8 @@
 # For 'pbx_try_nginx: True' -- FreePBX's initial page (Admin user registration)
 # tries to set up a cron job but fails:
 #   "Exception: Trying to edit user asterisk, when I'm running as www-data"
-# 2021-08-10: Hacking /etc/freepbx.conf WAS NOT TESTED PROPERLY -- AS VARS MUST
-# BE NEAR BOTTOM OF FILE: github.com/iiab/iiab/pull/2916#issuecomment-894585322
+# 2021-08-10: Hacking /etc/freepbx.conf WAS NOT TESTED PROPERLY -- some vars MAY
+# need to be NEAR BOTTOM: github.com/iiab/iiab/pull/2916#issuecomment-894585322
 # - name: "2021-08-06: Try \"$amp_conf['AMPASTERISKWEBUSER'] = 'www-data';\" in /etc/freepbx.conf for #2916 registration cron fix ?'"
 #   lineinfile:
 #     path: /etc/freepbx.conf

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -250,7 +250,7 @@
     dest: /etc/systemd/system/
 
 # Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
-- name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 2 MIN OR LONGER!
+- name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
   command: fwconsole ma upgradeall
 
 - name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) - if pbx_try_nginx - so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -13,11 +13,11 @@
 # 2021-08-12: Let's try to track the "official" init.d / update-rc.d
 # instructions ('update-rc.d -f asterisk remove') but using systemd instead,
 # to be more future-proof?
-- name: "FreePBX - Disable 'asterisk' systemd service, giving FreePBX full control during boot - similar to officially recommended 'update-rc.d -f asterisk remove' at: https://wiki.freepbx.org/display/FOP/Installing+FreePBX+16+on+Debian+10.9"
+- name: FreePBX - Disable 'asterisk' service
   systemd:
     daemon_reload: yes
     name: asterisk
-    #state: stopped
+    state: stopped
     enabled: no
 
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -135,9 +135,9 @@
     name: "{{ asterisk_db_dbname }}"    # asterisk
     encoding: utf8
     collation: utf8_general_ci
-    # login_host: "{{ asterisk_db_host }}"
-    # login_user: root
-    # login_password: "{{ mysql_root_password }}"
+    login_host: "{{ asterisk_db_host }}"
+    login_user: "{{ asterisk_db_user  }}"
+    login_password: "{{ asterisk_db_password }}"
     state: present
 
 - name: FreePBX - Add cdr MySQL db ({{ asterisk_db_cdrdbname }})
@@ -147,6 +147,9 @@
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
     state: present
+    login_host: "{{ asterisk_db_host }}"
+    login_user: "{{ asterisk_db_user  }}"
+    login_password: "{{ asterisk_db_password }}"
 
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:
@@ -193,6 +196,13 @@
   - odbc.ini
   - odbcinst.ini
 
+- name: FreePBX - Create /etc/asterisk/cdr_mysql.conf
+  template:
+    src: "{{ item }}"
+    dest: /etc/asterisk/
+  with_items:
+    - cdr_mysql.conf
+
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"
   args:
@@ -200,14 +210,14 @@
     creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
   with_items:
     - ./start_asterisk start
-    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
 
 - name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
   command: "{{ item }}"
   with_items:
+    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     - fwconsole stop
     - killall -9 safe_asterisk        # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
-    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
     # - killall -9 asterisk       # 2021-08-05: Also from @jvonau's PR #2912, to brute force this.  In the end, above 'fwconsole stop' works more gracefully.
     # - ./start_asterisk stop     # Buggy!
     # - /usr/sbin/asterisk -rx "core stop gracefully"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -48,6 +48,11 @@
       - php{{ php_version }}-snmp
       - php{{ php_version }}-xml         # Likewise installed in mediawiki/tasks/install.yml, moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml -- AND REGARDLESS dragged in later by Admin Console's use of php-pear for roles/cmdsrv/tasks/main.yml -- run 'php -m | grep -i xml' which in the end shows {libxml, SimpleXML, xml, xmlreader, xmlwriter}
       - php{{ php_version }}-zip         # Likewise installed in moodle/tasks/install.yml, nextcloud/tasks/install.yml, wordpress/tasks/install.yml
+      - cmake
+      - make
+      - gcc
+      - libssl-dev
+      - unixodbc-dev
     state: latest
 
 # For PHP >= 8.0: phpX.Y-json is baked into PHP itself.
@@ -143,7 +148,6 @@
     login_host: "{{ asterisk_db_host }}"
     state: present
 
-
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:
     path: /var/lib/php/asterisk_sessions/
@@ -167,11 +171,27 @@
     group: asterisk
     create: yes
 
+- name: Freepbx -  Clone mariadb-connector-odbc
+  git:
+    repo: https://github.com/mariadb-corporation/mariadb-connector-odbc
+    dest: /usr/src/mariadb-connector-odbc
+    version: master
+    force: yes
+    depth: 1
 
-- name: FreePBX - Install /etc/odbc.ini from template (root:root, 0644 by default) for CDR 'asteriskcdrdb' - in future consider compiling ODBC driver for aarch64 per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+- name: FreePBX - Build mariadb-connector-odbc
+  command: "{{ iiab_dir }}/scripts/mk-odbc-connector"
+  args:
+    creates: /usr/local/lib/mariadb/libmaodbc.so
+
+# http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html
+- name: FreePBX - Install /etc/odbc.ini /etc/odbconit.ini from template (root:root, 0644 by default)
   template:
-    src: odbc.ini
+    src: "{{ item }}"
     dest: /etc/
+  with_items:
+  - odbc.ini
+  - odbcinst.ini
 
 - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
   command: "{{ item }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -146,10 +146,9 @@
     encoding: utf8
     collation: utf8_general_ci
     login_host: "{{ asterisk_db_host }}"
-    state: present
-    login_host: "{{ asterisk_db_host }}"
     login_user: "{{ asterisk_db_user  }}"
     login_password: "{{ asterisk_db_password }}"
+    state: present
 
 - name: FreePBX - Create new php sessions dir /var/lib/php/asterisk_sessions/ - SEE 'php_value session.save_path /var/lib/php/asterisk_sessions/' IN pbx/templates/freepbx.conf.j2
   file:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -213,12 +213,11 @@
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
     # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
-- name: "Run 'fwconsole stop' and 'killall -9 safe_asterisk' to stop both Asterisk processes -- this avoids \"Unable to run Pre-Asterisk hooks, because Asterisk is already running\" in 'journalctl -u freepbx' logs"
+- name: FreePBX - Run 'fwconsole stop', 'killall -9 safe_asterisk' to stop both main Asterisk processes - this avoids "Unable to run Pre-Asterisk hooks, because Asterisk is already running" in 'journalctl -u freepbx' logs
   command: "{{ item }}"
   with_items:
     - fwconsole stop
-    - killall -9 safe_asterisk        # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
-    - killall -9 "PM2 v4.5.0: God"    # 2021-08-09: Missed by fwconsole (does this matter?)
+    - killall -9 safe_asterisk    # 2021-08-08: Stronger medicine needed for 64-bit Ubuntu Server 21.04 on RPi 4.  Originally from @jvonau's PR #2912.
     # - killall -9 asterisk       # 2021-08-05: Also from @jvonau's PR #2912, to brute force this.  In the end, above 'fwconsole stop' works more gracefully.
     # - ./start_asterisk stop     # Buggy!
     # - /usr/sbin/asterisk -rx "core stop gracefully"
@@ -229,7 +228,11 @@
     # - fwconsole ma delete firewall
     # - fwconsole reload
     # - fwconsole restart
-  ignore_errors: yes    # 2021-08-08: For things like 'killall -9 safe_asterisk' that fail when process doesn't exist
+  ignore_errors: yes    # 2021-08-08: As 'killall -9 safe_asterisk' will fail when process doesn't exist (on many OS's!)
+
+- name: "FreePBX - Run 'killall -9 \"PM2 v4.5.0: God\"' for good measure"
+  command: 'killall -9 "PM2 v4.5.0: God"'    # 2021-08-09: Missed by above 'fwconsole stop' (does this matter?)
+  ignore_errors: yes    # 2021-08-16: As 'killall -9 "PM2 v4.5.0: God"' will fail if process doesn't exist (e.g. if version number changes, etc)
 
 # 2021-08-06: This stanza works, but above is more graceful.  (FYI PRs #2908,
 # #2912, #2913 didn't quite work -- whereas this PR #2915 at least worked!)
@@ -255,7 +258,7 @@
   when: pbx_try_nginx
 
 
-# - name: Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
+# - name: FreePBX - Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
 #   lineinfile:
 #     path: /etc/freepbx.conf
 #     insertbefore: '^\?>$'    # Match exact line '?>' -- BOTTOM OF FILE NEC!

--- a/roles/pbx/templates/cdr_mysql.conf
+++ b/roles/pbx/templates/cdr_mysql.conf
@@ -3,4 +3,4 @@ hostname = localhost
 dbname = asteriskcdrdb
 user = asterisk
 password = asterisk
-userfield=1
+userfield = 1

--- a/roles/pbx/templates/cdr_mysql.conf
+++ b/roles/pbx/templates/cdr_mysql.conf
@@ -1,0 +1,6 @@
+[global]
+hostname = localhost
+dbname = asteriskcdrdb
+user = asterisk
+password = asterisk
+userfield=1

--- a/roles/pbx/templates/cdr_mysql.conf
+++ b/roles/pbx/templates/cdr_mysql.conf
@@ -1,6 +1,0 @@
-[global]
-hostname = localhost
-dbname = asteriskcdrdb
-user = asterisk
-password = asterisk
-userfield = 1

--- a/roles/pbx/templates/cdr_mysql.conf.j2
+++ b/roles/pbx/templates/cdr_mysql.conf.j2
@@ -1,0 +1,6 @@
+[global]
+hostname = localhost
+dbname = {{ asterisk_db_cdrdbname }}
+user = {{ asterisk_db_password }}
+password = {{ asterisk_db_password }}
+userfield = 1

--- a/roles/pbx/templates/odbc.ini.j2
+++ b/roles/pbx/templates/odbc.ini.j2
@@ -1,8 +1,8 @@
 [MySQL-asteriskcdrdb]
-Description=MySQL connection to 'asteriskcdrdb' database
-driver=MySQL
-server=localhost
-database={{ asterisk_db_cdrdbname }}
-Port=3306
-Socket=/var/run/mysqld/mysqld.sock
-option=3
+Description = MySQL connection to 'asteriskcdrdb' database
+driver = MySQL
+server = localhost
+database = {{ asterisk_db_cdrdbname }}
+Port = 3306
+Socket = /var/run/mysqld/mysqld.sock
+option = 3

--- a/roles/pbx/templates/odbc.ini.j2
+++ b/roles/pbx/templates/odbc.ini.j2
@@ -2,7 +2,7 @@
 Description=MySQL connection to 'asteriskcdrdb' database
 driver=MySQL
 server=localhost
-database=asteriskcdrdb
+database={{ asterisk_db_cdrdbname }}
 Port=3306
 Socket=/var/run/mysqld/mysqld.sock
 option=3

--- a/roles/pbx/templates/odbcinst.ini
+++ b/roles/pbx/templates/odbcinst.ini
@@ -1,0 +1,4 @@
+[MySQL]
+Description = ODBC for MySQL (MariaDB)
+Driver = /usr/local/lib/mariadb/libmaodbc.so
+FileUsage = 1

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -1,0 +1,10 @@
+#!/bin/bash
+mkdir /usr/src/mariadb-connector-odbc/build
+cd /usr/src/mariadb-connector-odbc/build
+if [ -f /etc/rpi-issue ]; then
+    DM_DIR=/usr/lib/arm-linux-gnueabihf cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb -L/usr/lib"
+else
+    DM_DIR=/usr/lib/aarch64-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
+fi
+make
+make install

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -9,3 +9,9 @@ else
 fi
 make
 make install
+
+cat << EOF > /etc/ld.so.conf.d/99-iiab.conf
+/usr/local/lib/mariadb/
+EOF
+
+ldconfig

--- a/scripts/mk-odbc-connector
+++ b/scripts/mk-odbc-connector
@@ -1,10 +1,11 @@
 #!/bin/bash
+ARCH=$(uname -m)
 mkdir /usr/src/mariadb-connector-odbc/build
 cd /usr/src/mariadb-connector-odbc/build
 if [ -f /etc/rpi-issue ]; then
     DM_DIR=/usr/lib/arm-linux-gnueabihf cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb -L/usr/lib"
 else
-    DM_DIR=/usr/lib/aarch64-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
+    DM_DIR=/usr/lib/$ARCH-linux-gnu cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_C_FLAGS_RELWITHDEBINFO="-I/usr/include/mariadb" -DWITH_SSL=OPENSSL -DCMAKE_INSTALL_PREFIX=/usr/local
 fi
 make
 make install


### PR DESCRIPTION
This is @jvonau's PR #2942 breakthroughs compiling `/usr/local/lib/mariadb/libmaodbc.so` for FreePBX's CDR, packaged up here to be mainlined for wider testing.

Hopefully across all major platforms.

Everyone is invited to please set these 3 vars at the bottom of their [/etc/iiab/local_vars.yml](http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F) to help test FreePBX with NGINX!

```
pbx_install: True
pbx_enabled: True
pbx_try_nginx: True    # 2021-08-07: PLEASE TRY NGINX INSTEAD OF APACHE,
# AFTER READING https://github.com/iiab/iiab/issues/2914 AND #2916, THX !
```

(And not just on recent Ubuntus and recent Debians, but also on Raspberry Pi 11 Bullseye if that emerges in coming days!)

cc: @lemueldsouza, @m-anish 

Reinforcing the FreePBX-with-NGINX advances and more:

- #2914 
- PR #2916
- PR #2929 
- PR #2931
- PR #2941