### PR TITLE
kiwix/defaults/main.yml: Experiment w/ kiwix-tools 2021-12-21

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,9 +26,9 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-2021-12-17
-kiwix_version_linux64: kiwix-tools_linux-x86_64-2021-12-17
-kiwix_version_i686: kiwix-tools_linux-i586-2021-12-17
+kiwix_version_armhf: kiwix-tools_linux-armhf-2021-12-21
+kiwix_version_linux64: kiwix-tools_linux-x86_64-2021-12-21
+kiwix_version_i686: kiwix-tools_linux-i586-2021-12-21
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")


### PR DESCRIPTION
This will be merged overnight if tonight's kiwix-tools nightly build[1] passes the smell test to allow for the release[2] of [IIAB 7.2](https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes) Preview 3 here: https://github.com/iiab/iiab/releases

[1] i.e. the latest pre-release of [kiwix-tools 3.2.0](https://github.com/kiwix/kiwix-tools/milestone/1) &mdash; usually available soon after 8:30PM NYC Time, from: http://download.kiwix.org/nightly/

[2] Learning Equality will hopefully update their release link https://learningequality.org/r/kolibri-deb-latest to https://storage.googleapis.com/le-releases/downloads/kolibri/v0.15.0/kolibri_0.15.0-0ubuntu1_all.deb (or https://github.com/learningequality/kolibri/releases/download/v0.15.0/kolibri_0.15.0-0ubuntu1_all.deb, both work) before then, if all goes well.

Related:

- PR #2815
- PR #2965
- learningequality/kolibri#8963