### PR TITLE
Fix Ansible rpi_model != "none" boolean test for Raspberry Pi hardware [other systems like Mac Parallels VMs also use /proc/device-tree/model !]

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -94,7 +94,7 @@ tmp=$(git rev-parse --verify HEAD) &&
 #tmp=$(cat /proc/device-tree/mfg-data/MN) &&
 #    XO_MODEL=$tmp
 
-tmp=$(cat /proc/device-tree/model) &&
+tmp=$(grep -ai raspberry /proc/device-tree/model) &&
     RPI_MODEL=$tmp
 
 tmp=$(ansible --version) &&


### PR DESCRIPTION
Example of the bug in action:

Parallels (VM software on Mac) sets `/proc/device-tree/model` to "Parallels ARM Virtual Machine" (in VM's, e.g. an Ubuntu VM).

IIAB's current logic (prior to this PR) then erroneously interprets that to be Raspberry Pi hardware &mdash; as a result of: https://github.com/iiab/iiab/blob/032436421b9ecc24e701f89e6e41920d2f321f3d/scripts/local_facts.fact#L97-L98

Ref:

- #3039

cc: @avni, @jvonau