### PR TITLE
roles/www_base/tasks/php-stem.yml: Clarify... php_extension: "{{ php_extensions[php_version] }}"

### DIFF
--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -7,7 +7,8 @@
 # Original bug: https://github.com/iiab/iiab/issues/829
 
 
-- set_fact:
+- name: Populate php_extensions dictionary (lookup table of recent PHP versions and their corresponding YYYYMMDD, for /usr/lib/php/YYYYMMDD/stem.so)
+  set_fact:
     php_extensions:    # Dictionary keys (left side) are always strings, e.g. "7.2"
       7.2: 20170718    # Dictionary values (right side) can be of type int here, as it's auto-cast to string just below.  Strings would also work e.g. 7.2: "20170718"
       7.3: 20180731
@@ -15,7 +16,8 @@
       8.0: 20200930
       8.1: 20210902
 
-- set_fact:
+- name: Set php_extension to "{{ php_extensions[php_version] }}" using php_extensions[php_version]
+  set_fact:
     php_extension: "{{ php_extensions[php_version] }}"
 
 # Auto-lookup would also work...


### PR DESCRIPTION
Ansible looks up the PHP extension (YYYYMMDD) for that version of PHP, within dictionary (look-up table) php_extensions on top roles/www_base/tasks/php-stem.yml

So it can't hurt to explain that while installing IIAB, contextualizing this just-merged PR:

- PR #3080