### PR TITLE
osm_vector_maps was repeatedly failing to install, so use 'timeout: "{{ download_timeout }}"' with get_url (in 10 roles!) [& change IIAB's 'download_timeout: 200' to 100 sec]

### DIFF
--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -23,15 +23,15 @@
   get_url:
     url: "{{ docker_sh_url }}"
     dest: "{{ azuracast_host_dir }}/"
-    timeout: "{{ download_timeout }}"
     mode: 0755
+    timeout: "{{ download_timeout }}"
 
 - name: AzuraCast - Download AzuraCast's docker-compose.yml sample from GitHub to {{ azuracast_host_dir }}
   get_url: 
     url: "{{ docker_compose_url }}"
     dest: "{{ azuracast_host_dir }}/docker-compose.yml"
-    timeout: "{{ download_timeout }}"
     mode: 0755
+    timeout: "{{ download_timeout }}"
 
 #- name: AzuraCast - Make changes to docker.sh script so it runs headless
 #  lineinfile:

--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -11,6 +11,7 @@
   get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
+    timeout: "{{ download_timeout }}"
   with_items:
     - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
     - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -54,6 +54,7 @@
   get_url:
     url: "{{ gitea_integrity_url }}"
     dest: "{{ gitea_checksum_path }}"
+    timeout: "{{ download_timeout }}"
 
 - name: Verify Gitea binary with GPG signature
   shell: |

--- a/roles/minetest/tasks/minetest_install_mods.yml
+++ b/roles/minetest/tasks/minetest_install_mods.yml
@@ -8,6 +8,7 @@
     url: "{{item.url}}"
     dest: "{{ downloads_dir }}/{{ item.name }}.zip"
     mode: 0440
+    timeout: "{{ download_timeout }}"
   when: not minetest_mod.stat.exists
 
 - name: Extract mod into mods of current game

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -63,6 +63,7 @@
   get_url:
     url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
     dest: /usr/bin/networkd-dispatcher
+    timeout: "{{ download_timeout }}"
   when: internet_available and fix_dispatcher and ansible_distribution_release == "groovy"
   # 2021-08-29 context from @jvonau: Fix is 'Groovy' specific, 21.04 and later
   # should have the fix baked into a newer apt package installed by default.

--- a/roles/nodered/tasks/rpi_desk.yml
+++ b/roles/nodered/tasks/rpi_desk.yml
@@ -3,6 +3,7 @@
   get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
+    timeout: "{{ download_timeout }}"
   with_items:
     - url: https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-icon.svg
       dest: /usr/share/icons/hicolor/scalable/apps/node-red-icon.svg
@@ -22,6 +23,7 @@
     url: "{{ item }}"
     dest: /usr/bin
     mode: a+x
+    timeout: "{{ download_timeout }}"
   with_items:
     - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-start
     - https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-stop

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -14,11 +14,13 @@
   get_url:
     url: "{{ map_catalog_url }}/map-catalog.json"    # http://download.iiab.io/content/OSM/vector-tiles
     dest: "{{ iiab_etc_path }}"    # /etc/iiab
+    timeout: "{{ download_timeout }}"
 
 - name: Download {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
   get_url:
     url: "{{ iiab_map_url }}/assets/regions.json"    # http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
     dest: "{{ iiab_etc_path }}"
+    timeout: "{{ download_timeout }}"
 
 # - name: Does 26M cities database {{ vector_map_path }}/viewer/cities1000.sqlite exist?
 #   stat:
@@ -30,6 +32,7 @@
   get_url:
     url: "{{ iiab_map_url }}/regional-resources/cities1000.sqlite"
     dest: "{{ vector_map_path }}/viewer/"
+    timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
 
 - name: Symlink {{ doc_root }}/common/assets/map-catalog.json -> /etc/iiab/map-catalog.json
@@ -55,6 +58,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/{{ item }}"    # https://raw.githubusercontent.com/iiab/maps / master
     dest: "{{ vector_map_path }}/test-page/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - test-page-bundle.js
     - index.html
@@ -64,6 +68,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/{{ item }}"
     dest: "{{ vector_map_path }}/viewer/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - index.html
     - viewer-bundle.js
@@ -73,6 +78,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/{{ item }}"
     dest: "{{ vector_map_path }}/viewer/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - mbtileinfo.php
     - popup.css
@@ -83,6 +89,7 @@
   get_url:
     url: "{{ map_catalog_url }}/planet_z0-z6_2019.mbtiles"
     dest: "{{ vector_map_path }}/installer/"
+    timeout: "{{ download_timeout }}"
 
 - name: Symlink {{ vector_map_path }}/installer/detail.mbtiles -> {{ vector_map_path }}/installer/planet_z0-z6_2019.mbtiles
   file:
@@ -100,11 +107,13 @@
   get_url:
     url: "{{ map_catalog_url }}/satellite_z0-z6_v3.mbtiles"
     dest: "{{ vector_map_path }}/viewer/tiles/"
+    timeout: "{{ download_timeout }}"
 
 - name: Download {index.html, installer-bundle.js} from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/build/* to {{ vector_map_path }}/installer/ -- for map installer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/build/{{ item }}"
     dest: "{{ vector_map_path }}/installer/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - index.html
     - installer-bundle.js
@@ -113,6 +122,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/{{ item }}"
     dest: "{{ vector_map_path }}/installer/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - map.css
     - style-osm.json
@@ -124,6 +134,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/assets/{{ item }}"
     dest: "{{ vector_map_path }}/viewer/assets/"
+    timeout: "{{ download_timeout }}"
   with_items:
     - bboxes.geojson
     - center.png
@@ -170,6 +181,7 @@
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect"
     dest: "{{ vector_map_path }}/maplist/index.html"
     force: yes
+    timeout: "{{ download_timeout }}"
 
 - name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
   package:
@@ -186,6 +198,7 @@
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/scripts/{{ item }}"
     dest: /usr/bin/
     mode: 0755
+    timeout: "{{ download_timeout }}"
   with_items:
     - iiab-install-map-region
     - iiab-extend-sat.py

--- a/roles/phpmyadmin/tasks/install.yml
+++ b/roles/phpmyadmin/tasks/install.yml
@@ -2,7 +2,7 @@
   get_url:
     url: "{{ phpmyadmin_dl_url }}"    # e.g. https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-all-languages.zip
     dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
-    timeout: "{{ download_timeout }}"    # 200
+    timeout: "{{ download_timeout }}"
   when: internet_available
 
 - name: Does {{ downloads_dir }}/{{ phpmyadmin_name_zip }} exist?
@@ -18,7 +18,7 @@
     dest: /opt
     owner: "{{ apache_user }}"    # www-data on debuntu
     group: "{{ apache_user }}"
-    #timeout: "{{ download_timeout }}" # Use get_url if timeout (200s) required
+    #timeout: "{{ download_timeout }}"    # Use get_url if timeout (200s) required
 
 - name: Symlink /opt/phpmyadmin -> {{ phpmyadmin_name }}
   file:

--- a/roles/phpmyadmin/tasks/install.yml
+++ b/roles/phpmyadmin/tasks/install.yml
@@ -18,7 +18,7 @@
     dest: /opt
     owner: "{{ apache_user }}"    # www-data on debuntu
     group: "{{ apache_user }}"
-    #timeout: "{{ download_timeout }}"    # Use get_url if timeout (200s) required
+    #timeout: "{{ download_timeout }}"    # Use get_url if timeout (100s) required
 
 - name: Symlink /opt/phpmyadmin -> {{ phpmyadmin_name }}
   file:

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -13,6 +13,7 @@
     url: "{{ remoteit_device_url }}"
     dest: "{{ downloads_dir }}/"
     force: yes
+    timeout: "{{ download_timeout }}"
 
 - name: Uninstall previously installed 'remoteit*' device apt package(s)
   apt:
@@ -37,6 +38,7 @@
     dest: /usr/bin/remoteit
     mode: 0755
     force: yes
+    timeout: "{{ download_timeout }}"
 
 
 # RECORD remoteit AS INSTALLED

--- a/roles/www_base/tasks/php-stem.yml
+++ b/roles/www_base/tasks/php-stem.yml
@@ -45,18 +45,21 @@
   get_url:
     url: https://github.com/iiab/php-stem/raw/main/so/stem-armhf-{{ php_version }}.so
     dest: /usr/lib/php/{{ php_extension }}/stem.so
+    timeout: "{{ download_timeout }}"
   when: ansible_machine == "armv6l" or ansible_machine == "armv7l"
 
 - name: Download https://github.com/iiab/php-stem/raw/main/so/stem-aarch64-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (aarch64)
   get_url:
     url: https://github.com/iiab/php-stem/raw/main/so/stem-aarch64-{{ php_version }}.so
     dest: /usr/lib/php/{{ php_extension }}/stem.so
+    timeout: "{{ download_timeout }}"
   when: ansible_machine == "aarch64"
 
 - name: Download https://github.com/iiab/php-stem/raw/main/so/stem-x64-{{ php_version }}.so to /usr/lib/php/{{ php_extension }}/stem.so (x86_64)
   get_url:
     url: https://github.com/iiab/php-stem/raw/main/so/stem-x64-{{ php_version }}.so
     dest: /usr/lib/php/{{ php_extension }}/stem.so
+    timeout: "{{ download_timeout }}"
   when: ansible_machine == "x86_64"
 
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -41,7 +41,7 @@ doc_root: "{{ doc_base }}/html"
 py3_dist_path: /usr/lib/python3/dist-packages
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 200
+download_timeout: 100
 
 # Real-time clock: RTC chip family.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?  Used in 1-prep/tasks/raspberry_pi.yml

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -13,7 +13,7 @@
 
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 200
+download_timeout: 100
 
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -13,7 +13,7 @@
 
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 200
+download_timeout: 100
 
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -13,7 +13,7 @@
 
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 200
+download_timeout: 100
 
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?


### PR DESCRIPTION
IIAB's OpenStreetMap installer ([osm-vector-maps/tasks/install.yml](https://github.com/iiab/iiab/blob/master/roles/osm-vector-maps/tasks/install.yml)) is very fragile when GitHub and/or your ISP (Internet) is overwhelmed.

As I discovered repeatedly yesterday, the problem is especially acute when trying to install osm-vector-maps as a result of this role downloading so many different files.

This PR fixes the problem, by avoiding Ansible's default timeout for `get_url:` of 10 seconds, and using 100 seconds instead.  

This PR also establishes `'timeout: "{{ download_timeout }}"'` essentially across the board, for almost all of repo iiab/iiab's ~50 uses of get_url, as this was missing from almost 10 roles.

The exception (where we do not want to use `timeout: "{{ download_timeout }}"`) is: https://github.com/iiab/iiab/blob/2634fa207bece346d6f40e07ced388966293f783/roles/0-init/tasks/network.yml#L22-L31

Note that the Internet is comparatively more stable in major cities around the world in 2021, as compared to 5 years ago, so this PR also lowers `download_timeout: 200` to `download_timeout: 100` (seconds), to try to avoid pointlessly frustrating delays.

**In future years we (might!) possibly want to further lower this IIAB setting (in default_vars.yml etc) from 100 seconds, down to 60 seconds or so?**

Tangentially related:

- #3077
- PR #3082