### PR TITLE
Allow remote.it license key to be pasted into local_vars.yml & document both registration options

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -8,24 +8,29 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 
 ## Getting Started
 
-### Create a remote.it account + install its desktop application
+### Create a remote.it account + consider its desktop application
 
 1. Browse to [https://remote.it](https://remote.it) (Web Portal) and sign up for an account.
 
-2. Download and install the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes sufficient, but less functional.
+2. Consider downloading and installing the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes sufficient, but less functional.
 
    COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
 <!-- ### Install remote.it onto an IIAB + register it + authorize services/ports -->
 ### OPTION #1: Generate a remote.it claim code for your IIAB + register it + authorize services/ports
+<!-- ### OPTION #1: Run `sudo iiab-remoteit` to enable remote.it -->
 
-Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  It means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
+Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  This means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
 
 1. Run `sudo iiab-remoteit` to enable remote.it on your IIAB.
 
-   Hit `[Enter]` (repeatedly if necessary, to accept all defaults) if you want to quickly generate a new claim code for your IIAB.
+   Hit `[Enter]` <!-- (repeatedly if necessary, to accept all defaults) --> if this is a fresh install, to quickly generate a claim code for your IIAB.
 
    (The claim code is put in `/etc/remoteit/config.json` and must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install).)
+
+   NOTE: If a remote.it license key is found in `/etc/iiab/local_vars.yml` or `/etc/remoteit/registration`, that will be tried first (prior to generating a claim code).
+
+   *If the license key works, you will not get a claim code, as the IIAB device auto-registers to your remote.it account (skip to Step 3. below).*
 
 <!--
 1. Connect your IIAB device to the Internet.
@@ -103,14 +108,16 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 4. If your IIAB software is already installed, make sure your IIAB is online.
 
-   Now register your IIAB to your remote.it account (while enabling remote.it on your IIAB device) by running:
+   Now register the IIAB device to your remote.it account, by running `sudo iiab-remoteit` (this also enables remote.it on your IIAB).
+
+   Or, if you prefer the legacy approach, run:
 
    ```
    cd /opt/iiab/iiab
    sudo ./runrole remoteit
    ```
 
-   If you also want to reinstall the (latest) remote.it Device Package on your IIAB, you can instead run:
+   The legacy approach can also reinstall the (latest) remote.it Device Package on your IIAB, if you instead run:
 
    ```
    cd /opt/iiab/iiab

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -101,11 +101,20 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
    When that's complete, skip to Step 5.
 
-4. If your IIAB software is already installed, make sure your IIAB is online, and then run:
+4. If your IIAB software is already installed, make sure your IIAB is online.
+
+   Now register your IIAB to your remote.it account (while enabling remote.it on your IIAB device) by running:
 
    ```
    cd /opt/iiab/iiab
    sudo ./runrole remoteit
+   ```
+
+   If you also want to reinstall the (latest) remote.it Device Package on your IIAB, you can instead run:
+
+   ```
+   cd /opt/iiab/iiab
+   sudo ./runrole --reinstall remoteit
    ```
 
 5. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these [screenshots](https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device).

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -85,7 +85,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 ### OPTION #2: Paste your remote.it license key to IIAB + enable it + authorize services/ports
 
-1. Copy your remote.it account _license key_ from their Desktop Application (https://remote.it/download/) (or from their https://remote.it Web Portal) as shown in this [screenshot](https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account#3.-user-receives-the-device-and-registers-his-account).
+1. Copy your remote.it account _license key_ from their Desktop Application (https://remote.it/download/) or from their Web Portal (https://remote.it) &mdash; as shown in this [screenshot](https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account#3.-user-receives-the-device-and-registers-his-account).
 
    Paste it into your IIAB's [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) as in this example:
 
@@ -94,6 +94,8 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
    ```
 
 2. Also set `remoteit_enabled: True` in /etc/iiab/local_vars.yml
