### PR TITLE
Raspberry Pi WiFi hotspot firmware reliability fix, incl new/better choices for 3B+ & 4 (WIP)

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -69,15 +69,15 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: Calibre
-  - option: description
-    value: '"Calibre is an extremely popular personal library system for e-books."'
-  - option: calibre_src_url
-    value: "{{ calibre_src_url }}"
-  - option: calibre_dbpath
-    value: "{{ calibre_dbpath }}"
-  - option: calibre_port
-    value: "{{ calibre_port }}"
-  - option: calibre_enabled
-    value: "{{ calibre_enabled }}"
+    - option: name
+      value: Calibre
+    - option: description
+      value: '"Calibre is an extremely popular personal library system for e-books."'
+    - option: calibre_src_url
+      value: "{{ calibre_src_url }}"
+    - option: calibre_dbpath
+      value: "{{ calibre_dbpath }}"
+    - option: calibre_port
+      value: "{{ calibre_port }}"
+    - option: calibre_enabled
+      value: "{{ calibre_enabled }}"

--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -1,22 +1,27 @@
-- name: Back up original e.g. OS-provided firmware (for RPi internal WiFi)
+- name: Back up 4 OS-provided firmware files to .orig (for RPi internal WiFi)
   copy:
-    src: "/lib/firmware/brcm/{{ item }}"
-    dest: "/lib/firmware/brcm/{{ item }}.orig"
+    src: /lib/firmware/brcm/{{ item }}
+    dest: /lib/firmware/brcm/{{ item }}.orig
   with_items:
     - brcmfmac43430-sdio.bin
+    - brcmfmac43430-sdio.clm_blob
     - brcmfmac43455-sdio.bin
     - brcmfmac43455-sdio.clm_blob
+  ignore_errors: yes
 
-- name: Download high-capacity older firmware (for RPi internal WiFi, per https://github.com/iiab/iiab/issues/823#issuecomment-662285202)
+- name: Download high-capacity firmware (for RPi internal WiFi, per https://github.com/iiab/iiab/issues/823#issuecomment-662285202)
   get_url:
-    url: "{{ item.url }}"
-    dest: "{{ item.dest }}"
+    url: "{{ item }}"
+    dest: /lib/firmware/brcm/
     timeout: "{{ download_timeout }}"
   with_items:
-    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab' }
-    - { url: 'http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65', dest: '/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab' }
-    - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab' }
-    - { url: 'http://d.iiab.io/packages/brcmfmac43455-sdio.clm_blob_2018-02-26_rpi', dest: '/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab' }
+    - http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2021-11-30_minimal                # 19 -- from https://github.com/RPi-Distro/firmware-nonfree/blob/feeeda21e930c2e182484e8e1269b61cca2a8451/debian/config/brcm80211/cypress/cyfmac43455-sdio-minimal.bin
+    - http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2021-10-05_3rd-trial-minimal      # 24
+    - http://d.iiab.io/packages/brcmfmac43455-sdio.clm_blob_2021-11-17_rpi               # Works w/ both above -- from https://github.com/RPi-Distro/firmware-nonfree/blob/dc406650e840705957f8403efeacf71d2d7543b3/debian/config/brcm80211/cypress/cyfmac43455-sdio.clm_blob
+    - http://d.iiab.io/packages/brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1    # 32
+    - http://d.iiab.io/packages/brcmfmac43455-sdio.clm_blob_2018-02-26_rpi
+    - http://d.iiab.io/packages/brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65             # 30
+    - http://d.iiab.io/packages/brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65
 
 
 # RECORD firmware AS DOWNLOADED

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -2,6 +2,67 @@
   include_tasks: download.yml
   when: firmware_downloaded is undefined    # SEE ALSO firmware_installed below
 
+
+# Set 2 symlinks for RPi 3 B+ and 4
+
+- name: Populate rpi3bplus_rpi4_wifi_firmwares dictionary (lookup table for 43455 .bin and .clm_blob files in /lib/firmware/brcm)
+  set_fact:
+    rpi3bplus_rpi4_wifi_firmwares:    # Dictionary keys (left side) are always strings, e.g. "19"
+      os:
+        - brcmfmac43455-sdio.bin.orig
+        - brcmfmac43455-sdio.clm_blob.orig
+      19:
+        - brcmfmac43455-sdio.bin_2021-11-30_minimal
+        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi
+      24:
+        - brcmfmac43455-sdio.bin_2021-10-05_3rd-trial-minimal
+        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi
+      32:
+        - brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1
+        - brcmfmac43455-sdio.clm_blob_2018-02-26_rpi
+
+- name: Symlink brcmfmac43455-sdio.bin.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+  file:
+    src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }}"
+    path: /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab
+    state: link
+    force: yes
+
+- name: Symlink brcmfmac43455-sdio.clm_blob.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+  file:
+    src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }}"
+    path: /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab
+    state: link
+    force: yes
+
+
+# Set 2 symlinks for RPi Zero W and 3
+
+- name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for 43430 .bin and .clm_blob files in /lib/firmware/brcm)
+  set_fact:
+    rpizerow_rpi3_wifi_firmwares:
+      os:
+        - brcmfmac43430-sdio.bin.orig
+        - brcmfmac43430-sdio.clm_blob.orig
+      30:
+        - brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65
+        - brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65
+
+- name: Symlink brcmfmac43430-sdio.bin.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+  file:
+    src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }}"
+    path: /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab
+    state: link
+    force: yes
+
+- name: Symlink brcmfmac43430-sdio.clm_blob.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+  file:
+    src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }}"
+    path: /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab
+    state: link
+    force: yes
+
+
 - name: 'Install from template: /usr/bin/iiab-check-firmware, /etc/systemd/system/iiab-check-firmware.service & /etc/profile.d/iiab-firmware-warn.sh'
   template:
     src: "{{ item.src }}"

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -3,9 +3,9 @@
   when: firmware_downloaded is undefined    # SEE ALSO firmware_installed below
 
 
