### PR TITLE
Support PHP 8.0 for Ubuntu 21.10 ETA 2021-10-14, in preparation for "PHP 8.1" on Ubuntu 22.04 ETA 2022-04-21

### DIFF
--- a/vars/ubuntu-21.yml
+++ b/vars/ubuntu-21.yml
@@ -23,7 +23,7 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.4    # 2021-04-22: Will Ubuntu 21.10 require 8.0?
-postgresql_version: 13    # 2021-04-22: Will Ubuntu 21.10 require 14?
+php_version: 8.0    # IIAB will no longer support non-LTS Ubuntu 21.04, as Ubuntu 21.10 (ETA 2021-10-14) is more important, in preparation for Ubuntu 22.04 (ETA 2022-04-21).
+postgresql_version: 13
 systemd_location: /lib/systemd/system
 python_ver: 3.9


### PR DESCRIPTION
With apologies to those having residual affections for Ubuntu 21.04, which will no longer be supported.

The old cliche remains as true as ever: "If we try to please everyone all the time, we will in the end accomplish nothing."

Refs:

- #2814
- #2818 
- #2864
- PR #2898 
- PR #2899
- #2914