### PR TITLE
Allow manual removal of /library/calibre-web/config/app.db for easier resetting of Calibre-Web app settings (without damaging your e-book collection metadata in /library/calibre-web/metadata.db !)

### DIFF
--- a/roles/calibre-web/README.rst
+++ b/roles/calibre-web/README.rst
@@ -90,9 +90,9 @@ Internet-in-a-Box (IIAB) is online.
 
 But first: back up your content **and** settings, as explained above.
 
-**Also move your /library/calibre-web/config/app.db and
+**Also move your /library/calibre-web/config/app.db AND/OR
 /library/calibre-web/metadata.db out of the way — if you're sure to want to
-fully reset your Calibre-Web settings (to install defaults) and remove all
+fully reset your Calibre-Web settings (to install defaults) AND/OR remove all
 e-book metadata!  Then run**::
 
   cd /opt/iiab/iiab

--- a/roles/calibre-web/README.rst
+++ b/roles/calibre-web/README.rst
@@ -91,7 +91,7 @@ Internet-in-a-Box (IIAB) is online.
 But first: back up your content **and** settings, as explained above.
 
 **Also move your /library/calibre-web/config/app.db AND/OR
-/library/calibre-web/metadata.db out of the way — if you're sure to want to
+/library/calibre-web/metadata.db out of the way — if you're sure you want to
 fully reset your Calibre-Web settings (to install defaults) AND/OR remove all
 e-book metadata!  Then run**::
 

--- a/roles/calibre-web/README.rst
+++ b/roles/calibre-web/README.rst
@@ -96,7 +96,7 @@ fully reset your Calibre-Web settings (to install defaults) AND/OR remove all
 e-book metadata!  Then run**::
 
   cd /opt/iiab/iiab
-  ./runrole calibre-web --reinstall
+  ./runrole --reinstall calibre-web
 
 Or, if you just want to upgrade Calibre-Web code alone, prior to proceeding
 manually::

--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -19,18 +19,19 @@ calibreweb_version: master    # WAS: master, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 0.6.8, 
 calibreweb_venv_path: /usr/local/calibre-web-py3
 calibreweb_exec_path: "{{ calibreweb_venv_path }}/cps.py"
 
-# Config files put in:
+# Config files (in reality just app.db) put in:
 calibreweb_config: "{{ calibreweb_home }}/config"
 
-# Calibre-Web will be provisioned with default administrative account,
-# metadata.db and language if /library/calibre-web/metadata.db does not exist.
-# NOT CURRENTLY IN USE: calibreweb_provision: True
-calibreweb_settings_database: app.db
-calibreweb_database: metadata.db
+# 2022-03-07: Calibre-Web will be reset to default settings if (re)installed
+# when /library/calibre-web/config/app.db doesn't exist:
+calibreweb_settings_database: app.db    # /library/calibre-web/config/app.db
+
+# UNUSED var as of 2022-03-07:
+# calibreweb_database: metadata.db    # /library/calibre-web/metadata.db
 
 # Files owned by:
 calibreweb_user: root
 
-# UNUSED variables, as of March 2019:
+# UNUSED vars, as of March 2019:
 # calibreweb_admin_user: Admin
 # calibreweb_admin_password: changeme

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -19,7 +19,6 @@
     path: "{{ item }}"
     owner: "{{ calibreweb_user }}"    # root
     group: "{{ apache_user }}"        # www-data on debuntu
-    #mode: '0755'
   with_items:
     - "{{ calibreweb_home }}"         # /library/calibre-web
     - "{{ calibreweb_config }}"       # /library/calibre-web/config
@@ -32,7 +31,7 @@
     dest: "{{ calibreweb_venv_path }}"
     force: yes
     depth: 1
-    version: "{{ calibreweb_version }}"    # e.g. master, 0.6.5
+    version: "{{ calibreweb_version }}"    # e.g. master, 0.6.17
 
 ## Ansible Pip Bug: Cannot use 'chdir' with 'env' https://github.com/ansible/ansible/issues/37912 (Patch landed)
 #- name: Download calibre-web dependencies into vendor subdirectory.
@@ -66,24 +65,25 @@
     dest: "{{ calibreweb_home }}"     # /library/calibre-web
     owner: "{{ calibreweb_user }}"    # root
     group: "{{ apache_user }}"        # www-data on debuntu
-    #mode: '0644'
     backup: yes
   with_items:
     - roles/calibre-web/files/metadata.db
     - roles/calibre-web/files/metadata_db_prefs_backup.json
   when: not metadatadb.stat.exists
-  #when: calibreweb_provision
 
-- name: Provision/Copy default admin settings to {{ calibreweb_config }}/app.db IF metadata.db did not exist
+- name: Does /library/calibre-web/config/app.db exist?
+  stat:
+    path: /library/calibre-web/config/app.db
+  register: appdb
+
+- name: Provision/Copy default admin settings to {{ calibreweb_config }}/app.db IF it did not exist
   copy:
     src: roles/calibre-web/files/app.db
     dest: "{{ calibreweb_config }}"    # /library/calibre-web/config
     owner: "{{ calibreweb_user }}"     # root
     group: "{{ apache_user }}"         # www-data on debuntu
-    #mode: '0644'
     backup: yes
-  when: not metadatadb.stat.exists
-  #when: calibreweb_provision
+  when: not appdb.stat.exists
 
 
 # RECORD Calibre-Web AS INSTALLED

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -70,5 +70,5 @@
       value: "{{ calibreweb_home }}"
     - option: calibreweb_port
       value: "{{ calibreweb_port }}"
-    - option: calibreweb_database
-      value: "{{ calibreweb_database }}"
+    - option: calibreweb_settings_database
+      value: "{{ calibreweb_settings_database }}"


### PR DESCRIPTION
To complete this resetting of Calibre-Web settings, (1) delete or move your pre-existing `/library/calibre-web/config/app.db` aside (2) then proceed as follows:

```
cd /opt/iiab/iiab
sudo ./runrole --reinstall calibre-web
```