### PR TITLE
Try box.lan -> box in /etc/hostname, for #2904

### DIFF
--- a/roles/0-init/tasks/hostname.yml
+++ b/roles/0-init/tasks/hostname.yml
@@ -11,8 +11,10 @@
     state: present
   when: cloudcfg_test.stat.exists
 
-- name: 'Turn the crank for systemd: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"'
-  command: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"
+- name: 'Turn the crank for systemd: hostnamectl set-hostname "{{ iiab_hostname }}"'
+  command: hostnamectl set-hostname "{{ iiab_hostname }}"
+  # 2021-08-31: Periods in /etc/hostname fail with some WiFi routers (#2904)
+  # command: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"
 
 #- name: Install /etc/sysconfig/network from template (redhat)
 #  template:

--- a/roles/0-init/tasks/hostname.yml
+++ b/roles/0-init/tasks/hostname.yml
@@ -11,7 +11,7 @@
     state: present
   when: cloudcfg_test.stat.exists
 
-- name: 'Turn the crank for systemd: hostnamectl set-hostname "{{ iiab_hostname }}"'
+- name: 'Set /etc/hostname by running: hostnamectl set-hostname "{{ iiab_hostname }}"'
   command: hostnamectl set-hostname "{{ iiab_hostname }}"
   # 2021-08-31: Periods in /etc/hostname fail with some WiFi routers (#2904)
   # command: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"


### PR DESCRIPTION
Thanks @darkenvy and _everyone_ for their patience working on this over 4 weeks now!

This PR might or might not suffice, but it's hopefully a start towards allowing people with funky home routers, e.g. those installed by CenturyLink (Lumen) across ~38 US states, to be able to install IIAB.

For background, please see the discussion here:

- #2904

Tangentially related:

- PR #2959