### PR TITLE
FreePBX 16 now officially works with Asterisk 19 (so remove temp patch)

### DIFF
--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -4,6 +4,11 @@
 
 https://internet-in-a-box.org[Internet-in-a-Box (IIAB)] can install https://asterisk.org/[Asterisk] and https://freepbx.org/[FreePBX] for Voice over IP (VoIP) calls using regular Android and iPhone softphone (SIP) apps — e.g. for low-cost and rural telephony.
 
+As of April 2022, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+19+Documentation[Asterisk 19] and https://www.freepbx.org/freepbx-16-is-now-released-for-general-availability/[FreePBX 16].
+
+PHP 7.4 is REQUIRED (https://github.com/iiab/iiab/pull/2899[PR #2899]) and PHP 8.x does not yet work (https://github.com/iiab/iiab/pull/3019#issuecomment-962469346[PR #3109]) &mdash; so please consider installing this on https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems[Ubuntu 20.04, Debian 11, or Raspberry Pi OS 11 "Bullseye"].
+
+////
 As of August 2021, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Documentation[Asterisk 18] and https://www.freepbx.org/freepbx-16-beta-is-here/[FreePBX 16 Beta], as required by the latest PHP 7.4 Linux OS's (https://github.com/iiab/iiab/pull/2899[PR #2899]).  Please consider installing this on https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems[Ubuntu 20.04+, Debian 11 — or the imminent Raspberry Pi OS 11 "Bullseye"].
 
 _PLEASE UNDERSTAND THIS MEANS THAT: IIAB no longer supports FreePBX 15 (Linux with PHP < 7.4, e.g. Raspberry Pi OS 10 "Buster").  Thank you for your understanding, as we look to the future together!_
@@ -11,7 +16,7 @@ _PLEASE UNDERSTAND THIS MEANS THAT: IIAB no longer supports FreePBX 15 (Linux wi
 _Upcoming:_ IIAB will consider supporting Asterisk 19, on or around its 2021-09-28 expected release date (https://github.com/iiab/iiab/issues/2934[#2934]).
 
 _Historical:_ Back in February 2019, IIAB had installed Asterisk 16 and FreePBX 15, e.g. for Ubuntu 18.04, Debian 9 "Stretch" and experimentally, Raspberry Pi (https://github.com/iiab/iiab/issues/1467[#1467]).
-
+////
 
 
 == What Asterisk & FreePBX do

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -96,17 +96,22 @@
     extra_opts: [--strip-components=1]
     creates: "{{ freepbx_src_dir }}/install"
 
-- name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/install.php"
-  replace:
-    path: /opt/iiab/freepbx/install.php
-    regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
-    replace: 'version_compare($astversion, "20", "ge")) {'
-
-- name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/installlib/installcommand.class.php"
-  replace:
-    path: /opt/iiab/freepbx/installlib/installcommand.class.php
-    regexp: 'version_compare\(\$matches\[1\], "19", "ge"\)\) \{$'
-    replace: 'version_compare($matches[1], "20", "ge")) {'
+# No longer needed since approx 2022-01-31 / 2022-02-14, as confirmed by:
+# https://github.com/FreePBX/framework/blob/release/16.0/install.php#L27
+# https://github.com/FreePBX/framework/blob/release/16.0/installlib/installcommand.class.php#L300
+# https://community.freepbx.org/t/asterisk-19-working-with-freepbx16/80965/14
+#
+# - name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/install.php"
+#   replace:
+#     path: /opt/iiab/freepbx/install.php
+#     regexp: 'version_compare\(\$astversion, "19", "ge"\)\) \{$'
+#     replace: 'version_compare($astversion, "20", "ge")) {'
+#
+# - name: "FreePBX - 2021-11-06: TEMPORARILY force FreePBX 16 to work with Asterisk 19 - patch /opt/iiab/freepbx/installlib/installcommand.class.php"
+#   replace:
+#     path: /opt/iiab/freepbx/installlib/installcommand.class.php
+#     regexp: 'version_compare\(\$matches\[1\], "19", "ge"\)\) \{$'
+#     replace: 'version_compare($matches[1], "20", "ge")) {'
 
 # 2021-08-04: FreePBX 16 no longer needs this FreePBX 15 patch
 # - name: FreePBX - Patch FreePBX source - IIAB Bug 1685


### PR DESCRIPTION
Building on:

- #2934
- PR #3018
- PR #3019

ASIDE: [PHP 8.x](https://github.com/iiab/iiab/pull/3019#issuecomment-962469346) is likely still NOT supported (: