### PR TITLE
freepbx-16.0-latest.tgz STALE so git clone to /opt/iiab/freepbx

### DIFF
--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -285,9 +285,9 @@ image::files/password_change.jpg[]
 
 == Known Issues
 
-Please also check the "Known Issues" at the bottom of https://github.com/iiab/iiab/wiki#our-evolution[IIAB's latest release notes].
+Please also check the "Known Issues" at the bottom of https://github.com/iiab/iiab/wiki#past-releases[IIAB's latest release notes].
 
-_If there's a bug or serious problem with IIAB, please do https://internet-in-a-box.org/pages/contributing.html[make contact] and post an issue here: https://github.com/iiab/iiab/issues_
+_If there's a bug or serious problem with IIAB, please do https://internet-in-a-box.org/contributing.html[make contact] and post an issue here: https://github.com/iiab/iiab/issues_
 
 . Apache's `/var/lib/php/asterisk_sessions/` directory might also be needed for NGINX?
 +

--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -4,7 +4,7 @@
 
 https://internet-in-a-box.org[Internet-in-a-Box (IIAB)] can install https://asterisk.org/[Asterisk] and https://freepbx.org/[FreePBX] for Voice over IP (VoIP) calls using regular Android and iPhone softphone (SIP) apps — e.g. for low-cost and rural telephony.
 
