### PR TITLE
mongodb/tasks/install.yml: bionic -> focal apt source repo for 64-bit RasPiOS Bullseye (aarch64 only for now) [tested with Sugarizer]

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -82,9 +82,9 @@
     when: is_debian and (ansible_architecture == "x86_64")
 
   # Debian 10 aarch64 might work below but is blocked in main.yml
-  - name: Use mongodb-org's Ubuntu bionic repo for RaspOS-aarch64
+  - name: Use mongodb-org's Ubuntu focal repo for RasPiOS-aarch64
     apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org
     when: is_raspbian and (ansible_architecture == "aarch64")


### PR DESCRIPTION
As proposed in discussion with @jvonau:

- https://github.com/iiab/iiab/issues/2820#issuecomment-966351981