### PR TITLE
Stage 6/7 bypass of apps not yet compatible w/ Ubuntu 22.04 (Kolibri, Nextcloud, Moodle, Sugarizer) [ASIDE: Node.js 18.x works manually or using deb.nodesource.com install script]

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -59,7 +59,7 @@
 - name: NEXTCLOUD
   include_role:
     name: nextcloud
-  when: nextcloud_install
+  when: nextcloud_install and not is_ubuntu_2204    # TEMPORARY
 
 - name: WORDPRESS
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install
+  when: kolibri_install and not is_ubuntu_2204    # TEMPORARY
 
 - name: KIWIX
   include_role:
@@ -21,7 +21,7 @@
 - name: MOODLE
   include_role:
     name: moodle
-  when: moodle_install
+  when: moodle_install and not is_ubuntu_2204    # TEMPORARY
 
 - name: OSM-VECTOR-MAPS
   include_role:
@@ -43,7 +43,7 @@
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install
+  when: sugarizer_install and not is_ubuntu_2204    # TEMPORARY
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:


### PR DESCRIPTION
This is just an interim shim patch for the coming weeks &mdash; especially for newcomers embracing Ubuntu 22.04 "Jammy Jellyfish" being released in not so many hours today (2022-04-21) after 2 years!

More advanced IIAB implementers wanting to keep up day-by-day &mdash; with the very latest feasibility of (Nextcloud, Kolibri, Moodle, Sugarizer) on Ubuntu 22.04 &mdash; should keep an eye on Section 2. of:

https://github.com/iiab/iiab/wiki/IIAB-Platforms

RECAP: Anybody is free to attempt `cd /opt/iiab/iiab` then `sudo ./runrole <role>` to later try to install any of these 4 apps/services.

But most important, this PR serves to keep implementers from drowning in confusion when MEDIUM-sized IIAB installs fail to install {Kolibri, Nextcloud, Sugarizer} and LARGE-sized IIAB installs fail to install {Moodle} &mdash; all 4 of which aren't yet/quite compatible with Ubuntu 22.04's + Python 3.10 and/or PHP 8.1 and/or MongoDB.

[Related:]

- #3182
- PR #3184
- PR #3186
- #3190
- PR #3208