-As of April 2022, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+19+Documentation[Asterisk 19] and https://www.freepbx.org/freepbx-16-is-now-released-for-general-availability/[FreePBX 16].
+As of May 2022, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+19+Documentation[Asterisk 19] and https://www.freepbx.org/freepbx-16-is-now-released-for-general-availability/[FreePBX 16].
 
 PHP 7.4 is REQUIRED (https://github.com/iiab/iiab/pull/2899[PR #2899]) and PHP 8.x does not yet work (https://github.com/iiab/iiab/pull/3019#issuecomment-962469346[PR #3109]) &mdash; so please consider installing this on https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems[Ubuntu 20.04, Debian 11, or Raspberry Pi OS 11 "Bullseye"].
 
@@ -55,7 +55,7 @@ Or, if you want to use FreePBX with Apache alone (http://box:83/freepbx), option
 pbx_use_nginx: False
 ----
 +
-If using PBX intensively, please adjust `/etc/php/X.Y/apache2/php.ini`, `/etc/php/X.Y/cli/php.ini` and/or `/etc/php/X.Y/nginx/php.ini` (where `X.Y` is typically 7.4) as outlined within https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L88-L131[/opt/iiab/iiab/roles/www_options/tasks/main.yml] &mdash; some of which happens automatically if you also set:
+If using PBX intensively, please adjust `/etc/php/X.Y/apache2/php.ini`, `/etc/php/X.Y/cli/php.ini` and/or `/etc/php/X.Y/nginx/php.ini` (where `X.Y` is typically 7.4) as outlined within link:../www_options/tasks/main.yml#L86-L129[/opt/iiab/iiab/roles/www_options/tasks/main.yml] &mdash; some of which happens automatically if you also set:
 +
 ----
 nginx_high_php_limits: True
@@ -291,15 +291,15 @@ _If there's a bug or serious problem with IIAB, please do https://internet-in-a-
 
 . Apache's `/var/lib/php/asterisk_sessions/` directory might also be needed for NGINX?
 +
-If not, the https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L174-L186[configuration of /var/lib/php/asterisk_sessions/] might be made conditional upon `when: not pbx_use_apache`
+If not, the link:tasks/freepbx.yml#L175-L187[configuration of /var/lib/php/asterisk_sessions/] might be made conditional upon `when: not pbx_use_apache`
 
-. The https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L213-L220[installation of /etc/odbc.ini] for CDR (Call Detail Records) database `asteriskcdrdb` might benefit from compiling the ODBC driver for aarch64, per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+. The link:tasks/freepbx.yml#L214-L221[installation of /etc/odbc.ini] for CDR (Call Detail Records) database `asteriskcdrdb` might benefit from compiling the ODBC driver for aarch64, per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
 +
 See the output of `asterisk -rx "cdr show status"` as mentioned at https://github.com/iiab/iiab/pull/2938#issuecomment-898693126[#2938] and https://github.com/iiab/iiab/pull/2942[PR #2942].
 
 . Raspberry Pi Zero W Warning
 +
-Node.js applications like Asterisk/FreePBX, Node-RED and Sugarizer won't work on Raspberry Pi Zero W (ARMv6) if you installed Node.js while on RPi 3, 3 B+ (ARMv7) or RPi 4 (ARMv8).  If necessary, run `apt remove nodejs` or `apt purge nodejs` then `rm /etc/apt/sources.list.d/nodesource.list; apt update` then (https://nodered.org/docs/hardware/raspberrypi#swapping-sd-cards[attempt!]) to https://github.com/iiab/iiab/blob/master/roles/nodejs/tasks/main.yml[install Node.js] _on the Raspberry Pi Zero W itself_ (a better approach than "cd /opt/iiab/iiab; ./runrole nodejs" is to try `apt install nodejs` or try installing the tar file mentioned at https://github.com/iiab/iiab/issues/2082#issuecomment-569344617[#2082]).  You might also need `apt install npm`.  Whatever versions of Node.js and npm you install, make sure `/etc/iiab/iiab_state.yml` contains the line `nodejs_installed: True` (add it if nec!)  Finally, proceed to install Asterisk/FreePBX, Node-RED and/or Sugarizer. https://github.com/iiab/iiab/issues/1799[#1799]
+Node.js applications like Asterisk/FreePBX, Node-RED and Sugarizer won't work on Raspberry Pi Zero W (ARMv6) if you installed Node.js while on RPi 3, 3 B+ (ARMv7) or RPi 4 (ARMv8).  If necessary, run `apt remove nodejs` or `apt purge nodejs` then `rm /etc/apt/sources.list.d/nodesource.list; apt update` then (https://nodered.org/docs/hardware/raspberrypi#swapping-sd-cards[attempt!]) to link:../nodejs/tasks/main.yml[install Node.js] _on the Raspberry Pi Zero W itself_ (a better approach than "cd /opt/iiab/iiab; ./runrole nodejs" is to try `apt install nodejs` or try installing the tar file mentioned at https://github.com/iiab/iiab/issues/2082#issuecomment-569344617[#2082]).  You might also need `apt install npm`.  Whatever versions of Node.js and npm you install, make sure `/etc/iiab/iiab_state.yml` contains the line `nodejs_installed: True` (add it if nec!)  Finally, proceed to install Asterisk/FreePBX, Node-RED and/or Sugarizer. https://github.com/iiab/iiab/issues/1799[#1799]
 
 
 ////

--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -289,18 +289,11 @@ Please also check the "Known Issues" at the bottom of https://github.com/iiab/ii
 
 _If there's a bug or serious problem with IIAB, please do https://internet-in-a-box.org/pages/contributing.html[make contact] and post an issue here: https://github.com/iiab/iiab/issues_
 
-. As of 2021-11-05, FreePBX 16 needed 2 lines to be manually patched in order to work with the new Asterisk 19 (https://github.com/iiab/iiab/issues/2934#issuecomment-962137815[#2934]).
-+
-As of 2021-11-06, these 2 lines are live-patched (automatically) by IIAB when installing FreePBX (https://github.com/iiab/iiab/pull/3019[PR #3019]).  We hope that this workaround becomes unnecessary in coming weeks, thanks to subsequent https://github.com/FreePBX/framework/tags[FreePBX 16 point releases].
-+
-*As of 2022-05-25, this issue remains (despite https://github.com/iiab/iiab/pull/3187[PR #3187]) and unnecessarily so as their `freepbx-16.0-latest.tgz` installer filename is unfortunately bogus (it's not really the latest, rather it's an earlier version of FreePBX from September 2021!)  So a manual workaround is to unpack the latest FreePBX 16.x .tar.gz from https://github.com/FreePBX/framework/tags to `/opt/iiab/freepbx` &mdash; _instead of_ https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L69-L97 &mdash; until a proper fix arrive (https://github.com/iiab/iiab/issues/3228[#3228]).*
-
-
 . Apache's `/var/lib/php/asterisk_sessions/` directory might also be needed for NGINX?
 +
-If not, the https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L151-L163[configuration of /var/lib/php/asterisk_sessions/] might be made conditional upon `when: not pbx_use_apache`
+If not, the https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L174-L186[configuration of /var/lib/php/asterisk_sessions/] might be made conditional upon `when: not pbx_use_apache`
 
-. The https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L208-L211[installation of /etc/odbc.ini] for CDR (Call Detail Records) database `asteriskcdrdb` might benefit from compiling the ODBC driver for aarch64, per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
+. The https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L213-L220[installation of /etc/odbc.ini] for CDR (Call Detail Records) database `asteriskcdrdb` might benefit from compiling the ODBC driver for aarch64, per http://mghadam.blogspot.com/2021/03/install-asterisk-18-freepbx-15-on.html ?
 +
 See the output of `asterisk -rx "cdr show status"` as mentioned at https://github.com/iiab/iiab/pull/2938#issuecomment-898693126[#2938] and https://github.com/iiab/iiab/pull/2942[PR #2942].
 

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -1,6 +1,9 @@
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# 2019: Worked on Ubuntu 18.04, Debian 9 w/ Node.js 10.x, and seemingly RPi 3+.
+#
+# 2022-05-25: PHP 7.4 REQUIRED -- PLEASE READ:
+# https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # 2021-08-03: Attempts FreePBX 16 Beta -- as required w/ PHP 7.4 OS's for #2897
+# 2019: Worked on Ubuntu 18.04, Debian 9 w/ Node.js 10.x, and seemingly RPi 3+.
 
 # pbx_install: False
 # pbx_enabled: False
@@ -22,8 +25,10 @@ asterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk
 asterisk_src_file: asterisk-19-current.tar.gz
 asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
-freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/7.4
-freepbx_src_file: freepbx-16.0-latest.tgz    # 2022-05-25: Filename is bogus (as it's not really the latest!) but manually unpacking the latest FreePBX 16.x .tar.gz from https://github.com/FreePBX/framework/tags to /opt/iiab/freepbx does appear to work -- instead of https://github.com/iiab/iiab/blob/master/roles/pbx/tasks/freepbx.yml#L69-L97 -- until a proper fix arrives (#3228).  FYI PHP 7.4 IS MANDATORY FOR NOW (you've been warned!)  Please also review https://github.com/iiab/iiab/tree/master/roles/pbx#readme
+# freepbx_url: http://mirror.freepbx.org/modules/packages/freepbx/7.4
+# freepbx_src_file: freepbx-16.0-latest.tgz    # 2022-05-25 #3228: Filename has become bogus (as it's not really the latest!)  Manually unpacking the latest .tar.gz for FreePBX 16.x from https://github.com/FreePBX/framework/tags to /opt/iiab/freepbx can work if absolutely nec.
+freepbx_git_url: https://github.com/FreePBX/framework
+freepbx_git_branch: release/16.0    # EMERGING OPTION AS OF MAY 2022: https://github.com/FreePBX/framework/tree/release/17.0
 freepbx_src_dir: "{{ iiab_base }}/freepbx"
 freepbx_install_dir: /var/www/html/freepbx
 

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -55,7 +55,7 @@
 #     name: aptitude
 #     state: latest
 
-- name: Asterisk - Run 'install_prereq install' for dependencies - CAN TAKE 5 MIN OR LONGER!
+- name: Asterisk - Run 'install_prereq install' for dependencies - CAN TAKE 2-5 MIN OR LONGER!
   shell: export DEBIAN_FRONTEND=noninteractive && ./contrib/scripts/install_prereq install
   args:
     chdir: "{{ asterisk_src_dir }}"
@@ -88,13 +88,13 @@
   args:
     chdir: "{{ asterisk_src_dir }}"
 
-- name: Asterisk - Run 'make' - CAN TAKE 8-30 MIN OR LONGER!
+- name: Asterisk - Run 'make' - CAN TAKE 4-30 MIN OR LONGER!
   command: make
   args:
     chdir: "{{ asterisk_src_dir }}"
     creates: defaults.h
 
-- name: Asterisk - Run 'make install' - CAN TAKE 2 MIN OR LONGER!
+- name: Asterisk - Run 'make install' - CAN TAKE TIME 1-2 MIN W/ SLOW DISKS?
   command: make install
   args:
     chdir: "{{ asterisk_src_dir }}"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -94,7 +94,7 @@
     chdir: "{{ asterisk_src_dir }}"
     creates: defaults.h
 
-- name: Asterisk - Run 'make install' - CAN TAKE TIME 1-2 MIN W/ SLOW DISKS?
+- name: Asterisk - Run 'make install' - CAN TAKE 1-2 MIN W/ SLOW DISKS?
   command: make install
   args:
     chdir: "{{ asterisk_src_dir }}"

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -1,5 +1,5 @@
-# 2021-08-16 README.adoc, with screenshots:
-# https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# 2022-05-25 README.adoc, with screenshots:
+# https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 
 
 # 2021-08-05: Asterisk's own install_prereq (below) handles essentially all of these

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -66,6 +66,7 @@
   include_tasks: apache.yml
   when: pbx_use_apache
 
+
 # - name: FreePBX - Download {{ freepbx_url }}/{{ freepbx_src_file }} to {{ downloads_dir }}
 #   get_url:
 #     url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
@@ -103,6 +104,7 @@
     version: "{{ freepbx_git_branch }}"    # e.g. release/16.0
     depth: 1
     force: yes
+
 
 # No longer needed since approx 2022-01-31 / 2022-02-14, as confirmed by:
 # https://github.com/FreePBX/framework/blob/release/16.0/install.php#L27
@@ -236,6 +238,7 @@
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
     # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
+
 # 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460
 - name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help to install the ~15 modules below!)
   command: fwconsole ma downloadinstall framework
@@ -247,6 +250,7 @@
 # DEFAULT MODULE LIST: https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 - name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - THIS CAN TAKE SEVERAL MIN!
   command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
+
 
 - name: FreePBX - Run 'fwconsole stop', 'killall -9 safe_asterisk' to stop both main Asterisk processes - this avoids "Unable to run Pre-Asterisk hooks, because Asterisk is already running" in 'journalctl -u freepbx' logs
   command: "{{ item }}"
@@ -284,7 +288,8 @@
     src: freepbx.service
     dest: /etc/systemd/system/
 
-# Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
+
+# 2022-05-25: Replaced by 'fwconsole ma downloadinstall' commands above
 # - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
 #   command: fwconsole ma upgradeall
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -226,7 +226,7 @@
     dest: /etc/asterisk/cdr_mysql.conf
 
 
-- name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - CAN TAKE 3-12 MIN OR LONGER!
+- name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
@@ -277,13 +277,14 @@
 #   command: fwconsole ma upgradeall
 
 # 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460
-- name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help the ~15 modules below to install!)
+- name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help the ~15 modules below install!)
   command: fwconsole ma downloadinstall framework
 
-- name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
-  command: fwconsole reload
+# ERROR: "Unable to connect to remote asterisk"
+# - name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
+#   command: fwconsole reload
 
-- name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - NOTE THIS CAN TAKE SEVERAL MINUTES
+- name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - THIS CAN TAKE SEVERAL MIN!
   command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
 
 # - name: FreePBX - Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_use_nginx"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -247,7 +247,8 @@
 - name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
   command: fwconsole reload
 
-# DEFAULT MODULE LIST: https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
+# DEFAULT MODULE LIST AUG 2021: https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
+# YIELDS 2 MORE AS OF MAY 2022: https://github.com/iiab/iiab/pull/3229#issuecomment-1138566339
 - name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - THIS CAN TAKE SEVERAL MIN!
   command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -273,8 +273,18 @@
     dest: /etc/systemd/system/
 
 # Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
-- name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
-  command: fwconsole ma upgradeall
+# - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
+#   command: fwconsole ma upgradeall
+
+# 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460
+- name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help the ~15 modules below to install!)
+  command: fwconsole ma downloadinstall framework
+
+- name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
+  command: fwconsole reload
+
+- name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - NOTE THIS CAN TAKE SEVERAL MINUTES
+  command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
 
 # - name: FreePBX - Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_use_nginx"
 #   lineinfile:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -236,6 +236,18 @@
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
     # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
+# 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460
+- name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help to install the ~15 modules below!)
+  command: fwconsole ma downloadinstall framework
+
+# ERROR IF RUN BELOW: "Unable to connect to remote asterisk"
+- name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
+  command: fwconsole reload
+
+# DEFAULT MODULE LIST: https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
+- name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - THIS CAN TAKE SEVERAL MIN!
+  command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
+
 - name: FreePBX - Run 'fwconsole stop', 'killall -9 safe_asterisk' to stop both main Asterisk processes - this avoids "Unable to run Pre-Asterisk hooks, because Asterisk is already running" in 'journalctl -u freepbx' logs
   command: "{{ item }}"
   with_items:
@@ -275,17 +287,6 @@
 # Default module list https://github.com/iiab/iiab/pull/2916#issuecomment-894601522
 # - name: FreePBX - Run 'fwconsole ma upgradeall' on installed FreePBX modules, e.g. 16 default modules (of about 70 total) - CAN TAKE 1 MIN OR LONGER!
 #   command: fwconsole ma upgradeall
-
-# 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460
-- name: FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help the ~15 modules below install!)
-  command: fwconsole ma downloadinstall framework
-
-# ERROR: "Unable to connect to remote asterisk"
-# - name: FreePBX - Run 'fwconsole reload' - as an additional precaution, per Ron Raikes @ https://community.freepbx.org/t/asterisk-19-1-0-and-freepbx-install/81029/15
-#   command: fwconsole reload
-
-- name: FreePBX - Download + Install 15 additional FreePBX default modules (of about 70 total) as if we were installing freepbx-16.0-latest.tgz - THIS CAN TAKE SEVERAL MIN!
-  command: fwconsole ma downloadinstall callrecording cdr conferences core customappsreg dashboard featurecodeadmin infoservices logfiles music pm2 recordings sipsettings soundlang voicemail
 
 # - name: FreePBX - Add "$amp_conf['CHECKREFERER'] = false;" to /etc/freepbx.conf #2931 - if pbx_use_nginx"
 #   lineinfile:

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -1,5 +1,5 @@
-# 2021-08-16 README.adoc, with screenshots:
-# https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# 2022-05-25 README.adoc, with screenshots:
+# https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 
 
 # 2021-08-04: Non-native systemd service 'asterisk.service' (redirects via
