### PR TITLE
scripts/local_facts.fact: End 15 days transitional support for RasPiOS 10 Buster — in favor of RasPiOS 11 Bullseye

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,6 +64,7 @@ OS_VER="$OS-$VERSION_ID"
     #"centos-7"     | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
+    #"raspbian-10"  | \
 
 # 2021-09-27: With Debian 12 (Bookworm) pre-releases, please manually add
 # this line to its /etc/os-release before installing IIAB: VERSION_ID="12"
@@ -77,7 +78,6 @@ case $OS_VER in
     "ubuntu-2204"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
-    "raspbian-10"  | \
     "raspbian-11")
         ;;
     *) echo -e "\n\e[41;1mOS '$OS_VER' IS NOT SUPPORTED. Please read:\e[0m\n\n\e[1mhttps://github.com/iiab/iiab/wiki/IIAB-Platforms\e[0m\n" ; exit 1    # Used by /opt/iiab/iiab/iiab-install


### PR DESCRIPTION
Ref:

- PR iiab/iiab#3034