### PR TITLE
remoteit/defaults/main.yml: 4.13.5 -> 4.13.6 (remote.it support)

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -34,7 +34,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    If not used before then, here is an *example (version & architecture can change in the .deb filename below!)* to re-run this installation command, to get a new claim code:
 
    ```
-   sudo apt reinstall /opt/iiab/downloads/remoteit-4.13.5.armhf.rpi.deb
+   sudo apt reinstall /opt/iiab/downloads/remoteit-4.13.6.armhf.rpi.deb
    ```
 
 4. After you've installed the https://remote.it client software onto a separate computer or device (e.g. your own laptop) click on the '+' icon, then enter the remote.it claim code (for the IIAB that you need to connect to).

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -6,7 +6,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-remoteit_version: 4.13.5
+remoteit_version: 4.13.6
 
 # See https://docs.remote.it/device-package/installation to refine URL below:
 device_suffixes:


### PR DESCRIPTION
As released at https://remote.it/download/ on 2021-12-16.