### PR TITLE
host maps on github

### DIFF
--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -15,6 +15,7 @@ maps_branch: 'master'    # Quotes not required
 
 # soft code sources
 archive_org_url: https://archive.org/download
+iiab_map_url: http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
 #map_catalog_url: http://download.iiab.io/content/OSM/vector-tiles
 map_catalog_url: http://timmoody.com/iiab-files/maps
 satellite_version: satellite_z0-z9_v3.mbtiles    # 2021-12-20: Var unused, but hard-coded in 11 places within https://github.com/iiab/iiab-admin-console -- #3077 discusses map-catalog.json & adm-map-catalog.json

--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -8,10 +8,10 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 # The following soft coded variables allow testing, before pulling PR's into master
-# osm_repo_url: https://raw.githubusercontent.com/iiab/maps
-osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
-#maps_branch: 'master'    # Quotes not required
-maps_branch: 'maps7.3'
+osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+maps_branch: 'master'    # Quotes not required
+#osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
+#maps_branch: 'maps7.3'
 
 # soft code sources
 archive_org_url: https://archive.org/download

--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -15,7 +15,7 @@ maps_branch: 'master'    # Quotes not required
 
 # soft code sources
 archive_org_url: https://archive.org/download
-iiab_map_url: http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
+#iiab_map_url: http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
 #map_catalog_url: http://download.iiab.io/content/OSM/vector-tiles
 map_catalog_url: http://timmoody.com/iiab-files/maps
 satellite_version: satellite_z0-z9_v3.mbtiles    # 2021-12-20: Var unused, but hard-coded in 11 places within https://github.com/iiab/iiab-admin-console -- #3077 discusses map-catalog.json & adm-map-catalog.json

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -10,6 +10,16 @@
     - "{{ vector_map_path }}/viewer/tiles"
     - "{{ vector_map_path }}/installer"
 
+- name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
+  package:
+    state: present
+    name:
+      - python3-geojson
+      - python3-pil
+      - python3-wget
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      - php{{ php_version }}-sqlite3
+
 # - name: Does 26M cities database {{ vector_map_path }}/viewer/cities1000.sqlite exist?
 #   stat:
 #     path: "{{ vector_map_path }}/viewer/cities1000.sqlite"
@@ -186,16 +196,6 @@
     dest: "{{ vector_map_path }}/maplist/index.html"
     force: yes
     timeout: "{{ download_timeout }}"
-
-- name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
-  package:
-    state: present
-    name:
-      - python3-geojson
-      - python3-pil
-      - python3-wget
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-sqlite3
 
 - name: Copy 6 scripts to /usr/bin, for downloading tiles (0755)
   get_url:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -27,16 +27,16 @@
 
 # - name: If not, download {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
 # At this point, fetches from github.com/'REPO'/maps from maps_branch
-- name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
+- name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/2022/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/2022/cities1000.sqlite"
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
 
-- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/map-catalog.json to {{ iiab_etc_path }}
+- name: Download {{ osm_repo_url }}/{{ maps_branch }}/2022/map-catalog.json to {{ iiab_etc_path }}
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/map-catalog.json"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/2022/map-catalog.json"
     dest: "{{ iiab_etc_path }}"    # /etc/iiab
     timeout: "{{ download_timeout }}"
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -27,16 +27,16 @@
 
 # - name: If not, download {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
 # At this point, fetches from github.com/'REPO'/maps from maps_branch
-- name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/2022/cities1000.sqlite to {{ vector_map_path }}/viewer/
+- name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/2022/cities1000.sqlite"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite"
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
 
-- name: Download {{ osm_repo_url }}/{{ maps_branch }}/2022/map-catalog.json to {{ iiab_etc_path }}
+- name: Download {{ osm_repo_url }}/{{ maps_branch }}/2020/map-catalog.json to {{ iiab_etc_path }}
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/2022/map-catalog.json"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/2020/map-catalog.json"
     dest: "{{ iiab_etc_path }}"    # /etc/iiab
     timeout: "{{ download_timeout }}"
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -52,17 +52,17 @@
     path: "{{ vector_map_path }}/test-page/assets/map-catalog.json"
     state: link
 
-- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
-  get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json"
-    dest: "{{ iiab_etc_path }}"
-    timeout: "{{ download_timeout }}"
+#- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
+#  get_url:
+#    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json"
+#    dest: "{{ iiab_etc_path }}"
+#    timeout: "{{ download_timeout }}"
 
-- name: Symlink {{ vector_map_path }}/maplist/assets/regions.json -> /etc/iiab/regions.json
-  file:
-    src: /etc/iiab/regions.json
-    path: "{{ vector_map_path }}/maplist/assets/regions.json"
-    state: link
+#- name: Symlink {{ vector_map_path }}/maplist/assets/regions.json -> /etc/iiab/regions.json
+#  file:
+#    src: /etc/iiab/regions.json
+#    path: "{{ vector_map_path }}/maplist/assets/regions.json"
+#    state: link
 
 - name: Download OpenLayers test page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/* to {{ vector_map_path }}/test-page/ -- for test page http://box/osm-vector-maps/installer/
   get_url:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -26,6 +26,7 @@
 #   register: cities_installed
 
 # - name: If not, download {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
+# At this point, fetches from github.com/'REPO'/maps from maps_branch
 - name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite"
@@ -63,7 +64,6 @@
     path: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
-# At this point, fetches from github.com/'REPO'/maps from maps_branch
 - name: Download OpenLayers test page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/* to {{ vector_map_path }}/test-page/ -- for test page http://box/osm-vector-maps/installer/
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/{{ item }}"    # https://raw.githubusercontent.com/iiab/maps / master

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -26,16 +26,16 @@
 #   register: cities_installed
 
 # - name: If not, download {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
-- name: Download 26M {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
+- name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
-    url: "{{ iiab_map_url }}/regional-resources/cities1000.sqlite"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/cities1000.sqlite"
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
 
-- name: Download {{ map_catalog_url }}/map-catalog.json to {{ iiab_etc_path }}
+- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/map-catalog.json to {{ iiab_etc_path }}
   get_url:
-    url: "{{ map_catalog_url }}/map-catalog.json"    # http://timmoody.com/iiab-files/maps
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/map-catalog.json"
     dest: "{{ iiab_etc_path }}"    # /etc/iiab
     timeout: "{{ download_timeout }}"
 
@@ -51,13 +51,9 @@
     path: "{{ vector_map_path }}/test-page/assets/map-catalog.json"
     state: link
 
-# regions.json is out of sync atm..
-#- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
-#  get_url: {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json
-
-- name: Download {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
+- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
   get_url:
-    url: "{{ iiab_map_url }}/assets/regions.json"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json"
     dest: "{{ iiab_etc_path }}"
     timeout: "{{ download_timeout }}"
 

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -10,12 +10,6 @@
     - "{{ vector_map_path }}/viewer/tiles"
     - "{{ vector_map_path }}/installer"
 
-- name: Download {{ map_catalog_url }}/map-catalog.json to {{ iiab_etc_path }}
-  get_url:
-    url: "{{ map_catalog_url }}/map-catalog.json"    # http://download.iiab.io/content/OSM/vector-tiles
-    dest: "{{ iiab_etc_path }}"    # /etc/iiab
-    timeout: "{{ download_timeout }}"
-
 # - name: Does 26M cities database {{ vector_map_path }}/viewer/cities1000.sqlite exist?
 #   stat:
 #     path: "{{ vector_map_path }}/viewer/cities1000.sqlite"
@@ -29,11 +23,10 @@
     timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
 
-# At this point, fetches from github.com/georgejhunt/maps from test branch
-- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
+- name: Download {{ map_catalog_url }}/map-catalog.json to {{ iiab_etc_path }}
   get_url:
-    url: "{{ osm_repo_url }}/master/resources/regions.json"
-    dest: "{{ iiab_etc_path }}"
+    url: "{{ map_catalog_url }}/map-catalog.json"    # http://timmoody.com/iiab-files/maps
+    dest: "{{ iiab_etc_path }}"    # /etc/iiab
     timeout: "{{ download_timeout }}"
 
 - name: Symlink {{ doc_root }}/common/assets/map-catalog.json -> /etc/iiab/map-catalog.json
@@ -48,12 +41,23 @@
     path: "{{ vector_map_path }}/test-page/assets/map-catalog.json"
     state: link
 
+# regions.json is out of sync atm..
+#- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
+#  get_url: {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json
+
+- name: Download {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
+  get_url:
+    url: "{{ iiab_map_url }}/assets/regions.json"
+    dest: "{{ iiab_etc_path }}"
+    timeout: "{{ download_timeout }}"
+
 - name: Symlink {{ vector_map_path }}/maplist/assets/regions.json -> /etc/iiab/regions.json
   file:
     src: /etc/iiab/regions.json
     path: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
+# At this point, fetches from github.com/'REPO'/maps from maps_branch
 - name: Download OpenLayers test page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/* to {{ vector_map_path }}/test-page/ -- for test page http://box/osm-vector-maps/installer/
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/{{ item }}"    # https://raw.githubusercontent.com/iiab/maps / master

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -176,10 +176,10 @@
     state: link
     force: yes
 
-- name: Copy fonts (16 files) to {{ doc_root }}/common/fonts/ for the general purpose map viewer (root:root, 0644 by default)
+- name: Copy fonts (16 files) to {{ vector_map_path }}/viewer/assets/ for the general purpose map viewer (root:root, 0644 by default)
   copy:
     src: "{{ item }}"
-    dest: "{{ doc_root }}/common/fonts/"
+    dest: "{{ vector_map_path }}/viewer/assets/"
     # mode: 0644
     # owner: root
     # group: root

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -16,12 +16,6 @@
     dest: "{{ iiab_etc_path }}"    # /etc/iiab
     timeout: "{{ download_timeout }}"
 
-- name: Download {{ iiab_map_url }}/assets/regions.json to {{ iiab_etc_path }}
-  get_url:
-    url: "{{ iiab_map_url }}/assets/regions.json"    # http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
-    dest: "{{ iiab_etc_path }}"
-    timeout: "{{ download_timeout }}"
-
 # - name: Does 26M cities database {{ vector_map_path }}/viewer/cities1000.sqlite exist?
 #   stat:
 #     path: "{{ vector_map_path }}/viewer/cities1000.sqlite"
@@ -34,6 +28,13 @@
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
 # when: not cities_installed.stat.exists
+
+# At this point, fetches from github.com/georgejhunt/maps from test branch
+- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
+  get_url:
+    url: "{{ osm_repo_url }}/master/resources/regions.json"
+    dest: "{{ iiab_etc_path }}"
+    timeout: "{{ download_timeout }}"
 
 - name: Symlink {{ doc_root }}/common/assets/map-catalog.json -> /etc/iiab/map-catalog.json
   file:
@@ -53,7 +54,6 @@
     path: "{{ vector_map_path }}/maplist/assets/regions.json"
     state: link
 
-# At this point, fetches from github.com/georgejhunt/maps from test branch
 - name: Download OpenLayers test page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/* to {{ vector_map_path }}/test-page/ -- for test page http://box/osm-vector-maps/installer/
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/{{ item }}"    # https://raw.githubusercontent.com/iiab/maps / master

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -488,9 +488,6 @@ osm_vector_maps_install: True
 osm_vector_maps_enabled: False
 # Set to "True" to download .mbtiles files from Archive.org (might be slow!)
 maps_from_internet_archive: False
-osm_repo_url: https://raw.githubusercontent.com/iiab/maps
-maps_branch: master    # Quotes not required
-
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 
 # MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -488,7 +488,9 @@ osm_vector_maps_install: True
 osm_vector_maps_enabled: False
 # Set to "True" to download .mbtiles files from Archive.org (might be slow!)
 maps_from_internet_archive: False
-iiab_map_url : http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
+osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+maps_branch: master    # Quotes not required
+
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 
 # MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.


### PR DESCRIPTION
Related https://github.com/iiab/iiab-admin-console/pull/483#issuecomment-1108922895 "I propose that we put the map-catalog.json on githubusercontent" 
Needs cities1000.sqlite and map-catalog.json added to [maps](https://github.com/iiab/maps) and regions.json corrected as per https://github.com/jvonau/maps/pull/1/files
Would need the last commit rolled back before committing to master, it's provided for testing convenience of the new github location scheme until the above changes are implemented in maps.
Tested on 22.04 VM

