### PR TITLE
Cleaner output for local_facts.fact on Raspberry Pi & similar, by hiding the null byte in /proc/device-tree/model

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -95,13 +95,13 @@ tmp=$(git rev-parse --verify HEAD) &&
 #tmp=$(cat /proc/device-tree/mfg-data/MN) &&
 #    XO_MODEL=$tmp
 
-tmp=$(grep -ai raspberry /proc/device-tree/model) &&
+tmp=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0') &&
     RPI_MODEL=$tmp
 
 # /proc/device-tree/model e.g. 'Parallels ARM Virtual Machine' identical to...
 # /sys/firmware/devicetree/base/model (also true on RPi hardware!)
 
-tmp=$(cat /proc/device-tree/model) &&
+tmp=$(tr -d '\0' < /proc/device-tree/model) &&
     DEVICETREE_MODEL=$tmp
 
 tmp=$(ansible --version) &&


### PR DESCRIPTION
This helps remove 2 very distracting warnings from the output of scripts/local_facts.fact &mdash; which appear almost immediately after [./iiab-install](https://github.com/iiab/iiab/blob/master/iiab-install#L46) begins running.

Thanks to:

https://stackoverflow.com/questions/46163678/get-rid-of-warning-command-substitution-ignored-null-byte-in-input/46163928#46163928

Tested on RasPiOS 11 Lite on RPi 4.