### PR TITLE
remoteit - visual feedback and recording claim code in iiab.ini & New feature auto registeration for early connections

### DIFF
--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -49,3 +49,4 @@ cli_suffixes:
   x86_64: x86_64
 remoteit_cli_suffix: "{{ cli_suffixes[ansible_architecture] | default('unknown') }}"
 remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_cli_suffix }}
+remoteit_REGISTRATION_CODE: none #eg "592AA9BB-68C8-520A-AACA-6E27654C3DF6" generated in the desktop or web portal

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,3 +1,7 @@
+- name: Using pre-created REGISTRATION_CODE from desktop or web portal
+  shell: echo {{ remoteit_REGISTRATION_CODE }} > /etc/remoteit/registration
+  when: remoteit_REGISTRATION_CODE is not none
+
 - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
   systemd:
     name: connectd
@@ -30,6 +34,10 @@
     systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*)
   ignore_errors: yes
   when: not remoteit_enabled
+
+- name: Clean up REGISTRATION_CODE from {{ iiab_local_vars_file }} if used
+  shell: sed -i '/remoteit_REGISTRATION_CODE/d' {{ iiab_local_vars_file }}
+  when: remoteit_REGISTRATION_CODE is not none
 
 # - name: Identify remoteit "Remote tcp connection service" unit file name, including uuid, e.g. remoteit@80:00:01:7F:7E:00:56:36.service
 #   shell: ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -32,6 +32,10 @@
 #   apt:
 #     deb: "{{ remoteit_device_url }}"
 
+- name: Going to use pre-created REGISTRATION_CODE from desktop or web portal
+  shell: mkdir /etc/remoteit || true && touch /etc/remoteit/registration
+  when: remoteit_REGISTRATION_CODE is not none
+
 - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 

--- a/roles/remoteit/tasks/main.yml
+++ b/roles/remoteit/tasks/main.yml
@@ -18,6 +18,9 @@
 
 - include_tasks: enable-or-disable.yml
 
+- name: Find the claim code if blank the machine was registrated
+  shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
+  register: remoteit_claim
 
 - name: Add 'remoteit' variable values to {{ iiab_ini_file }}
   ini_file:
@@ -34,3 +37,5 @@
       value: "{{ remoteit_install }}"
     - option: remoteit_enabled
       value: "{{ remoteit_enabled }}"
+    - option: remoteit_claim_code
+      value: "{{ remoteit_claim.stdout }}"


### PR DESCRIPTION
Record initial claim code, updates to blank when registered if ansible is run again.. Becomes viewable via iiab.ini thus available within iiab-diagnostics.