### PR TITLE
Remove 'when: internet_available' from 25 files [preserving it in network/tasks/netplan.yml + www_options/tasks/main.yml for now]

### DIFF
--- a/roles/1-prep/tasks/hardware.yml
+++ b/roles/1-prep/tasks/hardware.yml
@@ -14,4 +14,4 @@
     url: "{{ iiab_download_url }}/iwlwifi-8000C-13.ucode"
     dest: /lib/firmware
     timeout: "{{ download_timeout }}"
-  when: internet_available and usb_NUC6.stdout|int > 0
+  when: usb_NUC6.stdout|int > 0

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -25,7 +25,6 @@
     dest: "{{ azuracast_host_dir }}/"
     timeout: "{{ download_timeout }}"
     mode: 0755
-  when: internet_available
 
 - name: AzuraCast - Download AzuraCast's docker-compose.yml sample from GitHub to {{ azuracast_host_dir }}
   get_url: 
@@ -33,7 +32,6 @@
     dest: "{{ azuracast_host_dir }}/docker-compose.yml"
     timeout: "{{ download_timeout }}"
     mode: 0755
-  when: internet_available
 
 #- name: AzuraCast - Make changes to docker.sh script so it runs headless
 #  lineinfile:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -33,7 +33,6 @@
     force: yes
     depth: 1
     version: "{{ calibreweb_version }}"    # e.g. master, 0.6.5
-  when: internet_available
 
 ## Ansible Pip Bug: Cannot use 'chdir' with 'env' https://github.com/ansible/ansible/issues/37912 (Patch landed)
 #- name: Download calibre-web dependencies into vendor subdirectory.
@@ -50,7 +49,6 @@
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
     virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
-  when: internet_available
 
 - name: Install /etc/systemd/system/calibre-web.service from template
   template:

--- a/roles/calibre/tasks/create-db.yml
+++ b/roles/calibre/tasks/create-db.yml
@@ -8,7 +8,7 @@
     url: "{{ iiab_download_url }}/{{ calibre_sample_book }}"
     dest: "{{ content_base }}/downloads"
     timeout: "{{ download_timeout }}"
-  when: internet_available and not sample_bk.stat.exists
+  when: not sample_bk.stat.exists
 
 - name: Check if sample book exists in /opt/iiab/downloads
   stat:

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -30,7 +30,7 @@
 
 - name: Upgrade to latest Calibre using .deb's from testing (rpi)
   command: scripts/calibre-install-latest-rpi.sh    # WORKED for Calibre 3.33.1 on 2018-10-23.  And Calibre 3.28 on 2018-07-26 (PR #971).  Likewise for Calibre 3.26.x.  FAILED with Calibre 3.24+ ("calibre : Depends: python-pyqt5 (>= 5.10.1+dfsg-2) but 5.10.1+dfsg-1+rpi1 is to be installed") since June 2018.
-  when: is_raspbian and internet_available
+  when: is_raspbian
 
 #- name: Download PINNED version {{ calibre_deb_pin_version }} of calibre & calibre-bin (rpi)
 #  get_url:
@@ -49,10 +49,10 @@
 
 - name: Install/Upgrade to Calibre testing .deb's (not rpi)
   command: scripts/calibre-install-latest.sh
-  when: (not is_raspbian) and internet_available
+  when: (not is_raspbian)
   #when: (not is_raspbian) and (is_debian_9 or is_ubuntu_16) and internet_available
   #when: not is_raspbian and not is_ubuntu_18 and internet_available
 
 - name: Install/Upgrade to Calibre unstable .deb's IF calibre_unstable_debs
   command: scripts/calibre-install-unstable.sh
-  when: calibre_unstable_debs and internet_available
+  when: calibre_unstable_debs

--- a/roles/calibre/tasks/debs.yml
+++ b/roles/calibre/tasks/debs.yml
@@ -49,7 +49,7 @@
 
 - name: Install/Upgrade to Calibre testing .deb's (not rpi)
   command: scripts/calibre-install-latest.sh
-  when: (not is_raspbian)
+  when: not is_raspbian
   #when: (not is_raspbian) and (is_debian_9 or is_ubuntu_16) and internet_available
   #when: not is_raspbian and not is_ubuntu_18 and internet_available
 

