### PR TITLE
Freepbx - dual mode - for side by side testing [of Apache & NGINX]

### DIFF
--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -4,6 +4,8 @@
 
 # pbx_install: False
 # pbx_enabled: False
+pbx_use_apache: True
+pbx_use_nginx: True
 
 # pbx_try_nginx: False    # 2021-08-07: PLEASE TRY NGINX INSTEAD OF APACHE,
 # # AFTER READING https://github.com/iiab/iiab/issues/2914 AND #2916, THX !

--- a/roles/pbx/tasks/enable-or-disable.yml
+++ b/roles/pbx/tasks/enable-or-disable.yml
@@ -39,7 +39,7 @@
       enabled: no
     when: not pbx_enabled
 
-  when: not pbx_try_nginx
+  when: pbx_use_apache
 
 
 - block:
@@ -79,4 +79,8 @@
       name: nginx
       state: restarted
 
-  when: pbx_try_nginx
+  when: pbx_use_nginx
+
+- name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) - if pbx_try_nginx - so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec
+  command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
+  when: pbx_use_nginx and not pbx_use_apache

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -64,8 +64,7 @@
 
 - name: FreePBX - Install and configure Apache - if not pbx_try_nginx
   include_tasks: apache.yml
-  when: not pbx_try_nginx
-
+  when: pbx_use_apache
 
 - name: FreePBX - Download {{ freepbx_url }}/{{ freepbx_src_file }} to {{ downloads_dir }}
   get_url:
@@ -252,11 +251,6 @@
 # Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
   command: fwconsole ma upgradeall
-
-- name: FreePBX - Run 'fwconsole set CHECKREFERER 0' (0 means false) - if pbx_try_nginx - so 'Submit' button definitively works at http://box/freepbx >> Settings >> Advanced Settings -- FYI you can run 'fwconsole set -l' or 'fwconsole set CHECKREFERER' to view FreePBX settings -- FYI /etc/freepbx.conf can completely override FreePBX's stored settings if nec
-  command: fwconsole set CHECKREFERER 0    # Or/later run 'fwconsole set CHECKREFERER 1' (1 means true) to restore FreePBX's default strict checking.
-  when: pbx_try_nginx
-
 
 # - name: FreePBX - Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_try_nginx"
 #   lineinfile:

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -23,13 +23,11 @@
   include_tasks: install.yml
   when: pbx_installed is undefined
 
-
-- include_tasks: enable-or-disable.yml
-
 - name: Install chan_dongle for Huawei USB modems - if asterisk_chan_dongle
   include: chan_dongle.yml
   when: asterisk_chan_dongle
 
+- include_tasks: enable-or-disable.yml
 
 - name: Add 'pbx' variable values to {{ iiab_ini_file }}
   ini_file:


### PR DESCRIPTION
For testing and evaluation between the two options. Should allow both apache and nginx to serve up pbx at the same time on their respective urls.

To change from dual mode to nginx only on must first toggle pbx_enabled to False in local_var.yml then `./runrole pbx` to shut down apache cleanly.
Next edit local_vars again toggle pbx_enabled to True and add: 'pbx_use_apache: False' and `./runrole pbx` to apply the new config. You could add 'pbx_use_apache: False' prior to installing but the installer will skip installing apache so only add that after the initial install of you want side by side testing.