### PR TITLE
usb_lib/tasks/install.yml: 'apt install usbmount_0.0.22_all.deb' on Ubuntu too

### DIFF
--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -35,7 +35,7 @@
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
 # http://raspbian.raspberrypi.org/raspbian/pool/main/u/usbmount/usbmount_0.0.22_all.deb
-- name: Install {{ iiab_download_url }}/usbmount_0.0.22_all.deb, no longer supported by {RasPiOS,Debian, Ubuntu}
+- name: Install {{ iiab_download_url }}/usbmount_0.0.22_all.deb, no longer supported by {RasPiOS, Debian, Ubuntu}
   apt:
     deb: "{{ iiab_download_url }}/usbmount_0.0.22_all.deb"
   # when: is_debian

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -34,18 +34,18 @@
     state: restarted
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
-#http://raspbian.raspberrypi.org/raspbian/pool/main/u/usbmount/usbmount_0.0.22_all.deb
-- name: Install {{ iiab_download_url }}/usbmount_0.0.22_all.deb, missing from Debian
+# http://raspbian.raspberrypi.org/raspbian/pool/main/u/usbmount/usbmount_0.0.22_all.deb
+- name: Install {{ iiab_download_url }}/usbmount_0.0.22_all.deb, no longer supported by {RasPiOS,Debian, Ubuntu}
   apt:
     deb: "{{ iiab_download_url }}/usbmount_0.0.22_all.deb"
-  when: is_debian
+  # when: is_debian
 
 # check status of usbmount on mintlinux - should be ok Ubuntu variant
-- name: Install usbmount from OS repo for Ubuntu variants
-  package:
-    name: usbmount
-    state: present
-  when: is_ubuntu
+# - name: Install usbmount from OS repo for Ubuntu variants
+#   package:
+#     name: usbmount
+#     state: present
+#   when: is_ubuntu
 
 - name: Add dir {{ doc_root }}/local_content, where USB drive links can appear (0775)
   file:


### PR DESCRIPTION
Lifesaver workaround as suggested by @jvonau, which should hopefully preserve USB functionality[*] like http://box/usb (etc) on Ubuntu 22.04+ &mdash; i.e. for a few more years?

[*] Using the old usbmount apt package, from http://raspbian.raspberrypi.org/raspbian/pool/main/u/usbmount/usbmount_0.0.22_all.deb

Resolves:

- #3126
