### PR TITLE
use gitea as a template for remoteit

### DIFF
--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -7,6 +7,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 # See https://docs.remote.it/cli/overview to refine either value below:
+remoteit_version: 4.13.5
 iset_suffixes:
   x86_64: amd64
   aarch64: arm64
@@ -16,7 +17,8 @@ iset_suffixes:
   armv7: armhf.rpi
   armv7l: armhf.rpi
 remoteit_iset_suffix: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
-remoteit_device_url: https://downloads.remote.it/remoteit/v4.13.5/remoteit-4.13.5.{{ remoteit_iset_suffix }}.deb
+remoteit_deb: remoteit-{{ remoteit_version }}.{{ remoteit_iset_suffix }}.deb
+remoteit_device_url: https://downloads.remote.it/remoteit/v{{ remoteit_version }}/{{ remoteit_deb }}
 
 iset_suffixes2:
   x86_64: amd64
@@ -27,5 +29,4 @@ iset_suffixes2:
   armv7l: armv7
   armv8: arm64
 remoteit_iset_suffix2: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
-
 remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_iset_suffix2 }}

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -7,5 +7,25 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 # See https://docs.remote.it/cli/overview to refine either value below:
-remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_armv7
-remoteit_device_url: https://downloads.remote.it/remoteit/v4.13.5/remoteit-4.13.5.armhf.rpi.deb
+iset_suffixes:
+  x86_64: amd64
+  aarch64: arm64
+  armv8: arm64.rpi
+  armv6: armhf.rpi
+  armv6l: armhf.rpi
+  armv7: armhf.rpi
+  armv7l: armhf.rpi
+remoteit_iset_suffix: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
+remoteit_device_url: https://downloads.remote.it/remoteit/v4.13.5/remoteit-4.13.5.{{ remoteit_iset_suffix }}.deb
+
+iset_suffixes2:
+  x86_64: amd64
+  aarch64: arm64
+  armv6: armv6
+  armv6l: armv6
+  armv7: armv7
+  armv7l: armv7
+  armv8: arm64
+remoteit_iset_suffix2: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
+
+remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_iset_suffix2 }}

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -17,16 +17,16 @@
 - name: Download {{ remoteit_device_url }} device package to {{ downloads_dir }}
   get_url:
     url: '{{ remoteit_device_url }}'
-    dest: '{{ downloads_dir }}'
+    dest: '{{ downloads_dir }}/'
 
 - name: Uninstall the device package {{ remoteit_device_url | basename }}
   apt:
-    name: '{{ remoteit_device_url | basename }}'
+    name: '{{ remoteit_deb }}'
     state: absent
 
-- name: Install device package {{ downloads_dir }}/{{ remoteit_device_url | basename }}
+- name: Install device package {{ downloads_dir }}/{{ remoteit_deb }}
   apt:
-    deb: '{{ downloads_dir }}/{{ remoteit_device_url | basename }}'
+    deb: '{{ downloads_dir }}/{{ remoteit_deb }}'
     state: present
 
 

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -1,6 +1,6 @@
 - name: Fail if we detect unknown architecture
   fail:
-    msg: "Could not find a binary for the CPU architecture \"{{ ansible_architecture }}\""
+    msg: "Could not find an apt package for the CPU architecture \"{{ ansible_architecture }}\""
   when: remoteit_iset_suffix == "unknown"
 
 - name: Fail if we detect unknown architecture

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -1,3 +1,13 @@
+- name: Fail if we detect unknown architecture
+  fail:
+    msg: "Could not find a binary for the CPU architecture \"{{ ansible_architecture }}\""
+  when: remoteit_iset_suffix == "unknown"
+
+- name: Fail if we detect unknown architecture
+  fail:
+    msg: "Could not find a binary for the CPU architecture \"{{ ansible_architecture }}\""
+  when: remoteit_iset_suffix2 == "unknown"
+
 - name: Download the command line interface for this device to /usr/bin/{{ remoteit_cli_url }} (755)
   get_url:
     url: '{{ remoteit_cli_url }}'

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -14,12 +14,12 @@
     dest: /usr/bin/
     mode: 0755
 
-- name: Download {{ remoteit_device_url }} device package to {{ downloads_dir }}
+- name: Download {{ remoteit_device_url }} device package to {{ downloads_dir }}/
   get_url:
     url: '{{ remoteit_device_url }}'
     dest: '{{ downloads_dir }}/'
 
-- name: Uninstall the device package {{ remoteit_device_url | basename }}
+- name: Uninstall the device package {{ remoteit_deb }}
   apt:
     name: '{{ remoteit_deb }}'
     state: absent


### PR DESCRIPTION
### Fixes bug:
#3006
### Description of changes proposed in this pull request:
map archs to file names in defaults/main.yml like gitea does
### Smoke-tested on which OS or OS's:
not yet.