### PR TITLE
kiwix-nginx.conf.j2: Avoid "403 Forbidden" for articles that begin with a dot

### DIFF
--- a/roles/kiwix/templates/kiwix-nginx.conf.j2
+++ b/roles/kiwix/templates/kiwix-nginx.conf.j2
@@ -1,4 +1,4 @@
-location {{ kiwix_url }} {
+location ^~ {{ kiwix_url }} {    # ^~ allows articles like ".apple" to be shown: https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms#how-nginx-chooses-which-location-to-use-to-handle-requests
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host      $http_host;
     proxy_http_version 1.1;
@@ -8,5 +8,4 @@ location {{ kiwix_url }} {
     proxy_read_timeout {{ kiwix_nginx_timeout }};
     send_timeout {{ kiwix_nginx_timeout }};
     proxy_pass http://127.0.0.1:3000;
-    allow all;
 }


### PR DESCRIPTION
FYI `location ^~` is one way to allow articles like ".apple" to be shown.

Explanation: https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms#how-nginx-chooses-which-location-to-use-to-handle-requests

Resolves:

- #3072

Refs:

- kiwix/kiwix-tools#513
- PR #3073