### PR TITLE
Squid: Contextualize /etc/squid/squid.conf + allowlists for new implementers (HTTP/80 whitelists) + optimize its install in Stage 4-server-options

### DIFF
--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: Install pylibs (IIAB's python libs)
   include_role:
     name: pylibs
+  #when: pylibs_installed is undefined
   #when: pylibs_install    # Flag might be created in future?
 
 - name: SSHD -- also run by roles/1-prep/tasks/main.yml as required by OpenVPN
@@ -34,10 +35,10 @@
   include_tasks: roles/network/tasks/dhcpd.yml
   when: dhcpd_install is defined and dhcpd_install
 
-# LESS MAINTAINED as of July 2019: https://github.com/iiab/iiab/issues/1879
+# LESS MAINTAINED
 - name: Install Squid
   include_tasks: roles/network/tasks/squid.yml
-  when: squid_install is defined and squid_install
+  when: squid_install and squid_installed is undefined
 
 
 - name: Install Bluetooth - only on Raspberry Pi
@@ -69,7 +70,7 @@
 - name: WWW_OPTIONS (WWW_BASE should have been installed earlier)
   include_role:
     name: www_options
-  #when: www_options_install    # Flag might be created in future?
+  #when: www_options_installed is undefined    # NO: as we encourage frequent settings changes here, e.g. php.ini and many others!
 
 
 - name: Recording STAGE 4 HAS COMPLETED ==================

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -1,4 +1,4 @@
-- name: "Install package {{ proxy }} -- IIAB will later overwrite its /etc/squid/squid.conf"
+- name: Install package '{{ proxy }}' -- IIAB will later overwrite its /etc/squid/squid.conf
   package:
     name: "{{ proxy }}"    # squid (or 'squid3' on vars/debian-8.yml, vars/raspbian-8.yml)
       # - cadaver

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -1,4 +1,4 @@
-- name: "Install package: {{ proxy }}"
+- name: "Install package {{ proxy }} -- IIAB will later overwrite its /etc/squid/squid.conf"
   package:
     name: "{{ proxy }}"    # squid (or 'squid3' on vars/debian-8.yml, vars/raspbian-8.yml)
       # - cadaver
@@ -12,7 +12,7 @@
   systemd:
     name: "{{ proxy }}"
     state: stopped
-  when: squid_installed is undefined
+  # when: squid_installed is undefined
 
 # 2021-08-17: This stanza is gratuitous on most distros, where the user 'proxy'
 # or 'squid' is preinstalled (typically with UID and GID 13 in /etc/passwd) but
@@ -44,7 +44,7 @@
     group: "{{ proxy_user }}"
     mode: 0750
 
-- name: Install site allowlists/whitelists /etc/{{ proxy }}/allow_dst_domains, /etc/{{ proxy }}/allow_url_regexs from template (root:root, 0644 by default)
+- name: "Install site allowlists /etc/{{ proxy }}/allow_dst_domains, /etc/{{ proxy }}/allow_url_regexs from template (root:root, 0644 by default) -- activated for HTTP/80 if you set 'gw_squid_whitelist: True' in /etc/iiab/local_vars.yml -- SEE https://wiki.squid-cache.org/SquidFaq/SquidAcl"
   template:
     src: "{{ item }}"
     dest: /etc/{{ proxy }}/

--- a/roles/network/templates/squid/allow_dst_domains
+++ b/roles/network/templates/squid/allow_dst_domains
@@ -1,4 +1,6 @@
-# SEE ALSO /etc/squid/allow_url_regexs
+# SEE ALSO /etc/squid/squid.conf
+#          /etc/squid/allow_url_regexs
+#          https://wiki.squid-cache.org/SquidFaq/SquidAcl
 # the leading dot matches anything preceding
 # don't remove the .lan line
 # change this to your domain if necessary

--- a/roles/network/templates/squid/allow_url_regexs
+++ b/roles/network/templates/squid/allow_url_regexs
@@ -1,4 +1,6 @@
-# SEE ALSO /etc/squid/allow_url_regexs
+# SEE ALSO /etc/squid/squid.conf
+#          /etc/squid/allow_url_regexs
+#          https://wiki.squid-cache.org/SquidFaq/SquidAcl
 # put regular expressions that match desired urls
 translator
 translate

--- a/roles/network/templates/squid/allow_url_regexs
+++ b/roles/network/templates/squid/allow_url_regexs
@@ -1,5 +1,5 @@
 # SEE ALSO /etc/squid/squid.conf
-#          /etc/squid/allow_url_regexs
+#          /etc/squid/allow_dst_domains
 #          https://wiki.squid-cache.org/SquidFaq/SquidAcl
 # put regular expressions that match desired urls
 translator


### PR DESCRIPTION
Adds explanatory pointers to both sample allowlists (whitelists) for new IIAB implementers.

As these 2 files are directly mentioned in default_vars.yml and most local_vars.yml files.

Refs:

- #1028
- #1879
- PR #2962
- PR #2948