### PR TITLE
www_base/tasks/php-stem.yml needs phpX.Y-sqlite3 (es-wikihow search was failing when osm-vector-maps was not installed)

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -171,15 +171,15 @@
     dest: "{{ vector_map_path }}/maplist/index.html"
     force: yes
 
-- name: "Install packages for map installation: python3-wget, php{{ php_version }}-sqlite3, python3-geojson, python3-pil"
+- name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
   package:
     state: present
     name:
+      - python3-geojson
+      - python3-pil
       - python3-wget
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-sqlite3
-      - python3-geojson
-      - python3-pil
 
 - name: Copy 6 scripts to /usr/bin, for downloading tiles (0755)
   get_url:

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -7,6 +7,12 @@
 # Original bug: https://github.com/iiab/iiab/issues/829
 
 
+- name: Install apt package php{{ php_version }}-sqlite3 -- nec for http://box/modules/es-wikihow search -- can also installed by osm-vector-maps/tasks/install.yml
+  package:
+    state: present
+    name: php{{ php_version }}-sqlite3
+
+
 - name: Populate php_extensions dictionary (lookup table of recent PHP versions and their corresponding YYYYMMDD, for /usr/lib/php/YYYYMMDD/stem.so)
   set_fact:
     php_extensions:    # Dictionary keys (left side) are always strings, e.g. "7.2"

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -7,7 +7,7 @@
 # Original bug: https://github.com/iiab/iiab/issues/829
 
 
-- name: Install apt package php{{ php_version }}-sqlite3 -- nec for http://box/modules/es-wikihow search -- can also installed by osm-vector-maps/tasks/install.yml
+- name: Install apt package php{{ php_version }}-sqlite3 -- nec for http://box/modules/es-wikihow search -- can also be installed by osm-vector-maps/tasks/install.yml
   package:
     state: present
     name: php{{ php_version }}-sqlite3


### PR DESCRIPTION
Searching [es-wikihow](https://rachel.worldpossible.org/viewmod/es-wikihow) was not working when [osm-vector-maps](https://github.com/iiab/iiab/tree/master/roles/osm-vector-maps) was not installed.

This PR fixes the missing dependency bug.

Background reports:

- https://github.com/iiab/php-stem/pull/3#issuecomment-1001070050
- https://github.com/iiab/iiab/pull/3080#issuecomment-1001083415

Tangentially related:

- PR #3081