### PR TITLE
kiwix/defaults/main.yml: Try kiwix-tools 2022-01-04

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,9 +26,9 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-2022-01-01
-kiwix_version_linux64: kiwix-tools_linux-x86_64-2022-01-01
-kiwix_version_i686: kiwix-tools_linux-i586-2022-01-01
+kiwix_version_armhf: kiwix-tools_linux-armhf-2022-01-04
+kiwix_version_linux64: kiwix-tools_linux-x86_64-2022-01-04
+kiwix_version_i686: kiwix-tools_linux-i586-2022-01-04
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")


### PR DESCRIPTION
Tested on Raspberry Pi OS on RPi 4.

This is a big step forward, in that it's now possible to quickly see dependency versions of libkiwix and libzim (and their own dependencies, all statically linked i.e. internal to the binaries) when running things like:

```
/opt/iiab/kiwix/bin/kiwix-serve --version
```

Building on:

- #3089