### PR TITLE
local_facts.fact: Stop supporting Ubuntu 21.04

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -62,6 +62,7 @@ OS_VER="$OS-$VERSION_ID"
     #"ubuntu-17"    | \
     #"ubuntu-18"    | \
     #"ubuntu-19"    | \
+    #"ubuntu-2104"  | \
     #"centos-7"     | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
@@ -74,7 +75,6 @@ case $OS_VER in
     "debian-11"    | \
     "debian-12"    | \
     "ubuntu-2004"  | \
-    "ubuntu-2104"  | \
     "ubuntu-2110"  | \
     "ubuntu-2204"  | \
     "linuxmint-20" | \


### PR DESCRIPTION
Ubuntu 21.04 is a non-LTS release being EOL'd (end-of-life'd) by Ubuntu in January 2022.

It's time to look to the future — e.g. the pre-release daily builds of Ubuntu 22.04 LTS.