### PR TITLE
Simplify www_base/tasks/php-stem.yml for stem-armhf-7.4.so on RasPiOS 11 — for 12.6GB es-wikihow (2015 RACHEL module)

### DIFF
--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -25,8 +25,10 @@
 - name: Using html.yml
   include_tasks: html.yml
 
-- name: Using php-stem.yml
+- name: "Using php-stem.yml, when: php_version == 7.4"
   include_tasks: php-stem.yml
+  when: php_version == 7.4    # or php_version == 8.0 or php_version == 8.1 (IIAB MIGHT SUPPORT THESE LATER IN 2022)
+                              # or php_version == 7.2 or php_version == 7.3 (PROBABLY WORK, AT YOUR OWN RISK!)
 
 - name: Create dir {{ doc_root }}/home -- if you customized var iiab_home_url e.g. in /etc/iiab/local_vars.yml, that dir is created later -- by www_options/tasks/main.yml
   file:

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -1,59 +1,119 @@
-# Fixes search @ http://box/modules/es-wikihow (popular with Spanish youth)
-# Source code: http://download.iiab.io/packages/php-stem.src.tar
+# Fixes search @ http://box/modules/es-wikihow (for young Spanish speakers)
+
+# README & Code: https://github.com/iiab/php-stem
+
+# Source Code also here: http://download.iiab.io/packages/php-stem.src.tar
 # June 2018 debugging & compilation thanks to Tim Moody & George Hunt
 # Original bug: https://github.com/iiab/iiab/issues/829
 
-- name: Set fact stem available php 7.2 - includes x86_64 only
-  set_fact:
-    stem_available: True
-  when: ansible_machine == "x86_64" and php_version == 7.2
 
-- name: Set fact stem available php 7.3 - excludes i386
-  set_fact:
-    stem_available: True
-  when: not ansible_machine == "i386" and php_version == 7.3
+- set_fact:
+    php_extensions:    # Dictionary keys (left side) are always strings, e.g. "7.2"
+      7.2: 20170718    # Dictionary values (right side) can be of type int here, as it's auto-cast to string just below.  Strings would also work e.g. 7.2: "20170718"
+      7.3: 20180731
+      7.4: 20190902
+      8.0: 20200930
+      8.1: 20210902
 
-- name: Set fact stem available php 7.4
-  set_fact:
-    stem_available: True
-  when: php_version == 7.4 and (ansible_machine == "aarch64" or ansible_machine == "x86_64")
+- set_fact:
+    php_extension: "{{ php_extensions[php_version] }}"
 
-- name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.rpi.tar to / (rpi)
-  unarchive:
-    src: http://download.iiab.io/packages/php{{ php_version }}-stem.rpi.tar
-    dest: /
-    owner: root
-    group: root
-    #mode: ????
-    remote_src: yes
-  when: (ansible_machine == "armv7l" or ansible_machine == "armv6l") and stem_available is defined
+# Auto-lookup would also work...
+# php -i | grep 'PHP Extension =>' | cut -d' ' -f4
+#
+# Or...
+# ls -d /usr/lib/php/20?????? | cut -d/ -f5
+#
+# (Or in PHP code...)
+# phpinfo()
 
-- name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar to / (rpi)
-  unarchive:
-    src: http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar
-    dest: /
-    owner: root
-    group: root
-    #mode: ????
-    remote_src: yes
-  when: ansible_machine == "aarch64" and stem_available is defined
 
-- name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.x64.tar to / (x64)
-  unarchive:
-    src: http://download.iiab.io/packages/php{{ php_version }}-stem.x64.tar
-    dest: /
-    owner: root
-    group: root
-    #mode: ????
-    remote_src: yes
-  when: ansible_machine == "x86_64" and stem_available is defined
+- name: Download https://github.com/iiab/php-stem/raw/main/so/stem-armhf-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (armv6l or armv7l)
+  get_url:
+    url: https://github.com/iiab/php-stem/raw/main/so/stem-armhf-{{ php_version }}.so
+    dest: /usr/lib/php/{{ php_extension }}/stem.so
+  when: ansible_machine == "armv6l" or ansible_machine == "armv7l"
+
+- name: Download https://github.com/iiab/php-stem/raw/main/so/stem-aarch64-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (aarch64)
+  get_url:
+    url: https://github.com/iiab/php-stem/raw/main/so/stem-aarch64-{{ php_version }}.so
+    dest: /usr/lib/php/{{ php_extension }}/stem.so
+  when: ansible_machine == "aarch64"
+
+- name: Download https://github.com/iiab/php-stem/raw/main/so/stem-x64-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (x86_64)
+  get_url:
+    url: https://github.com/iiab/php-stem/raw/main/so/stem-x64-{{ php_version }}.so
+    dest: /usr/lib/php/{{ php_extension }}/stem.so
+  when: ansible_machine == "x86_64"
+
+
+- name: Install /etc/php/{{ php_version }}/mods-available/stem.ini
+  shell: |
+    cat > /etc/php/{{ php_version }}/mods-available/stem.ini << EOF
+    ; configuration for php common module
+    ; priority=20
+    extension=stem.so
+    EOF
 
 - name: Symlink /etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini -> /etc/php/{{ php_version }}/mods-available/stem.ini
   file:
