### PR TITLE
remoteit/defaults/main.yml: 4.13.6 -> 4.13.7

### DIFF
--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -6,7 +6,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-remoteit_version: 4.13.6
+# This should (generally) be the latest from https://remote.it/download/
+remoteit_version: 4.13.7
 
 # See https://docs.remote.it/device-package/installation to refine URL below:
 device_suffixes:

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -6,7 +6,12 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-# This should (generally) be the latest from https://remote.it/download/
+# This should (generally) be the latest from https://remote.it/download/ -- as
+# of Feb 2022 there are 4 such "Device Package" .deb files that may be useful:
+# - Debian Linux (ARM64)
+# - Debian Linux (x86_64)
+# - Pi OS (ARM)
+# - Pi OS (ARM64)
 remoteit_version: 4.13.7
 
 # See https://docs.remote.it/device-package/installation to refine URL below:


### PR DESCRIPTION
Per the latest at https://remote.it/download/

We should try to find the changelog within https://github.com/remoteit if it exists...