### PR TITLE
Prototype 'skip_role_on_error: True' in 4 roles {lokole, moodle, mongodb, sugarizer}

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: MOODLE
   include_role:
     name: moodle
-  when: moodle_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: moodle_install    # and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
 
 - name: OSM-VECTOR-MAPS
   include_role:
@@ -43,7 +43,7 @@
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: sugarizer_install    # and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:

--- a/roles/lokole/tasks/main.yml
+++ b/roles/lokole/tasks/main.yml
@@ -19,53 +19,62 @@
     quiet: yes
 
 
-- name: Install Lokole if lokole_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: lokole_installed is undefined
+- block:
+
+  - name: Install Lokole if lokole_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: lokole_installed is undefined
 
 
-- name: Do a 'systemctl daemon-reload'
-  systemd:
-    daemon_reload: yes
-  when: lokole_enabled
+  - name: Do a 'systemctl daemon-reload'
+    systemd:
+      daemon_reload: yes
+    when: lokole_enabled
 
-- name: Enable & Restart supervisor systemd service, if lokole_enabled
-  systemd:
-    name: supervisor
-    enabled: yes
-    state: restarted
-  when: lokole_enabled
+  - name: Enable & Restart supervisor systemd service, if lokole_enabled
+    systemd:
+      name: supervisor
+      enabled: yes
+      state: restarted
+    when: lokole_enabled
 
-- name: Disable & Stop supervisor systemd service, if not lokole_enabled
-  systemd:
-    name: supervisor
-    enabled: no
-    state: stopped
-  when: not lokole_enabled
+  - name: Disable & Stop supervisor systemd service, if not lokole_enabled
+    systemd:
+      name: supervisor
+      enabled: no
+      state: stopped
+    when: not lokole_enabled
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  - name: Enable/Disable/Restart NGINX
+    include_tasks: nginx.yml
 
 
-- name: Add 'lokole' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: lokole
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Lokole
-    - option: description
-      value: '"Lokole is an email service that works offline, for rural communities.  With a 3G/4G modem, you can arrange to batch-upload / batch-download emails once per night -- for almost no cost at all -- depending on mobile data plans in your country."'
-      #value: '"Lokole is an email service that works offline, for rural communities.  In some cases, emails can also be transmitted to/from the Internet, taking advantage of discounted mobile data rates."'
-    - option: lokole_install
-      value: "{{ lokole_install }}"
-    - option: lokole_enabled
-      value: "{{ lokole_enabled }}"
-    - option: lokole_settings
-      value: "{{ lokole_settings }}"
-    - option: lokole_url
-      value: "{{ lokole_url }}"
-    - option: lokole_full_url
-      value: "{{ lokole_full_url }}"
+  - name: Add 'lokole' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: lokole
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Lokole
+      - option: description
+        value: '"Lokole is an email service that works offline, for rural communities.  With a 3G/4G modem, you can arrange to batch-upload / batch-download emails once per night -- for almost no cost at all -- depending on mobile data plans in your country."'
+        #value: '"Lokole is an email service that works offline, for rural communities.  In some cases, emails can also be transmitted to/from the Internet, taking advantage of discounted mobile data rates."'
+      - option: lokole_install
+        value: "{{ lokole_install }}"
+      - option: lokole_enabled
+        value: "{{ lokole_enabled }}"
+      - option: lokole_settings
+        value: "{{ lokole_settings }}"
+      - option: lokole_url
+        value: "{{ lokole_url }}"
+      - option: lokole_full_url
+        value: "{{ lokole_full_url }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -44,29 +44,37 @@
 
 # ELSE...
 
-- name: Install MongoDB if 'mongodb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: mongodb_installed is undefined
-  # when: mongodb_installed is undefined and not (ansible_architecture == "aarch64" and is_debian_10 and not is_raspbian)
 
+- block:
 