-# Set 2 symlinks for RPi 3 B+ and 4
+# Set 2 symlinks for RPi 3 B+ and 4 (43455)
 
-- name: Populate rpi3bplus_rpi4_wifi_firmwares dictionary (lookup table for 43455 .bin and .clm_blob files in /lib/firmware/brcm)
+- name: Populate rpi3bplus_rpi4_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/brcm)
   set_fact:
     rpi3bplus_rpi4_wifi_firmwares:    # Dictionary keys (left side) are always strings, e.g. "19"
       os:
@@ -21,14 +21,14 @@
         - brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1
         - brcmfmac43455-sdio.clm_blob_2018-02-26_rpi
 
-- name: Symlink brcmfmac43455-sdio.bin.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+- name: Symlink /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
   file:
     src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }}"
     path: /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab
     state: link
     force: yes
 
-- name: Symlink brcmfmac43455-sdio.clm_blob.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+- name: Symlink /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
   file:
     src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }}"
     path: /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab
@@ -36,9 +36,9 @@
     force: yes
 
 
-# Set 2 symlinks for RPi Zero W and 3
+# Set 2 symlinks for RPi Zero W and 3 (43430)
 
-- name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for 43430 .bin and .clm_blob files in /lib/firmware/brcm)
+- name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/brcm)
   set_fact:
     rpizerow_rpi3_wifi_firmwares:
       os:
@@ -48,14 +48,14 @@
         - brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65
         - brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65
 
-- name: Symlink brcmfmac43430-sdio.bin.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+- name: Symlink /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
   file:
     src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }}"
     path: /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab
     state: link
     force: yes
 
-- name: Symlink brcmfmac43430-sdio.clm_blob.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+- name: Symlink /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
   file:
     src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }}"
     path: /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -1,14 +1,17 @@
-# Please set 'wifi_hotspot_capacity_rpi_fix: True' in /etc/iiab/local_vars.yml
-# to restore support for 30-32 WiFi client devices on most Raspberry Pis that
-# have internal WiFi.  This installs firmware 7.45.98.65 for Zero W and RPi 3
-# and firmware 7.45.18.0 for RPi 3 B+ and RPi 4.  Capacity testing writeup:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+# Please set 'rpi3bplus_rpi4_wifi_firmware' and 'rpizerow_rpi3_wifi_firmware' in
+# /etc/iiab/local_vars.yml to increase (or modify) the number of student WiFi
+# client devices that can access your Raspberry Pi's internal WiFi hotspot.
+
+# If IIAB's already installed, you should then run 'cd /opt/iiab/iiab'
+# followed by 'sudo ./runrole firmware'
+
+# Background: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 
 - name: Install firmware (for RPi internal WiFi)
   include_tasks: install.yml
   #when: firmware_installed is undefined
 
-# Two variable are placed in /etc/iiab/iiab_state.yml:
+# Two variables are placed in /etc/iiab/iiab_state.yml:
 #
 # - firmware_downloaded (set in download.yml) is used in install.yml
 #

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -1,44 +1,54 @@
 #!/bin/bash
 
-DATE=$(date +%F-%T)
-
 # 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
-# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L13
+# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
 # https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN
 