--- a/roles/calibre/tasks/py-installer.yml
+++ b/roles/calibre/tasks/py-installer.yml
@@ -12,7 +12,6 @@
     backup: yes
     timeout: "{{ download_timeout }}"
   register: calibre_download_output
-  when: internet_available
 
 # ALWAYS DEFINED, DESPITE get_url DOCUMENTATION CLAIM...
 # - debug:
@@ -44,7 +43,7 @@
   # meta: end_play
   fail:
     msg: "{{ downloads_dir }}/calibre-installer.py and an Internet connection are REQUIRED in order to install Calibre!"
-  when: (not calib_inst.stat.exists) or (not internet_available)
+  when: (not calib_inst.stat.exists)
   #when: (not calib_inst.stat.exists) or (not internet_available and not calib_uninst.stat.exists)
 
 # INSTALL THE LATEST CALIBRE (calibre, calibredb, calibre-server etc)
@@ -53,4 +52,3 @@
   shell: "{{ downloads_dir }}/calibre-installer.py >> /dev/null"
   #args:
   #  creates: /usr/bin/calibre-uninstall
-  when: internet_available

--- a/roles/calibre/tasks/py-installer.yml
+++ b/roles/calibre/tasks/py-installer.yml
@@ -43,7 +43,7 @@
   # meta: end_play
   fail:
     msg: "{{ downloads_dir }}/calibre-installer.py and an Internet connection are REQUIRED in order to install Calibre!"
-  when: (not calib_inst.stat.exists)
+  when: not calib_inst.stat.exists
   #when: (not calib_inst.stat.exists) or (not internet_available and not calib_uninst.stat.exists)
 
 # INSTALL THE LATEST CALIBRE (calibre, calibredb, calibre-server etc)

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -49,13 +49,11 @@
     dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.14
     mode: 0775
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: Download Gitea GPG signature {{ gitea_integrity_url }} to {{ gitea_checksum_path }}
   get_url:
     url: "{{ gitea_integrity_url }}"
     dest: "{{ gitea_checksum_path }}"
-  when: internet_available
 
 - name: Verify Gitea binary with GPG signature
   shell: |

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -47,7 +47,6 @@
   args:
     chdir: "{{ internetarchive_dir }}"
     creates: "{{ internetarchive_dir }}/node_modules/@internetarchive/dweb-mirror/internetarchive"
-  when: internet_available
 
 - name: mkdir {{ content_base }}/archiveorg
   file:

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -31,24 +31,24 @@
 
 - block:    # BEGIN 2-STANZA BLOCK
 
-  - name: "UPGRADE: Stop 'internetarchive' systemd service, if internetarchive_installed is defined and internet_available"
+  - name: "UPGRADE: Stop 'internetarchive' systemd service, if internetarchive_installed is defined"
     systemd:
       name: internetarchive
       daemon_reload: yes
       state: stopped
 
-  - name: "UPGRADE: Run 'yarn upgrade' in {{ internetarchive_dir }}, if internetarchive_installed is defined and internet_available"
+  - name: "UPGRADE: Run 'yarn upgrade' in {{ internetarchive_dir }}, if internetarchive_installed is defined"
     shell: yarn config set child-concurrency 1 && yarn install && yarn upgrade
     args:
       chdir: "{{ internetarchive_dir }}"
 
-  when: internetarchive_installed is defined and internet_available    # END 2-STANZA BLOCK
+  when: internetarchive_installed is defined    # END 2-STANZA BLOCK
 
 # "ELSE" INSTALL...
 
 - name: Install Internet Archive if 'internetarchive_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
   include_tasks: install.yml
-  when: internetarchive_installed is undefined and internet_available
+  when: internetarchive_installed is undefined
 
 
 # ENABLE/DISABLE/RESTART SYSTEMD SERVICE & WEB SERVERS AS NEC ?

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -48,7 +48,6 @@
     virtualenv_command: python3 -m venv "{{ jupyterhub_venv }}"    # 2021-07-29: This works on RaspiOS 10, Debian 11, Ubuntu 20.04 and Mint 20 -- however if you absolutely must use the older Debian 10 -- you can work around errors "can't find Rust compiler" and "This package requires Rust >=1.41.0" if you (1) revert this line to 'virtualenv_command: virtualenv' AND (2) uncomment the line just below
     #virtualenv_python: python3    # 2021-07-29: Was needed when above line was 'virtualenv_command: virtualenv' (generally for Python 2)
     extra_args: "--no-cache-dir"
