### PR TITLE
scripts/ansible: Recommend ansible-core 2.12.0

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -8,7 +8,7 @@
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER=undefined    # Ansible version you currently have installed
-GOOD_VER=2.11.6       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+GOOD_VER=2.12.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments


### PR DESCRIPTION
Thanks to extensive testing over recent weeks of ansible-core 2.12 Betas, Release Candidates, and its final release:

- #2996