### PR TITLE
Workaround to induce remote.it install on Linux Mint

### DIFF
--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -61,6 +61,14 @@
 #   apt:
 #     deb: "{{ remoteit_device_url }}"
 
+# 2022-04-29: https://downloads.remote.it/remoteit/install_agent.sh refuses to
+# install on Mint as "ID_LIKE=ubuntu" in /etc/os-release is lowercase.  So we
+# add a tag with the word 'Ubuntu' containing an uppercase 'U' as a workaround.
+# (This hack can later be removed, if remote.it adjusts install_agent.sh above)
+- name: If Linux Mint, add "IIAB_LIKE=Ubuntu" to /etc/os-release to force install of remote.it
+  shell: echo "IIAB_LIKE=Ubuntu" >> /etc/os-release
+  when: is_linuxmint
+
 # - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh -- this puts a claim code in /etc/remoteit/config.json which is valid for 24h
 - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh


### PR DESCRIPTION
Tested on Linux Mint 20.3 Una &mdash; remote.it now installs and works with this PR.

Many thanks to @shanti-bhardwa for helping IIAB beef up its Linux Mint support!

This resolves:

- #3199