@@ -66,35 +66,43 @@
   include_tasks: apache.yml
   when: pbx_use_apache
 
-- name: FreePBX - Download {{ freepbx_url }}/{{ freepbx_src_file }} to {{ downloads_dir }}
-  get_url:
-    url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
-    dest: "{{ downloads_dir }}"    # e.g. /opt/iiab/downloads/freepbx-16.0-latest.tgz
-    timeout: "{{ download_timeout }}"
+# - name: FreePBX - Download {{ freepbx_url }}/{{ freepbx_src_file }} to {{ downloads_dir }}
+#   get_url:
+#     url: "{{ freepbx_url }}/{{ freepbx_src_file }}"
+#     dest: "{{ downloads_dir }}"    # e.g. /opt/iiab/downloads/freepbx-16.0-latest.tgz
+#     timeout: "{{ download_timeout }}"
 
-- name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
-  stat:
-    path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
-  register: freepbx_src
+# - name: FreePBX - Check for {{ downloads_dir }}/{{ freepbx_src_file }}
+#   stat:
+#     path: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+#   register: freepbx_src
 
-- name: FreePBX - FAIL (force Ansible to exit) IF {{ downloads_dir }}/{{ freepbx_src_file }} doesn't exist
-  fail:
-    msg: "{{ downloads_dir }}/{{ freepbx_src_file }} is REQUIRED to install FreePBX."
-  when: not freepbx_src.stat.exists
+# - name: FreePBX - FAIL (force Ansible to exit) IF {{ downloads_dir }}/{{ freepbx_src_file }} doesn't exist
+#   fail:
+#     msg: "{{ downloads_dir }}/{{ freepbx_src_file }} is REQUIRED to install FreePBX."
+#   when: not freepbx_src.stat.exists
 
