### PR TITLE
Update main.yml [pbx/tasks/main.yml: Change include: to include_tasks: for ansible-core 2.16]

### DIFF
--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -24,7 +24,7 @@
   when: pbx_installed is undefined
 
 - name: Install & Enable chan_dongle for Huawei USB modems - if asterisk_chan_dongle
-  include: chan_dongle.yml
+  include_tasks: chan_dongle.yml
   when: asterisk_chan_dongle
 
 - include_tasks: enable-or-disable.yml


### PR DESCRIPTION
### Fixes DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated.

### Replaces include with include_tasks in L27

### cc @holta 