-if ! grep -q '^rpi3bplus_rpi4_wifi_firmware:\s\+os\b' /etc/iiab/local_vars.yml ; then
-    if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin ; then
-	mv /lib/firmware/brcm/brcmfmac43455-sdio.bin /lib/firmware/brcm/brcmfmac43455-sdio.bin.$DATE
-	ln -sf brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
-	echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.bin"
-	touch /tmp/.fw_replaced
-    fi
+iiab_var_value() {
+    v1=$(grep "^$1:\s" /opt/iiab/iiab/vars/default_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    v2=$(grep "^$1:\s" /etc/iiab/local_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    [ "$v2" != "" ] && echo $v2 || echo $v1    # [ "$v2" ] ALSO WORKS
+}
 
-    if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob ; then
-	mv /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.$DATE
-	ln -sf brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
-	echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob"
-	touch /tmp/.fw_replaced
+link_fw() {
+    if [[ $(readlink /lib/firmware/brcm/$1) != $1.iiab ]] ; then
+	echo
+	mv /lib/firmware/brcm/$1 /lib/firmware/brcm/$1.$(date +%F-%T)
+	ln -s $1.iiab /lib/firmware/brcm/$1
+	echo -e "\e[1mSymlinked /lib/firmware/brcm/$1 -> $1.iiab\e[0m"
+	touch /tmp/.fw_modified
     fi
+}
+
+if [[ $(iiab_var_value rpi3bplus_rpi4_wifi_firmware) != "os" ]] ; then
+    link_fw brcmfmac43455-sdio.bin
+    link_fw brcmfmac43455-sdio.clm_blob
 fi
 
-if ! grep -q '^rpizerow_rpi3_wifi_firmware:\s\+os\b' /etc/iiab/local_vars.yml ; then
-    if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin ; then
-	mv /lib/firmware/brcm/brcmfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.bin.$DATE
-	ln -sf brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
-	echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.bin"
-	touch /tmp/.fw_replaced
-    fi
-
-    if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob ; then
-	mv /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.$DATE
-	ln -sf brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
-	echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob"
-	touch /tmp/.fw_replaced
-    fi
+if [[ $(iiab_var_value rpizerow_rpi3_wifi_firmware) != "os" ]] ; then
+    link_fw brcmfmac43430-sdio.bin
+    link_fw brcmfmac43430-sdio.clm_blob
 fi
 
-bash < /etc/profile.d/iiab-firmware-warn.sh
+if [ -f /tmp/.fw_modified ]; then
+    bash /etc/profile.d/iiab-firmware-warn.sh
+else
+    echo -e "\n\e[1mWiFi Firmware links in /lib/firmware/brcm appear \e[92mCORRECT\e[0m\e[1m, per iiab/iiab#2853.\e[0m"
+    echo
+    echo -e "\e[100;1m(No reboot appears necessary!)\e[0m"
+    echo
+    echo -e "NOTE: If you change rpi3bplus_rpi4_wifi_firmware or rpizerow_rpi3_wifi_firmware"
+    echo -e "settings in /etc/iiab/local_vars.yml, please then run:"
+    echo
+    echo -e "   cd /opt/iiab/iiab"
+    echo -e "   sudo ./iiab-network"
+    echo -e "   sudo poweroff\n"
+    #echo
+    #echo -e "Disconnect your power cord before rebooting, for better WiFi firmware results.\n"
+fi
+
+# \e[1m = bright white    \e[100;1m = bright white, on gray    \n\e[41;1m = bright white, on red
+# \e[42;1m = bright white, on bright green    \e[92m = green on black

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-WARN=false
 DATE=$(date +%F-%T)
 
 # 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
@@ -10,53 +9,36 @@ DATE=$(date +%F-%T)
 # https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN
 
-if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
-    echo "'wifi_hotspot_capacity_rpi_fix: False' found in /etc/iiab/local_vars.yml"
-    echo "...so WiFi firmware will NOT be checked or replaced."
-    exit 0
-fi
+if ! grep -q '^rpi3bplus_rpi4_wifi_firmware:\s\+os\b' /etc/iiab/local_vars.yml ; then
+    if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin ; then
+	mv /lib/firmware/brcm/brcmfmac43455-sdio.bin /lib/firmware/brcm/brcmfmac43455-sdio.bin.$DATE
+	ln -sf brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
+	echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.bin"
+	touch /tmp/.fw_replaced
+    fi
 
-echo -e "'wifi_hotspot_capacity_rpi_fix: True' presumed..."
-echo -e "...in /etc/iiab/local_vars.yml (or /opt/iiab/iiab/vars/default_vars.yml ?)\n"
-
-if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin ; then
-    mv /lib/firmware/brcm/brcmfmac43455-sdio.bin /lib/firmware/brcm/brcmfmac43455-sdio.bin.$DATE
-    ln -sf brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
-    echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.bin"
-    WARN=true
-fi
-
-if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob ; then
-    mv /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.$DATE
-    ln -sf brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
-    echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob"
-    WARN=true
-fi
-
-if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin ; then
-    mv /lib/firmware/brcm/brcmfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.bin.$DATE
-    ln -sf brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
-    echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.bin"
-    WARN=true
-fi
-
-if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob ; then
-    mv /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.$DATE
-    ln -sf brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
-    echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob"
-    WARN=true
-fi
-
-if $($WARN); then
-    echo -e "\n \e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
-    echo -e " \e[41;1mReboot is required to activate.\e[0m\n"
-    touch /.fw_replaced
-    #echo "rebooting..."
-    #reboot
-else
-    echo -e " WiFi Firmware check \e[42;1mPASSED\e[0m, per iiab/iiab#823."    # Or \e[92m for green on black
-    echo -e " (Assuming you've rebooted since it was replaced!)\n"
-    if [ -f /.fw_replaced ]; then
-        rm /.fw_replaced
+    if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob ; then
+	mv /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.$DATE
+	ln -sf brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
+	echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob"
+	touch /tmp/.fw_replaced
     fi
 fi
+
+if ! grep -q '^rpizerow_rpi3_wifi_firmware:\s\+os\b' /etc/iiab/local_vars.yml ; then
+    if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin ; then
+	mv /lib/firmware/brcm/brcmfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.bin.$DATE
+	ln -sf brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
+	echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.bin"
+	touch /tmp/.fw_replaced
+    fi
+
+    if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob ; then
+	mv /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.$DATE
+	ln -sf brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
+	echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob"
+	touch /tmp/.fw_replaced
+    fi
+fi
+
+bash < /etc/profile.d/iiab-firmware-warn.sh

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WARN=0
+WARN=false
 DATE=$(date +%F-%T)
 
 # 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
@@ -13,43 +13,41 @@ DATE=$(date +%F-%T)
 if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
     echo "'wifi_hotspot_capacity_rpi_fix: False' found in /etc/iiab/local_vars.yml"
     echo "...so WiFi firmware will NOT be checked or replaced."
-
     exit 0
 fi
 
 echo -e "'wifi_hotspot_capacity_rpi_fix: True' presumed..."
 echo -e "...in /etc/iiab/local_vars.yml (or /opt/iiab/iiab/vars/default_vars.yml ?)\n"
 
-if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin); then
+if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin ; then
     mv /lib/firmware/brcm/brcmfmac43455-sdio.bin /lib/firmware/brcm/brcmfmac43455-sdio.bin.$DATE
-    cp /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
-    echo "Replacing /lib/firmware/brcm/brcmfmac43455-sdio.bin"
-    WARN=1
+    ln -sf brcmfmac43455-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43455-sdio.bin
+    echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.bin"
+    WARN=true
 fi
 
-if ! $(diff -q /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob); then
+if ! cmp -s /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob ; then
     mv /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.$DATE
-    cp /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
-    echo "Replacing /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob"
-    WARN=1
+    ln -sf brcmfmac43455-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
+    echo "Replaced /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob"
+    WARN=true
 fi
 
-if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin); then
+if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin ; then
     mv /lib/firmware/brcm/brcmfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.bin.$DATE
