### PR TITLE
MediaWiki 1.36.1 -> 1.36.2 (security release)

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: 1.36    # "1.35" also works
-mediawiki_minor_version: 1
+mediawiki_minor_version: 2
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Just Released:

https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/2IFS5CM2YV4VMSODPX3J2LFHKSEWVFV5/

Ref:

- PR #2825