### PR TITLE
Moodle 4.0 is now official

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -7,7 +7,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-moodle_version: 311
+moodle_version: 40
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -7,7 +7,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-moodle_version: 40
+moodle_version: 400
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -43,7 +43,7 @@
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
-- name: Download (clone) {{ moodle_repo_url }} to {{ moodle_base }} (~356 MB initially, ~376 MB later)
+- name: Download (clone) {{ moodle_repo_url }} to {{ moodle_base }} (~370 MB initially, ~390 MB later)
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle


### PR DESCRIPTION
Moodle 4.0 is now official: https://moodle.com/news/moodle-4-is-here/

This PR could use broad community testing on different OS's (after merging too) while we spot-check Moodle 4.0's official requirements[*] here:

- https://docs.moodle.org/dev/Moodle_4.0_release_notes#Server_requirements
- #3182

[*] Whether or not it yet works with Ubuntu 22.04's PHP 8.1!

Building on:

- PR #2841
- PR #2869