### PR TITLE
No net exit

### DIFF
--- a/roles/0-init/tasks/check_hostname.yml
+++ b/roles/0-init/tasks/check_hostname.yml
@@ -1,0 +1,31 @@
+- name: "Set 'iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}'"
+  set_fact:
+    iiab_fqdn: "{{ iiab_hostname }}.{{ iiab_domain }}"
+    FQDN_changed: False
+
+- name: Set hostname / domain (etc) in various places -- if iiab_fqdn != ansible_fqdn ({{ ansible_fqdn }})
+  include_tasks: hostname.yml
+  when: iiab_fqdn != ansible_fqdn
+
+# 2021-07-30: FQDN_changed isn't used as in the past -- its remaining use is
+# for {named, dhcpd, squid} in roles/network/tasks/main.yml -- possibly it
+# should be reconsidered?  See PR #2876: roles/network might become optional?
+- name: "Also set 'FQDN_changed: True' -- if iiab_fqdn != ansible_fqdn ({{ ansible_fqdn }})"
+  set_fact:
+    FQDN_changed: True
+  when: iiab_fqdn != ansible_fqdn
+
+
+# 2021-08-17: (1) iiab-gen-iptables works better if gui_port is set directly in
+# default_vars.yml and/or local_vars.yml (2) Admin Console's iiab-admin.yml
+# and js-menu.yml set 'adm_cons_force_ssl: False'
+
+# - name: "Set 'gui_port: 80' for Admin Console if not adm_cons_force_ssl"
+#   set_fact:
+#     gui_port: 80
+#   when: not adm_cons_force_ssl
+
+# - name: "Set 'gui_port: 443' for Admin Console if adm_cons_force_ssl"
+#   set_fact:
+#     gui_port: 443
+#   when: adm_cons_force_ssl

--- a/roles/0-init/tasks/detect_network.yml
+++ b/roles/0-init/tasks/detect_network.yml
@@ -40,35 +40,9 @@
     path: /tmp/heart-beat.txt
     state: absent
 
-
-- name: "Set 'iiab_fqdn: {{ iiab_hostname }}.{{ iiab_domain }}'"
-  set_fact:
-    iiab_fqdn: "{{ iiab_hostname }}.{{ iiab_domain }}"
-    FQDN_changed: False
-
-- name: Set hostname / domain (etc) in various places -- if iiab_fqdn != ansible_fqdn ({{ ansible_fqdn }})
-  include_tasks: hostname.yml
-  when: iiab_fqdn != ansible_fqdn
-
-# 2021-07-30: FQDN_changed isn't used as in the past -- its remaining use is
-# for {named, dhcpd, squid} in roles/network/tasks/main.yml -- possibly it
-# should be reconsidered?  See PR #2876: roles/network might become optional?
-- name: "Also set 'FQDN_changed: True' -- if iiab_fqdn != ansible_fqdn ({{ ansible_fqdn }})"
-  set_fact:
-    FQDN_changed: True
-  when: iiab_fqdn != ansible_fqdn
-
-
-# 2021-08-17: (1) iiab-gen-iptables works better if gui_port is set directly in
-# default_vars.yml and/or local_vars.yml (2) Admin Console's iiab-admin.yml
-# and js-menu.yml set 'adm_cons_force_ssl: False'
-
-# - name: "Set 'gui_port: 80' for Admin Console if not adm_cons_force_ssl"
-#   set_fact:
-#     gui_port: 80
-#   when: not adm_cons_force_ssl
-
-# - name: "Set 'gui_port: 443' for Admin Console if adm_cons_force_ssl"
-#   set_fact:
-#     gui_port: 443
-#   when: adm_cons_force_ssl
+- block:
+  - name: Stop the installer portion if internet is unavailable
+    fail:
+      msg: "New installs requires internet access which is not available"
+  - meta: end_play
+  when: not internet_available and iiab_stage|int < 9

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Test Gateway + Test Internet - exit if required
   include_tasks: detect_network.yml
 
-- name: Check hostname/domain (hostname.yml) if nec + Set 'gui_port' to 80 or 443 for Admin Console
+- name: Check hostname/domain (hostname.yml) if nec
   include_tasks: check_hostname.yml
 
 - name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -49,15 +49,17 @@
     path: /etc/iiab/diag
     mode: '0777'
 
