### PR TITLE
https://wordpress.org/latest.tar.gz fails in England, Scotland (and elsewhere?) when trying to install WordPress using Ansible's get_url ["HTTP Error 429: Too Many Requests"] — so let's try wget as an interim workaround 

### DIFF
--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -40,7 +40,7 @@
 
 - name: Delete {{ downloads_dir }}/wordpress.tar.gz if it exists
   file:
-    path: "{{ downloads_dir }}"/wordpress.tar.gz
+    path: "{{ downloads_dir }}/wordpress.tar.gz"
     state: absent
 
 - name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}/wordpress.tar.gz

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -39,10 +39,16 @@
 #  when: php_version is version('8.0', '<')
 
 - name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}
-  get_url:
-    url: "{{ wordpress_download_base_url }}/{{ wordpress_src }}"
-    dest: "{{ downloads_dir }}"
-    timeout: "{{ download_timeout }}"
+  command: wget {{ wordpress_download_base_url }}/{{ wordpress_src }} -P {{ downloads_dir }}
+  # 2022-05-04: Ansible approach below (get_url) fails with HTTP Error 429
+  # (Too Many Requests) b/c Ansible's User-Agent string?  Affecting 1 user in
+  # England and another user in Scotland, but not affecting many other
+  # countries/ISP's apparently?  WordPress must have recently changed their
+  # hosting arrangements for https://wordpress.org/latest.tar.gz
+  # get_url:
+  #   url: "{{ wordpress_download_base_url }}/{{ wordpress_src }}"
+  #   dest: "{{ downloads_dir }}"
+  #   timeout: "{{ download_timeout }}"
   register: wp_download_output
 
 - name: Symlink {{ downloads_dir }}/wordpress.tar.gz -> {{ wp_download_output.dest }}

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -38,6 +38,11 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
+- name: Delete {{ downloads_dir }}/wordpress.tar.gz if it exists
+  file:
+    path: "{{ downloads_dir }}"/wordpress.tar.gz
+    state: absent
+
 - name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}/wordpress.tar.gz
   command: wget {{ wordpress_download_base_url }}/{{ wordpress_src }} -O {{ downloads_dir }}/wordpress.tar.gz
   # 2022-05-04: Ansible approach below (get_url) fails with HTTP Error 429
@@ -58,15 +63,15 @@
 #     state: link
 #   when: wp_download_output.dest is defined
 
-- name: Does {{ downloads_dir }}/wordpress.tar.gz link exist?
+- name: Does {{ downloads_dir }}/wordpress.tar.gz exist?
   stat:
     path: "{{ downloads_dir }}/wordpress.tar.gz"    # /opt/iiab/downloads
-  register: wp_link
+  register: wp_tar_gz
 
 - name: FAIL (force Ansible to exit) IF {{ downloads_dir }}/wordpress.tar.gz doesn't exist
   fail:
     msg: "{{ downloads_dir }}/wordpress.tar.gz is REQUIRED in order to install WordPress."
-  when: not wp_link.stat.exists
+  when: not wp_tar_gz.stat.exists
 
 - name: "Unpack {{ downloads_dir }}/wordpress.tar.gz to permanent location {{ wp_install_path }}/wordpress - owner: root, group: {{ apache_user }}, mode: '0664', keep_newer: yes"
   unarchive:

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -38,8 +38,8 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
-- name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}
-  command: wget {{ wordpress_download_base_url }}/{{ wordpress_src }} -P {{ downloads_dir }}
+- name: Download {{ wordpress_download_base_url }}/{{ wordpress_src }} to {{ downloads_dir }}/wordpress.tar.gz
+  command: wget {{ wordpress_download_base_url }}/{{ wordpress_src }} -O {{ downloads_dir }}/wordpress.tar.gz
   # 2022-05-04: Ansible approach below (get_url) fails with HTTP Error 429
   # (Too Many Requests) b/c Ansible's User-Agent string?  Affecting 1 user in
   # England and another user in Scotland, but not affecting many other
@@ -49,14 +49,14 @@
   #   url: "{{ wordpress_download_base_url }}/{{ wordpress_src }}"
   #   dest: "{{ downloads_dir }}"
   #   timeout: "{{ download_timeout }}"
-  register: wp_download_output
+#   register: wp_download_output
 
-- name: Symlink {{ downloads_dir }}/wordpress.tar.gz -> {{ wp_download_output.dest }}
-  file:
-    src: "{{ wp_download_output.dest }}"
-    path: "{{ downloads_dir }}/wordpress.tar.gz"    # /opt/iiab/downloads
-    state: link
-  when: wp_download_output.dest is defined
+# - name: Symlink {{ downloads_dir }}/wordpress.tar.gz -> {{ wp_download_output.dest }}
+#   file:
+#     src: "{{ wp_download_output.dest }}"
+#     path: "{{ downloads_dir }}/wordpress.tar.gz"    # /opt/iiab/downloads
+#     state: link
+#   when: wp_download_output.dest is defined
 
 - name: Does {{ downloads_dir }}/wordpress.tar.gz link exist?
   stat:


### PR DESCRIPTION
Thanks @shanti-bhardwa, @jvonau and @tim-moody for helping to diagnose this overnight.

WordPress might or might not ever fix downloads of their own product (so that people can download WordPress using Ansible's [get_url](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html)) but in the meantime we need to act, for implementers who are currently being completely blockaded.

Prior work:

- #2836