### PR TITLE
Is guest

### DIFF
--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -63,3 +63,4 @@
   - name: Network
     include_role:
       name: network
+    when: not is_guest

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -60,9 +60,6 @@
 - name: Test Gateway + Test Internet + Set new hostname/domain (hostname.yml) if nec + Set 'gui_port' to 80 or 443 for Admin Console
   include_tasks: network.yml
 
-- name: Set hostname if FQDN_changed
-  include_tasks: hostname.yml
-  when: not is_guest
 
 - name: Add 'runtime' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -60,6 +60,9 @@
 - name: Test Gateway + Test Internet + Set new hostname/domain (hostname.yml) if nec + Set 'gui_port' to 80 or 443 for Admin Console
   include_tasks: network.yml
 
+- name: Set hostname if FQDN_changed
+  include_tasks: hostname.yml
+  when: not is_guest
 
 - name: Add 'runtime' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/0-init/tasks/network.yml
+++ b/roles/0-init/tasks/network.yml
@@ -48,7 +48,7 @@
 
 - name: Set hostname / domain (etc) in various places -- if iiab_fqdn != ansible_fqdn ({{ ansible_fqdn }})
   include_tasks: hostname.yml
-  when: iiab_fqdn != ansible_fqdn
+  when: iiab_fqdn != ansible_fqdn and not is_guest
 
 # 2021-07-30: FQDN_changed isn't used as in the past -- its remaining use is
 # for {named, dhcpd, squid} in roles/network/tasks/main.yml -- possibly it

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -25,6 +25,7 @@
 
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml
+  when: not is_guest
   #when: dnsmasq_install    # Flag might be used in future?
 
 - include_tasks: uuid.yml

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: "Network prep, including partial setup of iptables (firewall) -- SEE ALSO: 1-prep/tasks/raspberry_pi.yml"
   include_tasks: network.yml
+  when: not is_guest
 
 - include_tasks: iiab-startup.yml
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -43,6 +43,8 @@ py3_dist_path: /usr/lib/python3/dist-packages
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
 download_timeout: 200
 
+is_guest: False
+
 # Real-time clock: RTC chip family.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?  Used in 1-prep/tasks/raspberry_pi.yml
 


### PR DESCRIPTION
Replacement for part of #2834, looks like #3004 wants the same functionality, pick a name for the variable and go with that. Ether way I think hostname.yml should be suppressed.