### PR TITLE
Use moodle/tasks/enable-or-disable.yml like in other roles

### DIFF
--- a/roles/moodle/tasks/enable-or-disable.yml
+++ b/roles/moodle/tasks/enable-or-disable.yml
@@ -1,3 +1,18 @@
+- name: "Set 'postgresql_install: True' and 'postgresql_enabled: True'"
+  set_fact:
+    postgresql_install: True
+    postgresql_enabled: True    # Revert just below if...
+
+- name: "Set 'postgresql_enabled: False' if not moodle_enabled"
+  set_fact:
+    postgresql_enabled: False
+  when: not moodle_enabled    # and not (pathagar_enabled is defined and pathagar_enabled)
+
+- name: POSTGRESQL - run 'postgresql' role (Enable&Start or Disable&Stop PostgreSQL)
+  include_role:
+    name: postgresql
+
+
 - name: Enable http://box/moodle via NGINX, by installing {{ nginx_conf_dir }}/moodle-nginx.conf from template
   template:
     src: moodle-nginx.conf.j2

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -24,23 +24,7 @@
   when: moodle_installed is undefined
 
 
-- name: "Set 'postgresql_install: True' and 'postgresql_enabled: True'"
-  set_fact:
-    postgresql_install: True
-    postgresql_enabled: True    # Revert just below if...
-
-- name: "Set 'postgresql_enabled: False' if not moodle_enabled"
-  set_fact:
-    postgresql_enabled: False
-  when: not moodle_enabled    # and not (pathagar_enabled is defined and pathagar_enabled)
-
-- name: POSTGRESQL - run 'postgresql' role (Enable&Start or Disable&Stop PostgreSQL)
-  include_role:
-    name: postgresql
-
-
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+- include_tasks: enable-or-disable.yml
 
 
 - name: Add 'moodle' variable values to {{ iiab_ini_file }}


### PR DESCRIPTION
Aligns `roles/moodle` use of `tasks/enable-or-disable.yml` with other roles.

Similar to `roles/calibre-web` and `roles/kolibri` that were updated here:

- PR #3241

Tangentially related:

- #3182
- #3184