-
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml
 
+- name: Test Gateway + Test Internet - exit if required
+  include_tasks: detect_network.yml
+
+- name: Check hostname/domain (hostname.yml) if nec + Set 'gui_port' to 80 or 443 for Admin Console
+  include_tasks: check_hostname.yml
+
 - name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"
   include_tasks: tz.yml
-
-- name: Test Gateway + Test Internet + Set new hostname/domain (hostname.yml) if nec + Set 'gui_port' to 80 or 443 for Admin Console
-  include_tasks: network.yml
 
 
 - name: Add 'runtime' variable values to {{ iiab_ini_file }}


### PR DESCRIPTION
### Fixes bug:
No bug just better operation when internet is not present, prevents role operation rather than having the play fail at some later point requiring internet. Well this might prevent other bugs from showing up as some role's install.yml are peppered with "internet_available" which should be assumed to be available during the install and would be skipped. That style is a holdover from the pre iiab_state.yml days and should most likely be removed.

>grep internet_available roles/*/tasks/install.yml
roles/azuracast/tasks/install.yml:  when: internet_available
roles/azuracast/tasks/install.yml:  when: internet_available
roles/calibre-web/tasks/install.yml:  when: internet_available
roles/calibre-web/tasks/install.yml:  when: internet_available
roles/gitea/tasks/install.yml:  when: internet_available
roles/gitea/tasks/install.yml:  when: internet_available
roles/internetarchive/tasks/install.yml:  when: internet_available
roles/jupyterhub/tasks/install.yml:  when: internet_available
roles/kalite/tasks/install.yml:  when: internet_available
roles/kalite/tasks/install.yml:  when: internet_available
roles/kiwix/tasks/install.yml:  when: internet_available
roles/kolibri/tasks/install.yml:  when: internet_available
roles/lokole/tasks/install.yml:    - internet_available
roles/lokole/tasks/install.yml:    - internet_available
roles/lokole/tasks/install.yml:    - internet_available
roles/mediawiki/tasks/install.yml:  when: internet_available
roles/nextcloud/tasks/install.yml:  when: internet_available
roles/nodejs/tasks/install.yml:#  when: internet_available and is_debuntu
roles/nodejs/tasks/install.yml:  #when: internet_available    # 2021-08-04: Better to fail & notify implementer!
roles/nodejs/tasks/install.yml:  #when: internet_available and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
roles/nodejs/tasks/install.yml:  #when: internet_available    # 2021-08-04: Better to fail & notify implementer!
roles/nodejs/tasks/install.yml:  #when: internet_available and (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
roles/nodejs/tasks/install.yml:#   when: internet_available and not (is_debian_8 or is_debian_9 or is_ubuntu_16 or is_ubuntu_17)
roles/nodered/tasks/install.yml:  when: nodered_install and internet_available
roles/nodered/tasks/install.yml:  when: nodered_install and internet_available and is_raspbian
roles/nodered/tasks/install.yml:#  when: nodered_install and internet_available
roles/nodered/tasks/install.yml:#  when: nodered_install and internet_available
roles/nodered/tasks/install.yml:#  when: nodered_install and internet_available
roles/nodered/tasks/install.yml:  when: nodered_install and internet_available and is_raspbian
roles/phpmyadmin/tasks/install.yml:  when: internet_available
roles/sugarizer/tasks/install.yml:  when: internet_available
roles/sugarizer/tasks/install.yml:  when: internet_available
roles/sugarizer/tasks/install.yml:  when: internet_available    # "npm install" generally requires Internet access
roles/sugarizer/tasks/install.yml:# when: internet_available and git_sug_server_output.changed    # OLD WAY 3
roles/sugarizer/tasks/install.yml:# when: internet_available and not is_F18 and not node_modules_exists    # OLD WAY 1
roles/sugarizer/tasks/install.yml:  when: internet_available
roles/wordpress/tasks/install.yml:  when: internet_available
roles/wordpress/tasks/install.yml:  #when: internet_available    # Better to run it every time, installing from wp-keys.php.BAK if download fails
roles/yarn/tasks/install.yml:  when: internet_available and is_debuntu