+
+   (And verify that `remoteit_install: True` is set.)
 
 3. If your [IIAB software](https://download.iiab.io/) is not yet installed, do that e.g. by running `sudo iiab` and following any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
 

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -30,7 +30,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
    NOTE: If a remote.it license key is found in `/etc/iiab/local_vars.yml` or `/etc/remoteit/registration`, that will be tried first (prior to generating a claim code).
 
-   *If the license key works, you will not get a claim code, as the IIAB device auto-registers to your remote.it account (skip to Step 3. below).*
+   *If the license key works, you will not get a claim code (as the IIAB device auto-registers to your remote.it account) and you can skip to Step 3.*
 
 <!--
 1. Connect your IIAB device to the Internet.

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -17,7 +17,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
    COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
 <!-- ### Install remote.it onto an IIAB + register it + authorize services/ports -->
-### Generate a remote.it claim code for your IIAB + register it + authorize services/ports
+### OPTION #1: Generate a remote.it claim code for your IIAB + register it + authorize services/ports
 
 Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  It means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
 
@@ -78,6 +78,35 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
    Either way, click on the '+' icon to enter the remote.it claim code (to register the IIAB device to your remote.it account) as shown in this [screenshot](https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device).
 
 3. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these [screenshots](https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device).
+
+   SUMMARY: One or more [remote.it "Services"](https://support.remote.it/hc/en-us/articles/360060992631-Services) needs to be authorized (registered) to allow remote access to your IIAB device.
+
+   EXAMPLES: Add an SSH Service on port 22 and/or add an HTTP Service on port 80 ([screenshot guide](https://support.remote.it/hc/en-us/articles/360058603991-Configuring-remoteit-Services-on-devices-with-remote-it-Desktop)).
+
+### OPTION #2: Paste your remote.it license key to IIAB + enable it + authorize services/ports
+
+1. Copy your remote.it account _license key_ from their Desktop Application (https://remote.it/download/) (or from their https://remote.it Web Portal) as shown in this [screenshot](https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account#3.-user-receives-the-device-and-registers-his-account).
+
+   Paste it into your IIAB's [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) as in this example:
+
+   ```
+   remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
+   ```
+
+2. Also set `remoteit_enabled: True` in /etc/iiab/local_vars.yml
+
+3. If your [IIAB software](https://download.iiab.io/) is not yet installed, do that e.g. by running `sudo iiab` and following any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
+
+   When that's complete, skip to Step 5.
+
+4. If your IIAB software is already installed, make sure your IIAB is online, and then run:
+
+   ```
+   cd /opt/iiab/iiab
+   sudo ./runrole remoteit
+   ```
+
+5. Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device, as shown in these [screenshots](https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device).
 
    SUMMARY: One or more [remote.it "Services"](https://support.remote.it/hc/en-us/articles/360060992631-Services) needs to be authorized (registered) to allow remote access to your IIAB device.
 

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -20,7 +20,7 @@ For other approaches, please see http://FAQ.IIAB.IO -> "How can I remotely manag
 ### OPTION #1: Generate a remote.it claim code for your IIAB + register it + authorize services/ports
 <!-- ### OPTION #1: Run `sudo iiab-remoteit` to enable remote.it -->
 
-Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  This means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
+Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  This means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is already installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
 
 1. Run `sudo iiab-remoteit` to enable remote.it on your IIAB.
 
@@ -98,15 +98,17 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
    remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
    ```
 
+   _FYI to protect your credential, the above line will promptly be redacted (removed) from your /etc/iiab/local_vars.yml — after the key is copied to_ `/etc/remoteit/registration` _in Step 3. or 4. below._
+
 2. Also set `remoteit_enabled: True` in /etc/iiab/local_vars.yml
 
    (And verify that `remoteit_install: True` is set.)
 
-3. If your [IIAB software](https://download.iiab.io/) is not yet installed, do that e.g. by running `sudo iiab` and following any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
+3. If your [IIAB software](https://download.iiab.io/) is _not_ yet installed, do that e.g. by running `sudo iiab` and following any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
 
    When that's complete, skip to Step 5.
 
-4. If your IIAB software is already installed, make sure your IIAB is online.
+4. If your IIAB software _is_ already installed, make sure your IIAB is online.
 
    Now register the IIAB device to your remote.it account, by running `sudo iiab-remoteit` (this also enables remote.it on your IIAB).
 

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -23,7 +23,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 1. Run `sudo iiab-remoteit` to enable remote.it on your IIAB.
 
-   Hit `[Enter]` twice if you want to quickly generate a new claim code for your IIAB.
+   Hit `[Enter]` (repeatedly if necessary, to accept all defaults) if you want to quickly generate a new claim code for your IIAB.
 
    (The claim code is put in `/etc/remoteit/config.json` and must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install).)
 

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -49,3 +49,4 @@ cli_suffixes:
   x86_64: x86_64
 remoteit_cli_suffix: "{{ cli_suffixes[ansible_architecture] | default('unknown') }}"
 remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_cli_suffix }}
+remoteit_REGISTRATION_CODE: none #eg "592AA9BB-68C8-520A-AACA-6E27654C3DF6" generated in the desktop or web portal

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -49,4 +49,15 @@ cli_suffixes:
   x86_64: x86_64
 remoteit_cli_suffix: "{{ cli_suffixes[ansible_architecture] | default('unknown') }}"
 remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_cli_suffix }}
-remoteit_REGISTRATION_CODE: none #eg "592AA9BB-68C8-520A-AACA-6E27654C3DF6" generated in the desktop or web portal
+
+# OPTION #1: Run 'sudo iiab-remoteit' after IIAB is installed.
+
+# OPTION #2: Pre-populate your remote.it account "license key" (a.k.a.
+# R3_REGISTRATION_CODE) in /etc/iiab/local_vars.yml -- e.g. prior to installing
+# IIAB -- by using a line like:
+#
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
+#
+# BACKGROUND: You can obtain a license key at https://remote.it or by using
+# their Desktop Application (https://remote.it/download/) as shown here:
+# https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account#3.-user-receives-the-device-and-registers-his-account

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,6 +1,20 @@
-- name: Using pre-created REGISTRATION_CODE from desktop or web portal
-  shell: echo {{ remoteit_REGISTRATION_CODE }} > /etc/remoteit/registration
-  when: remoteit_REGISTRATION_CODE is not none
+- name: Copy OPTIONAL remoteit_license_key, e.g. from /etc/iiab/local_vars.yml to /etc/remoteit/registration, if remoteit_enabled and remoteit_license_key is defined
+  # shell: echo {{ remoteit_license_key }} > /etc/remoteit/registration
+  template:
+    src: registration.j2
+    dest: /etc/remoteit/registration
+  when: remoteit_enabled and remoteit_license_key is defined
+
+- name: Redact OPTIONAL remoteit_license_key from /etc/iiab/local_vars.yml, if remoteit_enabled and remoteit_license_key is defined
+  # shell: sed -i '/^remoteit_license_key:/d' {{ iiab_local_vars_file }}
+  lineinfile:
+    path: "{{ iiab_local_vars_file }}"
+    regexp: '^remoteit_license_key:.*'
+    state: absent
+  when: remoteit_enabled and remoteit_license_key is defined
+
+# 2022-04-06 QUESTION: Does connectd (below) delete /etc/remoteit/registration,
+# but only after confirming online that the license key is valid?
 
 - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
   systemd:
@@ -34,10 +48,6 @@
     systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*)
   ignore_errors: yes
   when: not remoteit_enabled
-
-- name: Clean up REGISTRATION_CODE from {{ iiab_local_vars_file }} if used
-  shell: sed -i '/remoteit_REGISTRATION_CODE/d' {{ iiab_local_vars_file }}
-  when: remoteit_REGISTRATION_CODE is not none
 
 # - name: Identify remoteit "Remote tcp connection service" unit file name, including uuid, e.g. remoteit@80:00:01:7F:7E:00:56:36.service
 #   shell: ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,3 +1,6 @@
+# Passwords and license keys in /etc/iiab/local_vars.yml are not a healthy
+# precedent :/  (Going forward let's try to keep credentials in their own apps)
+
 - name: Copy OPTIONAL remoteit_license_key, e.g. from /etc/iiab/local_vars.yml to /etc/remoteit/registration, if remoteit_license_key is defined
   # shell: echo {{ remoteit_license_key }} > /etc/remoteit/registration
   template:

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -13,8 +13,7 @@
     state: absent
   when: remoteit_enabled and remoteit_license_key is defined
 
-# 2022-04-06 QUESTION: Does connectd (below) delete /etc/remoteit/registration,
-# but only after confirming online that the license key is valid?
+# 2022-04-07 FYI: connectd (below) never deletes /etc/remoteit/registration
 
 - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
   systemd:

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -3,7 +3,7 @@
   template:
     src: registration.j2
     dest: /etc/remoteit/registration
-  when: remoteit_enabled and remoteit_license_key is defined
+  when: remoteit_license_key is defined
 
 - name: Redact OPTIONAL remoteit_license_key from /etc/iiab/local_vars.yml, if remoteit_enabled and remoteit_license_key is defined
   # shell: sed -i '/^remoteit_license_key:/d' {{ iiab_local_vars_file }}
@@ -11,7 +11,8 @@
     path: "{{ iiab_local_vars_file }}"
     regexp: '^remoteit_license_key:.*'
     state: absent
-  when: remoteit_enabled and remoteit_license_key is defined
+  when: remoteit_license_key is defined
+
 
 # 2022-04-07 FYI: connectd (below) never deletes /etc/remoteit/registration
 

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,3 +1,7 @@
+- name: Using pre-created REGISTRATION_CODE from desktop or web portal
+  shell: echo {{ remoteit_REGISTRATION_CODE }} > /etc/remoteit/registration
+  when: remoteit_REGISTRATION_CODE is not none
+
 - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
   systemd:
     name: connectd
@@ -30,6 +34,10 @@
     systemctl disable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*)
   ignore_errors: yes
   when: not remoteit_enabled
+
+- name: Clean up REGISTRATION_CODE from {{ iiab_local_vars_file }} if used
+  shell: sed -i '/remoteit_REGISTRATION_CODE/d' {{ iiab_local_vars_file }}
+  when: remoteit_REGISTRATION_CODE is not none
 
 # - name: Identify remoteit "Remote tcp connection service" unit file name, including uuid, e.g. remoteit@80:00:01:7F:7E:00:56:36.service
 #   shell: ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -1,11 +1,11 @@
-- name: Copy OPTIONAL remoteit_license_key, e.g. from /etc/iiab/local_vars.yml to /etc/remoteit/registration, if remoteit_enabled and remoteit_license_key is defined
+- name: Copy OPTIONAL remoteit_license_key, e.g. from /etc/iiab/local_vars.yml to /etc/remoteit/registration, if remoteit_license_key is defined
   # shell: echo {{ remoteit_license_key }} > /etc/remoteit/registration
   template:
     src: registration.j2
     dest: /etc/remoteit/registration
   when: remoteit_license_key is defined
 
-- name: Redact OPTIONAL remoteit_license_key from /etc/iiab/local_vars.yml, if remoteit_enabled and remoteit_license_key is defined
+- name: Redact OPTIONAL remoteit_license_key from /etc/iiab/local_vars.yml, if remoteit_license_key is defined
   # shell: sed -i '/^remoteit_license_key:/d' {{ iiab_local_vars_file }}
   lineinfile:
     path: "{{ iiab_local_vars_file }}"

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -17,6 +17,8 @@
 
 # 2022-04-03: Unfort still necessary, as their install_agent.sh below uses apt
 # with 'install -y' instead of '-y reinstall' or '-y --reinstall install'
+# FWIW: Some remoteit.*.deb installers also work with '-y --allow-downgrades install'
+# (e.g. *.amd64.deb) but others (e.g. both *.rpi.deb) do not.
 - name: Purge previously installed 'remoteit*' Device Package(s)
   apt:
     name: remoteit*
@@ -28,17 +30,27 @@
 # Speeds things up a bit, deferring online claim code generation if not nec:
 # https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account
 
-- name: "'mkdir /etc/remoteit' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+# - name: "'mkdir /etc/remoteit' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+#   file:
+#     state: directory
+#     path: /etc/remoteit
+#   when: remoteit_license_key is defined
+
+# - name: "'touch /etc/remoteit/registration' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+#   file:
+#     state: touch
+#     path: /etc/remoteit/registration
+#   when: remoteit_license_key is defined
+
+- name: "'mkdir /etc/remoteit'"
   file:
     state: directory
     path: /etc/remoteit
-  when: remoteit_license_key is defined
 
-- name: "'touch /etc/remoteit/registration' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+- name: "'touch /etc/remoteit/registration' to block generation of claim code below, also speeding things up a bit"
   file:
     state: touch
     path: /etc/remoteit/registration
-  when: remoteit_license_key is defined
 
 
 # - name: "Install Device Package: {{ downloads_dir }}/{{ remoteit_deb }}"
@@ -49,8 +61,16 @@
 #   apt:
 #     deb: "{{ remoteit_device_url }}"
 
-- name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh -- this puts a claim code in /etc/remoteit/config.json which is valid for 24h
+# - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh -- this puts a claim code in /etc/remoteit/config.json which is valid for 24h
+- name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
+
+
+- name: "'rm /etc/remoteit/registration' (empty file used just above)"
+  file:
+    state: absent
+    path: /etc/remoteit/registration
+  ignore_errors: yes    # In case a future version of install_agent.sh deletes it for us
 
 
 - name: Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly enable remote.it AND generate a new remote.it claim code (in /etc/remoteit/config.json) -- optionally downloading + installing the very latest Device Package (like the 2 steps above)

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -24,6 +24,23 @@
     purge: yes
   ignore_errors: yes
 
+
+# Speeds things up a bit, deferring online claim code generation if not nec:
+# https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account
+
+- name: "'mkdir /etc/remoteit' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+  file:
+    state: directory
+    path: /etc/remoteit
+  when: remoteit_license_key is defined
+
+- name: "'touch /etc/remoteit/registration' e.g. if your 'remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6' exists in /etc/iiab/local_vars.yml"
+  file:
+    state: touch
+    path: /etc/remoteit/registration
+  when: remoteit_license_key is defined
+
+
 # - name: "Install Device Package: {{ downloads_dir }}/{{ remoteit_deb }}"
 #   apt:
 #     deb: "{{ downloads_dir }}/{{ remoteit_deb }}"
@@ -32,12 +49,9 @@
 #   apt:
 #     deb: "{{ remoteit_device_url }}"
 
-- name: Going to use pre-created REGISTRATION_CODE from desktop or web portal
-  shell: mkdir /etc/remoteit || true && touch /etc/remoteit/registration
-  when: remoteit_REGISTRATION_CODE is not none
-
 - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh -- this puts a claim code in /etc/remoteit/config.json which is valid for 24h
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
+
 
 - name: Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly enable remote.it AND generate a new remote.it claim code (in /etc/remoteit/config.json) -- optionally downloading + installing the very latest Device Package (like the 2 steps above)
   template:

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -32,6 +32,10 @@
 #   apt:
 #     deb: "{{ remoteit_device_url }}"
 
+- name: Going to use pre-created REGISTRATION_CODE from desktop or web portal
+  shell: mkdir /etc/remoteit || true && touch /etc/remoteit/registration
+  when: remoteit_REGISTRATION_CODE is not none
+
 - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 

--- a/roles/remoteit/tasks/main.yml
+++ b/roles/remoteit/tasks/main.yml
@@ -18,9 +18,9 @@
 
 - include_tasks: enable-or-disable.yml
 
-- name: Find the claim code if blank the machine was registrated
-  shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
-  register: remoteit_claim
+# - name: Extract claim code from /etc/remoteit/config.json if it exists
+#   shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
+#   register: remoteit_claim_code
 
 - name: Add 'remoteit' variable values to {{ iiab_ini_file }}
   ini_file:
@@ -37,5 +37,5 @@
       value: "{{ remoteit_install }}"
     - option: remoteit_enabled
       value: "{{ remoteit_enabled }}"
-    - option: remoteit_claim_code
-      value: "{{ remoteit_claim.stdout }}"
+    # - option: remoteit_claim_code
+    #   value: "{{ remoteit_claim_code.stdout }}"

--- a/roles/remoteit/tasks/main.yml
+++ b/roles/remoteit/tasks/main.yml
@@ -18,6 +18,9 @@
 
 - include_tasks: enable-or-disable.yml
 
+- name: Find the claim code if blank the machine was registrated
+  shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
+  register: remoteit_claim
 
 - name: Add 'remoteit' variable values to {{ iiab_ini_file }}
   ini_file:
@@ -34,3 +37,5 @@
       value: "{{ remoteit_install }}"
     - option: remoteit_enabled
       value: "{{ remoteit_enabled }}"
+    - option: remoteit_claim_code
+      value: "{{ remoteit_claim.stdout }}"

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -20,6 +20,8 @@ echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
 [ ! -d /etc/remoteit ] &&
     mkdir /etc/remoteit
 
+# Passwords and license keys in /etc/iiab/local_vars.yml are not a healthy
+# precedent :/  (Going forward let's try to keep such fully in their own apps.)
 KEY1=$(iiab_var_value remoteit_license_key)
 if [[ $KEY1 != "" ]]; then
     if [ -s /etc/remoteit/registration ]; then    # Non-zero size
@@ -36,7 +38,7 @@ if [[ $KEY1 != "" ]]; then
     echo -e "Removed remoteit_license_key line from /etc/iiab/local_vars.yml\n"
 fi
 
-# /etc/remoteit/registration consequences summarized on lines 78-83
+# /etc/remoteit/registration consequences summarized on lines 80-85
 if [ -s /etc/remoteit/registration ]; then    # Non-zero size
     cp -p /etc/remoteit/registration /tmp/etc.remoteit.registration
     echo -e "License key $(cat /etc/remoteit/registration) will be attempted."

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -9,14 +9,26 @@
 
 # 2022-04-03: SEE ALSO roles/remoteit/templates/iiab-remote.old
 
-echo -e "\nhttps://remote.it can help you remotely manage this IIAB.  Summary:\n"
+echo -e "\nhttps://remote.it can help you remotely manage this IIAB.\n"
+
+echo -e "Let's generate a claim code and enable it.  Documentation:\n"
 
 echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
 
-echo -en "\e[1mTo proceed we will delete /etc/remoteit/config.json, Ok? [Y/n]\e[0m "
-read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
-echo
-[[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
+if [ -f /etc/remoteit/config.json ]; then
+    echo -en "\e[1mTo proceed we will delete /etc/remoteit/config.json, Ok? [Y/n]\e[0m "
+    read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+    echo
+    [[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
+fi
+
+# Explanation below, on lines 65-72
+if [ -f /etc/remoteit/registration ]; then
+    echo -en "\e[1mTo proceed we will delete /etc/remoteit/registration, Ok? [Y/n]\e[0m "
+    read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+    echo
+    [[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
+fi
 
 echo -e "\nThis IIAB must be online to begin!\n"
 
@@ -41,8 +53,23 @@ else
 
     systemctl stop connectd      # "Safer" (though it's generally exited already!)
 
-    # '|| true' overrides 'bash -e' so script continues if config.json missing
-    mv /etc/remoteit/config.json /etc/remoteit/config.json.$(date +%F_%T_%Z) || true
+    # If someone manually deleted the dir, this blocks generation of claim code
+    [ ! -d /etc/remoteit ] &&
+        mkdir /etc/remoteit
+
+    [ -f /etc/remoteit/config.json ] &&
+        mv /etc/remoteit/config.json /etc/remoteit/config.json.$(date +%F_%T_%Z)
+    [ -f /etc/remoteit/registration ] &&
+        mv /etc/remoteit/registration /etc/remoteit/registration.$(date +%F_%T_%Z)
+
+    # /etc/remoteit/registration is deleted above, but just FYI if it existed:
+    #
+    # 1) If /etc/remoteit/registration exists and is empty, connectd (below)
+    #    will not create /etc/remoteit/config.json
+    # 2) If /etc/remoteit/registration contains an invalid license key, connectd
+    #    (below) will create /etc/remoteit/config.json WITH a claim code.
+    # 3) If /etc/remoteit/registration contains a valid license key, connectd
+    #    (below) will create /etc/remoteit/config.json WITHOUT a claim code.
 
     systemctl start connectd     # Claim Code logic + kickstarts 2 svcs below
     # /usr/share/remoteit/refresh.sh does the same thing (or close) as per:

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -30,10 +30,10 @@ if [[ $KEY1 != "" ]]; then
         fi
     fi
     echo $KEY1 > /etc/remoteit/registration
-    echo -e "Copied {{ remoteit_license_key }} to /etc/remoteit/registration"
+    echo -e "Copied remoteit_license_key value to /etc/remoteit/registration"
 
     sed -i '/^remoteit_license_key:/d' /etc/iiab/local_vars.yml
-    echo -e "Removed remoteit_license_key from /etc/iiab/local_vars.yml\n"
+    echo -e "Removed remoteit_license_key line from /etc/iiab/local_vars.yml\n"
 fi
 
 # /etc/remoteit/registration consequences summarized on lines 78-83

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -1,79 +1,112 @@
 #!/bin/bash -e
 
-# Run 'sudo iiab-remoteit' to enable remote.it AND get a new claim code.  Also
-# lets you download + install the latest Device Package to IIAB.  GENERAL TIPS:
-# http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
-
 # 'remoteit' Device Package AND /usr/bin/remoteit CLI already installed by:
 # https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml
 
-# 2022-04-03: SEE ALSO roles/remoteit/templates/iiab-remote.old
+# http://FAQ.IIAB.IO -> "How can I remotely manage my Internet-in-a-Box?"
 
-echo -e "\nhttps://remote.it can help you remotely manage this IIAB.\n"
+iiab_var_value() {
+    v1=$(grep "^$1:\s" /opt/iiab/iiab/vars/default_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    v2=$(grep "^$1:\s" /etc/iiab/local_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    [[ $v2 != "" ]] && echo $v2 || echo $v1    # [ "$v2" ] ALSO WORKS
+}
 
-echo -e "Let's generate a claim code and enable it.  Documentation:\n"
+echo -e "\nLet's enable https://remote.it to help you remotely manage this IIAB:\n"
 
 echo -e "https://github.com/iiab/iiab/blob/master/roles/remoteit/README.md\n"
 
-if [ -f /etc/remoteit/config.json ]; then
-    echo -en "\e[1mTo proceed we will delete /etc/remoteit/config.json, Ok? [Y/n]\e[0m "
-    read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
-    echo
-    [[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
+# If someone manually deleted the dir, that blocks generation of claim code,
+# and also license key extraction from /etc/iiab/local_vars.yml just below.
+[ ! -d /etc/remoteit ] &&
+    mkdir /etc/remoteit
+
+KEY1=$(iiab_var_value remoteit_license_key)
+if [[ $KEY1 != "" ]]; then
+    if [ -s /etc/remoteit/registration ]; then    # Non-zero size
+        KEY2=$(cat /etc/remoteit/registration)
+        if [[ $KEY1 != $KEY2 ]]; then
+            mv /etc/remoteit/registration /etc/remoteit/registration.$(date +%F_%T_%Z)
+            echo -e "Old /etc/remoteit/registration moved aside.\n"
+        fi
+    fi
+    echo $KEY1 > /etc/remoteit/registration
+    echo -e "Copied {{ remoteit_license_key }} to /etc/remoteit/registration"
+
+    sed -i '/^remoteit_license_key:/d' /etc/iiab/local_vars.yml
+    echo -e "Removed remoteit_license_key from /etc/iiab/local_vars.yml\n"
 fi
 
-# Explanation below, on lines 65-72
-if [ -f /etc/remoteit/registration ]; then
-    echo -en "\e[1mTo proceed we will delete /etc/remoteit/registration, Ok? [Y/n]\e[0m "
-    read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
-    echo
-    [[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
+# /etc/remoteit/registration consequences summarized on lines 78-83
+if [ -s /etc/remoteit/registration ]; then    # Non-zero size
+    cp -p /etc/remoteit/registration /tmp/etc.remoteit.registration
+    echo -e "License key $(cat /etc/remoteit/registration) will be attempted."
+    echo -e "It's backed up from /etc/remoteit/registration to /tmp, in case of purge.\n"
+elif [ -f /etc/remoteit/registration ]; then    # Zero size, e.g. due to touch
+    rm /etc/remoteit/registration
+    echo -e "Empty /etc/remoteit/registration deleted, so claim code can be generated.\n"
 fi
 
 echo -e "\nThis IIAB must be online to begin!\n"
 
-echo -en "\e[1mOptionally download + install latest remote.it Device Package? [y/N]\e[0m "
+echo -en "\e[1mOptionally purge + install latest remote.it Device Package? [y/N]\e[0m "
 read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
 echo
 
 if [[ $ans = "y" ]] || [[ $ans = "Y" ]]; then
-    # 2022-04-02: Full Path Avoids problematic /usr/local/bin/apt on Linux Mint
+    # Full apt path avoids problematic /usr/local/bin/apt on Linux Mint
     /usr/bin/apt -y purge "remoteit*" || true
 
     # Why the brutal purge?  Even 'apt -y reinstall remoteit.*.deb' is stronger
     # than 'install -y' in install_agent.sh, but still sometimes insufficient!
+    # https://github.com/iiab/iiab/blob/master/roles/remoteit/tasks/install.yml#L18-L21
+
+    if [ -f /tmp/etc.remoteit.registration ]; then
+        # apt purge should rmdir /etc/remoteit but might be sloppy in future?
+        [ ! -d /etc/remoteit ] &&
+            mkdir /etc/remoteit
+
+        cp -p /tmp/etc.remoteit.registration /etc/remoteit/registration
+    fi
 
     # apt install & enable "latest" remote.it Device Package for your CPU/OS
     curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 else
-    # 2022-04-04: Stop/Delete/Bounce sequence follows official suggestion here:
+    # 2022-04-07: Stop/Delete/Start sequence follows official suggestions here:
     # https://support.remote.it/hc/en-us/articles/360061228252-Oops-I-cloned-an-SD-card-
+    # https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account
+    #
+    # FYI if /etc/remoteit/config.json DOESN'T EXIST:
+    #
+    # 1) If /etc/remoteit/registration exists and is EMPTY, bouncing connectd...          DOESN'T CREATE /etc/remoteit/config.json
+    # 2) If /etc/remoteit/registration DOESN'T EXIST, bouncing connectd...                CREATES /etc/remoteit/config.json WITH a claim code + WITHOUT an SSH service.
+    # 3) If /etc/remoteit/registration contains an INVALID license key, bouncing connectd CREATES /etc/remoteit/config.json WITH a claim code + WITHOUT an SSH service.
+    # 4) If /etc/remoteit/registration contains a VALID license key, bouncing connectd... CREATES /etc/remoteit/config.json WITHOUT a claim code + WITH an SSH service.
+    #
+    # FYI if /etc/remoteit/config.json EXISTS, bouncing connectd will update
+    # config.json's internal "timestamp" without changing anything else,
+    # regardless whether /etc/remoteit/registration exists and what it contains,
+    # and regardless whether /etc/remoteit/config.json contains a claim code.
 
     echo -e "In a few seconds, all 3 {connectd, schannel, remoteit@...} should be enabled!\n"
 
-    systemctl stop connectd      # "Safer" (though it's generally exited already!)
+    systemctl stop connectd    # "Safer" (though it's generally exited already!)
 
-    # If someone manually deleted the dir, this blocks generation of claim code
-    [ ! -d /etc/remoteit ] &&
-        mkdir /etc/remoteit
-
-    [ -f /etc/remoteit/config.json ] &&
+    #if [ ! -f /etc/remoteit/registration ] && [ -f /etc/remoteit/config.json ]; then
+    if [ -f /etc/remoteit/config.json ]; then
+        # echo -en "\n\e[1mMove /etc/remoteit/config.json, so registration can begin? [Y/n]\e[0m "
+        # read ans < /dev/tty    # Strips outer whitespace, whether we like it or not!
+        # echo
+        # [[ $ans = "n" ]] || [[ $ans = "N" ]] && exit 1
         mv /etc/remoteit/config.json /etc/remoteit/config.json.$(date +%F_%T_%Z)
-    [ -f /etc/remoteit/registration ] &&
-        mv /etc/remoteit/registration /etc/remoteit/registration.$(date +%F_%T_%Z)
+        #echo -e "/etc/remoteit/config.json moved aside, so claim code can be generated.\n"
+        #echo -e "/etc/remoteit/config.json moved aside, so device registration can begin.\n"
+        echo -e "/etc/remoteit/config.json moved aside, for fresh device registration.\n"
+    fi
 
-    # /etc/remoteit/registration is deleted above, but just FYI if it existed:
-    #
-    # 1) If /etc/remoteit/registration exists and is empty, connectd (below)
-    #    will not create /etc/remoteit/config.json
-    # 2) If /etc/remoteit/registration contains an invalid license key, connectd
-    #    (below) will create /etc/remoteit/config.json WITH a claim code.
-    # 3) If /etc/remoteit/registration contains a valid license key, connectd
-    #    (below) will create /etc/remoteit/config.json WITHOUT a claim code.
-
-    systemctl start connectd     # Claim Code logic + kickstarts 2 svcs below
-    # /usr/share/remoteit/refresh.sh does the same thing (or close) as per:
-    # https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account
+    systemctl start connectd    # Registration logic (use license key or
+    # generate claim code) then kickstart 2 "child" services below.
+    # FYI running /usr/share/remoteit/refresh.sh appears to do the exact same
+    # thing (as bouncing service connectd).
 
     systemctl enable connectd    # 2 enable lines, like enable-or-disable.yml
 
@@ -94,11 +127,27 @@ else
     echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
 fi
 
-claim_code=$(grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev)
-echo -e "\nYour new claim code is \e[44;1m${claim_code}\e[0m -- YOUR NEXT STEPS ARE...\n"
+if grep -q claim /etc/remoteit/config.json; then
+    claim_code=$(grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev)
+    echo -e "\nYour new claim code is \e[44;1m${claim_code}\e[0m -- YOUR NEXT STEPS ARE...\n"
 
-echo -e "\e[1m1) Install the remote.it Desktop Application on your own laptop/computer:\e[0m"
-echo -e "   https://remote.it/download/\n"
+    echo -e "\e[1m1) Log in to https://remote.it or its Desktop Application on your own PC:\e[0m"
+    echo -e "   https://remote.it/download/\n"
 
-echo -e "\e[1m2) Use the above 8-character claim code WITHIN 24H as shown here:\e[0m"
-echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\n"
+    echo -e "\e[1m2) Use the above 8-character claim code WITHIN 24H as shown here:\e[0m"
+    echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\n"
+
+    echo -e "\e[1m3) Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device:\e[0m"
+    echo -e "   https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device\n"
+else
+    echo -e "\nLicense key (if valid!) hopefully worked -- YOUR NEXT STEPS ARE...\n"
+
+    echo -e "\e[1m1) Log in to https://remote.it or its Desktop Application on your own PC:\e[0m"
+    echo -e "   https://remote.it/download/\n"
+
+    echo -e '\e[1m2) In the "Devices" section on the left, check that your IIAB is now present:\e[0m'
+    echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\n"
+
+    echo -e "\e[1m3) Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device:\e[0m"
+    echo -e "   https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device\n"
+fi

--- a/roles/remoteit/templates/registration.j2
+++ b/roles/remoteit/templates/registration.j2
@@ -1,0 +1,1 @@
+{{ remoteit_license_key }}

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -213,6 +213,8 @@ sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/remoteit
 remoteit_install: True
 remoteit_enabled: False
+# OPTION #1: Run 'sudo iiab-remoteit' later.  OPTION #2: Set this now:
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
 
 # SECURITY WARNING: https://wiki.iiab.io/go/Security
 openvpn_install: True

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -128,6 +128,8 @@ sshd_enabled: True
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/remoteit
 remoteit_install: True
 remoteit_enabled: False
+# OPTION #1: Run 'sudo iiab-remoteit' later.  OPTION #2: Set this now:
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
 
 # SECURITY WARNING: https://wiki.iiab.io/go/Security
 openvpn_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -128,6 +128,8 @@ sshd_enabled: True
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/remoteit
 remoteit_install: True
 remoteit_enabled: False
+# OPTION #1: Run 'sudo iiab-remoteit' later.  OPTION #2: Set this now:
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
 
 # SECURITY WARNING: https://wiki.iiab.io/go/Security
 openvpn_install: True

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -128,6 +128,8 @@ sshd_enabled: True
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/remoteit
 remoteit_install: True
 remoteit_enabled: False
+# OPTION #1: Run 'sudo iiab-remoteit' later.  OPTION #2: Set this now:
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
 
 # SECURITY WARNING: https://wiki.iiab.io/go/Security
 openvpn_install: True

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -128,6 +128,8 @@ sshd_enabled: True
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/remoteit
 remoteit_install: True
 remoteit_enabled: False
+# OPTION #1: Run 'sudo iiab-remoteit' later.  OPTION #2: Set this now:
+# remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6
 
 # SECURITY WARNING: https://wiki.iiab.io/go/Security
 openvpn_install: True


### PR DESCRIPTION
Building on @jvonau's PR #3169, using Ansible rather than bash approaches where possible.

FWIW I'm uncomfortable with the claim code being disseminating as part of `/etc/iiab/iiab.ini` or similar files, so that part is commented out.

Earlier refs:

- #3006
- PR #3156
- PR #3161
- PR #3167