### PR TITLE
mongodb/tasks/install.yml: Try 5.0.x (was 4.4.x) on all four 64-bit OS's (for Sugarizer)

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -66,7 +66,7 @@
 
 - block:
   - name: Add mongodb.org signing key (only 64-bit support available)
-    shell: wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
+    shell: wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
     args:
       warn: false
 
@@ -75,7 +75,7 @@
       # 2020-10-28: http://repo.mongodb.org/apt/debian/dists/ supports only
       # {buster 10, stretch 9, jessie 8, wheezy 7}
       # so Debian 11 "Bullseye" (testing branch) can revert to buster for now:
-      repo: deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main
+      repo: deb http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main
       #repo: deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       state: present
       filename: mongodb-org
@@ -84,14 +84,14 @@
   # Debian 10 aarch64 might work below but is blocked in main.yml
   - name: Use mongodb-org's Ubuntu focal repo for RasPiOS-aarch64
     apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
       state: present
       filename: mongodb-org
     when: is_raspbian and (ansible_architecture == "aarch64")
 
   - name: Use mongodb-org's Ubuntu focal repo for Linux Mint - 64bit only
     apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
       state: present
       filename: mongodb-org
     when: is_linuxmint
@@ -101,7 +101,7 @@
       # 2020-10-27: https://repo.mongodb.org/apt/ubuntu/dists/ supports only
       # {focal 20.04, bionic 18.04, xenial 16.04, trusty 14.04, precise 12.04}
       # so other Ubuntu's like groovy 20.10 need to revert to recent LTS repo:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse
+      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
       #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
       state: present
       filename: mongodb-org


### PR DESCRIPTION
Thanks to @llaske's recommendation at:

- #3190