### PR TITLE
roles/remoteit/tasks/install.yml: Set 'force: yes' for both downloads

### DIFF
--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -12,6 +12,7 @@
   get_url:
     url: "{{ remoteit_device_url }}"
     dest: "{{ downloads_dir }}/"
+    force: yes
 
 - name: Uninstall previously installed 'remoteit*' device apt package(s)
   apt:
@@ -35,6 +36,7 @@
     url: "{{ remoteit_cli_url }}"
     dest: /usr/bin/remoteit
     mode: 0755
+    force: yes
 
 
 # RECORD remoteit AS INSTALLED


### PR DESCRIPTION
So that the following might in future help with very basic upgrading of remote.it to a new/higher version number:

```
cd /opt/iiab/iiab
sudo ./runrole --reinstall remoteit
```

Building on:

- PR #3003
- PR #3005 
- #3006
- PR #3007 
- PR #3009
- PR #3010