### PR TITLE
default_vars.yml & local_vars.yml: Caution that 'squid_enabled: True' acts like 'iiab_gateway_enabled: True' (but only for Port 80)

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -123,6 +123,7 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
+# CAUTION: Setting 'squid_enabled: True' (BELOW) acts as a gateway for Port 80.
 
 # Gateway mode
 iiab_lan_enabled: True
@@ -258,7 +259,7 @@ nginx_log_dir: /var/log/nginx
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_dst_domains
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_url_regexs
 squid_install: False
-squid_enabled: False         # SET 'iiab_gateway_enabled' FURTHER ABOVE ?
+squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
 

--- a/vars/local_vars_big.yml
+++ b/vars/local_vars_big.yml
@@ -69,6 +69,7 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
+# CAUTION: Setting 'squid_enabled: True' (BELOW) acts as a gateway for Port 80.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -151,7 +152,7 @@ pi_swap_file_size: 1024
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_dst_domains
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_url_regexs
 squid_install: False
-squid_enabled: False         # SET 'iiab_gateway_enabled' FURTHER ABOVE ?
+squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -69,6 +69,7 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
+# CAUTION: Setting 'squid_enabled: True' (BELOW) acts as a gateway for Port 80.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -151,7 +152,7 @@ pi_swap_file_size: 1024
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_dst_domains
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_url_regexs
 squid_install: False
-squid_enabled: False         # SET 'iiab_gateway_enabled' FURTHER ABOVE ?
+squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
 

--- a/vars/local_vars_min.yml
+++ b/vars/local_vars_min.yml
@@ -69,6 +69,7 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
+# CAUTION: Setting 'squid_enabled: True' (BELOW) acts as a gateway for Port 80.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -151,7 +152,7 @@ pi_swap_file_size: 1024
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_dst_domains
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_url_regexs
 squid_install: False
-squid_enabled: False         # SET 'iiab_gateway_enabled' FURTHER ABOVE ?
+squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
 

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -69,6 +69,7 @@ wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:
 iiab_gateway_enabled: False
+# CAUTION: Setting 'squid_enabled: True' (BELOW) acts as a gateway for Port 80.
 
 # See "How do I set a static IP address?" for Ethernet, in http://FAQ.IIAB.IO
 wan_ip: dhcp       # wan_ip: 192.168.1.99
@@ -151,7 +152,7 @@ pi_swap_file_size: 1024
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_dst_domains
 # e.g. /opt/iiab/iiab/roles/network/templates/squid/allow_url_regexs
 squid_install: False
-squid_enabled: False         # SET 'iiab_gateway_enabled' FURTHER ABOVE ?
+squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
 


### PR DESCRIPTION
Contextualizing last week's Squid fix PR for mainstream IIAB implementers, building upon:

- #1028
- #1323
- #1879
- #2525
- PR #2948