### PR TITLE
kiwix-tools 3.3.0 is coming very soon (with "opensearch")

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -26,9 +26,9 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 # http://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
 # http://download.kiwix.org/nightly/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-3.2.0-5
-kiwix_version_linux64: kiwix-tools_linux-x86_64-3.2.0-5
-kiwix_version_i686: kiwix-tools_linux-i586-3.2.0-5
+kiwix_version_armhf: kiwix-tools_linux-armhf-3.3.0
+kiwix_version_linux64: kiwix-tools_linux-x86_64-3.3.0
+kiwix_version_i686: kiwix-tools_linux-i586-3.3.0
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")


### PR DESCRIPTION
Opensearch has apparently been included:

- PR kiwix/libkiwix#731

Testing the latest nightly version of kiwix-tools may very be helpful here &mdash; feedback very much appreciated from anybody who sees improvements (or problems!) with title search and full-text search right here:

- http://iiab.me/kiwix/wikipedia_en_all_maxi_2022-05/

(Currently the above site is running [kiwix-tools_linux-x86_64-2022-06-06.tar.gz](https://download.kiwix.org/nightly/2022-06-06/kiwix-tools_linux-x86_64-2022-06-06.tar.gz))

All this builds on:

- kiwix/kiwix-tools#554
  - https://github.com/kiwix/kiwix-tools/milestone/2
- PR #3221
- https://twitter.com/internet_in_box/status/1526948631135264770

Note this will be included as part of IIAB 8.0 Preview 2 shortly:

- https://twitter.com/internet_in_box/status/1533815764683194371