-    cp /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
-    cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
-    echo "Replacing /lib/firmware/brcm/brcmfmac43430-sdio.bin"
-    WARN=1
+    ln -sf brcmfmac43430-sdio.bin.iiab /lib/firmware/brcm/brcmfmac43430-sdio.bin
+    echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.bin"
+    WARN=true
 fi
 
-if ! $(diff -q /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob); then
+if ! cmp -s /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob ; then
     mv /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.$DATE
-    cp /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
-    echo "Replacing /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob"
-    WARN=1
+    ln -sf brcmfmac43430-sdio.clm_blob.iiab /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
+    echo "Replaced /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob"
+    WARN=true
 fi
 
-if [ "$WARN" = "1" ]; then
+if $($WARN); then
     echo -e "\n \e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
     echo -e " \e[41;1mReboot is required to activate.\e[0m\n"
     touch /.fw_replaced
@@ -62,5 +60,3 @@ else
         rm /.fw_replaced
     fi
 fi
-
-# exit 0

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ -f /tmp/.fw_replaced ]; then
-    echo -e "\n\e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
-    echo -e "\e[41;1mReboot is required to activate.\e[0m"
+if [ -f /tmp/.fw_modified ]; then
+    echo -e "\n\e[41;1mWiFi Firmware link(s) modified, per iiab/iiab#2853: PLEASE REBOOT!\e[0m"
     echo
