### PR TITLE
workaround php8.1 [e.g. for Moodle 4.0 on Ubuntu 22.04]

### DIFF
--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -65,6 +65,11 @@
     strip: 1
   when: ansible_local.local_facts.os_ver == "ubuntu-2204"
 
+- name: Save working branch
+  shell: "cd {{ moodle_base }} && git commit -a -m 'local_copy'"
+  when: ansible_local.local_facts.os_ver == "ubuntu-2204"
+  ignore_errors: yes
+
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:
     path: "{{ moodle_base }}"

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -49,8 +49,21 @@
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
     version: "MOODLE_{{ moodle_version }}_STABLE"
+    update: no
     #version: master   # TEMPORARY DURING MAY 2018 TESTING, installed 3.5beta+ = https://download.moodle.org/releases/development/
-  #ignore_errors: yes
+
+- name: New working branch
+  shell: "cd {{ moodle_base }} && git checkout -b local_copy"
+  when: ansible_local.local_facts.os_ver == "ubuntu-2204"
+  ignore_errors: yes
+
+- name: Patch moodle for php8.1
+  ansible.posix.patch:
+    src: "{{ iiab_dir }}/roles/moodle/templates/php81.patch"
+    dest: "{{ moodle_base }}/lib/xmlize.php"
+    state: present
+    strip: 1
+  when: ansible_local.local_facts.os_ver == "ubuntu-2204"
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:

--- a/roles/moodle/templates/php81.patch
+++ b/roles/moodle/templates/php81.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/xmlize.php b/lib/xmlize.php
+index 78cf82b2..94d118bd 100644
+--- a/lib/xmlize.php
++++ b/lib/xmlize.php
+@@ -43,7 +43,7 @@ class xml_format_exception extends moodle_exception {
+     /** @var string */
+     public $errorstring;
+     /** @var int */
+-    public $line;
++    public int $line;
+     /** @var char */
+     public $char;
+     /**


### PR DESCRIPTION
https://moodle.org/mod/forum/discuss.php?d=429511

### Fixes bug:
Not sure if this is a fix or not #3184
### Description of changes proposed in this pull request:
Allows install to continue to allow exploring what else might be broken with the shift to php8.1
### Smoke-tested on which OS or OS's:
multipass-2204vm
