### PR TITLE
scripts/ansible: pip -> 'pip3 config set global.cache-dir false' (PR #3013)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -170,7 +170,7 @@ $APT_PATH/apt -y install python3-pip
 # 2021-10-30: Using pip is messy, leaving behind cached files, so turn off pip
 # cache system-wide before installing:
 # https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
-pip config set global.cache-dir false
+pip3 config set global.cache-dir false
 echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
 if grep -qr buster /etc/apt; then
     pip3 install --upgrade ansible-core==2.11.6    # TEMPORARY support for RasPiOS Buster's Python 3.7


### PR DESCRIPTION
Fixes this small bug (is this fix [good enough](https://github.com/iiab/iiab/pull/3013#issuecomment-962509987) ?) that crept in a week ago:

- https://github.com/iiab/iiab/pull/3013#issuecomment-962508868

Which didn't affect all OS's, but did however affect the dominant one (Raspberry Pi OS).