-    echo -e "\e[100;1mIf you want these warnings to stop, run:\e[0m"
-    echo -e "\e[100;1msudo rm /tmp/.fw_replaced\e[0m\n"
+    echo -e "If you want these warnings to stop, run: sudo rm /tmp/.fw_modified\n"
 fi
+
+# \e[1m = bright white    \e[100;1m = bright white, on gray    \n\e[41;1m = bright white, on red

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-if [ -f /.fw_replaced ]; then
-    echo -e "\n \e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
-    if grep -q '^wifi_hotspot_capacity_rpi_fix:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
-        echo -e " \e[100;1mIf you want these warnings to stop, run:\e[0m"
-        echo
-        echo -e " \e[100;1msudo rm /.fw_replaced\e[0m\n"
-    else
-        echo -e " \e[41;1mReboot is required to activate.\e[0m\n"
-    fi
+if [ -f /tmp/.fw_replaced ]; then
+    echo -e "\n\e[41;1mWiFi Firmware has been replaced, per iiab/iiab#823.\e[0m"
+    echo -e "\e[41;1mReboot is required to activate.\e[0m"
+    echo
+    echo -e "\e[100;1mIf you want these warnings to stop, run:\e[0m"
+    echo -e "\e[100;1msudo rm /tmp/.fw_replaced\e[0m\n"
 fi

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -47,15 +47,15 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: "KA Lite"
-  - option: description
-    value: '"KA Lite downloads Khan Academy videos for offline use, with exercises and accounts if students want to track their own progress."'
-  - option: kalite_install
-    value: "{{ kalite_install }}"
-  - option: kalite_enabled
-    value: "{{ kalite_enabled }}"
-  - option: path
-    value: "{{ kalite_root }}"
-  - option: port
-    value: "{{ kalite_server_port }}"
+    - option: name
+      value: "KA Lite"
+    - option: description
+      value: '"KA Lite downloads Khan Academy videos for offline use, with exercises and accounts if students want to track their own progress."'
+    - option: kalite_install
+      value: "{{ kalite_install }}"
+    - option: kalite_enabled
+      value: "{{ kalite_enabled }}"
+    - option: path
+      value: "{{ kalite_root }}"
+    - option: port
+      value: "{{ kalite_server_port }}"

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -34,23 +34,23 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: Kiwix
-  - option: description
-    value: '"Part of https://github.com/kiwix/kiwix-tools/ -- kiwix-serve is the most used web server for ZIM files."'
-  - option: kiwix_install
-    value: "{{ kiwix_install }}"
-  - option: kiwix_enabled
-    value: "{{ kiwix_enabled }}"
-  - option: kiwix_url
-    value: "{{ kiwix_url }}"
-  - option: kiwix_url_plus_slash
-    value: "{{ kiwix_url_plus_slash }}"
-  - option: kiwix_path
-    value: "{{ kiwix_path }}"
-  - option: kiwix_port
-    value: "{{ kiwix_port }}"
-  - option: iiab_zim_path
-    value: "{{ iiab_zim_path }}"
-  - option: kiwix_library_xml
-    value: "{{ kiwix_library_xml }}"
+    - option: name
+      value: Kiwix
+    - option: description
+      value: '"Part of https://github.com/kiwix/kiwix-tools/ -- kiwix-serve is the most used web server for ZIM files."'
+    - option: kiwix_install
+      value: "{{ kiwix_install }}"
+    - option: kiwix_enabled
+      value: "{{ kiwix_enabled }}"
+    - option: kiwix_url
+      value: "{{ kiwix_url }}"
+    - option: kiwix_url_plus_slash
+      value: "{{ kiwix_url_plus_slash }}"
+    - option: kiwix_path
+      value: "{{ kiwix_path }}"
+    - option: kiwix_port
+      value: "{{ kiwix_port }}"
+    - option: iiab_zim_path
+      value: "{{ iiab_zim_path }}"
+    - option: kiwix_library_xml
+      value: "{{ kiwix_library_xml }}"

