### PR TITLE
osm-vector-maps: Lint + clarify for readability e.g. map_installer_url -- and speed up initial install of 48MB planet_z0-z6_2020.mbtiles + 25MB satellite_z0-z6_2020.mbtiles

### DIFF
--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -1,23 +1,32 @@
 # osm_vector_maps_install: True
 # osm_vector_maps_enabled: True
 
-# iiab_map_url : http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
-# vector_map_path: "{{ content_base }}/www/osm-vector-maps"
+# maps_from_internet_archive: False
+# vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-# The following soft coded variables allow testing, before pulling PR's into master
-osm_repo_url: https://raw.githubusercontent.com/iiab/maps
-maps_branch: 'master'    # Quotes not required
-#osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
-#maps_branch: 'maps7.3'
 
-# soft code sources
-archive_org_url: https://archive.org/download
-#iiab_map_url: http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden
-#map_catalog_url: http://download.iiab.io/content/OSM/vector-tiles
-map_catalog_url: http://timmoody.com/iiab-files/maps
-satellite_version: satellite_z0-z9_v3.mbtiles    # 2021-12-20: Var unused, but hard-coded in 11 places within https://github.com/iiab/iiab-admin-console -- #3077 discusses map-catalog.json & adm-map-catalog.json
+# Pulls in ~38 files thx to @jvonau's #3192 -- change these 2 during testing:
+osm_repo_url: https://raw.githubusercontent.com/iiab/maps
+maps_branch: master    # Quotes not required
+#osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
+#maps_branch: maps7.3
+
+# 2022-04-30 -- Bluehost (timmoody.com) has become extremely slow!
+#map_installer_url: http://timmoody.com/iiab-files/maps
+map_installer_url: http://download.iiab.io/content/OSM/vector-tiles
+
 installer_planet: planet_z0-z6_2020.mbtiles
 installer_satellite: satellite_z0-z6_2020.mbtiles
+
+
+# 2022-04-30 WIP -- CLI approach to installing larger .mbtiles OSM "continents" a.k.a. regions:
+# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region
+# 2022-04-30 WIP -- This var might be used in future: (with boolean var maps_from_internet_archive)
+archive_org_url: https://archive.org/download
+
+
+# 2022-04-30 -- Unused, but URL illustrates legacy approach:
+#iiab_map_url: http://download.iiab.io/content/OSM/vector-tiles/maplist/hidden

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -1,3 +1,13 @@
+- name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
+  package:
+    state: present
+    name:
+      - python3-geojson
+      - python3-pil
+      - python3-wget
+      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
+      - php{{ php_version }}-sqlite3
+
 - name: Make 5 directories (0755 by default)
   file:
     path: "{{ item }}"
@@ -10,29 +20,12 @@
     - "{{ vector_map_path }}/viewer/tiles"
     - "{{ vector_map_path }}/installer"
 
