### PR TITLE
roles/pbx/defaults/main.yml: Asterisk 18 -> 19

### DIFF
--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -19,7 +19,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk
-asterisk_src_file: asterisk-18-current.tar.gz
+asterisk_src_file: asterisk-19-current.tar.gz
 asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
 freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/7.4


### PR DESCRIPTION
It's time to make the jump, to accelerate testing of the newly released Asterisk 19.0 with IIAB:

- #2934

2021-11-02 Announcements:

- http://lists.digium.com/pipermail/asterisk-announce/2021-November/000832.html
- https://www.asterisk.org/asterisk-news/asterisk-19-0-0-now-available/