-- name: Enable or Disable MongoDB, if mongodb_installed is defined (sugarizer.service auto-starts MongoDB as nec, so doesn't need this or care what happens here!)
-  include_tasks: enable-or-disable.yml
-  when: mongodb_installed is defined
+  - name: Install MongoDB if 'mongodb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: mongodb_installed is undefined
+    # when: mongodb_installed is undefined and not (ansible_architecture == "aarch64" and is_debian_10 and not is_raspbian)
 
+  - name: Enable or Disable MongoDB, if mongodb_installed is defined (sugarizer.service auto-starts MongoDB as nec, so doesn't need this or care what happens here!)
+    include_tasks: enable-or-disable.yml
+    when: mongodb_installed is defined
 
-- name: Add 'mongodb' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: mongodb
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: MongoDB
-    - option: description
-      value: '"MongoDB is an open-source document database that provides high performance, high availability, and automatic scaling."'
-    - option: mongodb_install
-      value: "{{ mongodb_install }}"
-    - option: mongodb_enabled
-      value: "{{ mongodb_enabled }}"
+  - name: Add 'mongodb' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: mongodb
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: MongoDB
+      - option: description
+        value: '"MongoDB is an open-source document database that provides high performance, high availability, and automatic scaling."'
+      - option: mongodb_install
+        value: "{{ mongodb_install }}"
+      - option: mongodb_enabled
+        value: "{{ mongodb_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -19,28 +19,35 @@
     quiet: yes
 
 
-- name: Install Moodle if 'moodle_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: moodle_installed is undefined
+- block:
 
+  - name: Install Moodle if 'moodle_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: moodle_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'moodle' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: moodle
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Moodle
+      - option: description
+        value: '"Access the Moodle learning management system."'
+      - option: moodle_install
+        value: "{{ moodle_install }}"
+      - option: moodle_enabled
+        value: "{{ moodle_enabled }}"
+      - option: moodle_base
+        value: "{{ moodle_base }}"
 
-- name: Add 'moodle' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: moodle
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Moodle
-    - option: description
-      value: '"Access the Moodle learning management system."'
-    - option: moodle_install
-      value: "{{ moodle_install }}"
-    - option: moodle_enabled
-      value: "{{ moodle_enabled }}"
-    - option: moodle_base
-      value: "{{ moodle_base }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/sugarizer/tasks/main.yml
+++ b/roles/sugarizer/tasks/main.yml
@@ -19,39 +19,53 @@
     quiet: yes
 
 
-# 3 stanzas moved up from install.yml, so Debian-or-any-OS-where-MongoDB-fails
-# still finish their "LARGE-sized" IIAB install: (WITH LOUD RED WARNINGS!)
+- block:
 
-- name: "Set 'mongodb_install: True'"
-  set_fact:
-    mongodb_install: True
+  # 3 stanzas moved up from install.yml, so Debian-or-any-OS-where-MongoDB-fails
+  # still finish their "LARGE-sized" IIAB install: (WITH LOUD RED WARNINGS!)
 
-- name: 'CAUTION: IF ''mongodb.service'' IS STOPPED FOR ANY REASON, IT WILL IMMEDIATELY CAUSE SUGARIZER TO FAIL ("502 Bad Gateway") !'
-  debug:
-    msg: "/etc/systemd/system/sugarizer.service Line 4 'Requires=mongodb.service' tries to auto-start MongoDB every time Sugarizer starts.  IIAB (roles/mongodb/tasks/enable-or-disable.yml) tries its best to keep Ansible var 'mongodb_enabled' in sync with its systemd equivalent, i.e. the output of 'systemctl is-enabled mongodb' (as of 2020-10-29 both are typically disabled, unless other apps/services/operators choose to use MongoDB)."
+  - name: "Set 'mongodb_install: True'"
+    set_fact:
+      mongodb_install: True
 
-- name: MONGODB - run 'mongodb' role (attempt to install MongoDB)
-  include_role:
-    name: mongodb
+  - name: 'CAUTION: IF ''mongodb.service'' IS STOPPED FOR ANY REASON, IT WILL IMMEDIATELY CAUSE SUGARIZER TO FAIL ("502 Bad Gateway") !'
+    debug:
+      msg: "/etc/systemd/system/sugarizer.service Line 4 'Requires=mongodb.service' tries to auto-start MongoDB every time Sugarizer starts.  IIAB (roles/mongodb/tasks/enable-or-disable.yml) tries its best to keep Ansible var 'mongodb_enabled' in sync with its systemd equivalent, i.e. the output of 'systemctl is-enabled mongodb' (as of 2020-10-29 both are typically disabled, unless other apps/services/operators choose to use MongoDB)."
+
+  - name: MONGODB - run 'mongodb' role (attempt to install MongoDB)
+    include_role:
+      name: mongodb
 
 
-- name: EXIT 'sugarizer' ROLE & CONTINUE, IF 'mongodb_installed is undefined'
-  fail:    # FORCE IT RED THIS ONCE!
-    msg: MongoDB INSTALLATION FAILED, perhaps because your OS is Debian 10 on aarch64?  Nevertheless IIAB will continue (consider this a warning!)
-  when: mongodb_installed is undefined
-  ignore_errors: yes
+  # - name: EXIT 'sugarizer' ROLE & CONTINUE, IF 'mongodb_installed is undefined'
+  #   fail:    # FORCE IT RED THIS ONCE!
+  #     msg: MongoDB INSTALLATION FAILED, perhaps because MongoDB doesn't yet support Ubuntu 22.04 with libssl3?  Nevertheless IIAB will continue (consider this a warning!)
+  #   when: mongodb_installed is undefined
+  #   ignore_errors: yes    # RESCUE (BELOW) NOW HANDLES THIS
 
-# ELSE...
+  - name: Verify that mongodb_installed is defined
+    fail:
+      msg: MongoDB INSTALLATION FAILED, perhaps because MongoDB doesn't yet support Ubuntu 22.04 with libssl3? #3190
+    when: mongodb_installed is undefined
 
-- name: Install/Enable/Disable/Record Sugarizer (main2.yml) IF 'mongodb_installed is defined'
-  include_tasks: main2.yml
-  when: mongodb_installed is defined
+  # ELSE...
 
-# THE block: APPROACH BELOW WORKS JUST LIKE main2.yml ABOVE.
-# BUT IT VISUALLY POLLUTES: MANY BLUE "skipping:" MESSAGES IN ANSIBLE'S OUTPUT.
+  - name: Install/Enable/Disable/Record Sugarizer (main2.yml) IF 'mongodb_installed is defined'
+    include_tasks: main2.yml
+    when: mongodb_installed is defined
 
-# - block:    # ENTIRE BLOCK CONDITIONED ON 'when: mongodb_installed is defined'
-#
-#   [MOVED TO main2.yml]
-#
-#   when: mongodb_installed is defined    # CONDITION FOR ENTIRE ABOVE block:
+  # THE block: APPROACH BELOW WORKS JUST LIKE main2.yml ABOVE.
+  # BUT IT VISUALLY POLLUTES: MANY BLUE "skipping:" MESSAGES IN ANSIBLE'S OUTPUT.
+
+  # - block:    # ENTIRE BLOCK CONDITIONED ON 'when: mongodb_installed is defined'
+  #
+  #   [MOVED TO main2.yml]
+  #
+  #   when: mongodb_installed is defined    # CONDITION FOR ENTIRE ABOVE block:
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -16,6 +16,8 @@
 iiab_base_ver: 8.0
 iiab_revision: 0
 
+skip_role_on_error: False
+
 iiab_etc_path: /etc/iiab
 
 # Main configuration file


### PR DESCRIPTION
It's not just that humanity is impatient (the world is melting after all) but also that some prefer to race through all roles and then look at the individual errors later.

So this PR prototypes an unblocking mechanism, allowing Ansible to continue to the next role(s) even despite serious errors in individual roles.

It uses Ansible's block/rescue technique.  All this really does is indent most all of ROLE/tasks/main.yml &mdash; and then tack this on the bottom:

```
  rescue:

  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
    fail:
      msg: ""
    when: not skip_role_on_error
```

This means that if you override default_vars.yml to set `skip_role_on_error: True` you will get a `rescued=2` count of all bypassed (rescued) errors in the bottom-right &mdash; to notify you of how many error(s) need to be addressed &mdash; as in this example output:

```
TASK [mongodb : SOME SERIOUS ERROR TRYING TO INSTALL MongoDB] **************************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "DEEP FAIL 1! (MongoDB)"}

TASK [mongodb : SEE ERROR ABOVE (skip_role_on_error: False)] ***********************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": ""}

TASK [sugarizer : SEE ERROR ABOVE (skip_role_on_error: False)] *********************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": ""}

PLAY RECAP *************************************************************************************************************************************************************
127.0.0.1                  : ok=42   changed=7    unreachable=0    failed=1    skipped=5    rescued=2    ignored=0
```

As you can see above, it immediately "pops to the top of the stack" if encountering an error in a deeply nested role when `skip_role_on_error: False`

On the other hand, those who choose to override default_vars.yml to set `skip_role_on_error: True` later need to **take responsibility for all the errors they intentionally chose to bypass!**  One way to do this is:

```
cd /opt/iiab/iiab
grep -B1 'SEE ERROR ABOVE' *.log
```

The `-B1` flag is the essential part, as it includes the _actual error_ on the previous line of the log file(s), for every error.

PS This technique should very likely be expanded to most all/other user-facing IIAB apps (i.e. their roles) in the coming days, if it proves to work well!

Related:

- #3182 
- #3184 
- #3189
- #3190
- #3242 
- #3244