--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -158,17 +158,17 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: iiab_wan_enabled
-    value: "{{ iiab_wan_enabled }}"
-  - option: user_wan_iface
-    value: "{{ user_wan_iface }}"
-  - option: iiab_wan_iface
-    value: "{{ iiab_wan_iface }}"
-  - option: iiab_lan_enabled
-    value: "{{ iiab_lan_enabled }}"
-  - option: user_lan_iface
-    value: "{{ user_lan_iface }}"
-  - option: iiab_lan_iface
-    value: "{{ iiab_lan_iface }}"
-  - option: iiab_network_mode
-    value: "{{ iiab_network_mode }}"
+    - option: iiab_wan_enabled
+      value: "{{ iiab_wan_enabled }}"
+    - option: user_wan_iface
+      value: "{{ user_wan_iface }}"
+    - option: iiab_wan_iface
+      value: "{{ iiab_wan_iface }}"
+    - option: iiab_lan_enabled
+      value: "{{ iiab_lan_enabled }}"
+    - option: user_lan_iface
+      value: "{{ user_lan_iface }}"
+    - option: iiab_lan_iface
+      value: "{{ iiab_lan_iface }}"
+    - option: iiab_network_mode
+      value: "{{ iiab_network_mode }}"

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -228,38 +228,38 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: has_ifcfg_gw
-    value: "{{ has_ifcfg_gw }}"
-  - option: prior_gateway_device
-    value: "{{ prior_gw_device }}"
-  - option: dhcpcd_result
-    value: "{{ dhcpcd_result }}"
-  - option: network_manager_active
-    value: "{{ network_manager_active }}"
-  - option: systemd_networkd_active
-    value: "{{ systemd_networkd_active }}"
-  - option: wan_in_interfaces
-    value: "{{ wan_in_interfaces }}"
-  - option: wireless_list_1(wifi1)
-    value: "{{ wifi1 }}"
-  - option: wireless_list_2(wifi2)
-    value: "{{ wifi2 }}"
-  - option: num_wifi_interfaces
-    value: "{{ num_wifi_interfaces }}"
-  - option: discovered_wireless_iface
-    value: "{{ discovered_wireless_iface }}"
-  - option: discovered_wired_iface
-    value: "{{ discovered_wired_iface }}"
-  - option: 'exclude_devices'
-    value: "{{ exclude_devices }}"
-  - option: num_lan_interfaces
-    value: "{{ num_lan_interfaces }}"
-  - option: gui_static_wan
-    value: "{{ gui_static_wan }}"
-  - option: iiab_lan_iface
-    value: "{{ iiab_lan_iface }}"
-  - option: iiab_wan_iface
-    value: "{{ iiab_wan_iface }}"
+    - option: has_ifcfg_gw
+      value: "{{ has_ifcfg_gw }}"
+    - option: prior_gateway_device
+      value: "{{ prior_gw_device }}"
+    - option: dhcpcd_result
+      value: "{{ dhcpcd_result }}"
+    - option: network_manager_active
+      value: "{{ network_manager_active }}"
+    - option: systemd_networkd_active
+      value: "{{ systemd_networkd_active }}"
+    - option: wan_in_interfaces
+      value: "{{ wan_in_interfaces }}"
+    - option: wireless_list_1(wifi1)
+      value: "{{ wifi1 }}"
+    - option: wireless_list_2(wifi2)
+      value: "{{ wifi2 }}"
+    - option: num_wifi_interfaces
+      value: "{{ num_wifi_interfaces }}"
+    - option: discovered_wireless_iface
+      value: "{{ discovered_wireless_iface }}"
+    - option: discovered_wired_iface
+      value: "{{ discovered_wired_iface }}"
+    - option: 'exclude_devices'
+      value: "{{ exclude_devices }}"
+    - option: num_lan_interfaces
+      value: "{{ num_lan_interfaces }}"
+    - option: gui_static_wan
+      value: "{{ gui_static_wan }}"
+    - option: iiab_lan_iface
+      value: "{{ iiab_lan_iface }}"
+    - option: iiab_wan_iface
+      value: "{{ iiab_wan_iface }}"
 
 # well if there ever was a point to tell the user things are FUBAR this is it.
 # limit 2 network adapters wifi wired

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -36,7 +36,7 @@ IPTABLES_DATA=/etc/sysconfig/iptables
 
 # 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
-# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L13
+# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
 # https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -56,21 +56,21 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: OpenVPN
