### PR TITLE
Nextcloud 24.0.0 works w/ PHP 8.1 on Ubuntu 22.04

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -59,7 +59,7 @@
 - name: NEXTCLOUD
   include_role:
     name: nextcloud
-  when: nextcloud_install and not is_ubuntu_2204    # TEMPORARY
+  when: nextcloud_install
 
 - name: WORDPRESS
   include_role:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -91,7 +91,7 @@
     state: directory
     path: "{{ nextcloud_root_dir }}"    # /library/www/nextcloud
 
-- name: Unarchive {{ nextcloud_dl_url }} (~133 MB) to {{ nextcloud_root_dir }} (~476 MB initially, 498+ MB later, {{ apache_user }}:{{ apache_user }})
+- name: Unarchive {{ nextcloud_dl_url }} (~118 MB) to {{ nextcloud_root_dir }} (~406 MB initially, 428+ MB later, {{ apache_user }}:{{ apache_user }})
   unarchive:
     remote_src: yes    # Overwrite even if "already exists on the target"
     src: "{{ nextcloud_dl_url }}"

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -43,7 +43,7 @@
 # February 2020: See @m-anish's PR #2119 and follow-up PR #2258.
 # 2021-07-06: If you're running Nextcloud 22+ in production, carefully check the latest required AND recommended prereqs:
 # https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-# https://docs.nextcloud.com/server/21/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+# https://docs.nextcloud.com/server/24/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 - name: Install ffmpeg + libxml2 + 11 PHP packages (run 'php -m' or 'php -i' to verify)
   package:
     name:


### PR DESCRIPTION
Tested successfully with [Nextcloud 24.0.0](https://download.nextcloud.com/server/prereleases/) on Ubuntu 22.04 on x86_64.

This PR can be merged in coming hours when the download becomes official at:
https://download.nextcloud.com/server/releases/latest.tar.bz2

In short, Nextcloud appears to work well with PHP 8.1, despite their official requirements doc not yet reflecting this:
https://docs.nextcloud.com/server/24/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

Refs:

- PR #2684
- PR #2832
- PR #3189