-  when: internet_available
 
 - name: "Install from template: {{ jupyterhub_venv }}/etc/jupyterhub/jupyterhub_config.py"
   template:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -3,7 +3,6 @@
     url: "{{ kalite_requirements }}"
     dest: "{{ pip_packages_dir }}/kalite.txt"    # /opt/iiab/pip-packages/kalite.txt
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 # 2020-01-19: https://github.com/piwheels/packages/issues/74 says the following is no longer needed...
 #- name: Run 'mv /etc/pip.conf /etc/pip.conf.see-iiab-issue-2139' as "TEMPORARY" workaround (2020-01-17) for piwheels.org's setuptools Python 2/3 brokenness on RPi (https://github.com/iiab/iiab/issues/2139)
@@ -41,7 +40,6 @@
     virtualenv_command: /usr/bin/virtualenv
     virtualenv_python: python2.7
     extra_args: "--no-cache-dir"
-  when: internet_available
 
 - name: "Install from templates: venv wrapper /usr/bin/kalite, unit file /etc/systemd/system/kalite-serve.service"
   template:

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -37,7 +37,6 @@
     url: "{{ iiab_download_url }}/{{ kiwix_src_file }}"    # http://download.iiab.io/packages
     dest: "{{ downloads_dir }}/{{ kiwix_src_file }}"    # /opt/iiab/downloads
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: "Create dirs, including parent dirs: {{ kiwix_path }}/bin (executables), {{ iiab_zim_path }}/content (ZIM files), {{ iiab_zim_path }}/index (legacy indexes) (by default 0755)"
   file:

--- a/roles/kiwix/tasks/kiwix-apk.yml
+++ b/roles/kiwix/tasks/kiwix-apk.yml
@@ -9,7 +9,6 @@
     url: "{{ kiwix_apk_src  }}"    # https://download.kiwix.org/release/kiwix-android/kiwix.apk
     dest: "{{ doc_root }}{{ kiwix_apk_url }}"
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: Symlink {{ doc_root }}{{ kiwix_apk_url }}/zims -> {{ iiab_zim_path }}/content
   file:

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -37,7 +37,6 @@
   environment:
     KOLIBRI_HOME: "{{ kolibri_home }}"    # these don't do a thing for now but
     KOLIBRI_USER: "{{ kolibri_user }}"    # both can't hurt & Might Help Later
-  when: internet_available
 
 - name: 'Install from template: /etc/systemd/system/kolibri.service'
   template:

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -32,8 +32,7 @@
     virtualenv: "{{ lokole_venv }}"
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
-  when:
-    - lokole_commit is defined
+  when: lokole_commit is defined
 
 # For development purposes -- To install a given pip version of Lokole, add
 # the following line to roles/lokole/defaults/main.yml:
@@ -45,8 +44,7 @@
     virtualenv: "{{ lokole_venv }}"
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
-  when:
-    - lokole_version is defined
+  when: lokole_version is defined
 
 - name: "DEFAULT: pip install opwen_email_client (Lokole, latest available version) from PyPI to {{ lokole_venv }}, if above vars both UNdefined"
   pip:
@@ -54,8 +52,7 @@
     virtualenv: "{{ lokole_venv }}"
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
-  when:
-    - lokole_commit is undefined and lokole_version is undefined
+  when: lokole_commit is undefined and lokole_version is undefined
 
 - name: Compile translations
   shell: |

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -33,7 +33,6 @@
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
   when:
-    - internet_available
     - lokole_commit is defined
 
 # For development purposes -- To install a given pip version of Lokole, add
@@ -47,7 +46,6 @@
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
   when:
-    - internet_available
     - lokole_version is defined
 
 - name: "DEFAULT: pip install opwen_email_client (Lokole, latest available version) from PyPI to {{ lokole_venv }}, if above vars both UNdefined"
@@ -57,7 +55,6 @@
     virtualenv_command: python3 -m venv "{{ lokole_venv }}"
     extra_args: --no-cache-dir    # To avoid caching issues e.g. soon after new releases hit https://pypi.org/project/opwen-email-client/
   when:
-    - internet_available
     - lokole_commit is undefined and lokole_version is undefined
 
 - name: Compile translations

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -25,7 +25,6 @@
     timeout: "{{ download_timeout }}"
     #force: yes
     #backup: yes
-  when: internet_available
 
 - name: Unarchive (unpack) it to permanent location {{ mediawiki_abs_path }} ({{ apache_user }}:{{ apache_user }}, u+rw,g+r,o+r)
   unarchive:

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -63,7 +63,7 @@
   get_url:
     url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
     dest: /usr/bin/networkd-dispatcher
-  when: internet_available and fix_dispatcher and ansible_distribution_release == "groovy"
+  when: fix_dispatcher and ansible_distribution_release == "groovy"
 
 #- name: Supply netplan template
 #  template:

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -63,7 +63,9 @@
   get_url:
     url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
     dest: /usr/bin/networkd-dispatcher
-  when: fix_dispatcher and ansible_distribution_release == "groovy"
+  when: internet_available and fix_dispatcher and ansible_distribution_release == "groovy"
+  # 2021-08-29 context from @jvonau: Fix is 'Groovy' specific, 21.04 and later
+  # should have the fix baked into a newer apt package installed by default.
 
 #- name: Supply netplan template
 #  template:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -100,7 +100,6 @@
     owner: "{{ apache_user }}"           # www-data on debuntu
     group: "{{ apache_user }}"
     extra_opts: --strip-components=1     # Or use 'dest: /library/www' above
-  when: internet_available
 
 - name: Provision Nextcloud's MySQL DB, run Nextcloud's install wizard, etc
   include_tasks: setup.yml

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -48,11 +48,11 @@
   command: npm install -g --unsafe-perm node-red node-red-admin node-red-dashboard
   #command: npm install -g --unsafe-perm node-red@latest node-red-admin@latest node-red-dashboard@latest
   # Above "@latest" is recommended by https://nodered.org/docs/hardware/raspberrypi (SHOULD WE CONSIDER?)
-  when: nodered_install and internet_available
+  when: nodered_install
 
 - name: "Globally 'npm install' 8 Node-RED learning examples for RPi: node-red-contrib-ibm-watson-iot, node-red-contrib-play-audio, node-red-node-ledborg, node-red-node-ping, node-red-node-pi-sense-hat, node-red-node-random, node-red-node-serialport, node-red-node-smooth"
   command: npm install -g --unsafe-perm node-red-contrib-ibm-watson-iot node-red-contrib-play-audio node-red-node-ledborg node-red-node-ping node-red-node-pi-sense-hat node-red-node-random node-red-node-serialport node-red-node-smooth
-  when: nodered_install and internet_available and is_raspbian
+  when: nodered_install and is_raspbian
 
 ## To protect pre-installed packages within /usr/lib/node_modules in graphical
 ## desktop OS's like Raspbian Desktop & Ubermix, we now only install those that
@@ -93,7 +93,7 @@
   when: nodered_install and not is_raspbian
 
 - include_tasks: rpi_desk.yml
-  when: nodered_install and internet_available and is_raspbian
+  when: nodered_install and is_raspbian
 
 - name: Install /etc/systemd/system/nodered.service systemd unit file from template
   template:

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -20,7 +20,6 @@
     url: "{{ asterisk_url }}/{{ asterisk_src_file }}"
     dest: "{{ downloads_dir }}"    # e.g. /opt/iiab/downloads/asterisk-18-current.tar.gz
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: Asterisk - Check for {{ downloads_dir }}/{{ asterisk_src_file }}
   stat:

