### PR TITLE
templates/iiab-remoteit: Warn if /etc/remoteit/config.json exists...and try it if operator really wants to?

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -24,15 +24,19 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 1. Run `sudo iiab-remoteit` to enable remote.it on your IIAB:
 
-   - Hit [Enter] <!-- (repeatedly if necessary, to accept all defaults) --> if this is a fresh install, to quickly generate a claim code for your IIAB.
+   - Hit [Enter] (repeatedly if necessary, to accept all defaults) to quickly generate a claim code for your IIAB.
 
      The claim code must be used [within 24 hours](https://docs.remote.it/device-package/installation#2.-update-your-package-manager-and-install) (Step 2., below).
 
      Just FYI a copy is also put in: `/etc/remoteit/config.json`
 
-   - EXCEPTION: If a remote.it license key happens to be found in `/etc/iiab/local_vars.yml` or `/etc/remoteit/registration`, that will be tried first (prior to, and instead of generating a claim code).
+   - EXCEPTION #1: If a remote.it license key happens to be found in `/etc/iiab/local_vars.yml` or `/etc/remoteit/registration`, that will be tried first (prior to, and instead of generating a claim code).
 
      *If the license key works, you will not get a claim code (as the IIAB device auto-registers to your remote.it account) so jump to Step 5. in OPTION #2.*
+
+   - EXCEPTION #2: If you have an existing `/etc/remoteit/config.json` you will be given the option to try that (e.g. if you already registered the IIAB device to your remote.it account).
+
+     *Verify that by jumping to Step 5. in OPTION #2.*
 
 <!--
 1. Connect your IIAB device to the Internet.

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -36,7 +36,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
    - EXCEPTION #2: If you have an existing `/etc/remoteit/config.json` you will be given the option to try that (e.g. if you already registered the IIAB device to your remote.it account).
 
-     *Verify that by jumping to Step 5. in OPTION #2.*
+     *Verify that after `sudo iiab-remoteit` completes, by jumping to Step 5. in OPTION #2.*
 
 <!--
 1. Connect your IIAB device to the Internet.

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -48,14 +48,14 @@ elif [ -f /etc/remoteit/registration ]; then    # Zero size, e.g. due to touch
     echo -e "Empty /etc/remoteit/registration deleted, so claim code can be generated.\n"
 fi
 
-echo -e "\nThis IIAB must be online to begin!\n"
+echo -e "\nThis IIAB must be online to begin!"
 
 if [ -f /etc/remoteit/config.json ]; then
-    echo -en "For fresh registration let's remove /etc/remoteit/config.json, Ok? [Y/n] "
+    echo -en "\n\e[1mFor fresh registration let's remove /etc/remoteit/config.json, Ok? [Y/n]\e[0m "
     read -n 1 -r ans < /dev/tty    # Prompt for a single character
     echo; echo
 
-    if [[ $ans != "y" && $ans != "Y" ]]; then
+    if [[ $ans = "n" || $ans = "N" ]]; then
         echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
 
         systemctl enable connectd
@@ -68,11 +68,23 @@ if [ -f /etc/remoteit/config.json ]; then
             echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
         fi
 
+        echo -e "\e[1m\nYou can now check for this IIAB device in your https://remote.it account."
+        echo -e "(IF your pre-existing /etc/remoteit/config.json was working in the past!)\e[0m\n"
+
+        echo -e "\e[1m1) Log in to https://remote.it or its Desktop Application on your own PC:\e[0m"
+        echo -e "   https://remote.it/download/\n"
+
+        echo -e '\e[1m2) In the "Devices" section on the left, check that your IIAB is now present:\e[0m'
+        echo -e "   https://docs.remote.it/software/device-package/installation#3.-claim-and-register-the-device\n"
+        
+        echo -e "\e[1m3) Authorize services/ports (e.g. SSH, HTTP, etc) for your IIAB device:\e[0m"
+        echo -e "   https://docs.remote.it/software/device-package/installation#4.-set-up-services-on-your-device\n"
+
         exit 0
     fi
 fi
 
-echo -en "\e[1mOptionally purge + install latest remote.it Device Package? [y/N]\e[0m "
+echo -en "\e[1m\nOptionally purge + install latest remote.it Device Package? [y/N]\e[0m "
 read -n 1 -r ans < /dev/tty    # Prompt for a single character
 echo; echo
 

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -38,7 +38,7 @@ if [[ $KEY1 != "" ]]; then
     echo -e "Removed remoteit_license_key line from /etc/iiab/local_vars.yml\n"
 fi
 
-# /etc/remoteit/registration consequences summarized on lines 80-85
+# /etc/remoteit/registration consequences summarized on lines 114-119
 if [ -s /etc/remoteit/registration ]; then    # Non-zero size
     cp -p /etc/remoteit/registration /tmp/etc.remoteit.registration
     echo -e "License key $(cat /etc/remoteit/registration) will be attempted."
@@ -55,7 +55,7 @@ if [ -f /etc/remoteit/config.json ]; then
     read -n 1 -r ans < /dev/tty    # Prompt for a single character
     echo; echo
 
-    if [[ $ans = "n" || $ans = "N" ]]; then
+    if [[ $ans = "n" || $ans = "N" ]]; then    # Nearly the same as Lines 142-189
         echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
 
         systemctl enable connectd

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -50,6 +50,28 @@ fi
 
 echo -e "\nThis IIAB must be online to begin!\n"
 
+if [ -f /etc/remoteit/config.json ]; then
+    echo -en "For fresh registration let's remove /etc/remoteit/config.json, Ok? [Y/n] "
+    read -n 1 -r ans < /dev/tty    # Prompt for a single character
+    echo; echo
+
+    if [[ $ans != "y" && $ans != "Y" ]]; then
+        echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
+
+        systemctl enable connectd
+        systemctl restart connectd
+        systemctl enable schannel
+
+        if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
+            sed -i "s/^remoteit_enabled:.*/remoteit_enabled: True/" /etc/iiab/local_vars.yml
+        else
+            echo "remoteit_enabled: True" >> /etc/iiab/local_vars.yml
+        fi
+
+        exit 0
+    fi
+fi
+
 echo -en "\e[1mOptionally purge + install latest remote.it Device Package? [y/N]\e[0m "
 read -n 1 -r ans < /dev/tty    # Prompt for a single character
 echo; echo


### PR DESCRIPTION
A precautionary prompt is added, for IIAB implementers/operators who run `sudo iiab-remoteit` repeatedly &mdash; to make more clear that they can wipe their IIAB device's remote.it registration each time &mdash; or try to enable an existing remote.it device registration within `/etc/remoteit/config.json`

Building on:

- PR #3156
- PR #3157
- PR #3161
- PR #3162
- PR #3167
- PR #3172 
- PR #3176