### PR TITLE
Fix vars/local_vars_unittest.yml: 'download_timeout: 100' (not 200)

### DIFF
--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -13,7 +13,7 @@
 
 
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
-download_timeout: 200
+download_timeout: 100
 
 # Real-time clock: set RTC chip family here.  Future auto-detection plausible?
 rtc_id: none    # Or ds3231 ?


### PR DESCRIPTION
Oops this one was missed 4 months ago here:

- PR #3083