### PR TITLE
Always install the latest remote.it Device Package (instead of hard-coding a new version# every 1-2 months!)

### DIFF
--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -6,15 +6,14 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-# This should (generally) be the latest from https://remote.it/download/ -- as
-# of Feb 2022 there are 4 such "Device Package" .deb files that may be useful:
-# - Debian Linux (ARM64)
-# - Debian Linux (x86_64)
-# - Pi OS (ARM)
-# - Pi OS (ARM64)
-remoteit_version: 4.14.1
 
-# See https://docs.remote.it/device-package/installation to refine URL below:
+# 2022-03-31: https://remote.it/download/ offers 4 relevant "Device Packages"
+# 1) Raspberry Pi (ARM)    = armhf.rpi
+# 2) Raspberry Pi (ARM64)  = arm64.rpi
+# 3) Debian Linux (ARM64)  = arm64
+# 4) Debian Linux (x86_64) = amd64
+
+# See https://docs.remote.it/software/device-package/installation to refine URL below:
 device_suffixes:
   armv6: armhf.rpi
   armv6l: armhf.rpi
@@ -24,11 +23,22 @@ device_suffixes:
   aarch64: arm64
   x86_64: amd64
 remoteit_device_suffix: "{{ device_suffixes[ansible_architecture] | default('unknown') }}"
-remoteit_deb: remoteit-{{ remoteit_version }}.{{ remoteit_device_suffix }}.deb
-remoteit_device_url: https://downloads.remote.it/remoteit/v{{ remoteit_version }}/{{ remoteit_deb }}
-# Example...         https://downloads.remote.it/remoteit/v4.13.5/remoteit-4.13.5.armhf.rpi.deb
+remoteit_device_url: https://downloads.remote.it/remoteit/latest/remoteit.{{ remoteit_device_suffix }}.deb
 
-# See https://docs.remote.it/cli/overview to refine URL below:
+# 2022-03-31: Use "latest" above, instead of ever-changing version below
+# remoteit_version: 4.14.1
+# remoteit_deb: remoteit-{{ remoteit_version }}.{{ remoteit_device_suffix }}.deb
+# remoteit_device_url: https://downloads.remote.it/remoteit/v{{ remoteit_version }}/{{ remoteit_deb }}
+# # Example...         https://downloads.remote.it/remoteit/v4.14.1/remoteit-4.14.1.armhf.rpi.deb
+
+
+# 2022-03-31: https://remote.it/download/ offers 4 relevant "CLI" installs:
+# 1) Debian Linux (ARM v6) OR Raspberry Pi (ARM)   = armv6
+# 2) Debian Linux (ARM v7)                         = armv7
+# 3) Debian Linux (ARM64)  OR Raspberry Pi (ARM64) = arm64
+# 4) Debian Linux (x86_64)                         = x86_64
+
+# See https://docs.remote.it/software/cli/overview to refine URL below:
 cli_suffixes:
   armv6: armv6
   armv6l: armv6
@@ -36,7 +46,6 @@ cli_suffixes:
   armv7l: armv7
   armv8: arm64
   aarch64: arm64
-  x86_64: amd64
+  x86_64: x86_64
 remoteit_cli_suffix: "{{ cli_suffixes[ansible_architecture] | default('unknown') }}"
 remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_cli_suffix }}
-# Example...      https://downloads.remote.it/cli/latest/remoteit_linux_armv7

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -1,30 +1,33 @@
 - name: Fail if architecture remoteit_device_suffix == "unknown"
   fail:
-    msg: "Could not find a remote.it device apt package for CPU architecture \"{{ ansible_architecture }}\""
+    msg: "Could not find a remote.it Device Package (.deb) for CPU architecture \"{{ ansible_architecture }}\""
   when: remoteit_device_suffix == "unknown"
 
-- name: mkdir {{ downloads_dir }}    # As roles/2-common/tasks/fl.yml has not run yet
-  file:
-    path: "{{ downloads_dir }}"    # /opt/iiab/downloads
-    state: directory
+# - name: mkdir {{ downloads_dir }}    # As roles/2-common/tasks/fl.yml has not run yet
+#   file:
+#     path: "{{ downloads_dir }}"    # /opt/iiab/downloads
+#     state: directory
 
-- name: Download {{ remoteit_device_url }} (device) for arch {{ remoteit_device_suffix }} into {{ downloads_dir }}/
-  get_url:
-    url: "{{ remoteit_device_url }}"
-    dest: "{{ downloads_dir }}/"
-    force: yes
-    timeout: "{{ download_timeout }}"
+# - name: Download {{ remoteit_device_url }} (Device Package) for arch {{ remoteit_device_suffix }} into {{ downloads_dir }}/
+#   get_url:
+#     url: "{{ remoteit_device_url }}"
+#     dest: "{{ downloads_dir }}/"
+#     force: yes
+#     timeout: "{{ download_timeout }}"
 
-- name: Uninstall previously installed 'remoteit*' device apt package(s)
+- name: Uninstall previously installed 'remoteit*' Device Package(s)
   apt:
     name: remoteit*
     state: absent
   ignore_errors: yes
 
-- name: Install device apt package {{ downloads_dir }}/{{ remoteit_deb }}
+# - name: "Install Device Package: {{ downloads_dir }}/{{ remoteit_deb }}"
+#   apt:
+#     deb: "{{ downloads_dir }}/{{ remoteit_deb }}"
+
+- name: "Install Device Package: {{ remoteit_device_url }}"
   apt:
-    deb: "{{ downloads_dir }}/{{ remoteit_deb }}"
-    state: present
+    deb: "{{ remoteit_device_url }}"
 
 
 - name: Fail if architecture remoteit_cli_suffix == "unknown"
@@ -32,7 +35,7 @@
     msg: "Could not find a remote.it CLI binary for CPU architecture \"{{ ansible_architecture }}\""
   when: remoteit_cli_suffix == "unknown"
 
-- name: Download {{ remoteit_cli_url }} (CLI) for arch {{ remoteit_cli_suffix }} to /usr/bin/remoteit (755)
+- name: Download OPTIONAL {{ remoteit_cli_url }} (CLI) to /usr/bin/remoteit (755)
   get_url:
     url: "{{ remoteit_cli_url }}"
     dest: /usr/bin/remoteit
@@ -41,7 +44,7 @@
     timeout: "{{ download_timeout }}"
 
 
-# RECORD remoteit AS INSTALLED
+# RECORD remote.it AS INSTALLED
 
 - name: "Set 'remoteit_installed: True'"
   set_fact:


### PR DESCRIPTION
This PR also:

- Fixes a longstanding bug with the CPU arch specified incorrectly for remote.it's CLI package &mdash; whose filename in fact requires `x86_64` instead of `amd64`.
- Better documents what's happening in {remoteit/defaults/main.yml, remoteit/tasks/install.yml}

Tested on 64-bit RasPiOS Lite on RPi 4.  Testing is ongoing on an Ubuntu Desktop 22.04 VM.

Building on:

- #3006
- PR #3116
- PR #3128
- PR #3154