### PR TITLE
Fix explanations in /usr/bin/iiab-remoteit & /usr/bin/iiab-remoteit-off

### DIFF
--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -37,7 +37,7 @@ else
     # 2022-04-04: Stop/Delete/Bounce sequence follows official suggestion here:
     # https://support.remote.it/hc/en-us/articles/360061228252-Oops-I-cloned-an-SD-card-
 
-    echo -e "In a few secs, all 3 svcs {connectd, schannel, remoteit@...} should be back!\n"
+    echo -e "In a few seconds, all 3 {connectd, schannel, remoteit@...} should be enabled!\n"
 
     systemctl stop connectd      # "Safer" (though it's generally exited already!)
 
@@ -52,9 +52,10 @@ else
 
     # "Remote tcp connection service" appears a few seconds after connectd is
     # started above.  Auto-enabled when spawned by connectd, SO NOT NEC HERE:
-    # systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@)
-    # Its systemd service name (e.g. remoteit@80:00:01:7F:7E:00:56:36.service)
-    # changes when a new claim code is generated!
+    # systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*)
+    # These systemd service names e.g. remoteit@80:00:01:7F:7E:00:56:36.service
+    # change, e.g. when a new claim code is generated, and more arise when the
+    # IIAB device is registered to a remote.it account (#3166), etc.
 fi
 
 if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -28,6 +28,6 @@ systemctl disable schannel
 # "Remote tcp connection service"
 systemctl stop $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*) || true
 systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*) || true
-# FYI these systemd service names e.g. remoteit@80:00:01:7F:7E:00:56:36.service
-# change, and arise when a new claim code is generated, when the IIAB device is
-# registed, etc.  2022-04-05 Example: https://github.com/iiab/iiab/issues/3166
+# These systemd service names e.g. remoteit@80:00:01:7F:7E:00:56:36.service
+# change, e.g. when a new claim code is generated, and more arise when the
+# IIAB device is registered to a remote.it account (#3166), etc.


### PR DESCRIPTION
Building on:

- PR #3161
- PR #3167
- 40e1571 (remoteit/README.md: Cleaner verbiage (3 tiny editorial fixes)