-- name: FreePBX - Create source dir {{ freepbx_src_dir }}
-  file:
-    path: "{{ freepbx_src_dir }}"    # /opt/iiab/freepbx
-    state: directory
+# - name: FreePBX - Create source dir {{ freepbx_src_dir }}
+#   file:
+#     path: "{{ freepbx_src_dir }}"    # /opt/iiab/freepbx
+#     state: directory
 
-- name: FreePBX - Extract to source dir (root:root)
-  unarchive:
-    src: "{{ downloads_dir }}/{{ freepbx_src_file }}"
-    dest: "{{ freepbx_src_dir }}"
-    owner: root
-    group: root
-    extra_opts: [--strip-components=1]
-    creates: "{{ freepbx_src_dir }}/install"
+# - name: FreePBX - Extract to source dir (root:root)
+#   unarchive:
+#     src: "{{ downloads_dir }}/{{ freepbx_src_file }}"
+#     dest: "{{ freepbx_src_dir }}"
+#     owner: root
+#     group: root
+#     extra_opts: [--strip-components=1]
+#     creates: "{{ freepbx_src_dir }}/install"
+
+- name: FreePBX - git clone {{ freepbx_git_url }} -b {{ freepbx_git_branch }} --depth 1 {{ freepbx_src_dir }} (force)
+  git:
+    repo: "{{ freepbx_git_url }}"          # https://github.com/FreePBX/framework
+    dest: "{{ freepbx_src_dir }}"          # /opt/iiab/freepbx
+    version: "{{ freepbx_git_branch }}"    # e.g. release/16.0
+    depth: 1
+    force: yes
 
 # No longer needed since approx 2022-01-31 / 2022-02-14, as confirmed by:
 # https://github.com/FreePBX/framework/blob/release/16.0/install.php#L27
