### PR TITLE
scripts/iiab-diagnostics: Graphical Desktop?

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -137,6 +137,7 @@ cat_file /etc/issue.net
 cat_file /etc/debian_version
 cat_cmd 'dpkg --print-architecture' 'RaspiOS-on-PC shows: i386'
 cat_cmd 'dpkg --print-foreign-architectures' 'RaspiOS-on-PC shows: amd64'
+cat_cmd 'systemctl is-active display-manager.service' 'Graphical Desktop?'
 cat_cmd 'grep "^openvpn_" /etc/iiab/local_vars.yml'
 
 echo -e '\n\n  1. Files Specially Requested: (from "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n'


### PR DESCRIPTION
Possibly there is a better, more universal test as to whether an OS has a Graphical Desktop installed and in use?

But this seems to work in most cases.

Ref:

- #2986