### PR TITLE
Tolerate Ubuntu 22.10 Kinetic Kudu to help with testing

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -77,6 +77,7 @@ case $OS_VER in
     "ubuntu-2004"  | \
     "ubuntu-2110"  | \
     "ubuntu-2204"  | \
+    "ubuntu-2210"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
     "raspbian-11")

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -735,6 +735,7 @@ pbx_http_port: 83
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)
 
 is_ubuntu: False    # Covers: Ubuntu, Linux Mint
+is_ubuntu_2210: False
 is_ubuntu_2204: False
 is_ubuntu_2110: False
 is_ubuntu_2104: False

--- a/vars/ubuntu-2210.yml
+++ b/vars/ubuntu-2210.yml
@@ -1,0 +1,29 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
+is_ubuntu_2210: True
+
+# 2019-03-23: These apply if-only-if named_install and/or dhcpd_install are True
+# (This is quite rare now that vars/default_vars.yml sets dnsmasq_install: True)
+dns_service: bind9
+dns_user: bind
+dhcp_service: isc-dhcp-server
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_user: www-data
+apache_conf_dir: apache2/sites-available
+apache_log_dir: /var/log/apache2
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+apache_log: /var/log/apache2/access.log
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: 8.1
+postgresql_version: 14
+systemd_location: /lib/systemd/system
+python_ver: 3.10


### PR DESCRIPTION
Both Microsoft (WSL2) and Ubuntu (https://Multipass.run) have made it dead easy to install daily builds of this pre-release OS.

To help with testing, long before its Thur Oct 20th release date late this year.