-  - option: description
-    value: '"OpenVPN enables live/remote support by connecting machines anywhere on the Internet, via a middleman server, using Virtual Private Network (VPN) techniques to create secure connections."'
-  - option: openvpn_install
-    value: "{{ openvpn_install }}"
-  - option: openvpn_enabled
-    value: "{{ openvpn_enabled }}"
-  - option: openvpn_handle
-    value: "{{ openvpn_handle }}"
-  - option: openvpn_cron_enabled
-    value: "{{ openvpn_cron_enabled }}"
-  - option: openvpn_server
-    value: "{{ openvpn_server }}"
-  - option: openvpn_server_virtual_ip
-    value: "{{ openvpn_server_virtual_ip }}"
-  - option: openvpn_server_port
-    value: "{{ openvpn_server_port }}"
+    - option: name
+      value: OpenVPN
+    - option: description
+      value: '"OpenVPN enables live/remote support by connecting machines anywhere on the Internet, via a middleman server, using Virtual Private Network (VPN) techniques to create secure connections."'
+    - option: openvpn_install
+      value: "{{ openvpn_install }}"
+    - option: openvpn_enabled
+      value: "{{ openvpn_enabled }}"
+    - option: openvpn_handle
+      value: "{{ openvpn_handle }}"
+    - option: openvpn_cron_enabled
+      value: "{{ openvpn_cron_enabled }}"
+    - option: openvpn_server
+      value: "{{ openvpn_server }}"
+    - option: openvpn_server_virtual_ip
+      value: "{{ openvpn_server_virtual_ip }}"
+    - option: openvpn_server_port
+      value: "{{ openvpn_server_port }}"

--- a/roles/openvpn/templates/iiab-support
+++ b/roles/openvpn/templates/iiab-support
@@ -12,7 +12,7 @@ INVENTORY="ansible_hosts"
 
 # 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
-# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L13
+# https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
 # https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN

--- a/roles/remoteit/tasks/main.yml
+++ b/roles/remoteit/tasks/main.yml
@@ -26,11 +26,11 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: remote.it
-  - option: description
-    value: '"https://remote.it can help you remotely maintain an IIAB.  Some benefits include: crossing multiple NATs/firewalls using a single TCP port, without requiring router port forwarding, and reducing your network''s vulnerability."'
-  - option: remoteit_install
-    value: "{{ remoteit_install }}"
-  - option: remoteit_enabled
-    value: "{{ remoteit_enabled }}"
+    - option: name
+      value: remote.it
+    - option: description
+      value: '"https://remote.it can help you remotely maintain an IIAB.  Some benefits include: crossing multiple NATs/firewalls using a single TCP port, without requiring router port forwarding, and reducing your network''s vulnerability."'
+    - option: remoteit_install
+      value: "{{ remoteit_install }}"
+    - option: remoteit_enabled
+      value: "{{ remoteit_enabled }}"

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -34,13 +34,13 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-  - option: name
-    value: sshd
-  - option: description
-    value: '"Secure Shell daemon (typically implemented by openssh-server) for remote login using the ''ssh'' low-level protocol."'
-  - option: sshd_install
-    value: "{{ sshd_install }}"
-  - option: sshd_enabled
-    value: "{{ sshd_enabled }}"
-  - option: sshd_port
-    value: "{{ sshd_port }}"
+    - option: name
+      value: sshd
+    - option: description
+      value: '"Secure Shell daemon (typically implemented by openssh-server) for remote login using the ''ssh'' low-level protocol."'
+    - option: sshd_install
+      value: "{{ sshd_install }}"
+    - option: sshd_enabled
+      value: "{{ sshd_enabled }}"
+    - option: sshd_port
+      value: "{{ sshd_port }}"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -128,10 +128,10 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 #
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
-# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+# internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
-rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+#rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -111,14 +111,29 @@ host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
-hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
+hostapd_secure: False    # 2021-03-02 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
 hostapd_install: True    # 2020-01-21: this var MIGHT be implemented in future.
 hostapd_enabled: True
-wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
-# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
-wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
+
+# Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
+# internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
+# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+#
+#rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
+#rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
+#rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
+#
+# BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+#
+# Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
+# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+#
+#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+
+wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -1,7 +1,7 @@
 # This is local_vars_large.yml -- copy it to /etc/iiab/local_vars.yml then...
 # modify variables below, to override /opt/iiab/iiab/vars/default_vars.yml
 
-# PLZ READ http://wiki.laptop.org/go/IIAB/local_vars.yml AND http://FAQ.IIAB.IO
+# READ "What is local_vars.yml and how do I customize it?" AT http://FAQ.IIAB.IO
 # Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # IIAB does NOT currently support uninstalling apps!  So: if any IIAB app is
@@ -54,17 +54,32 @@ iiab_domain: lan
 # YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
 # CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
 #
-# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires WiFi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
-hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
-wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
-# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
-wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
+hostapd_secure: False    # 2021-03-02 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
+
+# Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
+# internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
+# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+#
+#rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
+#rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
+#rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
+#
+# BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+#
+# Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
+# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+#
+#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+
+wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -74,10 +74,10 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 #
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
-# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+# internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
-rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+#rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -1,7 +1,7 @@
 # This is local_vars_medium.yml -- copy it to /etc/iiab/local_vars.yml then...
 # modify variables below, to override /opt/iiab/iiab/vars/default_vars.yml
 
