### PR TITLE
roles/pbx/tasks/freepbx.yml: TEMPORARILY force FreePBX 16 to work with Asterisk 19 [NOTE: FreePBX 16 does not yet work with PHP 8.x]

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -96,13 +96,13 @@
     extra_opts: [--strip-components=1]
     creates: "{{ freepbx_src_dir }}/install"
 
-- name: 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 -- patch /opt/iiab/freepbx/install.php
+- name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/install.php"
   replace:
     path: /opt/iiab/freepbx/install.php
     regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
     replace: 'version_compare($astversion, "20", "ge")) {'
 
-- name: 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 -- patch /opt/iiab/freepbx/installlib/installcommand.class.php
+- name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/installlib/installcommand.class.php"
   replace:
     path: /opt/iiab/freepbx/installlib/installcommand.class.php
     regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -105,8 +105,8 @@
 - name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/installlib/installcommand.class.php"
   replace:
     path: /opt/iiab/freepbx/installlib/installcommand.class.php
-    regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
-    replace: 'version_compare($astversion, "20", "ge")) {'
+    regexp: 'version_compare\(\$matches\[1\], "19", "ge"\)\) \{$'
+    replace: 'version_compare($matches[1], "20", "ge")) {'
 
 # 2021-08-04: FreePBX 16 no longer needs this FreePBX 15 patch
 # - name: FreePBX - Patch FreePBX source - IIAB Bug 1685

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -96,6 +96,18 @@
     extra_opts: [--strip-components=1]
     creates: "{{ freepbx_src_dir }}/install"
 
+- name: 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 -- patch /opt/iiab/freepbx/install.php
+  replace:
+    path: /opt/iiab/freepbx/install.php
+    regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
+    replace: 'version_compare($astversion, "20", "ge")) {'
+
+- name: 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 -- patch /opt/iiab/freepbx/installlib/installcommand.class.php
+  replace:
+    path: /opt/iiab/freepbx/installlib/installcommand.class.php
+    regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
+    replace: 'version_compare($astversion, "20", "ge")) {'
+
 # 2021-08-04: FreePBX 16 no longer needs this FreePBX 15 patch
 # - name: FreePBX - Patch FreePBX source - IIAB Bug 1685
 #   patch:


### PR DESCRIPTION
Automating the manual process described here:

- https://github.com/iiab/iiab/issues/2934#issuecomment-962137815

Building on:

- PR #3018

Testing is ongoing on Ubuntu Desktop 21.10...