### PR TITLE
nginx/templates/server.conf.j2: client_max_body_size 1M -> 500M solves "413 Request Entity Too Large" [for Calibre-Web, and other LMS-like apps — compare Nextcloud's 512M]

### DIFF
--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -7,6 +7,15 @@ server {
 
     index index.php index.html index.htm;
 
+    # NGINX's 1MB default is far too low for Calibre-Web and LMS-like apps.
+    # So IIAB sets this to 500M, roughly aligning with similar settings...
+    # 1. 'upload_max_filesize = 500M' and 'post_max_size = 500M' are SOMETIMES set in:
+    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L106-L107
+    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L120-L121
+    # 2. 'client_max_body_size 512M;' is set in:
+    #    https://github.com/iiab/iiab/blob/master/roles/nextcloud/templates/nextcloud-nginx.conf.j2#L62
+    client_max_body_size 500M;
+
     # let individual services drop location blocks in conf.d
     include {{ nginx_conf_dir }}/*;
 


### PR DESCRIPTION
Tested on Raspberry Pi OS Lite on RPi 4.

This fixes Calibre-Web (https://github.com/iiab/iiab/tree/master/roles/calibre-web#calibre-web-readme) and other LMS-like apps, restoring IIAB teachers' and users' ability to upload contemporary books/docs and media into IIAB.

(In short NGINX's 1MB default is obscenely low for 2002, and this was long overdue for a fix since [IIAB transitioned from Apache to NGINX](https://github.com/iiab/iiab/tree/master/roles/nginx#transition-to-nginx), given that LMS-like apps are nearly useless in practice in 2022, when users are blocked from uploading everyday photos and docs...that are very rarely smaller than 1MB...unlike when NGINX defined its defaults more than a decade ago.)

Background: the error message was "413 Request Entity Too Large" within apps like Calibre-Web (http://box/books).