-# PLZ READ http://wiki.laptop.org/go/IIAB/local_vars.yml AND http://FAQ.IIAB.IO
+# READ "What is local_vars.yml and how do I customize it?" AT http://FAQ.IIAB.IO
 # Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # IIAB does NOT currently support uninstalling apps!  So: if any IIAB app is
@@ -54,17 +54,32 @@ iiab_domain: lan
 # YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
 # CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
 #
-# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires WiFi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
-hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
-wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
-# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
-wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
+hostapd_secure: False    # 2021-03-02 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
+
+# Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
+# internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
+# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+#
+#rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
+#rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
+#rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
+#
+# BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+#
+# Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
+# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+#
+#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+
+wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -74,10 +74,10 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 #
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
-# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+# internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
-rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+#rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -1,7 +1,7 @@
 # This is local_vars_small.yml -- copy it to /etc/iiab/local_vars.yml then...
 # modify variables below, to override /opt/iiab/iiab/vars/default_vars.yml
 
-# PLZ READ http://wiki.laptop.org/go/IIAB/local_vars.yml AND http://FAQ.IIAB.IO
+# READ "What is local_vars.yml and how do I customize it?" AT http://FAQ.IIAB.IO
 # Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # IIAB does NOT currently support uninstalling apps!  So: if any IIAB app is
@@ -54,17 +54,32 @@ iiab_domain: lan
 # YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
 # CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
 #
-# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires WiFi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: Internet in a Box
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
-hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
-wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
-# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
-wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
+hostapd_secure: False    # 2021-03-02 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
+
+# Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
+# internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
+# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+#
+#rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
+#rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
+#rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
+#
+# BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+#
+# Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
+# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+#
+#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+
+wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -74,10 +74,10 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 #
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
-# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+# internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
-rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+#rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -1,7 +1,7 @@
 # This is local_vars_unittest.yml -- copy it to /etc/iiab/local_vars.yml then...
 # modify variables below, to override /opt/iiab/iiab/vars/default_vars.yml
 
-# PLZ READ http://wiki.laptop.org/go/IIAB/local_vars.yml AND http://FAQ.IIAB.IO
+# READ "What is local_vars.yml and how do I customize it?" AT http://FAQ.IIAB.IO
 # Orig Idea: branch github.com/xsce/xsce-local for your deployment/community
 
 # IIAB does NOT currently support uninstalling apps!  So: if any IIAB app is
@@ -54,17 +54,32 @@ iiab_domain: lan
 # YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM
 # CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
 #
-# Raspberry Pi OS requires Wi-Fi country since March 2018.  Please set it here:
+# Raspberry Pi OS requires WiFi country since March 2018.  Please set it here:
 host_country_code: US
 host_ssid: unittest
 host_wifi_mode: g
 host_channel: 6
-hostapd_secure: False # 2021-03-02 #2696 WiFi EAPOL fails if hotspot passwords,
-hostapd_password: changeme # eg if firmware wifi_hotspot_capacity_rpi_fix: True
-wifi_hotspot_capacity_rpi_fix: True    # Restores the ability of RPi internal
-# WiFi hotspots to service 30-to-32 client devices.  Background explanation:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and PR #2472.
-wifi_up_down: True    # Creates a 2nd virtual WiFi adapter for upstream WiFi
+hostapd_secure: False    # 2021-03-02 WiFi EAPOL fails if hotspot passwords,
+hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
+
+# Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
+# internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
+# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+#
+#rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
+#rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
+#rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
+#
+# BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+#
+# Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
+# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+#
+#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+
+wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).
 
 # Set True if client machines should have "passthrough" access to WAN/Internet:

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -74,10 +74,10 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # BACKGROUND: https://github.com/iiab/iiab/issues/823#issuecomment-662285202
 #
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
-# internal WiFi hotspot.  Or you can increase this to 30 student WiFi devices:
+# internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-#rpizerow_rpi3_wifi_firmware: os    # Use yr OS WiFi firmware e.g. 7.45.98.118
-rpizerow_rpi3_wifi_firmware: 30     # Or firmware 7.45.98.65 from 2018-09-28
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+#rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi
 # (e.g. to Internet) in addition to downstream WiFi (e.g. classroom hotspot).


### PR DESCRIPTION
Broad community testing will be useful here, on Raspberry Pi 3 B+ and 4's especially.

And also on Raspberry Pi Zero W's, Zero 2 W's and Raspberry Pi 3's.

This will be back-ported to the (intentionally not yet announced) IIAB Release 7.2 in coming days, when this fix + reworked explanations hopefully prove solid.

Refs:

- #823
- PR #2472
- #2820
- https://github.com/iiab/iiab/issues/2853#issuecomment-1004380083