### PR TITLE
local_facts.fact: $RPI_MODEL should be "none" when not a Raspberry Pi

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -95,8 +95,8 @@ tmp=$(git rev-parse --verify HEAD) &&
 #tmp=$(cat /proc/device-tree/mfg-data/MN) &&
 #    XO_MODEL=$tmp
 
-tmp=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0') &&
-    RPI_MODEL=$tmp
+grep -iq raspberry /proc/device-tree/model &&
+    RPI_MODEL=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0')
 
 # /proc/device-tree/model e.g. 'Parallels ARM Virtual Machine' identical to...
 # /sys/firmware/devicetree/base/model (also true on RPi hardware!)


### PR DESCRIPTION
Fix tested on Ubuntu 22.04 LTS pre-release and Raspberry Pi OS Lite.

Fixes:

- PR #3086