### PR TITLE
(1) iiab-diagnostics: Emphasize /proc/device-tree/model (2) Record IIAB Ansible var devicetree_model to /etc/iiab/iiab.ini

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -39,3 +39,5 @@
     #  value: "{{ xo_model }}"
     - option: rpi_model
       value: "{{ rpi_model }}"
+    - option: devicetree_model
+      value: "{{ devicetree_model }}"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -7,9 +7,10 @@
 
 # Higher-level purpose explained at the bottom of:
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
-- name: "Ansible just ran /etc/ansible/facts.d/local_facts.fact to set 10 vars -- here we extract 2 of those -- rpi_model: {{ ansible_local.local_facts.rpi_model }}, iiab_stage: {{ ansible_local.local_facts.stage }}"
+- name: "Ansible just ran /etc/ansible/facts.d/local_facts.fact to set 11 vars -- here we extract 3 of those -- rpi_model: {{ ansible_local.local_facts.rpi_model }}, devicetree_model: {{ ansible_local.local_facts.devicetree_model }}, iiab_stage: {{ ansible_local.local_facts.stage }}"
   set_fact:
     rpi_model: "{{ ansible_local.local_facts.rpi_model }}"
+    devicetree_model: "{{ ansible_local.local_facts.devicetree_model }}"
     #xo_model: "{{ ansible_local.local_facts.xo_model }}"
     iiab_stage: "{{ ansible_local.local_facts.stage }}"
 
@@ -93,6 +94,8 @@
       value: "{{ internet_available }}"
     - option: rpi_model
       value: "{{ rpi_model }}"
+    - option: devicetree_model
+      value: "{{ devicetree_model }}"
     - option: first_run
       value: "{{ first_run }}"
     - option: local_tz    # e.g. 'EDT' (summer) or 'EST' (winter) after Ansible interprets symlink /etc/localtime -- or 'UTC' if /etc/localtime doesn't exist

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -39,7 +39,7 @@
       - pip
       - wheel
       - ipywidgets
-      - jupyterhub==2.0.0rc4
+      - jupyterhub
       - jupyterlab
       - jupyterhub_firstuseauthenticator
       - jupyterhub-systemdspawner

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -39,7 +39,7 @@
       - pip
       - wheel
       - ipywidgets
-      - jupyterhub
+      - jupyterhub==2.0.0rc4
       - jupyterlab
       - jupyterhub_firstuseauthenticator
       - jupyterhub-systemdspawner

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -119,7 +119,7 @@ echo "iiab commit:               $HASH1" >> $outfile
 echo "iiab-admin-console commit: $HASH2" >> $outfile
 echo >> $outfile
 cat_file /etc/iiab/pr-list-pulled
-cat_file /sys/firmware/devicetree/base/model
+cat_file /proc/device-tree/model    # Should be identical to /sys/firmware/devicetree/base/model
 cat_file /etc/rpi-issue
 echo "-IIAB-EXPLANATION-OF-THE-ABOVE-------------------------------------------------" >> $outfile
 echo >> $outfile

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -3,7 +3,7 @@
 # Higher-level purpose explained at the bottom of:
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
 
-# 2020-10-27: Most of the 10 variables require a command[*] to be run to
+# 2020-10-27: Most of the 11 variables require a command[*] to be run to
 # establish the var's value.  WE DISPLAY ALL ERRORS / DIAGNOSTICS AND CONTINUE.
 #
 # [*] DOESN'T MATTER WHAT COMMAND: so long as it fails with Return Code != 0
@@ -16,6 +16,7 @@ IIAB_BRANCH="none"
 IIAB_COMMIT="none"
 #XO_MODEL="none"
 RPI_MODEL="none"
+DEVICETREE_MODEL="none"
 ANSIBLE_VERSION="none"
 DHCPCD="none"    # The last 3 conditioned on string output not RC.  SEE BELOW.
 NETWORK_MANAGER="none"
@@ -97,6 +98,12 @@ tmp=$(git rev-parse --verify HEAD) &&
 tmp=$(grep -ai raspberry /proc/device-tree/model) &&
     RPI_MODEL=$tmp
 
+# /proc/device-tree/model e.g. 'Parallels ARM Virtual Machine' identical to...
+# /sys/firmware/devicetree/base/model (also true on RPi hardware!)
+
+tmp=$(cat /proc/device-tree/model) &&
+    DEVICETREE_MODEL=$tmp
+
 tmp=$(ansible --version) &&
     ANSIBLE_VERSION=$(echo "$tmp" | head -1 | cut -f 2- -d " " | sed 's/.* \([^ ]*\)\].*/\1/')
     # Above works with 'ansible [core 2.11.0rc2]' -- these old ways do not:
@@ -134,6 +141,7 @@ cat <<EOF
 "iiab_branch"             : "$IIAB_BRANCH",
 "iiab_commit"             : "$IIAB_COMMIT",
 "rpi_model"               : "$RPI_MODEL",
+"devicetree_model"        : "$DEVICETREE_MODEL",
 "ansible_version"         : "$ANSIBLE_VERSION",
 "os"                      : "$OS",
 "os_ver"                  : "$OS_VER"}


### PR DESCRIPTION
A readability-centric touchup to [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md), inspired by:

- #3039
- PR #3050