### PR TITLE
test.yml: Document ansible_facts['distribution'] etc — "avoid ansible_distribution since Ansible 2.7"

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -56,9 +56,19 @@
       var: f
 
   - debug:
-      var: ansible_local.local_facts
+      var: ansible_local.local_facts    # SEE: /opt/iiab/iiab/scripts/local_facts.fact
   - debug:
       var: ansible_local.local_facts.os_ver
+
+  # Since Ansible 2.7, avoid ansible_distribution: https://github.com/iiab/iiab/pull/3237
+  # https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#commonly-used-facts
+
+  - debug:
+      var: ansible_facts['distribution']                  # ansible_facts.distribution ?
+  - debug:
+      var: ansible_facts['os_family']                     # ansible_facts.os_family ?
+  - debug:
+      var: ansible_facts['distribution_major_version']    # ansible_facts.distribution_major_version ?
   - debug:
       var: ansible_architecture
   - debug:


### PR DESCRIPTION
Thanks to @tim-moody's suggestion, building on:

- PR #3237