--- a/roles/pbx/tasks/chan_dongle.yml
+++ b/roles/pbx/tasks/chan_dongle.yml
@@ -5,7 +5,6 @@
     url: "{{ chan_dongle_url }}/{{ chan_dongle_src_file }}"    # /opt/iiab/downloads/master.zip
     dest: "{{ downloads_dir }}/{{ chan_dongle_src_file }}"     # Keep name as "master.zip" whereas browsers rename it to asterisk-chan-dongle-master.zip
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: chan_dongle - Check for {{ downloads_dir }}/{{ chan_dongle_src_file }}
   stat:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -71,7 +71,6 @@
     url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
     dest: "{{ downloads_dir }}"    # e.g. /opt/iiab/downloads/freepbx-16.0-latest.tgz
     timeout: "{{ download_timeout }}"
-  when: internet_available
 
 - name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
   stat:

--- a/roles/phpmyadmin/tasks/install.yml
+++ b/roles/phpmyadmin/tasks/install.yml
@@ -16,7 +16,6 @@
     owner: "{{ apache_user }}"    # www-data on debuntu
     group: "{{ apache_user }}"
     #timeout: "{{ download_timeout }}" # Use get_url if timeout (200s) required
-  when: internet_available
 
 - name: Symlink /opt/phpmyadmin -> {{ phpmyadmin_name }}
   file:

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -36,7 +36,6 @@
     version: "{{ sugarizer_git_version }}"
     force: yes
     depth: 1
-  when: internet_available
 
 - name: Symlink /opt/iiab/sugarizer -> /opt/iiab/{{ sugarizer_dir_version }}
   file:
@@ -69,7 +68,6 @@
     version: "{{ sugarizer_server_git_version }}"
     force: yes
     depth: 1
-  when: internet_available
 
 - name: Symlink /opt/iiab/sugarizer-server -> /opt/iiab/{{ sugarizer_server_dir_version }}
   file:
@@ -133,7 +131,7 @@
   args:
     chdir: "{{ iiab_base }}/sugarizer-server"
     #creates: "{{ iiab_base }}/sugarizer-server/node_modules"    # OLD WAY 2
-  when: internet_available    # "npm install" generally requires Internet access
+# when: internet_available    # "npm install" generally requires Internet access
 # when: internet_available and git_sug_server_output.changed    # OLD WAY 3
 # when: internet_available and not is_F18 and not node_modules_exists    # OLD WAY 1
 
@@ -144,7 +142,6 @@
   command: npm install --allow-root --unsafe-perm=true path-prefix-proxy
   args:
     chdir: "{{ iiab_base }}/sugarizer-server"
-  when: internet_available
 
 
 # 5. CONFIG FILES

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -44,7 +44,6 @@
     dest: "{{ downloads_dir }}"
     timeout: "{{ download_timeout }}"
   register: wp_download_output
-  when: internet_available
 
 - name: Symlink {{ downloads_dir }}/wordpress.tar.gz -> {{ wp_download_output.dest }}
   file:

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -158,7 +158,7 @@
 
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed in Stage 3 = roles/3-base-server/tasks/main.yml, which ran roles/www_base/tasks/main.yml)
   command: /usr/bin/iiab-refresh-wiki-docs
-  when: not nodocs
+  when: internet_available and not nodocs
 
 
 - name: (Re)Start '{{ apache_service }}' systemd service, if installed & enabled

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -158,7 +158,7 @@
 
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed in Stage 3 = roles/3-base-server/tasks/main.yml, which ran roles/www_base/tasks/main.yml)
   command: /usr/bin/iiab-refresh-wiki-docs
-  when: internet_available and not nodocs
+  when: not nodocs
 
 
 - name: (Re)Start '{{ apache_service }}' systemd service, if installed & enabled

--- a/roles/yarn/tasks/install.yml
+++ b/roles/yarn/tasks/install.yml
@@ -25,7 +25,6 @@
   package:
     name: yarn
     state: latest
-  when: is_debuntu
 
 
 # RECORD Yarn AS INSTALLED

--- a/roles/yarn/tasks/install.yml
+++ b/roles/yarn/tasks/install.yml
@@ -25,7 +25,7 @@
   package:
     name: yarn
     state: latest
-  when: internet_available and is_debuntu
+  when: is_debuntu
 
 
 # RECORD Yarn AS INSTALLED


### PR DESCRIPTION
Building on @jvonau's:

- PR #2971

This is years overdue, given that `when: internet_available` was never used as intended, as explained at #2959.

Testing is ongoing to verify.