### PR TITLE
default_vars.yml: iiab_base_ver: 8.0 (PRE-)release version number

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -13,7 +13,7 @@
 
 
 # IIAB (PRE-)release version number, for {{ iiab_env_file }}
-iiab_base_ver: 7.2
+iiab_base_ver: 8.0
 iiab_revision: 0
 
 iiab_etc_path: /etc/iiab


### PR DESCRIPTION
Long overdue.  Onwards.