### PR TITLE
vars/local_vars_large.yml: Don't install Lokole due to #3132

### DIFF
--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -232,8 +232,8 @@ jupyterhub_install: True
 jupyterhub_enabled: True
 
 # Lokole (email for rural communities) from https://ascoderu.ca
-lokole_install: True
-lokole_enabled: True
+lokole_install: False    # 2022-03-13: Needs work with Python 3.9+
+lokole_enabled: False    # https://github.com/iiab/iiab/issues/3132
 
 # Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: True


### PR DESCRIPTION
Hopefully this is just a temporary measure.

Until a Python developer is found to help @nzola work this out.

Background:

- #2833
- #2986 
- #3047
- #3132