### PR TITLE
Explain how to turn off overzealous WiFi firmware warnings

### DIFF
--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -50,13 +50,13 @@ if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware
 fi
 
 if [ "$WARN" = "1" ]; then
-    echo -e "\n \033[31;5mWiFi Firmware has been replaced, per iiab/iiab#823.\033[0m"
-    echo -e " \033[31;5mReboot is required to activate.\033[0m\n"
+    echo -e "\n \e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
+    echo -e " \e[41;1mReboot is required to activate.\e[0m\n"
     touch /.fw_replaced
     #echo "rebooting..."
     #reboot
 else
-    echo -e " WiFi Firmware check \033[32;5mPASSED\033[0m, per iiab/iiab#823."
+    echo -e " WiFi Firmware check \e[42;1mPASSED\e[0m, per iiab/iiab#823."    # Or \e[92m for green on black
     echo -e " (Assuming you've rebooted since it was replaced!)\n"
     if [ -f /.fw_replaced ]; then
         rm /.fw_replaced

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -3,7 +3,7 @@
 if [ -f /.fw_replaced ]; then
     echo -e "\n \033[31;5mWiFi Firmware has been replaced, per iiab/iiab#823.\033[0m"
     if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
-        echo -e " \033[31;5mYou can delete /.fw_replaced if you want these warnings to stop.\033[0m\n"
+        echo -e " \033[31;5mRun 'sudo rm /.fw_replaced' if you want these warnings to stop.\033[0m\n"
     else
         echo -e " \033[31;5mReboot is required to activate.\033[0m\n"
     fi

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -2,5 +2,9 @@
 
 if [ -f /.fw_replaced ]; then
     echo -e "\n \033[31;5mWiFi Firmware has been replaced, per iiab/iiab#823.\033[0m"
-    echo -e " \033[31;5mReboot is required to activate.\033[0m\n"
+    if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
+        echo -e " \033[31;5mYou can delete /.fw_replaced if you want these warnings to stop.\033[0m\n"
+    else
+        echo -e " \033[31;5mReboot is required to activate.\033[0m\n"
+    fi
 fi

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 if [ -f /.fw_replaced ]; then
-    echo -e "\n \033[31;5mWiFi Firmware has been replaced, per iiab/iiab#823.\033[0m"
+    echo -e "\n \e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
     if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
-        echo -e " \033[31;5mRun 'sudo rm /.fw_replaced' if you want these warnings to stop.\033[0m\n"
+        echo -e " \e[100;1mIf you want these warnings to stop, run:\e[0m"
+        echo
+        echo -e " \e[100;1msudo rm /.fw_replaced\e[0m\n"
     else
-        echo -e " \033[31;5mReboot is required to activate.\033[0m\n"
+        echo -e " \e[41;1mReboot is required to activate.\e[0m\n"
     fi
 fi


### PR DESCRIPTION
Thanks to input from @tim-moody and @jvonau.

The overzealous warnings were arising when an IIAB operator changed var 'wifi_hotspot_capacity_rpi_fix: True' to 'False' before the usual WiFi firmware upgrading reboot had taken place.

Context:

- https://github.com/iiab/iiab/blob/011139bde6fc202ca83ddf85a5acfa04f85c8554/roles/firmware/templates/iiab-check-firmware#L52-L64
- PR #2472 
- PR #2478 
- #2564
- PR #2697
- #2820
- #2853