-- name: "Install packages for map installation: python3-geojson, python3-pil, python3-wget, php{{ php_version }}-sqlite3 (can also be installed by www_base/tasks/php-stem.yml)"
-  package:
-    state: present
-    name:
-      - python3-geojson
-      - python3-pil
-      - python3-wget
-      #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
-      - php{{ php_version }}-sqlite3
-
-# - name: Does 26M cities database {{ vector_map_path }}/viewer/cities1000.sqlite exist?
-#   stat:
-#     path: "{{ vector_map_path }}/viewer/cities1000.sqlite"
-#   register: cities_installed
-
-# - name: If not, download {{ iiab_map_url }}/regional-resources/cities1000.sqlite to {{ vector_map_path }}/viewer/
-# At this point, fetches from github.com/'REPO'/maps from maps_branch
 - name: Download 26M {{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite"
+    url: "{{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite"    # e.g. https://raw.githubusercontent.com/iiab/maps + / + master + ...
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
-# when: not cities_installed.stat.exists
+
 
 - name: Download {{ osm_repo_url }}/{{ maps_branch }}/2020/map-catalog.json to {{ iiab_etc_path }}
   get_url:
@@ -52,17 +45,6 @@
     path: "{{ vector_map_path }}/test-page/assets/map-catalog.json"
     state: link
 
-#- name: Download {{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json to {{ iiab_etc_path }}
-#  get_url:
-#    url: "{{ osm_repo_url }}/{{ maps_branch }}/resources/regions.json"
-#    dest: "{{ iiab_etc_path }}"
-#    timeout: "{{ download_timeout }}"
-
-#- name: Symlink {{ vector_map_path }}/maplist/assets/regions.json -> /etc/iiab/regions.json
-#  file:
-#    src: /etc/iiab/regions.json
-#    path: "{{ vector_map_path }}/maplist/assets/regions.json"
-#    state: link
 
 - name: Download OpenLayers test page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/test-page/build/* to {{ vector_map_path }}/test-page/ -- for test page http://box/osm-vector-maps/installer/
   get_url:
@@ -74,7 +56,6 @@
     - index.html
 
 - name: Download OpenLayers viewer page stuff (JavaScript bundle etc) from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/* to {{ vector_map_path }}/viewer/
-# At this point, fetches from github.com/iiab/maps from {{ maps_branch }} branch
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/build/{{ item }}"
     dest: "{{ vector_map_path }}/viewer/"
@@ -95,9 +76,10 @@
     - searchapi.php
     - tileserver.php
 
-- name: Download 34MB {{ map_catalog_url }}/{{ installer_planet }} to {{ vector_map_path }}/installer/ -- for map installer
+
+- name: Download 48MB {{ map_installer_url }}/{{ installer_planet }} to {{ vector_map_path }}/installer/ -- for map installer
   get_url:
-    url: "{{ map_catalog_url }}/{{ installer_planet }}"
+    url: "{{ map_installer_url }}/{{ installer_planet }}"    # e.g. http://download.iiab.io/content/OSM/vector-tiles + / + planet_z0-z6_2020.mbtiles
     dest: "{{ vector_map_path }}/installer/"
     timeout: "{{ download_timeout }}"
 
@@ -113,11 +95,12 @@
     path: "{{ vector_map_path }}/viewer/tiles/{{ installer_planet }}"
     state: link
 
-- name: Download abbreviated satellite images from {{ map_catalog_url }}/{{ installer_satellite }} to {{ vector_map_path }}/viewer/tiles/
+- name: Download 25MB {{ map_installer_url }}/{{ installer_satellite }} to {{ vector_map_path }}/viewer/tiles/ -- basic satellite photos
   get_url:
-    url: "{{ map_catalog_url }}/{{ installer_satellite }}"
+    url: "{{ map_installer_url }}/{{ installer_satellite }}"    # e.g. satellite_z0-z6_2020.mbtiles
     dest: "{{ vector_map_path }}/viewer/tiles/"
     timeout: "{{ download_timeout }}"
+
 
 - name: Download {index.html, installer-bundle.js} from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/installer/build/* to {{ vector_map_path }}/installer/ -- for map installer
   get_url:
@@ -139,7 +122,6 @@
     - installer-functions.js
     - tileserver.php
 
-# the following was changed to grab from the iiab/maps repo
 - name: Download 15 common assets from {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/assets/* to {{ vector_map_path }}/viewer/assets/ -- for the general purpose map viewer
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/assets/{{ item }}"
@@ -176,20 +158,19 @@
     state: link
     force: yes
 
+
 - name: Copy noto-sans fonts (15 files) to {{ doc_root }}/common/fonts/ for the general purpose map viewer (root:root, 0644 by default)
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/fonts/"
-    # mode: 0644
-    # owner: root
-    # group: root
   with_fileglob:
     - fonts/noto-sans*
 
-- name: copy fonts.css to {{ vector_map_path }}/viewer/assets
+- name: Copy fonts.css to {{ vector_map_path }}/viewer/assets/
   copy:
     src: fonts/fonts.css
-    dest: "{{ vector_map_path }}/viewer/assets/fonts.css"
+    dest: "{{ vector_map_path }}/viewer/assets/"
+
 
 - name: Force Download redirect {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect to test page {{ vector_map_path }}/maplist/index.html
   get_url:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -149,7 +149,7 @@
     - bboxes.geojson
     - center.png
     - countries.json
-    - fonts.css
+    # - fonts.css
     - ol-layerswitcher.css
     - ol-contextmenu.css
     - pin_drop.png
@@ -176,7 +176,7 @@
     state: link
     force: yes
 
-- name: Copy fonts (16 files) to {{ doc_root }}/common/fonts/ for the general purpose map viewer (root:root, 0644 by default)
+- name: Copy noto-sans fonts (15 files) to {{ doc_root }}/common/fonts/ for the general purpose map viewer (root:root, 0644 by default)
   copy:
     src: "{{ item }}"
     dest: "{{ doc_root }}/common/fonts/"
@@ -184,7 +184,12 @@
     # owner: root
     # group: root
   with_fileglob:
-    - fonts/*
+    - fonts/noto-sans*
+
+- name: copy fonts.css to {{ vector_map_path }}/viewer/assets
+  copy:
+    src: fonts/fonts.css
+    dest: "{{ vector_map_path }}/viewer/assets/fonts.css"
 
 - name: Force Download redirect {{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/installer-index.redirect to test page {{ vector_map_path }}/maplist/index.html
   get_url:


### PR DESCRIPTION
Tested with @tim-moody's PR #3203 and all looks good!

FYI these pop-ups may be alarming + unnecessary (when you repeatedly use Admin Console > Install Content > Get Map Regions > Install Selected Region) but they are harmless:

```
INST-OSM-VECT-SET FAILED and reported osm-planet_z0-z10_2020.mbtiles is already downloaded INST-OSM-VECT-SET.
INST-OSM-VECT-SET FAILED and reported osm-satellite_z0-z9_2020.mbtiles is already downloaded INST-OSM-VECT-SET.
```

Building on:

- #3077 
- PR #3192 
- iiab/maps#57
- PR #3203

_Thanks to many people pulling together, especially @jvonau and @tim-moody and @georgejhunt._

There's a lot of documentation-centric work remaining but we're getting very close!

PS I will update the CLI approach ([/usr/bin/iiab-install-map-region](https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region)) soon in coming days.