### PR TITLE
local_vars_medium.yml: Let's give Kolibri a shot

### DIFF
--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -260,8 +260,8 @@ kalite_install: True
 kalite_enabled: True
 
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
-kolibri_install: False
-kolibri_enabled: False
+kolibri_install: True
+kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console


### PR DESCRIPTION
I believe it's time.

As [Kolibri 0.15](https://github.com/learningequality/kolibri/releases/tag/v0.15.0) is finally somewhat mature — it installs quickly — and adds only 282MB on RasPiOS Lite (that's much smaller than things like Sugarizer, and rather comparable to Nextcloud!)

Yes it's true that Kolibri's runtime (systemd service) resources can sometimes be a pig, when observed using [htop](https://htop.dev/) and similar, despite very little happening at all.

And yes it's also true that KA Lite running on the very same IIAB as Kolibri can sometimes be superfluous and gratuitous.  _However: there are more than a few communities and implementers asking for exactly that, to be able to run both (despite Learning Equality's doctrine, wishing KA Lite would completely go away ;-)_

Conclusion: Kolibri is getting more functional and popular so let's give it a shot in 2022.

And absolute worst case, this can be reversed later in 2022, if in the end the public rejects Kolibri.