### PR TITLE
Try out Node.js 18.x (now released, becomes LTS on 2022-10-25)

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -9,10 +9,10 @@
   include_role:
     name: nodejs
 
-- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 16.x
+- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 18.x
   assert:
-    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('16.x', '<=')
-    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 16.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('18.x', '<=')
+    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 18.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
     quiet: yes
 
 - name: "Set 'yarn_install: True' and 'yarn_enabled: True'"

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -5,7 +5,7 @@
 # nodejs_install: False
 # nodejs_enabled: False
 
-# nodejs_version: 16.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17
+# nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-XX-YY
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -5,7 +5,7 @@
 # nodejs_install: False
 # nodejs_enabled: False
 
-# nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-XX-YY
+# nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -420,7 +420,7 @@ mosquitto_port: 1883
 # JupyterHub, nodered (Node-RED), pbx (Asterix, FreePBX) &/or Sugarizer:
 nodejs_install: False
 nodejs_enabled: False
-nodejs_version: 16.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17
+nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-XX-YY
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -420,7 +420,7 @@ mosquitto_port: 1883
 # JupyterHub, nodered (Node-RED), pbx (Asterix, FreePBX) &/or Sugarizer:
 nodejs_install: False
 nodejs_enabled: False
-nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-XX-YY
+nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
If this appears to work just as well as Node.js 16.x across the board, this should be merged in coming months if not earlier:

- https://nodejs.org/en/blog/announcements/v18-release-announce/
- https://nodejs.org/en/blog/release/v18.0.0/ (notable changes)
- https://nodejs.org/en/about/releases/ (release calendar)

In any case Node.js 16.x will no longer be "Active LTS" on 2022-10-18, so we should transition well before then.