### PR TITLE
Revert "upstream fonts.css does not have mapping to 'common'"

### DIFF
--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -149,6 +149,7 @@
     - bboxes.geojson
     - center.png
     - countries.json
+    - fonts.css
     - ol-layerswitcher.css
     - ol-contextmenu.css
     - pin_drop.png
@@ -184,13 +185,6 @@
     # group: root
   with_fileglob:
     - fonts/*
-
-- name: Force Symlink {{ vector_map_path }}/viewer/assets/fonts.css -> {{ doc_root }}/common/fonts/fonts.css
-  file:
-    src: "{{ doc_root }}/common/fonts/fonts.css"
-    path: "{{ vector_map_path }}/viewer/assets/fonts.css"
-    state: link
-    force: yes
 
 - name: Force Download redirect {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect to test page {{ vector_map_path }}/maplist/index.html
   get_url:


### PR DESCRIPTION
Reverts iiab/iiab#3197

@tim-moody confirms PR #3197 appears to cause this serif font problem:

> if I zero in on Oaxaca font family is [sans serif]
>
> as is all the text