### PR TITLE
pip install latest PRE-release of JupyterHub — until JupyterHub 2.0.0 is released very shortly

### DIFF
--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -47,7 +47,8 @@
     virtualenv_site_packages: no
     virtualenv_command: python3 -m venv "{{ jupyterhub_venv }}"    # 2021-07-29: This works on RaspiOS 10, Debian 11, Ubuntu 20.04 and Mint 20 -- however if you absolutely must use the older Debian 10 -- you can work around errors "can't find Rust compiler" and "This package requires Rust >=1.41.0" if you (1) revert this line to 'virtualenv_command: virtualenv' AND (2) uncomment the line just below
     #virtualenv_python: python3    # 2021-07-29: Was needed when above line was 'virtualenv_command: virtualenv' (generally for Python 2)
-    extra_args: "--no-cache-dir"
+    state: latest
+    extra_args: "--no-cache-dir --pre"
 
 - name: "Install from template: {{ jupyterhub_venv }}/etc/jupyterhub/jupyterhub_config.py"
   template:

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -47,8 +47,7 @@
     virtualenv_site_packages: no
     virtualenv_command: python3 -m venv "{{ jupyterhub_venv }}"    # 2021-07-29: This works on RaspiOS 10, Debian 11, Ubuntu 20.04 and Mint 20 -- however if you absolutely must use the older Debian 10 -- you can work around errors "can't find Rust compiler" and "This package requires Rust >=1.41.0" if you (1) revert this line to 'virtualenv_command: virtualenv' AND (2) uncomment the line just below
     #virtualenv_python: python3    # 2021-07-29: Was needed when above line was 'virtualenv_command: virtualenv' (generally for Python 2)
-    state: latest
-    extra_args: "--no-cache-dir --pre"    # 2021-11-30: The "--pre" flag (and "state: latest" above) should likely be removed after JupyterHub 2.0.0 is released.
+    extra_args: "--no-cache-dir --pre"    # 2021-11-30: The "--pre" flag should likely be removed after JupyterHub 2.0.0 is released.
 
 - name: "Install from template: {{ jupyterhub_venv }}/etc/jupyterhub/jupyterhub_config.py"
   template:

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -48,7 +48,7 @@
     virtualenv_command: python3 -m venv "{{ jupyterhub_venv }}"    # 2021-07-29: This works on RaspiOS 10, Debian 11, Ubuntu 20.04 and Mint 20 -- however if you absolutely must use the older Debian 10 -- you can work around errors "can't find Rust compiler" and "This package requires Rust >=1.41.0" if you (1) revert this line to 'virtualenv_command: virtualenv' AND (2) uncomment the line just below
     #virtualenv_python: python3    # 2021-07-29: Was needed when above line was 'virtualenv_command: virtualenv' (generally for Python 2)
     state: latest
-    extra_args: "--no-cache-dir --pre"
+    extra_args: "--no-cache-dir --pre"    # 2021-11-30: The "--pre" flag (and "state: latest" above) should likely be removed after JupyterHub 2.0.0 is released.
 
 - name: "Install from template: {{ jupyterhub_venv }}/etc/jupyterhub/jupyterhub_config.py"
   template:


### PR DESCRIPTION
To broaden community-testing.

Related:

- PR #2796
- #3002
- PR #3046