### PR TITLE
MediaWiki 1.37.0 Released!  (So IIAB will install this going forward, instead of 1.36.2)

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: 1.36    # "1.35" also works
-mediawiki_minor_version: 2
+mediawiki_major_version: 1.37    # "1.35" also works
+mediawiki_minor_version: 0
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/XEVG4HTPHRDHTV6GXJ4SP2ZSIJBBN27K/

Ref:

- PR #2992