### PR TITLE
Disable the use of pip cache system wide

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -166,7 +166,8 @@ $APT_PATH/apt -y install python3-pip
 #              python3-setuptools python3-packaging python3-venv virtualenv
 
 #$APT_PATH/apt -y --allow-downgrades install ansible-core \
-
+# Using pip is messy, leaving behind cashed files, turn off pip cache system wide before installing 
+pip config set global.cache-dir false
 echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
 pip3 install --upgrade ansible-core
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -165,8 +165,11 @@ $APT_PATH/apt -y install python3-pip
 #              python3-pymysql python3-psycopg2 python3-passlib python3-pip \
 #              python3-setuptools python3-packaging python3-venv virtualenv
 
-#$APT_PATH/apt -y --allow-downgrades install ansible-core \
-# Using pip is messy, leaving behind cashed files, turn off pip cache system wide before installing 
+#$APT_PATH/apt -y --allow-downgrades install ansible-core
+
+# 2021-10-30: Using pip is messy, leaving behind cached files, so turn off pip
+# cache system-wide before installing:
+# https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
 pip config set global.cache-dir false
 echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
 pip3 install --upgrade ansible-core


### PR DESCRIPTION
Disable the use of pip cache system wide, leaves no files hanging around in /root/.pip when disabled.
