### PR TITLE
Unblock Kolibri 0.15.3 installs on Python 3.10, e.g. Ubuntu 22.04, 22.10

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: kolibri_install
 
 - name: KIWIX
   include_role:


### PR DESCRIPTION
Kolibri 0.15.3 (released ~6 hours ago) is confirmed to work on Ubuntu 22.04

Merging this just awaits final posting of 0.15.3's .deb file to https://learningequality.org/download/ (hopefully that will happen later today).

This builds on:

- #3189
- learningequality/kolibri#9392
- PR learningequality/kolibri#9393