### PR TITLE
Update roles/www_base/templates/iiab-refresh-wiki-docs.sh used during IIAB installs — which live-scrapes docs to http://box/info

### DIFF
--- a/roles/www_base/templates/iiab-refresh-wiki-docs.sh
+++ b/roles/www_base/templates/iiab-refresh-wiki-docs.sh
@@ -34,7 +34,7 @@ rsync -av $OUTPUT/ $DESTPATH
 
 # Download FAQ etc
 lynx -reload -source https://wiki.iiab.io/go/FAQ > $DESTPATH/FAQ.html
-#lynx -reload -source https://wiki.laptop.org/go/IIAB/Security > $DESTPATH/Security.html
+lynx -reload -source https://wiki.iiab.io/go/Security > $DESTPATH/Security.html
 #lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars.yml > $DESTPATH/local_vars.yml
 #lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars_min.yml > $DESTPATH/local_vars_min.yml
 #lynx -reload -source https://wiki.laptop.org/go/IIAB/local_vars_big.yml > $DESTPATH/local_vars_big.yml


### PR DESCRIPTION
The transition from https://wiki.laptop.org/go/IIAB/FAQ etc to https://wiki.iiab.io (and/or to other more professional doc platforms) will take time.

This is just the beginning.

Not everything will be 100% final + perfect in time for IIAB 7.2's release (expected before the end of November) and that's 100% Ok.

As everyone's doing their best, and these things take an awful lot of work to get right.

FYI this PR builds on:

- PR #3042