@@ -190,7 +198,7 @@
     create: yes
 
 
-- name: FreePBX - git clone https://github.com/mariadb-corporation/mariadb-connector-odbc to /usr/src/mariadb-connector-odbc
+- name: FreePBX - git clone https://github.com/mariadb-corporation/mariadb-connector-odbc --depth 1 /usr/src/mariadb-connector-odbc (force)
   git:
     repo: https://github.com/mariadb-corporation/mariadb-connector-odbc
     dest: /usr/src/mariadb-connector-odbc

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -1,4 +1,4 @@
-- name: "ONLY PHP 7.4 IS SUPPORTED AS OF AUG 2021 -- PLEASE READ: https://github.com/iiab/iiab/tree/master/roles/pbx/#pbx-readme"
+- name: "ONLY PHP 7.4 IS SUPPORTED AS OF MAY 2022 -- PLEASE READ: https://github.com/iiab/iiab/tree/master/roles/pbx#readme"
   meta: noop
 
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -657,7 +657,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
-# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -408,7 +408,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
-# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -408,7 +408,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
-# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -408,7 +408,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
-# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -408,7 +408,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
-# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#pbx-readme
+# INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False
 pbx_enabled: False


### PR DESCRIPTION
Following the suggestion at https://github.com/iiab/iiab/issues/3228#issuecomment-1137869435, this should resolve:

- #3228 

Also cleans up [roles/pbx](https://github.com/iiab/iiab/tree/master/roles/pbx)

Tested on Ubuntu Server 20.04 LTS (x86_64 VM).

Refs:

- PR #3187