### PR TITLE
New command /usr/bin/iiab-remoteit to quickly obtain a new Claim Code for https://remote.it (allows remote connections to manage an IIAB)

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -8,16 +8,26 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 ## Getting Started
 
-### Create a remote.it account + consider its desktop application
+### Create a remote.it account + install its desktop application
 
 1. Browse to [https://remote.it](https://remote.it) (Web Portal) and sign up for an account.
 
-2. Download the [remote.it desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) to your own laptop/computer &mdash; if you prefer this over the https://remote.it Web Portal and its [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages).
+2. Download and install the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes possible, but less functional.
 
    COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
-### Install remote.it onto an IIAB + register it + authorize services/ports
+<!-- ### Install remote.it onto an IIAB + register it + authorize services/ports -->
+### Generate a remote.it claim code for your IIAB + register it + authorize services/ports
 
+Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml`.
+
+1. Run `sudo iiab-remoteit`
+
+   Hit `[Enter]` twice if you want to quickly generate a new claim code for your IIAB.
+
+   The claim code is stored in `/etc/remoteit/config.json` and must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install).
+
+<!--
 1. Connect your IIAB device to the Internet.
 
 2. If your IIAB software is already installed, run `sudo iiab-remoteit` then skip to Step 5. below.
@@ -25,6 +35,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)
 
    Install [IIAB software](https://download.iiab.io/) e.g. by running `sudo iiab` then follow any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
+-->
 
    <!-- , and when that's complete go directly to Step 3. below.
 
@@ -42,7 +53,8 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    sudo ./runrole --reinstall remoteit
    ``` -->
 
-   (This installs and enables the remote.it [Device Package](https://docs.remote.it/software/device-package) for your CPU and OS.  This also installs the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
+<!--
+(This installs and enables the remote.it [Device Package](https://docs.remote.it/software/device-package) for your CPU and OS.  This also installs the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
 
 4. To obtain your IIAB's 8-character remote.it claim code (allowing you to make a remote connection to this IIAB device) run:
 
@@ -53,6 +65,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    *The claim code must be used within 24 hours, per:* https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install
 
    _If your claim code has expired, please run_ `sudo iiab-remoteit` _just as in Step 2._
+-->
 
    <!-- If necessary, run this command to get a new claim code: *(adjust version & architecture in the .deb filename as appropriate!)*
 
@@ -60,15 +73,15 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    sudo apt install /opt/iiab/downloads/remoteit-4.14.1.armhf.rpi.deb
    ``` -->
 
-5. Submit the claim code within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.  Or if you prefer, do that by logging into their Web Portal at https://remote.it
+2. Submit the claim code within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.  Or if you prefer, do that by logging into their Web Portal at: https://remote.it
  
-   Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your account) as shown in this screenshot: https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device
+   Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your account) as shown in this [screenshot](https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device).
 
-6. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these screenshots: https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device
+3. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these [screenshots](https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device).
 
-   SUMMARY: One or more remote.it "Services" need to be authorized (registered) to allow remote access to your IIAB device: https://support.remote.it/hc/en-us/articles/360060992631-Services
+   SUMMARY: One or more remote.it "Services" need to be authorized (registered) to allow remote access to your IIAB device:<br>https://support.remote.it/hc/en-us/articles/360060992631-Services
 
-   EXAMPLES: SSH (port 22) and/or HTTP (port 80): https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop
+   EXAMPLES: SSH (port 22) and/or HTTP (port 80):<br>https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop
 
 ### How to I disable remote.it on my IIAB?
 
@@ -79,6 +92,13 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    ```
    cd /opt/iiab/iiab
    sudo ./runrole remoteit
+   ```
+
+3. If want to completely remove the remote.it software and its settings, also run:
+
+   ```
+   sudo apt purge "remoteit*"
+   sudo rm /usr/bin/remoteit
    ```
 
 ## Docs

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -12,7 +12,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 1. Browse to [https://remote.it](https://remote.it) (Web Portal) and sign up for an account.
 
-2. Download the [remote.it desktop application](https://remote.it/download/) e.g. for Windows, macOS or Linux to your own laptop/computer &mdash; if you prefer this over the https://remote.it Web Portal and its [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages).
+2. Download the [remote.it desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) to your own laptop/computer &mdash; if you prefer this over the https://remote.it Web Portal and its [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages).
 
    COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
@@ -22,7 +22,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 2. If your IIAB software is already installed, run `sudo iiab-remoteit` then skip to Step 5. below.
 
-3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F).
+3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)
 
    Install [IIAB software](https://download.iiab.io/) e.g. by running `sudo iiab` then follow any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
 
@@ -42,7 +42,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    sudo ./runrole --reinstall remoteit
    ``` -->
 
-   (This installs and enables the remote.it [Device Package](https://docs.remote.it/software/device-package) for your CPU and OS.  This approach also installs the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
+   (This installs and enables the remote.it [Device Package](https://docs.remote.it/software/device-package) for your CPU and OS.  This also installs the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
 
 4. To obtain your IIAB's 8-character remote.it claim code (allowing you to make a remote connection to this IIAB device) run:
 
@@ -52,7 +52,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
    *The claim code must be used within 24 hours, per:* https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install
 
-   _If your claim code has expired, please run `sudo iiab-remoteit` just as in Step 2._
+   _If your claim code has expired, please run_ `sudo iiab-remoteit` _just as in Step 2._
 
    <!-- If necessary, run this command to get a new claim code: *(adjust version & architecture in the .deb filename as appropriate!)*
 
@@ -60,7 +60,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    sudo apt install /opt/iiab/downloads/remoteit-4.14.1.armhf.rpi.deb
    ``` -->
 
-5. Submit the claim code at https://remote.it (log into their Web Portal), or within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.
+5. Submit the claim code within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.  Or if you prefer, do that by logging into their Web Portal at https://remote.it
  
    Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your account) as shown in this screenshot: https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device
 
@@ -74,7 +74,12 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 1. Run `sudo nano /etc/iiab/local_vars.yml` to set `remoteit_enabled: False`
 
-2. Run `cd /opt/iiab/iiab` and then `sudo ./runrole remoteit`
+2. Then run:
+
+   ```
+   cd /opt/iiab/iiab
+   sudo ./runrole remoteit
+   ```
 
 ## Docs
 

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -18,11 +18,15 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 ### Install remote.it onto an IIAB + register it + authorize services/ports
 
-1. Set `remoteit_install` and `remoteit_enabled` to `True` in your IIAB's [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)
+1. Connect your IIAB device to the Internet.
 
-   (If possible, do that prior to [installing IIAB](https://download.iiab.io/), then install IIAB using `sudo iiab`, and when that's complete go directly to Step 3. below.)
+2. If your IIAB software is already installed, run `sudo iiab-remoteit` then skip to Step 5. below.
 
-2. Make sure your IIAB is connected to the Internet.
+3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F).
+
+   Install [IIAB software](https://download.iiab.io/) e.g. by running `sudo iiab` then follow any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
+
+   <!-- , and when that's complete go directly to Step 3. below.
 
    Then install and enable remote.it (its [Device Package](https://docs.remote.it/software/device-package)) on your IIAB, by running:
 
@@ -36,13 +40,11 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    ```
    cd /opt/iiab/iiab
    sudo ./runrole --reinstall remoteit
-   ```
+   ``` -->
 
-   (While rarely needed, both above also install the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
+   (This installs and enables the remote.it [Device Package](https://docs.remote.it/software/device-package) for your CPU and OS.  This approach also installs the _optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), which offers [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.)
 
-   <!--EXPLANATION: The above installs remote.it, in a way that was originally designed to be interactive, and provide you the claim code needed to make a remote connection to this IIAB.  The claim code is further explained below.-->
-
-3. To obtain your IIAB's 8-character remote.it claim code (allowing you to make a remote connection to this IIAB device) run:
+4. To obtain your IIAB's 8-character remote.it claim code (allowing you to make a remote connection to this IIAB device) run:
 
    ```
    sudo grep claim /etc/remoteit/config.json
@@ -50,7 +52,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
    *The claim code must be used within 24 hours, per:* https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install
 
-   _If your claim code has expired, please reinstall the latest remote.it (in Step 2. above!)_
+   _If your claim code has expired, please run `sudo iiab-remoteit` just as in Step 2._
 
    <!-- If necessary, run this command to get a new claim code: *(adjust version & architecture in the .deb filename as appropriate!)*
 
@@ -58,15 +60,21 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    sudo apt install /opt/iiab/downloads/remoteit-4.14.1.armhf.rpi.deb
    ``` -->
 
-4. Submit the claim code at https://remote.it (log into the Web Portal), or within the remote.it desktop application if you installed that on your own laptop/computer.
+5. Submit the claim code at https://remote.it (log into their Web Portal), or within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.
  
    Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your account) as shown in this screenshot: https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device
 
-5. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these screenshots: https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device
+6. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these screenshots: https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device
 
    SUMMARY: One or more remote.it "Services" need to be authorized (registered) to allow remote access to your IIAB device: https://support.remote.it/hc/en-us/articles/360060992631-Services
 
    EXAMPLES: SSH (port 22) and/or HTTP (port 80): https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop
+
+### How to I disable remote.it on my IIAB?
+
+1. Run `sudo nano /etc/iiab/local_vars.yml` to set `remoteit_enabled: False`
+
+2. Run `cd /opt/iiab/iiab` and then `sudo ./runrole remoteit`
 
 ## Docs
 

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -12,20 +12,20 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 1. Browse to [https://remote.it](https://remote.it) (Web Portal) and sign up for an account.
 
-2. Download and install the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes possible, but less functional.
+2. Download and install the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes sufficient, but less functional.
 
    COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
 <!-- ### Install remote.it onto an IIAB + register it + authorize services/ports -->
 ### Generate a remote.it claim code for your IIAB + register it + authorize services/ports
 
-Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml`.
+Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml`
 
 1. Run `sudo iiab-remoteit`
 
    Hit `[Enter]` twice if you want to quickly generate a new claim code for your IIAB.
 
-   The claim code is stored in `/etc/remoteit/config.json` and must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install).
+   The claim code is put in `/etc/remoteit/config.json` and must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install).
 
 <!--
 1. Connect your IIAB device to the Internet.
@@ -75,13 +75,13 @@ Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_st
 
 2. Submit the claim code within the remote.it [desktop application](https://remote.it/download/) on your own laptop/computer.  Or if you prefer, do that by logging into their Web Portal at: https://remote.it
  
-   Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your account) as shown in this [screenshot](https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device).
+   Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your remote.it account) as shown in this [screenshot](https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device).
 
 3. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these [screenshots](https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device).
 
-   SUMMARY: One or more remote.it "Services" need to be authorized (registered) to allow remote access to your IIAB device:<br>https://support.remote.it/hc/en-us/articles/360060992631-Services
+   SUMMARY: One or more [remote.it "Services"](https://support.remote.it/hc/en-us/articles/360060992631-Services) needs to be authorized (registered) to allow remote access to your IIAB device.
 
-   EXAMPLES: SSH (port 22) and/or HTTP (port 80):<br>https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop
+   EXAMPLES: Add an SSH Service on port 22 and/or add an http Service on port 80 [screenshot guide](https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop).
 
 ### How to I disable remote.it on my IIAB?
 
@@ -123,4 +123,4 @@ Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_st
 ## Known Issues
 
 - <strike>2021-10-27: This needs to be enhanced rather urgently, so remote.it also works when IIAB is installed on Raspberry Pi OS 11 (Bullseye), Ubuntu, Mint and Debian:</strike> [#3006](https://github.com/iiab/iiab/issues/3006)
-- 2021-10-29: The above OS issues should be resolved by [PR #3007](https://github.com/iiab/iiab/pull/3007), [PR #3009](https://github.com/iiab/iiab/pull/3009) and [PR #3010](https://github.com/iiab/iiab/pull/3010) &mdash; but this needs final testing!  (Initial testing occurred on [1] 32-bit Raspberry Pi OS Lite on Raspberry Pi 4 and [2] Ubuntu Server 20.04 on x86_64 VM.)
+- <strike>2021-10-29: The above OS issues should be resolved by [PR #3007](https://github.com/iiab/iiab/pull/3007), [PR #3009](https://github.com/iiab/iiab/pull/3009) and [PR #3010](https://github.com/iiab/iiab/pull/3010) &mdash; but this needs final testing!  (Initial testing occurred on [1] 32-bit Raspberry Pi OS Lite on Raspberry Pi 4 and [2] Ubuntu Server 20.04 on x86_64 VM.)</strike>

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -85,16 +85,9 @@ Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_st
 
 ### How to I disable remote.it on my IIAB?
 
-1. Run `sudo nano /etc/iiab/local_vars.yml` to set `remoteit_enabled: False`
+1. Run `iiab-remoteit-off`
 
-2. Then run:
-
-   ```
-   cd /opt/iiab/iiab
-   sudo ./runrole remoteit
-   ```
-
-3. If want to completely remove the remote.it software and its settings, also run:
+2. If want to completely remove all remote.it software and its settings, also run:
 
    ```
    sudo apt purge "remoteit*"

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -81,11 +81,11 @@ Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_st
 
    SUMMARY: One or more [remote.it "Services"](https://support.remote.it/hc/en-us/articles/360060992631-Services) needs to be authorized (registered) to allow remote access to your IIAB device.
 
-   EXAMPLES: Add an SSH Service on port 22 and/or add an http Service on port 80 [screenshot guide](https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop).
+   EXAMPLES: Add an SSH Service on port 22 and/or add an http Service on port 80 ([screenshot guide](https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop)).
 
 ### How to I disable remote.it on my IIAB?
 
-1. Run `iiab-remoteit-off`
+1. Run `sudo iiab-remoteit-off`
 
 2. If want to completely remove all remote.it software and its settings, also run:
 
@@ -115,5 +115,5 @@ Prerequisite: Find an IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_st
 
 ## Known Issues
 
-- <strike>2021-10-27: This needs to be enhanced rather urgently, so remote.it also works when IIAB is installed on Raspberry Pi OS 11 (Bullseye), Ubuntu, Mint and Debian:</strike> [#3006](https://github.com/iiab/iiab/issues/3006)
+- <strike>2021-10-27: This needs to be enhanced rather urgently, so remote.it also works when IIAB is installed on Raspberry Pi OS 11 (Bullseye), Ubuntu, Mint and Debian: [#3006](https://github.com/iiab/iiab/issues/3006)</strike>
 - <strike>2021-10-29: The above OS issues should be resolved by [PR #3007](https://github.com/iiab/iiab/pull/3007), [PR #3009](https://github.com/iiab/iiab/pull/3009) and [PR #3010](https://github.com/iiab/iiab/pull/3010) &mdash; but this needs final testing!  (Initial testing occurred on [1] 32-bit Raspberry Pi OS Lite on Raspberry Pi 4 and [2] Ubuntu Server 20.04 on x86_64 VM.)</strike>

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -7,29 +7,29 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# 2022-03-31: https://remote.it/download/ offers 4 relevant "Device Packages"
-# 1) Raspberry Pi (ARM)    = armhf.rpi
-# 2) Raspberry Pi (ARM64)  = arm64.rpi
-# 3) Debian Linux (ARM64)  = arm64
-# 4) Debian Linux (x86_64) = amd64
+# # 2022-03-31: https://remote.it/download/ offers 4 relevant "Device Packages"
+# # 1) Raspberry Pi (ARM)    = armhf.rpi
+# # 2) Raspberry Pi (ARM64)  = arm64.rpi
+# # 3) Debian Linux (ARM64)  = arm64
+# # 4) Debian Linux (x86_64) = amd64
 
-# See https://docs.remote.it/software/device-package/installation to refine URL below:
-device_suffixes:
-  armv6: armhf.rpi
-  armv6l: armhf.rpi
-  armv7: armhf.rpi
-  armv7l: armhf.rpi
-  armv8: arm64.rpi
-  aarch64: arm64
-  x86_64: amd64
-remoteit_device_suffix: "{{ device_suffixes[ansible_architecture] | default('unknown') }}"
-remoteit_device_url: https://downloads.remote.it/remoteit/latest/remoteit.{{ remoteit_device_suffix }}.deb
+# # See https://docs.remote.it/software/device-package/installation to refine URL below:
+# device_suffixes:
+#   armv6: armhf.rpi
+#   armv6l: armhf.rpi
+#   armv7: armhf.rpi
+#   armv7l: armhf.rpi
+#   armv8: arm64.rpi
+#   aarch64: arm64
+#   x86_64: amd64
+# remoteit_device_suffix: "{{ device_suffixes[ansible_architecture] | default('unknown') }}"
+# remoteit_device_url: https://downloads.remote.it/remoteit/latest/remoteit.{{ remoteit_device_suffix }}.deb
 
-# 2022-03-31: Use "latest" above, instead of ever-changing version below
-# remoteit_version: 4.14.1
-# remoteit_deb: remoteit-{{ remoteit_version }}.{{ remoteit_device_suffix }}.deb
-# remoteit_device_url: https://downloads.remote.it/remoteit/v{{ remoteit_version }}/{{ remoteit_deb }}
-# # Example...         https://downloads.remote.it/remoteit/v4.14.1/remoteit-4.14.1.armhf.rpi.deb
+# # 2022-03-31: Use "latest" above, instead of ever-changing version below
+# # remoteit_version: 4.14.1
+# # remoteit_deb: remoteit-{{ remoteit_version }}.{{ remoteit_device_suffix }}.deb
+# # remoteit_device_url: https://downloads.remote.it/remoteit/v{{ remoteit_version }}/{{ remoteit_deb }}
+# # # Example...         https://downloads.remote.it/remoteit/v4.14.1/remoteit-4.14.1.armhf.rpi.deb
 
 
 # 2022-03-31: https://remote.it/download/ offers 4 relevant "CLI" installs:

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,17 +1,23 @@
-- name: Enable & (Re)Start remote.it's connectd daemon which calls home
+- name: Enable & (Re)Start remote.it's daemons {connectd, schannel}
   systemd:
-    name: connectd
+    name: "{{ item }}"
     daemon_reload: yes
     enabled: yes
     state: restarted    
+  with_items:
+    - connectd
+    - schannel
   when: remoteit_enabled
 
 
-- name: Disable & Stop remote.it's connectd daemon
+- name: Disable & Stop remote.it's daemons {connectd, schannel}
   systemd:
-    name: connectd
+    name: "{{ item }}"
     enabled: no
     state: stopped
+  with_items:
+    - connectd
+    - schannel
   when: not remoteit_enabled
 
 - name: Identify remoteit service (connector) unit file name, including uuid

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,16 +1,20 @@
-- name: Enable & (Re)Start remote.it's daemons {connectd, schannel}
+- name: Enable & Restart remote.it service connectd, which exits after spawning 2 services/daemons below
   systemd:
-    name: "{{ item }}"
+    name: connectd
     daemon_reload: yes
     enabled: yes
-    state: restarted    
-  with_items:
-    - connectd
-    - schannel
+    state: restarted
+  when: remoteit_enabled
+
+- name: Enable remote.it daemon schannel ("Remote tcp command service") -- try to avoid contention with connectd also spawning it above!
+  systemd:
+    name: schannel
+    enabled: yes
+    state: started
   when: remoteit_enabled
 
 
-- name: Disable & Stop remote.it's daemons {connectd, schannel}
+- name: Disable & Stop remote.it services {connectd, schannel}
   systemd:
     name: "{{ item }}"
     enabled: no
@@ -20,8 +24,8 @@
     - schannel
   when: not remoteit_enabled
 
-- name: Identify remoteit service (connector) unit file name, including uuid
-  shell: ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit    # e.g. remoteit@80:00:01:7F:7E:00:56:36.service
+- name: Identify remoteit "Remote tcp connection service" unit file name, including uuid, e.g. remoteit@80:00:01:7F:7E:00:56:36.service
+  shell: ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit
   register: remoteit_service
   ignore_errors: yes
 

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,4 +1,4 @@
-- name: Enable & Restart remote.it service connectd, which exits after spawning 2 services/daemons below
+- name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
   systemd:
     name: connectd
     daemon_reload: yes
@@ -6,7 +6,7 @@
     state: restarted
   when: remoteit_enabled
 
-- name: Enable remote.it daemon schannel ("Remote tcp command service") -- try to avoid contention with connectd also spawning it above!
+- name: Enable remote.it daemon schannel ("Remote tcp command service") -- try to avoid contention with connectd which auto-spawns it as nec (just above)
   systemd:
     name: schannel
     enabled: yes
@@ -29,7 +29,7 @@
   register: remoteit_service
   ignore_errors: yes
 
-- name: "Disable & Stop remoteit service: {{ remoteit_service.stdout }}"
+- name: "Disable & Stop the actual service: {{ remoteit_service.stdout }}"
   systemd:
     name: "{{ remoteit_service.stdout }}"
     enabled: no

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -42,7 +42,7 @@
     dest: /usr/bin
     mode: 0755
 
-- name: "Install /usr/bin/iiab-remoteit-off from template -- so IIAB operators can quickly disable remote.it services on this IIAB"
+- name: "Install /usr/bin/iiab-remoteit-off from template -- so IIAB operators can quickly turn off AND disable remote.it services on this IIAB"
   template:
     src: iiab-remoteit-off
     dest: /usr/bin

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -36,9 +36,15 @@
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 
 
-- name: "Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly generate a new remote.it claim code (in /etc/remoteit/config.json) AND enable remoteit's 3 systemd services -- optionally downloading + installing the very latest Device Package (like the 2 steps above)"
+- name: "Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly enable remote.it AND generate a new remote.it claim code (in /etc/remoteit/config.json) -- optionally downloading + installing the very latest Device Package (like the 2 steps above)"
   template:
     src: iiab-remoteit
+    dest: /usr/bin
+    mode: 0755
+
+- name: "Install /usr/bin/iiab-remoteit-off from template -- so IIAB operators can quickly disable remote.it services on this IIAB"
+  template:
+    src: iiab-remoteit-off
     dest: /usr/bin
     mode: 0755
 

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -15,6 +15,8 @@
 #     force: yes
 #     timeout: "{{ download_timeout }}"
 
+# 2022-04-03: Unfort still necessary, as their install_agent.sh below uses apt
+# with 'install -y' instead of '-y reinstall' or '-y --reinstall install'
 - name: Purge previously installed 'remoteit*' Device Package(s)
   apt:
     name: remoteit*
@@ -34,7 +36,7 @@
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 
 
-- name: "Install from template /usr/bin/iiab-remoteit to quickly obtain a new remote.it claim code, if later nec (much like the above 2 steps)"
+- name: "Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly generate a new remote.it claim code (in /etc/remoteit/config.json) AND enable remoteit's 3 systemd services -- optionally downloading + installing the very latest Device Package (like the 2 steps above)"
   template:
     src: iiab-remoteit
     dest: /usr/bin

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -1,7 +1,7 @@
-- name: Fail if architecture remoteit_device_suffix == "unknown"
-  fail:
-    msg: "Could not find a remote.it Device Package (.deb) for CPU architecture \"{{ ansible_architecture }}\""
-  when: remoteit_device_suffix == "unknown"
+# - name: Fail if architecture remoteit_device_suffix == "unknown"
+#   fail:
+#     msg: "Could not find a remote.it Device Package (.deb) for CPU architecture \"{{ ansible_architecture }}\""
+#   when: remoteit_device_suffix == "unknown"
 
 # - name: mkdir {{ downloads_dir }}    # As roles/2-common/tasks/fl.yml has not run yet
 #   file:
@@ -15,19 +15,30 @@
 #     force: yes
 #     timeout: "{{ download_timeout }}"
 
-- name: Uninstall previously installed 'remoteit*' Device Package(s)
+- name: Purge previously installed 'remoteit*' Device Package(s)
   apt:
     name: remoteit*
     state: absent
+    purge: yes
   ignore_errors: yes
 
 # - name: "Install Device Package: {{ downloads_dir }}/{{ remoteit_deb }}"
 #   apt:
 #     deb: "{{ downloads_dir }}/{{ remoteit_deb }}"
 
-- name: "Install Device Package: {{ remoteit_device_url }}"
-  apt:
-    deb: "{{ remoteit_device_url }}"
+# - name: "Install Device Package: {{ remoteit_device_url }}"
+#   apt:
+#     deb: "{{ remoteit_device_url }}"
+
+- name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
+  shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
+
+
+- name: "Install from template /usr/bin/iiab-remoteit to quickly obtain a new remote.it claim code, if later nec (much like the above 2 steps)"
+  template:
+    src: iiab-remoteit
+    dest: /usr/bin
+    mode: 0755
 
 
 - name: Fail if architecture remoteit_cli_suffix == "unknown"

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# Run 'sudo iiab-remoteit' to (re)install & enable remote.it -- GENERAL TIPS:
+# http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
+
+# /usr/bin/remoteit CLI is already be installed by:
+# https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml
+
+echo -e "\nhttps://remote.it can help you remotely manage this IIAB:"
+echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
+
+echo -en "\e[1mInstall remote.it Device Package after purging all prior versions? [Y/n]\e[0m "
+read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+echo
+[ "$ans" = "n" ] || [ "$ans" = "N" ] && exit 1
+
+if grep -q '^remoteit_install:' /etc/iiab/local_vars.yml; then
+    sed -i "s/^remoteit_install:.*/remoteit_install: True/" /etc/iiab/local_vars.yml
+else
+    echo "remoteit_install: True" >> /etc/iiab/local_vars.yml
+fi
+
+if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
+    sed -i "s/^remoteit_enabled:.*/remoteit_enabled: True/" /etc/iiab/local_vars.yml
+else
+    echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
+fi
+
+# 2022-04-02: Full Path Avoids problematic /usr/local/bin/apt on Linux Mint
+/usr/bin/apt -y purge remoteit*
+
+# Why the brutal purge?  Even 'apt -y reinstall remoteit.*.deb' is much stronger
+# than 'install -y' in install_agent.sh below, but still insufficient.  Maybe in
+# future years their /usr/bin/remoteit CLI might seed a new claim code when nec?
+
+# apt install & enable "latest" remote.it Device Package for your CPU/OS
+curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
+
+if grep -q '^remoteit_installed:' /etc/iiab/iiab_state.yml; then
+    sed -i "s/^remoteit_installed:.*/remoteit_installed: True/" /etc/iiab/iiab_state.yml
+else
+    echo "remoteit_installed: True" >> /etc/iiab/iiab_state.yml
+fi
+
+echo -e "\e[44;1mNEXT STEPS...\e[0m\n"
+
+echo -e "\e[1m1) Install the remote.it Desktop Application on your own laptop/computer:"
+echo -e "   https://remote.it/download/\n"
+
+echo -e "2) Use the above 8-character claim code within 24h as shown here:"
+echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\e[0m\n"

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -36,19 +36,19 @@ else
     # '|| true' overrides 'bash -e' so script continues if config.json missing
     mv /etc/remoteit/config.json /etc/remoteit/config.json.$(date +%F_%T_%Z) || true
 
-    echo -e "In just a few seconds, all 3 services should be enabled + started.\n"
+    echo -e "In just a few seconds, all 3 services should be enabled/started.\n"
 
     systemctl restart connectd    # Claim Code logic + kickstarts 2 svcs below
-    systemctl enable connectd     # 3 enable lines, like enable-or-disable.yml
+    systemctl enable connectd     # 2 enable lines, like enable-or-disable.yml
 
-    # "Remote tcp command service" started above
-    systemctl enable schannel     # 3 enable lines, like enable-or-disable.yml
+    # schannel = "Remote tcp command service" started by connectd above if nec
+    systemctl enable schannel     # 2 enable lines, like enable-or-disable.yml
 
     # "Remote tcp connection service" appears a few seconds after connectd is
-    # started above.  It's also auto-enabled by above, so this may be overkill:
-    systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)    # 3 enable lines, like enable-or-disable.yml
+    # started above.  Auto-enabled when spawned by connectd, SO NOT NEC HERE:
+    # systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
     # Its systemd service name (e.g. remoteit@80:00:01:7F:7E:00:56:36.service)
-    # changes when a new claim code is generated.
+    # changes when a new claim code is generated!
 fi
 
 if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-# Run 'sudo iiab-remoteit' to (re)install & enable remote.it -- GENERAL TIPS:
+# Run 'sudo iiab-remoteit' to enable remote.it AND get a new claim code.  Also
+# lets you download+install the latest Device Package to IIAB.  GENERAL TIPS:
 # http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
 
 # 'remoteit' Device Package AND /usr/bin/remoteit CLI already installed by:

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Run 'sudo iiab-remoteit' to enable remote.it AND get a new claim code.  Also
-# lets you download+install the latest Device Package to IIAB.  GENERAL TIPS:
+# lets you download + install the latest Device Package to IIAB.  GENERAL TIPS:
 # http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
 
 # 'remoteit' Device Package AND /usr/bin/remoteit CLI already installed by:

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -3,21 +3,52 @@
 # Run 'sudo iiab-remoteit' to (re)install & enable remote.it -- GENERAL TIPS:
 # http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
 
-# /usr/bin/remoteit CLI is already be installed by:
+# 'remoteit' Device Package AND /usr/bin/remoteit CLI already installed by:
 # https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml
 
-echo -e "\nhttps://remote.it can help you remotely manage this IIAB:"
+# 2022-04-03: SEE ALSO roles/remoteit/templates/iiab-remote.old
+
+echo -e "\nhttps://remote.it can help you remotely manage this IIAB.  Summary:\n"
+
 echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
 
-echo -en "\e[1mInstall remote.it Device Package after purging all prior versions? [Y/n]\e[0m "
+echo -en "\e[1mTo proceed we will delete /etc/remoteit/config.json, Ok? [Y/n]\e[0m "
 read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
 echo
-[ "$ans" = "n" ] || [ "$ans" = "N" ] && exit 1
+[[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
 
-if grep -q '^remoteit_install:' /etc/iiab/local_vars.yml; then
-    sed -i "s/^remoteit_install:.*/remoteit_install: True/" /etc/iiab/local_vars.yml
+echo -e "\nThis IIAB must be online to begin!\n"
+
+echo -en "\e[1mOptionally download + install latest remote.it Device Package? [y/N]\e[0m "
+read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+echo
+
+if [[ $ans = "y" ]] || [[ $ans = "Y" ]]; then
+    # 2022-04-02: Full Path Avoids problematic /usr/local/bin/apt on Linux Mint
+    /usr/bin/apt -y purge "remoteit*" || true
+
+    # Why the brutal purge?  Even 'apt -y reinstall remoteit.*.deb' is stronger
+    # than 'install -y' in install_agent.sh, but still sometimes insufficient!
+
+    # apt install & enable "latest" remote.it Device Package for your CPU/OS
+    curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 else
-    echo "remoteit_install: True" >> /etc/iiab/local_vars.yml
+    # '|| true' overrides 'bash -e' so script continues if config.json missing
+    mv /etc/remoteit/config.json /etc/remoteit/config.json.$(date +%F_%T_%Z) || true
+
+    echo -e "In just a few seconds, all 3 services should be enabled + started.\n"
+
+    systemctl restart connectd    # Claim Code logic + kickstarts 2 svcs below
+    systemctl enable connectd     # 3 enable lines, like enable-or-disable.yml
+
+    # "Remote tcp command service" started above
+    systemctl enable schannel     # 3 enable lines, like enable-or-disable.yml
+
+    # "Remote tcp connection service" appears a few seconds after connectd is
+    # started above.  It's also auto-enabled by above, so this may be overkill:
+    systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)    # 3 enable lines, like enable-or-disable.yml
+    # Its systemd service name (e.g. remoteit@80:00:01:7F:7E:00:56:36.service)
+    # changes when a new claim code is generated.
 fi
 
 if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
@@ -26,26 +57,11 @@ else
     echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
 fi
 
-# 2022-04-02: Full Path Avoids problematic /usr/local/bin/apt on Linux Mint
-/usr/bin/apt -y purge remoteit*
+claim_code=$(grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev)
+echo -e "\nYour new claim code is \e[44;1m${claim_code}\e[0m -- YOUR NEXT STEPS ARE...\n"
 
-# Why the brutal purge?  Even 'apt -y reinstall remoteit.*.deb' is much stronger
-# than 'install -y' in install_agent.sh below, but still insufficient.  Maybe in
-# future years their /usr/bin/remoteit CLI might seed a new claim code when nec?
-
-# apt install & enable "latest" remote.it Device Package for your CPU/OS
-curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
-
-if grep -q '^remoteit_installed:' /etc/iiab/iiab_state.yml; then
-    sed -i "s/^remoteit_installed:.*/remoteit_installed: True/" /etc/iiab/iiab_state.yml
-else
-    echo "remoteit_installed: True" >> /etc/iiab/iiab_state.yml
-fi
-
-echo -e "\e[44;1mNEXT STEPS...\e[0m\n"
-
-echo -e "\e[1m1) Install the remote.it Desktop Application on your own laptop/computer:"
+echo -e "\e[1m1) Install the remote.it Desktop Application on your own laptop/computer:\e[0m"
 echo -e "   https://remote.it/download/\n"
 
-echo -e "2) Use the above 8-character claim code within 24h as shown here:"
-echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\e[0m\n"
+echo -e "\e[1m2) Use the above 8-character claim code WITHIN 24H as shown here:\e[0m"
+echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\n"

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -14,6 +14,9 @@ else
     echo "remoteit_enabled: False" >> /etc/iiab/local_vars.yml
 fi
 
+# 3 sections below should be equivalent to -- and much faster than:
+# https://github.com/iiab/iiab/tree/master/roles/remoteit/tasks/enable-or-disable.yml
+
 # remote.it "parent" service
 systemctl stop connectd
 systemctl disable connectd
@@ -23,7 +26,7 @@ systemctl stop schannel
 systemctl disable schannel
 
 # "Remote tcp connection service"
-systemctl stop $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
-systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
+systemctl stop $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@) || true
+systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@) || true
 # Its systemd service name (e.g. remoteit@80:00:01:7F:7E:00:56:36.service)
 # changes when a new claim code is generated!

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -1,0 +1,29 @@
+#!/bin/bash -xe
+
+# Run 'sudo iiab-remoteit-off' to disable remote.it on this IIAB. GENERAL TIPS:
+# http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
+
+# GUIDE: https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md
+
+# FYI 'remoteit' Device Package AND /usr/bin/remoteit CLI are installed by:
+# https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml
+
+if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
+    sed -i "s/^remoteit_enabled:.*/remoteit_enabled: False/" /etc/iiab/local_vars.yml
+else
+    echo "remoteit_enabled: False" >> /etc/iiab/local_vars.yml
+fi
+
+# remote.it "parent" service
+systemctl stop connectd
+systemctl disable connectd
+
+# "Remote tcp command service"
+systemctl stop schannel
+systemctl disable schannel
+
+# "Remote tcp connection service"
+systemctl stop $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
+systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
+# Its systemd service name (e.g. remoteit@80:00:01:7F:7E:00:56:36.service)
+# changes when a new claim code is generated!

--- a/roles/remoteit/templates/iiab-remoteit.old
+++ b/roles/remoteit/templates/iiab-remoteit.old
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# Run 'sudo iiab-remoteit' to (re)install & enable remote.it -- GENERAL TIPS:
+# http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
+
+# /usr/bin/remoteit CLI is already be installed by:
+# https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml
+
+echo -e "\nhttps://remote.it can help you remotely manage this IIAB:"
+echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
+
+echo -en "\e[1mInstall remote.it Device Package after purging all prior versions? [Y/n]\e[0m "
+read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+echo
+[ "$ans" = "n" ] || [ "$ans" = "N" ] && exit 1
+
+if grep -q '^remoteit_install:' /etc/iiab/local_vars.yml; then
+    sed -i "s/^remoteit_install:.*/remoteit_install: True/" /etc/iiab/local_vars.yml
+else
+    echo "remoteit_install: True" >> /etc/iiab/local_vars.yml
+fi
+
+if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
+    sed -i "s/^remoteit_enabled:.*/remoteit_enabled: True/" /etc/iiab/local_vars.yml
+else
+    echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
+fi
+
+# 2022-04-02: Full Path Avoids problematic /usr/local/bin/apt on Linux Mint
+/usr/bin/apt -y purge remoteit*
+
+# Why the brutal purge?  Even 'apt -y reinstall remoteit.*.deb' is much stronger
+# than 'install -y' in install_agent.sh below, but still insufficient.  Maybe in
+# future years their /usr/bin/remoteit CLI might seed a new claim code when nec?
+
+# apt install & enable "latest" remote.it Device Package for your CPU/OS
+curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
+
+if grep -q '^remoteit_installed:' /etc/iiab/iiab_state.yml; then
+    sed -i "s/^remoteit_installed:.*/remoteit_installed: True/" /etc/iiab/iiab_state.yml
+else
+    echo "remoteit_installed: True" >> /etc/iiab/iiab_state.yml
+fi
+
+echo -e "\e[44;1mNEXT STEPS...\e[0m\n"
+
+echo -e "\e[1m1) Install the remote.it Desktop Application on your own laptop/computer:"
+echo -e "   https://remote.it/download/\n"
+
+echo -e "2) Use the above 8-character claim code within 24h as shown here:"
+echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\e[0m\n"


### PR DESCRIPTION
Thanks to @jvonau's ideas at #3158 and building on:

- #3006
- PR #3154
- PR #3156
- PR #3157

This PR also overhauls and dramatically simplifies the installation of remote.it's Device Package, using their official 1-line installer ("curl -L https://downloads.remote.it/remoteit/install_agent.sh") as recommended by their 2022-01-24 document ["Streamlined installation for Linux and Raspberry Pi platforms"](https://support.remote.it/hc/en-us/articles/4422773654669-Streamlined-installation-for-Linux-and-Raspberry-Pi-platforms).

Note that `apt purge remoteit*` is regrettably necessary at this time [prior to running remote.it's `install_agent.sh`], <strike>in order to get a new Claim Code in many corner cases, and</strike> for several reasons.  One of those reasons is that the Device Package .deb files (same thing you get at https://remote.it/download/) are oddly each built in slightly different ways.  Without going into all the ugly details, the situation and its resolution are summarized here:

https://github.com/holta/iiab/blob/5854ab7c619b3c01446951f925c5f27eb37ed077/roles/remoteit/templates/iiab-remoteit#L32-L34

FYI this PR intentionally avoids Ansible, so that the `/usr/bin/iiab-remoteit` command runs as quickly and resiliently as possible, quite similar to `/usr/bin/iiab-support` with OpenVPN.

This PR is tested on the latest pre-release of Ubuntu Desktop 22.04, with more testing ongoing on other OS's too, including 32-bit and 64-bit RasPiOS on Raspberry Pi 4.