### PR TITLE
Recommend ansible-core 2.11.5

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -8,7 +8,7 @@
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER=undefined    # Ansible version you currently have installed
-GOOD_VER=2.11.4       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+GOOD_VER=2.11.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -58,13 +58,13 @@ GOOD_VER=2.11.4       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 #pip3 install --upgrade ansible-core    # Then start a new shell, so /usr/local/bin works
 #ansible-galaxy collection install -r collections.yml
 
-# TEMPORARILY USE ansible-base 2.10.13 (REMOVE W/ "pip3 uninstall ansible-base")
+# TEMPORARILY USE ansible-base 2.10.14 (REMOVE W/ "pip3 uninstall ansible-base")
 #apt install python3-pip
-#pip3 install ansible-base==2.10.13   # Start new shell, so /usr/local/bin works
+#pip3 install ansible-base==2.10.14   # Start new shell, so /usr/local/bin works
 
-# TEMPORARILY USE ANSIBLE 2.9.25 (REMOVE IT WITH "pip3 uninstall ansible")
+# TEMPORARILY USE ANSIBLE 2.9.26 (REMOVE IT WITH "pip3 uninstall ansible")
 #apt install python3-pip
-#pip3 install ansible==2.9.25
+#pip3 install ansible==2.9.26
 
 # TEMPORARILY USE ANSIBLE 2.4.2 DUE TO 2.4.3 MEMORY BUG. Details: iiab/iiab#669
 #echo "Install http://download.iiab.io/packages/ansible_2.4.2.0-1ppa~xenial_all.deb"


### PR DESCRIPTION
To be merged later today, after ansible-core 2.11.5 RC1 is officially released as 2.11.5:

- https://groups.google.com/g/ansible-devel/c/o07LJvYcvfk
- https://pypi.org/project/ansible-core/
- https://releases.ansible.com/ansible-core/

Related:

- PR #2956