### PR TITLE
ansible_is_chroot

### DIFF
--- a/roles/0-init/tasks/hostname.yml
+++ b/roles/0-init/tasks/hostname.yml
@@ -13,6 +13,7 @@
 
 - name: 'Set /etc/hostname by running: hostnamectl set-hostname "{{ iiab_hostname }}"'
   command: hostnamectl set-hostname "{{ iiab_hostname }}"
+  when: not ansible_is_chroot
   # 2021-08-31: Periods in /etc/hostname fail with some WiFi routers (#2904)
   # command: hostnamectl set-hostname "{{ iiab_hostname }}.{{ iiab_domain }}"
 


### PR DESCRIPTION
### Fixes bug:
Long standing issue building images within a chroot environment. 
### Description of changes proposed in this pull request:
```
ansible -m setup localhost --connection=localhost | grep chroot
[WARNING]: No inventory was parsed, only implicit localhost is available
        "ansible_is_chroot": false,
```
ansible now provides a builtin variable for such a situation, use it in place of having to maintain custom branches for a workaround.
### Smoke-tested on which OS or OS's:
within a chroot and needs normal install testing but will be fine.

