### PR TITLE
Use 'raspi-config --expand-rootfs' in 1-prep/templates/iiab-rpi-max-rootfs.sh (for external USB disks, that also need their filesystem expanded)

### DIFF
--- a/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
+++ b/roles/1-prep/templates/iiab-rpi-max-rootfs.sh
@@ -1,20 +1,32 @@
 #!/bin/bash -x
-# Resize rootfs and its partition on the rpi SD card to maximum size
-# To be used by systemd service on boot
-# Only resizes if /.resize-rootfs exists
-# Assumes root is last partition
-# Only works on F22 + where resizepart command exists
-# Assumes sd card style partition name like <device>p<partition number>
 
-if [  -f /.resize-rootfs ];then
-  echo "$0: maximizing rootfs partion"
-  # Calculate root partition
-  root_part=`lsblk -aP -o NAME,MOUNTPOINT|grep  'MOUNTPOINT="/"' |awk -F\" '{ print $2 }'`
-  root_dev=${root_part:0:-2}
-  root_part_no=${root_part: (-1)}
+# Resize rootfs and its partition on the rpi SD card (or external USB
+# disk if possible, e.g. with Raspberry Pi OS) to maximum size.
 
-  # Resize partition
-  growpart /dev/$root_dev $root_part_no
-  resize2fs /dev/$root_part
-  rm /.resize-rootfs
+# To be used by /etc/systemd/system/iiab-rpi-root-resize.service on boot.
+# Only resizes if /.resize-rootfs exists.
+# Assumes root is last partition.
+
+if [ -f /.resize-rootfs ]; then
+    echo "$0: maximizing rootfs partion"
+
+    if [ -x /usr/bin/raspi-config ]; then
+        # 2022-02-17: Works in many more situations, e.g. with USB disks (not
+        # just microSD cards).  IF ONLY THIS ALSO WORKED ON Ubuntu/Mint/etc !
+        raspi-config --expand-rootfs
+    else
+        # Assumes sd card style partition name like <device>p<partition number>
+        # Only works on F22 + where resizepart command exists
+
+        # Calculate root partition
+        root_part=`lsblk -aP -o NAME,MOUNTPOINT | grep  'MOUNTPOINT="/"' | awk -F\" '{ print $2 }'`
+        root_dev=${root_part:0:-2}
+        root_part_no=${root_part: (-1)}
+
+        # Resize partition
+        growpart /dev/$root_dev $root_part_no
+        resize2fs /dev/$root_part
+    fi
+
+    rm /.resize-rootfs
 fi


### PR DESCRIPTION
Background: `/etc/systemd/system/iiab-rpi-root-resize.service` invokes `/usr/sbin/iiab-rpi-max-rootfs.sh` on boot, which tries to expand IIAB's root filesystem if the file `/.resize-roofs` exsits.

The shortcoming of `/usr/sbin/iiab-rpi-max-rootfs.sh` to date, is that until now it assumed... 

```
# Assumes sd card style partition name like <device>p<partition number>
# Only works on F22 + where resizepart command exists
```

So with this PR, external IIAB boot disks/devices are now possible, at least in the case where Raspberry Pi OS is being used (or any OS that makes available the command `/usb/bin/raspi-config --expand-rootfs` !)

Further improvement to make this work on other OS's would be great in future &mdash; e.g. on Ubuntu, Mint and Debian?

In any case, this PR was tested and confirmed to work with 32-bit Raspberry Pi OS Lite on RPi 4, using an external USB disk.