### PR TITLE
scripts/iiab-diagnostics: 'which' command deprecated by Ubuntu 22.04 [use 'command -v' instead]

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -86,7 +86,7 @@ function cat_cmd() {                        # $1 = command + params, $2 = explan
     echo "     $1  # $2"
     echo "=IIAB==========================================================================" >> $outfile
     cmd=$(echo "$1" | sed 's/\s.*$//')        # Keep command on left; Drop params on right
-    pth=$(which $cmd | sed 's/[^/]*$//')    # Keep only path on left; Drop command on right
+    pth=$(command -v $cmd | sed 's/[^/]*$//')    # Keep only path on left; Drop command on right
     if [ "$2" = "" ]; then
 	echo "COMMAND: $pth$1" >> $outfile
     else


### PR DESCRIPTION
So use POSIX-compliant `command -v` instead.

FYI Ubuntu 22.04 daily build pre-releases show this error:

```
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
```

Ref:

- #3047