-    src: "/etc/php/{{ php_version }}/mods-available/stem.ini"
-    path: "/etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini"
+    src: /etc/php/{{ php_version }}/mods-available/stem.ini
+    path: /etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini
     state: link
-  when: stem_available is defined
+
+
+# - name: Set fact stem available php 7.2 - includes x86_64 only
+#   set_fact:
+#     stem_available: True
+#   when: ansible_machine == "x86_64" and php_version == 7.2
+
+# - name: Set fact stem available php 7.3 - excludes i386
+#   set_fact:
+#     stem_available: True
+#   when: not ansible_machine == "i386" and php_version == 7.3
+
+# - name: Set fact stem available php 7.4
+#   set_fact:
+#     stem_available: True
+#   when: php_version == 7.4 and (ansible_machine == "aarch64" or ansible_machine == "x86_64")
+
+# - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.rpi.tar to / (rpi)
+#   unarchive:
+#     src: http://download.iiab.io/packages/php{{ php_version }}-stem.rpi.tar
+#     dest: /
+#     owner: root
+#     group: root
+#     #mode: ????
+#     remote_src: yes
+#   when: (ansible_machine == "armv7l" or ansible_machine == "armv6l") and stem_available is defined
+
+# - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar to / (rpi)
+#   unarchive:
+#     src: http://download.iiab.io/packages/php{{ php_version }}-stem.aarch64.tar
+#     dest: /
+#     owner: root
+#     group: root
+#     #mode: ????
+#     remote_src: yes
+#   when: ansible_machine == "aarch64" and stem_available is defined
+
+# - name: Unarchive http://download.iiab.io/packages/php{{ php_version }}-stem.x64.tar to / (x64)
+#   unarchive:
+#     src: http://download.iiab.io/packages/php{{ php_version }}-stem.x64.tar
+#     dest: /
+#     owner: root
+#     group: root
+#     #mode: ????
+#     remote_src: yes
+#   when: ansible_machine == "x86_64" and stem_available is defined
+
+# - name: Symlink /etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini -> /etc/php/{{ php_version }}/mods-available/stem.ini
+#   file:
+#     src: "/etc/php/{{ php_version }}/mods-available/stem.ini"
+#     path: "/etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini"
+#     state: link
+#   when: stem_available is defined
+
 
 # Not sure what to do for apache, so do nothing for now
 

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -61,6 +61,9 @@
     path: /etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini
     state: link
 
+- name: YOU MAY NEED TO 'systemctl restart php{{ php_version }}-fpm' -- whereas during an IIAB install, roles/www_options does that for you
+  meta: noop:
+
 
 # - name: Set fact stem available php 7.2 - includes x86_64 only
 #   set_fact:

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -61,8 +61,8 @@
     path: /etc/php/{{ php_version }}/fpm/conf.d/20-stem.ini
     state: link
 
-- name: YOU MAY NEED TO 'systemctl restart php{{ php_version }}-fpm' -- whereas during an IIAB install, roles/www_options does that for you
-  meta: noop:
+- debug:
+    msg: YOU MAY NEED TO 'systemctl restart php{{ php_version }}-fpm' -- whereas during an IIAB install, roles/www_options does that for you
 
 
 # - name: Set fact stem available php 7.2 - includes x86_64 only

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -27,6 +27,11 @@
 # (Or in PHP code...)
 # phpinfo()
 
+# Or consider https://github.com/iiab/php-stem/issues/2 in future?
+# "Current practice is to put the stem.so file in a different place for each php version.
+# Would it be better to create a directory /usr/local/lib/php-stem and always put it there.
+# Then put that location in stem.ini"
+
 
 - name: Download https://github.com/iiab/php-stem/raw/main/so/stem-armhf-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (armv6l or armv7l)
   get_url:

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -67,7 +67,7 @@
     state: link
 
 - debug:
-    msg: YOU MAY NEED TO 'systemctl restart php{{ php_version }}-fpm' -- whereas during an IIAB install, roles/www_options does that for you
+    msg: YOU MAY NEED TO 'systemctl reload php{{ php_version }}-fpm' -- whereas during an IIAB install, roles/www_options restarts it for you
 
 
 # - name: Set fact stem available php 7.2 - includes x86_64 only


### PR DESCRIPTION
Thanks to @tim-moody's Thursday work:

- https://github.com/iiab/php-stem/pull/3

Tested on RasPiOS 11 on RPi 4 _(but searching es-wikihow didn't work without `systemctl reload php7.4-fpm` and apt package `php7.4-sqlite3` — as alluded to at https://github.com/iiab/php-stem/pull/3#issuecomment-1001051625)._

Prior work:

- #829
- #983
- #2123
- PR #2269
- PR #2349
- #2797
- PR #2799
- #2835
- PR #2837
- PR #2838
- #2864
- iiab/php-stem#2