### PR TITLE
remoteit/tasks/install.yml: Refine PR #3201 using Ansible not bash

### DIFF
--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -66,7 +66,10 @@
 # add a tag with the word 'Ubuntu' containing an uppercase 'U' as a workaround.
 # (This hack can later be removed, if remote.it adjusts install_agent.sh above)
 - name: If Linux Mint, add "IIAB_LIKE=Ubuntu" to /etc/os-release to force install of remote.it
-  shell: echo "IIAB_LIKE=Ubuntu" >> /etc/os-release
+  # shell: echo "IIAB_LIKE=Ubuntu" >> /etc/os-release
+  lineinfile:
+    path: /etc/os-release
+    line: IIAB_LIKE=Ubuntu
   when: is_linuxmint
 
 # - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh -- this puts a claim code in /etc/remoteit/config.json which is valid for 24h


### PR DESCRIPTION
Bonus: using the Ansible approach also avoids duplicate `IIAB_LIKE=Ubuntu` lines in `/etc/os-release` e.g. in the rare case when someone reinstalls https://remote.it

Tested on Linux Mint 20.3 Una.

Building on:

- #3199
- PR #3201