### PR TITLE
kiwix-tools 3.2.0-2: kiwix-serve security fix

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,9 +26,9 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-3.2.0-1
-kiwix_version_linux64: kiwix-tools_linux-x86_64-3.2.0-1
-kiwix_version_i686: kiwix-tools_linux-i586-3.2.0-1
+kiwix_version_armhf: kiwix-tools_linux-armhf-3.2.0-2
+kiwix_version_linux64: kiwix-tools_linux-x86_64-3.2.0-2
+kiwix_version_i686: kiwix-tools_linux-i586-3.2.0-2
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")


### PR DESCRIPTION
As released today at:

https://download.kiwix.org/release/kiwix-tools/

Building on:

- PR #3115