### PR TITLE
Check hardware for AP and if so record 'can_be_ap = True' to /etc/iiab/iiab.ini

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -59,6 +59,7 @@ virtual_network_devices: "-e ap0 -e lo -e br0 -e tun -e br- -e docker -e bridge0
 # Set defaults for discovery process as strings
 wifi1: "not found-1"
 wifi2: "not found-2"
+can_be_ap: False
 exclude_devices: none
 device_gw: none
 prior_gw_device: unset

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -101,15 +101,16 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout|int }}"
 
-- name: Check for Access Point capablility with 'iw list'
-  command: iw list | grep -v AP: | grep AP | wc -l
+- name: Run 'iw list' to check for Access Point capability
+  #command: iw list | grep -v AP: | grep AP | wc -l # False positives 'EAP' etc
+  shell: iw list | grep '^[[:space:]]*\* AP$'
   register: look_for_ap
   when: discovered_wireless_iface != "none"
 
-- name: Setting can_be_ap
+- name: Set can_be_ap if 'iw list' output contains suitable '* AP'
   set_fact:
     can_be_ap: True
-  when: look_for_ap.stdout|int != 0
+  when: look_for_ap is defined and not look_for_ap.failed
 
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -101,6 +101,16 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout|int }}"
 
+- name: Check for Access Point capablility with 'iw list'
+  command: iw list | grep AP | wc -l
+  register: look_for_ap
+  when: discovered_wireless_iface != "none"
+
+- name: Setting can_be_ap
+  set_fact:
+    can_be_ap: True
+  when: look_for_ap|int != "0"
+
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l
   register: wifi_gateway_found
@@ -260,6 +270,8 @@
       value: "{{ iiab_lan_iface }}"
     - option: iiab_wan_iface
       value: "{{ iiab_wan_iface }}"
+    - option: can_be_ap
+      value: "{{ can_be_ap }}"
 
 # well if there ever was a point to tell the user things are FUBAR this is it.
 # limit 2 network adapters wifi wired

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -110,7 +110,7 @@
 - name: Set can_be_ap if 'iw list' output contains suitable '* AP'
   set_fact:
     can_be_ap: True
-  when: look_for_ap is defined and not look_for_ap.failed
+  when: look_for_ap.failed is defined and not look_for_ap.failed
 
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -102,14 +102,14 @@
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout|int }}"
 
 - name: Check for Access Point capablility with 'iw list'
-  command: iw list | grep AP | wc -l
+  command: iw list | grep -v AP: | grep AP | wc -l
   register: look_for_ap
   when: discovered_wireless_iface != "none"
 
 - name: Setting can_be_ap
   set_fact:
     can_be_ap: True
-  when: look_for_ap|int != "0"
+  when: look_for_ap.stdout|int != 0
 
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -69,7 +69,6 @@
     owner: root
     group: root
     mode: 0755
-  when: can_be_ap
 
 - name: Create /usr/bin/iiab-hotspot-off from template when hardware supports AP
   template:
@@ -78,7 +77,6 @@
     owner: root
     group: root
     mode: 0755
-  when: can_be_ap
 
 - name: Create dhcpcd hook for hostapd and ap0 when wifi_up_down True
   template:

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -4,10 +4,10 @@
     enabled: no
     masked: no
 
-- name: Disable hostapd when not using ap0 and wifi gateway present, or no WiFi hardware present
+- name: Disable hostapd when not using ap0 and wifi gateway present, or no WiFi hardware present or support not detected
   set_fact:
     hostapd_enabled: False
-  when: (not wifi_up_down and discovered_wireless_iface == iiab_wan_iface) or discovered_wireless_iface == "none"
+  when: (not wifi_up_down and discovered_wireless_iface == iiab_wan_iface) or discovered_wireless_iface == "none" or not can_be_ap
 
 - name: Detect current Wifi channel
   shell: iw {{ discovered_wireless_iface }} info | grep channel | cut -d' ' -f2
@@ -29,7 +29,7 @@
   with_items:
     - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf' }
     - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf.iiab' }
-  when: discovered_wireless_iface != "none"
+  when: can_be_ap
 
 - name: Generate new random mac address for ap0
   shell: tr -dc A-F0-9 < /dev/urandom | head -c 10 | sed -r 's/(..)/\1:/g;s/:$//;s/^/02:/'
@@ -51,7 +51,7 @@
     - { src: 'hostapd/iiab-clone-wifi.service.j2', dest: '/etc/systemd/system/iiab-clone-wifi.service', mode: '0644' }
     - { src: 'hostapd/iiab-wifi-test.service.j2', dest: '/etc/systemd/system/iiab-wifi-test.service', mode: '0644'}
     - { src: 'hostapd/iiab-test-wifi.j2', dest: '/usr/sbin/iiab-test-wifi', mode: '0755' }
-  when: discovered_wireless_iface != "none"
+  when: can_be_ap
 
 - name: Use custom 'hostapd' systemd service unit file for {{ discovered_wireless_iface }} when not wifi_up_down
   template:
@@ -60,23 +60,25 @@
     owner: root
     group: root
     mode: 0644
-  when: discovered_wireless_iface != "none" and not wifi_up_down
+  when: not wifi_up_down and can_be_ap
 
-- name: Create /usr/bin/iiab-hotspot-on from template
+- name: Create /usr/bin/iiab-hotspot-on from template when hardware supports AP
   template:
     src: network/iiab-hotspot-on
     dest: /usr/bin/iiab-hotspot-on
     owner: root
     group: root
     mode: 0755
+  when: can_be_ap
 
-- name: Create /usr/bin/iiab-hotspot-off from template
+- name: Create /usr/bin/iiab-hotspot-off from template when hardware supports AP
   template:
     src: network/iiab-hotspot-off
     dest: /usr/bin/iiab-hotspot-off
     owner: root
     group: root
     mode: 0755
+  when: can_be_ap
 
 - name: Create dhcpcd hook for hostapd and ap0 when wifi_up_down True
   template:

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -62,7 +62,7 @@
     mode: 0644
   when: not wifi_up_down and can_be_ap
 
-- name: Create /usr/bin/iiab-hotspot-on from template when hardware supports AP
+- name: Create /usr/bin/iiab-hotspot-on from template
   template:
     src: network/iiab-hotspot-on
     dest: /usr/bin/iiab-hotspot-on
@@ -70,7 +70,7 @@
     group: root
     mode: 0755
 
-- name: Create /usr/bin/iiab-hotspot-off from template when hardware supports AP
+- name: Create /usr/bin/iiab-hotspot-off from template
   template:
     src: network/iiab-hotspot-off
     dest: /usr/bin/iiab-hotspot-off


### PR DESCRIPTION
Tested on 5 different hardware scenarios.

Refines the following PR, which also needed a couple Ansible fixes:

- PR #3070