### PR TITLE
"Power Off" button leads to big classroom problems, even when /library/www/html/home/menu.json contains: "allow_poweroff": false;

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -324,7 +324,7 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this True to enable http://box/common/services/power_off.php button:
+# Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -324,8 +324,8 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# Make this True to enable http://box/common/services/power_off.php button:
+apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -204,8 +204,8 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# Make this True to enable http://box/common/services/power_off.php button:
+apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -204,7 +204,7 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this True to enable http://box/common/services/power_off.php button:
+# Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)

--- a/vars/local_vars_medical.yml
+++ b/vars/local_vars_medical.yml
@@ -14,6 +14,7 @@ vnstat_install: True
 vnstat_enabled: True
 openvpn_handle: "MEDICAL - Put Your Name Here"
 usb_lib_umask0000_for_kolibri: False
+apache_allow_sudo: True
 # By default
 # kiwix
 # awstats

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -204,8 +204,8 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# Make this True to enable http://box/common/services/power_off.php button:
+apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -204,7 +204,7 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this True to enable http://box/common/services/power_off.php button:
+# Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -204,8 +204,8 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# Make this True to enable http://box/common/services/power_off.php button:
+apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -204,7 +204,7 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this True to enable http://box/common/services/power_off.php button:
+# Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -204,8 +204,8 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this False to disable http://box/common/services/power_off.php button:
-apache_allow_sudo: True
+# Make this True to enable http://box/common/services/power_off.php button:
+apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -204,7 +204,7 @@ nginx_high_php_limits: False
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L53-L133
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 
-# Make this True to enable http://box/common/services/power_off.php button:
+# Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)


### PR DESCRIPTION
This is an ongoing problem, year after year.

Apparently this longstanding issue results from partially loaded or cached versions (of an installed IIAB's home page) which reveal to students how they can effectively sabotage an entire classroom's use of IIAB — using the "Power Off" button shown below:

![IMG-20220114-WA0000~2](https://user-images.githubusercontent.com/2458907/149563621-5c8c950d-9753-4374-98a0-4dc89419fd06.jpg)

So this PR resolves default_vars.yml and local_vars files to do what most all schools want — put an end to these disruptive problems.

At the same time this precautionary default can easily be overridden — for family-sized IIAB installs if necessary, among a very tightknit group of people where routine sabotage is less of a risk, by setting `apache_allow_sudo: True` — or using local_vars_medical.yml to do exactly that, e.g. for a small clinic wanting the "Power Off" button available to all, to save energy when IIAB is not in use.