### PR TITLE
Temporary patch so IIAB installs can proceed, while wiki.laptop.org is in transition [for /usr/bin/iiab-refresh-wiki-docs live-scraping to http://box/info]

### DIFF
--- a/roles/www_base/templates/iiab-refresh-wiki-docs.sh
+++ b/roles/www_base/templates/iiab-refresh-wiki-docs.sh
@@ -34,10 +34,10 @@ rsync -av $OUTPUT/ $DESTPATH
 
 # Download FAQ etc
 lynx -reload -source https://wiki.iiab.io/go/FAQ > $DESTPATH/FAQ.html
-lynx -reload -source http://wiki.laptop.org/go/IIAB/Security > $DESTPATH/Security.html
-lynx -reload -source http://wiki.laptop.org/go/IIAB/local_vars.yml > $DESTPATH/local_vars.yml
-lynx -reload -source http://wiki.laptop.org/go/IIAB/local_vars_min.yml > $DESTPATH/local_vars_min.yml
-lynx -reload -source http://wiki.laptop.org/go/IIAB/local_vars_big.yml > $DESTPATH/local_vars_big.yml
+#lynx -reload -source https://wiki.laptop.org/go/IIAB/Security > $DESTPATH/Security.html
+#lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars.yml > $DESTPATH/local_vars.yml
+#lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars_min.yml > $DESTPATH/local_vars_min.yml
+#lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars_big.yml > $DESTPATH/local_vars_big.yml
 
 # Download older release notes
 lynx -reload -source https://github.com/XSCE/xsce/wiki/IIAB-6.2-Release-Notes > $DESTPATH/IIAB-6.2-Release-Notes.html


### PR DESCRIPTION
Not the final word!

But at least this patch to [/usr/bin/iiab-refresh-wiki-docs](https://github.com/iiab/iiab/blob/master/roles/www_base/templates/iiab-refresh-wiki-docs.sh) will allow IIAB testing to proceed more efficiently, so that [IIAB 7.2](https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes) can hopefully be released before the end of November.