### PR TITLE
scripts/local_facts.fact: 15 days transitional support for LTS OS's (e.g. both raspbian-10 & raspbian-11 in this case)

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,7 +64,6 @@ OS_VER="$OS-$VERSION_ID"
     #"centos-7"     | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
-    #"raspbian-10"  | \
 
 # 2021-09-27: With Debian 12 (Bookworm) pre-releases, please manually add
 # this line to its /etc/os-release before installing IIAB: VERSION_ID="12"
@@ -78,6 +77,7 @@ case $OS_VER in
     "ubuntu-2204"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
+    "raspbian-10"  | \
     "raspbian-11")
         ;;
     *) echo -e "\n\e[41;1mOS '$OS_VER' IS NOT SUPPORTED. Please read:\e[0m\n\n\e[1mhttps://github.com/iiab/iiab/wiki/IIAB-Platforms\e[0m\n" ; exit 1    # Used by /opt/iiab/iiab/iiab-install


### PR DESCRIPTION
Raspberry Pi OS 10 Buster is not really [LTS](https://en.wikipedia.org/wiki/Long-term_support) (but that's ok, close enough, the Raspberry Pi Foundation is looking into that possibility especially for industrial/IoT sales in the future) will be de-supported in `/opt/iiab/iiab/scripts/local_facts.fact` on 2021-11-23.

After this 15-day transition to [Raspberry Pi OS 11 Bullseye](https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/) (released on 2021-11-08) is complete.

Thank you to @icebox827 for his spirit of compromise.  _Trying to forge meaningful balance here &mdash; out of very different hard-working and sincere people, each bringing together overlapping but very different experiences and perspectives from each of their lives and viewpoints._

Refs:

- PR #3023 
- #3027 
- PR #3028
- PR #3029 
- PR #3031