### PR TITLE
scripts/iiab-diagnostics: Redact wep-key[0-3]=PASSWORD (for old WiFi routers)

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -38,12 +38,12 @@ function cat_file_raw() {    # $1 = path/filename; $2 = # of lines, for tail
             echo "FILE EXISTS BUT IS EMPTY!" >> $outfile
         elif [ $# -eq 1 ]; then
             echo >> $outfile
-            # Redact most passwords from /etc/iiab/local_vars.yml, /etc/hostapd/hostapd.conf, /etc/wpa_supplicant/wpa_supplicant.conf, /etc/netplan/*, /etc/network/interfaces, /etc/network/interfaces.d/* ETC -- not much to worry about in /etc/iiab/iiab.ini (' = ')
-            cat "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            # Redact (mask) most passwords from /etc/iiab/local_vars.yml, /etc/hostapd/hostapd.conf, /etc/wpa_supplicant/wpa_supplicant.conf, /etc/netplan/*, /etc/network/interfaces, /etc/network/interfaces.d/*, /etc/NetworkManager/system-connections/* ETC -- not much to worry about in /etc/iiab/iiab.ini (' = ')
+            cat "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
         else    # e.g. last 100 lines, maximum
             echo "                        ...ITS LAST $2 LINES FOLLOW..." >> $outfile
             echo >> $outfile
-            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
         fi
         echo >> $outfile
     elif [ -h "$1" ]; then
@@ -178,7 +178,7 @@ echo -e "\n  3. Content of Directories: (1-level deep)\n"
 echo -e "\n\n\n\n3. CONTENT OF DIRECTORIES (1-LEVEL DEEP)\n" >> $outfile
 cat_dir /etc/network/interfaces.d
 cat_dir /etc/systemd/network
-cat_dir /etc/NetworkManager/system-connections
+cat_dir /etc/NetworkManager/system-connections    # Redacts most passwords above
 cat_dir /etc/netplan    # Redacts most passwords above
 #cat_dir /etc/sysconfig/network-scripts/if-cfg*    # No longer common
 #cat_dir /etc/network    # Above file /etc/network/interfaces suffices


### PR DESCRIPTION
Thanks @shanti-bhardwa for surfacing the fact that some ancient/insecure WiFi routers are still out there and in use.

Quickly tested and these WEP passwords should also now be redacted (masked) from [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md) output going forward.