### PR TITLE
Install apt pkg 'smbclient' instead of virtual pkg 'samba-client' (in samba/tasks/install.yml)

### DIFF
--- a/roles/samba/tasks/install.yml
+++ b/roles/samba/tasks/install.yml
@@ -13,12 +13,13 @@
     state: directory
 
 # Install and configure samba server (requires ports 137, 138, 139, 445 open).
-- name: "Install 4 packages: samba, samba-client, samba-common, cifs-client"
+- name: "Install 4 packages: samba, samba-common, smbclient, cifs-client"
   package:
     name:
       - samba
-      - samba-client
+      #- samba-client    # 2022-04-13: Virtual package fails to install w/ ansible-core 2.13.0b0
       - samba-common
+      - smbclient
       - cifs-utils
     state: present
 


### PR DESCRIPTION
This resolves:

- #3177 

And is probably a good idea regardless.  So as to avoid problems if/when the legacy package name is deprecated (regardless whether using ansible-core 2.13 or not!)