### PR TITLE
Revert "install fonts to '/viewer/assets/'"

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -176,10 +176,10 @@
     state: link
     force: yes
 
-- name: Copy fonts (16 files) to {{ vector_map_path }}/viewer/assets/ for the general purpose map viewer (root:root, 0644 by default)
+- name: Copy fonts (16 files) to {{ doc_root }}/common/fonts/ for the general purpose map viewer (root:root, 0644 by default)
   copy:
     src: "{{ item }}"
-    dest: "{{ vector_map_path }}/viewer/assets/"
+    dest: "{{ doc_root }}/common/fonts/"
     # mode: 0644
     # owner: root
     # group: root


### PR DESCRIPTION
This reverts commit a784d5ec2758518e052b70d7d7e05e7546912063.

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
