### PR TITLE
Support skip_role_on_error in 23+3 more roles (Stages 6-9) [and FreePBX module 'sipsettings' won't install?]

### DIFF
--- a/roles/awstats/tasks/main.yml
+++ b/roles/awstats/tasks/main.yml
@@ -19,27 +19,34 @@
     quiet: yes
 
 
-- name: Install AWStats if 'awstats_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: awstats_installed is undefined
+- block:
 
+  - name: Install AWStats if 'awstats_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: awstats_installed is undefined
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  - name: Enable/Disable/Restart NGINX
+    include_tasks: nginx.yml
 
+  - name: Add 'awstats' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: awstats
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: AWStats
+      - option: description
+        value: '"AWStats (originally known as Advanced Web Statistics) is a package written in Perl which generates static or dynamic html summaries based upon web server logs."'
+      - option: awstats_install
+        value: "{{ awstats_install }}"
+      - option: awstats_enabled
+        value: "{{ awstats_enabled }}"
 
-- name: Add 'awstats' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: awstats
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: AWStats
-    - option: description
-      value: '"AWStats (originally known as Advanced Web Statistics) is a package written in Perl which generates static or dynamic html summaries based upon web server logs."'
-    - option: awstats_install
-      value: "{{ awstats_install }}"
-    - option: awstats_enabled
-      value: "{{ awstats_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -19,40 +19,47 @@
     quiet: yes
 
 
-- name: Install Calibre-Web if 'calibreweb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: calibreweb_installed is undefined
+- block:
 
+  - name: Install Calibre-Web if 'calibreweb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: calibreweb_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'calibre-web' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: calibre-web
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Calibre-Web
+      - option: description
+        value: '"Calibre-Web is a web app providing a clean interface for browsing, reading and downloading e-books."'
+      - option: calibreweb_install
+        value: "{{ calibreweb_install }}"
+      - option: calibreweb_enabled
+        value: "{{ calibreweb_enabled }}"
+      - option: calibreweb_url1
+        value: "{{ calibreweb_url1 }}"
+      - option: calibreweb_url2
+        value: "{{ calibreweb_url2 }}"
+      - option: calibreweb_url3
+        value: "{{ calibreweb_url3 }}"
+      - option: calibreweb_path
+        value: "{{ calibreweb_venv_path }}"
+      - option: calibreweb_home
+        value: "{{ calibreweb_home }}"
+      - option: calibreweb_port
+        value: "{{ calibreweb_port }}"
+      - option: calibreweb_settings_database
+        value: "{{ calibreweb_settings_database }}"
 
-- name: Add 'calibre-web' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: calibre-web
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Calibre-Web
-    - option: description
-      value: '"Calibre-Web is a web app providing a clean interface for browsing, reading and downloading e-books."'
-    - option: calibreweb_install
-      value: "{{ calibreweb_install }}"
-    - option: calibreweb_enabled
-      value: "{{ calibreweb_enabled }}"
-    - option: calibreweb_url1
-      value: "{{ calibreweb_url1 }}"
-    - option: calibreweb_url2
-      value: "{{ calibreweb_url2 }}"
-    - option: calibreweb_url3
-      value: "{{ calibreweb_url3 }}"
-    - option: calibreweb_path
-      value: "{{ calibreweb_venv_path }}"
-    - option: calibreweb_home
-      value: "{{ calibreweb_home }}"
-    - option: calibreweb_port
-      value: "{{ calibreweb_port }}"
-    - option: calibreweb_settings_database
-      value: "{{ calibreweb_settings_database }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/calibre/tasks/enable-or-disable.yml
+++ b/roles/calibre/tasks/enable-or-disable.yml
@@ -1,0 +1,29 @@
+# http://box:8080 & http://box:8080/mobile WORK BUT OTHER URL'S LIKE http://box/calibre ARE A MESS (BOOKS RARELY DISPLAY)
+#
+# 2018-08-27 POSSIBLE FIX...CONSIDER THIS ProxyPass / ProxyPassReverse TECHNIQUE:
+# https://github.com/iiab/iiab/tree/master/roles/calibre-web/templates/calibre-web.conf.j2
+#    (anyway this works great for calibre-web, allowing http://box/books
+#    to work even better than http://box:8083 when box == 192.168.0.x !)
+#
+#- name: Attempt to enable http://box/calibre via Apache (UNTESTED)
+#  command: a2ensite calibre.conf
+#  when: apache_installed and calibre_enabled
+#
+#- name: Attempt to disable http://box/calibre via Apache (UNTESTED)
+#  command: a2dissite calibre.conf
+#  when: apache_installed and not calibre_enabled
+
+- name: Enable & (Re)Start 'calibre-serve' service, if calibre_enabled
+  systemd:
+    daemon_reload: yes
+    name: calibre-serve
+    enabled: yes
+    state: restarted
+  when: calibre_enabled
+
+- name: Disable & Stop 'calibre-serve' service, if not calibre_enabled
+  systemd:
+    name: calibre-serve
+    enabled: no
+    state: stopped
+  when: not calibre_enabled

--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -19,65 +19,37 @@
     quiet: yes
 
 
-- name: Install Calibre if 'calibre_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: calibre_installed is undefined
+- block:
 
-# http://box:8080 & http://box:8080/mobile WORK BUT OTHER URL'S LIKE http://box/calibre ARE A MESS (BOOKS RARELY DISPLAY)
-#
-# 2018-08-27 POSSIBLE FIX...CONSIDER THIS ProxyPass / ProxyPassReverse TECHNIQUE:
-# https://github.com/iiab/iiab/tree/master/roles/calibre-web/templates/calibre-web.conf.j2
-#    (anyway this works great for calibre-web, allowing http://box/books
-#    to work even better than http://box:8083 when box == 192.168.0.x !)
-#
-#- name: Attempt to enable http://box/calibre via Apache (UNTESTED)
-#  command: a2ensite calibre.conf
-#  when: apache_installed and calibre_enabled
-#
-#- name: Attempt to disable http://box/calibre via Apache (UNTESTED)
-#  command: a2dissite calibre.conf
-#  when: apache_installed and not calibre_enabled
+  - name: Install Calibre if 'calibre_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: calibre_installed is undefined
 
-- name: Enable & (Re)Start 'calibre-serve' service, if calibre_enabled
-  systemd:
-    daemon_reload: yes
-    name: calibre-serve
-    enabled: yes
-    state: restarted
-  when: calibre_enabled
+  - include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop 'calibre-serve' service, if not calibre_enabled
-  systemd:
-    name: calibre-serve
-    enabled: no
-    state: stopped
-  when: not calibre_enabled
+  - name: Add 'calibre' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: calibre
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Calibre
+      - option: description
+        value: '"Calibre is an extremely popular personal library system for e-books."'
+      - option: calibre_src_url
+        value: "{{ calibre_src_url }}"
+      - option: calibre_dbpath
+        value: "{{ calibre_dbpath }}"
+      - option: calibre_port
+        value: "{{ calibre_port }}"
+      - option: calibre_enabled
+        value: "{{ calibre_enabled }}"
 
-#- name: Enable/Disable/Restart Apache if primary
-#  include_tasks: apache.yml
-#  when: not nginx_enabled
-#
-#- name: Enable/Disable/Restart NGINX if primary
-#  include_tasks: nginx.yml
-#  when: nginx_enabled
+  rescue:
 
-
-- name: Add 'calibre' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: calibre
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Calibre
-    - option: description
-      value: '"Calibre is an extremely popular personal library system for e-books."'
-    - option: calibre_src_url
-      value: "{{ calibre_src_url }}"
-    - option: calibre_dbpath
-      value: "{{ calibre_dbpath }}"
-    - option: calibre_port
-      value: "{{ calibre_port }}"
-    - option: calibre_enabled
-      value: "{{ calibre_enabled }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/captiveportal/tasks/main.yml
+++ b/roles/captiveportal/tasks/main.yml
@@ -19,27 +19,33 @@
     quiet: yes
 
 
-- name: Install Captive Portal if 'captiveportal_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: captiveportal_installed is undefined
+- block:
 
+  - name: Install Captive Portal if 'captiveportal_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: captiveportal_installed is undefined
 
-- name: Enable or Disable Captive Portal
-  include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'captiveportal' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: captiveportal
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Captive Portal
+      - option: description
+        value: '"Captive Portal tries to open the browser automatically, so users don''t have to type in URL''s like http://box.lan in support of kiosk-like situations, in multilingual and less literate communities."'
+      - option: captiveportal_install
+        value: "{{ captiveportal_install }}"
+      - option: captiveportal_enabled
+        value: "{{ captiveportal_enabled }}"
 
-- name: Add 'captiveportal' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: captiveportal
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Captive Portal
-    - option: description
-      value: '"Captive Portal tries to open the browser automatically, so users don''t have to type in URL''s like http://box.lan in support of kiosk-like situations, in multilingual and less literate communities."'
-    - option: captiveportal_install
-      value: "{{ captiveportal_install }}"
-    - option: captiveportal_enabled
-      value: "{{ captiveportal_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/gitea/tasks/enable-or-disable.yml
+++ b/roles/gitea/tasks/enable-or-disable.yml
@@ -1,17 +1,17 @@
-  - name: Enable & Restart 'gitea' systemd service, if gitea_enabled
-    systemd:
-      name: gitea
-      daemon_reload: yes
-      enabled: yes
-      state: restarted
-    when: gitea_enabled
+- name: Enable & Restart 'gitea' systemd service, if gitea_enabled
+  systemd:
+    name: gitea
+    daemon_reload: yes
+    enabled: yes
+    state: restarted
+  when: gitea_enabled
 
-  - name: Disable & Stop 'gitea' systemd service, if not gitea_enabled
-    systemd:
-      name: gitea
-      enabled: no
-      state: stopped
-    when: not gitea_enabled
+- name: Disable & Stop 'gitea' systemd service, if not gitea_enabled
+  systemd:
+    name: gitea
+    enabled: no
+    state: stopped
+  when: not gitea_enabled
 
 
 - name: Enable http://box{{ gitea_url }} via NGINX, by installing {{ nginx_conf_dir }}/gitea-nginx.conf from template

--- a/roles/gitea/tasks/enable-or-disable.yml
+++ b/roles/gitea/tasks/enable-or-disable.yml
@@ -1,3 +1,19 @@
+  - name: Enable & Restart 'gitea' systemd service, if gitea_enabled
+    systemd:
+      name: gitea
+      daemon_reload: yes
+      enabled: yes
+      state: restarted
+    when: gitea_enabled
+
+  - name: Disable & Stop 'gitea' systemd service, if not gitea_enabled
+    systemd:
+      name: gitea
+      enabled: no
+      state: stopped
+    when: not gitea_enabled
+
+
 - name: Enable http://box{{ gitea_url }} via NGINX, by installing {{ nginx_conf_dir }}/gitea-nginx.conf from template
   template:
     src: gitea-nginx.conf.j2

--- a/roles/gitea/tasks/main.yml
+++ b/roles/gitea/tasks/main.yml
@@ -19,46 +19,37 @@
     quiet: yes
 
 
-- name: Install Gitea {{ gitea_version }} if 'gitea_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: gitea_installed is undefined
+- block:
 
+  - name: Install Gitea {{ gitea_version }} if 'gitea_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: gitea_installed is undefined
 
-- name: Enable & Restart 'gitea' systemd service, if gitea_enabled
-  systemd:
-    name: gitea
-    daemon_reload: yes
-    enabled: yes
-    state: restarted
-  when: gitea_enabled
+  - include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop 'gitea' systemd service, if not gitea_enabled
-  systemd:
-    name: gitea
-    enabled: no
-    state: stopped
-  when: not gitea_enabled
+  - name: Add 'gitea' to list of services at {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: gitea
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Gitea
+      - option: description
+        value: '"Gitea is like GitHub for more offline communities: Git with a cup of tea"'
+      - option: gitea_install
+        value: "{{ gitea_install }}"
+      - option: gitea_enabled
+        value: "{{ gitea_enabled }}"
+      - option: gitea_run_directory
+        value: "{{ gitea_run_directory }}"
+      - option: gitea_url
+        value: "{{ gitea_url }}"
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  rescue:
 
-
-- name: Add 'gitea' to list of services at {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: gitea
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Gitea
-    - option: description
-      value: '"Gitea is like GitHub for more offline communities: Git with a cup of tea"'
-    - option: gitea_install
-      value: "{{ gitea_install }}"
-    - option: gitea_enabled
-      value: "{{ gitea_enabled }}"
-    - option: gitea_run_directory
-      value: "{{ gitea_run_directory }}"
-    - option: gitea_url
-      value: "{{ gitea_url }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/internetarchive/tasks/enable-or-disable.yml
+++ b/roles/internetarchive/tasks/enable-or-disable.yml
@@ -1,3 +1,19 @@
+- name: Enable & Restart 'internetarchive' systemd service, if internetarchive_enabled
+  systemd:
+    name: internetarchive
+    daemon_reload: yes
+    enabled: yes
+    state: restarted
+  when: internetarchive_enabled
+
+- name: Disable & Stop 'internetarchive' systemd service, if not internetarchive_enabled
+  systemd:
+    name: internetarchive
+    enabled: no
+    state: stopped
+  when: not internetarchive_enabled
+
+
 - name: Enable http://box/archive via NGINX, by installing {{ nginx_conf_dir }}/internetarchive-nginx.conf from template
   template:
     src: internetarchive-nginx.conf.j2    # TO DO: roles/internetarchive/templates/internetarchive-nginx.conf.j2

--- a/roles/internetarchive/tasks/main.yml
+++ b/roles/internetarchive/tasks/main.yml
@@ -19,76 +19,60 @@
     quiet: yes
 
 
-# 2020-02-11: @mitra42 & @holta agree (#2247) that the following 2-stanza
-# "UPDATE internetarchive" block should run whenever one isn't installing
-# (or reinstalling) internetarchive, for now.  We're aware this means slowness
-# during "./runrole internetarchive" but that's very intentional for now -- as
-# it leads to more testing of more recent versions of internetarchive, which
-# is strongly desired.  Finally, these current norms can and probably will be
-# changed in future, when broader IIAB norms develop around "./runrole
-# --upgrade internetarchive" or "./runrole --update internetarchive" or such,
-# as may evolve @ https://github.com/iiab/iiab/pull/2238#discussion_r376168178
+- block:
 
-- block:    # BEGIN 2-STANZA BLOCK
+  # 2020-02-11: @mitra42 & @holta agree (#2247) that the following 2-stanza
+  # "UPDATE internetarchive" portion should run whenever one isn't installing
+  # (or reinstalling) internetarchive, for now.  We're aware this means slowness
+  # during "./runrole internetarchive" but that's very intentional for now -- as
+  # it leads to more testing of more recent versions of internetarchive, which
+  # is strongly desired.  Finally, these current norms can and probably will be
+  # changed in future, when broader IIAB norms develop around "./runrole
+  # --upgrade internetarchive" or "./runrole --update internetarchive" or such,
+  # as may evolve @ https://github.com/iiab/iiab/pull/2238#discussion_r376168178
 
   - name: "UPGRADE: Stop 'internetarchive' systemd service, if internetarchive_installed is defined"
     systemd:
       name: internetarchive
       daemon_reload: yes
       state: stopped
+    when: internetarchive_installed is defined
 
   - name: "UPGRADE: Run 'yarn upgrade' in {{ internetarchive_dir }}, if internetarchive_installed is defined"
     shell: yarn config set child-concurrency 1 && yarn install && yarn upgrade
     args:
       chdir: "{{ internetarchive_dir }}"
+    when: internetarchive_installed is defined
 
-  when: internetarchive_installed is defined    # END 2-STANZA BLOCK
+  # "ELSE" INSTALL...
 
-# "ELSE" INSTALL...
-
-- name: Install Internet Archive if 'internetarchive_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: internetarchive_installed is undefined
-
-
-# ENABLE/DISABLE/RESTART SYSTEMD SERVICE & WEB SERVERS AS NEC ?
-
-- name: Enable & Restart 'internetarchive' systemd service, if internetarchive_enabled
-  systemd:
-    name: internetarchive
-    daemon_reload: yes
-    enabled: yes
-    state: restarted
-  when: internetarchive_enabled
-
-- name: Disable & Stop 'internetarchive' systemd service, if not internetarchive_enabled
-  systemd:
-    name: internetarchive
-    enabled: no
-    state: stopped
-  when: not internetarchive_enabled
-
-# - name: Enable/Disable/Restart Apache if primary
-#   include_tasks: apache.yml
-#   when: apache_installed is defined and not nginx_enabled
-
-- name: Enable/Disable/Restart NGINX if primary
-  include_tasks: nginx.yml
-  #when: nginx_enabled
+  - name: Install Internet Archive if 'internetarchive_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: internetarchive_installed is undefined
 
 
-- name: Add 'internetarchive' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: internetarchive
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Internet Archive
-    - option: description
-      value: '"Take the Internet Archive experience and materials offline, in a decentralized way!"'
-    - option: internetarchive_install
-      value: "{{ internetarchive_install }}"
-    - option: internetarchive_enabled
-      value: "{{ internetarchive_enabled }}"
+  - include_tasks: enable-or-disable.yml
+
+
+  - name: Add 'internetarchive' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: internetarchive
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Internet Archive
+      - option: description
+        value: '"Take the Internet Archive experience and materials offline, in a decentralized way!"'
+      - option: internetarchive_install
+        value: "{{ internetarchive_install }}"
+      - option: internetarchive_enabled
+        value: "{{ internetarchive_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -19,26 +19,33 @@
     quiet: yes
 
 
-- name: Install Jupyter if jupyterhub_installed not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: jupyterhub_installed is undefined
+- block:
 
+  - name: Install Jupyter if jupyterhub_installed not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: jupyterhub_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'jupyterhub' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: jupyterhub
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: JupyterHub
+      - option: description
+        value: '"High Schools may want to consider JupyterHub to integrate coding with dynamic interactive graphing — A New Way to Think About Programming — allowing students to integrate science experiment results and program output within their notebook/document/blog."'
+      - option: jupyterhub_install
+        value: "{{ jupyterhub_install }}"
+      - option: jupyterhub_enabled
+        value: "{{ jupyterhub_enabled }}"
 
-- name: Add 'jupyterhub' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: jupyterhub
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: JupyterHub
-    - option: description
-      value: '"High Schools may want to consider JupyterHub to integrate coding with dynamic interactive graphing — A New Way to Think About Programming — allowing students to integrate science experiment results and program output within their notebook/document/blog."'
-    - option: jupyterhub_install
-      value: "{{ jupyterhub_install }}"
-    - option: jupyterhub_enabled
-      value: "{{ jupyterhub_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/kalite/tasks/enable-or-disable.yml
+++ b/roles/kalite/tasks/enable-or-disable.yml
@@ -1,0 +1,14 @@
+- name: Enable & (Re)Start 'kalite-serve' service, if kalite_enabled
+  systemd:
+    daemon_reload: yes
+    name: kalite-serve
+    enabled: yes
+    state: restarted
+  when: kalite_enabled
+
+- name: Disable & Stop 'kalite-serve' service, if not kalite_enabled
+  systemd:
+    name: kalite-serve
+    enabled: no
+    state: stopped
+  when: not kalite_enabled

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -19,43 +19,37 @@
     quiet: yes
 
 
-- name: Install KA Lite if 'kalite_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: kalite_installed is undefined
+- block:
 
+  - name: Install KA Lite if 'kalite_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: kalite_installed is undefined
 
-- name: Enable & (Re)Start 'kalite-serve' service, if kalite_enabled
-  systemd:
-    daemon_reload: yes
-    name: kalite-serve
-    enabled: yes
-    state: restarted
-  when: kalite_enabled
+  - include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop 'kalite-serve' service, if not kalite_enabled
-  systemd:
-    name: kalite-serve
-    enabled: no
-    state: stopped
-  when: not kalite_enabled
+  - name: Add 'kalite' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: kalite
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: "KA Lite"
+      - option: description
+        value: '"KA Lite downloads Khan Academy videos for offline use, with exercises and accounts if students want to track their own progress."'
+      - option: kalite_install
+        value: "{{ kalite_install }}"
+      - option: kalite_enabled
+        value: "{{ kalite_enabled }}"
+      - option: path
+        value: "{{ kalite_root }}"
+      - option: port
+        value: "{{ kalite_server_port }}"
 
+  rescue:
 
-- name: Add 'kalite' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: kalite
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: "KA Lite"
-    - option: description
-      value: '"KA Lite downloads Khan Academy videos for offline use, with exercises and accounts if students want to track their own progress."'
-    - option: kalite_install
-      value: "{{ kalite_install }}"
-    - option: kalite_enabled
-      value: "{{ kalite_enabled }}"
-    - option: path
-      value: "{{ kalite_root }}"
-    - option: port
-      value: "{{ kalite_server_port }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -19,38 +19,45 @@
     quiet: yes
 
 
-- name: Install Kiwix if 'kiwix_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: kiwix_installed is undefined
+- block:
 
+  - name: Install Kiwix if 'kiwix_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: kiwix_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'kiwix' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"
+      section: kiwix
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Kiwix
+      - option: description
+        value: '"Part of https://github.com/kiwix/kiwix-tools/ -- kiwix-serve is the most used web server for ZIM files."'
+      - option: kiwix_install
+        value: "{{ kiwix_install }}"
+      - option: kiwix_enabled
+        value: "{{ kiwix_enabled }}"
+      - option: kiwix_url
+        value: "{{ kiwix_url }}"
+      - option: kiwix_url_plus_slash
+        value: "{{ kiwix_url_plus_slash }}"
+      - option: kiwix_path
+        value: "{{ kiwix_path }}"
+      - option: kiwix_port
+        value: "{{ kiwix_port }}"
+      - option: iiab_zim_path
+        value: "{{ iiab_zim_path }}"
+      - option: kiwix_library_xml
+        value: "{{ kiwix_library_xml }}"
 
-- name: Add 'kiwix' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"
-    section: kiwix
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Kiwix
-    - option: description
-      value: '"Part of https://github.com/kiwix/kiwix-tools/ -- kiwix-serve is the most used web server for ZIM files."'
-    - option: kiwix_install
-      value: "{{ kiwix_install }}"
-    - option: kiwix_enabled
-      value: "{{ kiwix_enabled }}"
-    - option: kiwix_url
-      value: "{{ kiwix_url }}"
-    - option: kiwix_url_plus_slash
-      value: "{{ kiwix_url_plus_slash }}"
-    - option: kiwix_path
-      value: "{{ kiwix_path }}"
-    - option: kiwix_port
-      value: "{{ kiwix_port }}"
-    - option: iiab_zim_path
-      value: "{{ iiab_zim_path }}"
-    - option: kiwix_library_xml
-      value: "{{ kiwix_library_xml }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -19,37 +19,46 @@
     quiet: yes
 
 
-#- name: "Set 'kolibri_provision: False' for a more lightweight (re)install"
-#  set_fact:
-#    kolibri_provision: False
-#  when: ???
+- block:
 
-- name: Install Kolibri, if 'kolibri_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: kolibri_installed is undefined
+  #- name: "Set 'kolibri_provision: False' for a more lightweight (re)install"
+  #  set_fact:
+  #    kolibri_provision: False
+  #  when: ???
+
+  - name: Install Kolibri, if 'kolibri_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: kolibri_installed is undefined
 
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
 
-- name: Add 'kolibri' variable values to {{ iiab_ini_file }}    # /etc/iiab/iiab.ini
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: kolibri
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Kolibri
-    - option: description
-      value: '"Kolibri is an open-source educational platform specially designed to provide offline access to a wide range of quality, openly licensed educational contents in low-resource contexts like rural schools, refugee camps, orphanages, and also in non-formal school programs."'
-    - option: kolibri_install
-      value: "{{ kolibri_install }}"
-    - option: kolibri_enabled
-      value: "{{ kolibri_enabled }}"
-    - option: kolibri_url
-      value: "{{ kolibri_url }}"
-    - option: kolibri_path
-      value: "{{ kolibri_exec_path }}"
-    - option: kolibri_port
-      value: "{{ kolibri_http_port }}"
+  - name: Add 'kolibri' variable values to {{ iiab_ini_file }}    # /etc/iiab/iiab.ini
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: kolibri
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Kolibri
+      - option: description
+        value: '"Kolibri is an open-source educational platform specially designed to provide offline access to a wide range of quality, openly licensed educational contents in low-resource contexts like rural schools, refugee camps, orphanages, and also in non-formal school programs."'
+      - option: kolibri_install
+        value: "{{ kolibri_install }}"
+      - option: kolibri_enabled
+        value: "{{ kolibri_enabled }}"
+      - option: kolibri_url
+        value: "{{ kolibri_url }}"
+      - option: kolibri_path
+        value: "{{ kolibri_exec_path }}"
+      - option: kolibri_port
+        value: "{{ kolibri_http_port }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -19,39 +19,46 @@
     quiet: yes
 
 
-- name: Install MediaWiki {{ mediawiki_version }} if 'mediawiki_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: mediawiki_installed is undefined
+- block:
 
+  - name: Install MediaWiki {{ mediawiki_version }} if 'mediawiki_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: mediawiki_installed is undefined
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  - name: Enable/Disable/Restart NGINX
+    include_tasks: nginx.yml
 
+  - name: Add 'mediawiki' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: mediawiki
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: MediaWiki
+      - option: description
+        value: '"MediaWiki is a blog and web site management application, from the people who create Wikipedia."'
+      - option: mediawiki_install
+        value: "{{ mediawiki_install }}"
+      - option: mediawiki_enabled
+        value: "{{ mediawiki_enabled }}"
+      - option: mediawiki_src
+        value: "{{ mediawiki_src }}"
+      - option: mediawiki_abs_path
+        value: "{{ mediawiki_abs_path }}"
+      - option: mediawiki_db_name
+        value: "{{ mediawiki_db_name }}"
+      - option: mediawiki_db_user
+        value: "{{ mediawiki_db_user }}"
+      - option: mediawiki_url
+        value: "{{ mediawiki_url }}"
+      - option: mediawiki_full_url
+        value: "{{ mediawiki_full_url }}"
 
-- name: Add 'mediawiki' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: mediawiki
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: MediaWiki
-    - option: description
-      value: '"MediaWiki is a blog and web site management application, from the people who create Wikipedia."'
-    - option: mediawiki_install
-      value: "{{ mediawiki_install }}"
-    - option: mediawiki_enabled
-      value: "{{ mediawiki_enabled }}"
-    - option: mediawiki_src
-      value: "{{ mediawiki_src }}"
-    - option: mediawiki_abs_path
-      value: "{{ mediawiki_abs_path }}"
-    - option: mediawiki_db_name
-      value: "{{ mediawiki_db_name }}"
-    - option: mediawiki_db_user
-      value: "{{ mediawiki_db_user }}"
-    - option: mediawiki_url
-      value: "{{ mediawiki_url }}"
-    - option: mediawiki_full_url
-      value: "{{ mediawiki_full_url }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/minetest/tasks/main.yml
+++ b/roles/minetest/tasks/main.yml
@@ -19,32 +19,39 @@
     quiet: yes
 
 
-- name: Install Minetest if 'minetest_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: provision.yml    # i.e. install.yml in other roles
-  when: minetest_installed is undefined
+- block:
 
+  - name: Install Minetest if 'minetest_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: provision.yml    # i.e. install.yml in other roles
+    when: minetest_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'minetest' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: minetest
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Minetest Server
+      - option: description
+        value: '"Minetest is an open source clone of the Minecraft building blocks game."'
+      - option: minetest_install
+        value: "{{ minetest_install }}"
+      - option: minetest_enabled
+        value: "{{ minetest_enabled }}"
+      - option: minetest_world_dir
+        value: "{{ minetest_world_dir }}"
+      - option: minetest_port
+        value: "{{ minetest_port }}"
+      - option: minetest_world_dir
+        value: "{{ minetest_world_dir }}"
 
-- name: Add 'minetest' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: minetest
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Minetest Server
-    - option: description
-      value: '"Minetest is an open source clone of the Minecraft building blocks game."'
-    - option: minetest_install
-      value: "{{ minetest_install }}"
-    - option: minetest_enabled
-      value: "{{ minetest_enabled }}"
-    - option: minetest_world_dir
-      value: "{{ minetest_world_dir }}"
-    - option: minetest_port
-      value: "{{ minetest_port }}"
-    - option: minetest_world_dir
-      value: "{{ minetest_world_dir }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/mongodb/tasks/enable-or-disable.yml
+++ b/roles/mongodb/tasks/enable-or-disable.yml
@@ -1,6 +1,7 @@
 - name: Enable & (Re)Start 'mongodb.service' if mongodb_enabled
   systemd:
     name: mongodb
+    daemon_reload: yes
     enabled: yes
     state: restarted
   when: mongodb_enabled

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -52,9 +52,8 @@
     when: mongodb_installed is undefined
     # when: mongodb_installed is undefined and not (ansible_architecture == "aarch64" and is_debian_10 and not is_raspbian)
 
-  - name: Enable or Disable MongoDB, if mongodb_installed is defined (sugarizer.service auto-starts MongoDB as nec, so doesn't need this or care what happens here!)
+  - name: Enable or Disable MongoDB (FYI sugarizer.service auto-starts MongoDB as nec, so doesn't need this or care what happens here!)
     include_tasks: enable-or-disable.yml
-    when: mongodb_installed is defined
 
   - name: Add 'mongodb' variable values to {{ iiab_ini_file }}
     ini_file:

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -19,43 +19,52 @@
     quiet: yes
 
 
-# 2019-07-06: The 'monit' package was suddenly removed from Debian 10.0.0
-# "Buster" during the very final days prior to release, as confirmed by the
-# sudden disappearance of these 2 pages:
-#
-#   https://packages.debian.org/buster/monit
-#   https://packages.debian.org/source/buster/monit
-#
-# And yet Raspbian Buster (is_raspbian_10, which confusingly IIAB declares to
-# be is_debian_10 in vars/raspbian-10.yml for now!) still provides 'monit' via
-# apt -- so eliminating "Debian 10+" requires this funky conditional:
+- block:
 
-# 2020-09-21: The 'monit' package appears to be returning to Debian 11, per:
-#
-#   https://packages.debian.org/bullseye/monit
-#   https://packages.debian.org/source/bullseye/monit
-#
-# SEE iiab/iiab#1849 re: "Debian 10 Buster no longer includes Monit" etc.
+  # 2019-07-06: The 'monit' package was suddenly removed from Debian 10.0.0
+  # "Buster" during the very final days prior to release, as confirmed by the
+  # sudden disappearance of these 2 pages:
+  #
+  #   https://packages.debian.org/buster/monit
+  #   https://packages.debian.org/source/buster/monit
+  #
+  # And yet Raspbian Buster (is_raspbian_10, which confusingly IIAB declares to
+  # be is_debian_10 in vars/raspbian-10.yml for now!) still provides 'monit' via
+  # apt -- so eliminating "Debian 10+" requires this funky conditional:
 
-- name: Install Monit if 'monit_installed' not defined, e.g. in {{ iiab_state_file }} AND not Debian 10    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: monit_installed is undefined and not (is_debian_10 and not is_raspbian)
-  #when: monit_installed is undefined and not ((is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9))
+  # 2020-09-21: The 'monit' package appears to be returning to Debian 11, per:
+  #
+  #   https://packages.debian.org/bullseye/monit
+  #   https://packages.debian.org/source/bullseye/monit
+  #
+  # SEE iiab/iiab#1849 re: "Debian 10 Buster no longer includes Monit" etc.
+
+  - name: Install Monit if 'monit_installed' not defined, e.g. in {{ iiab_state_file }} AND not Debian 10    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: monit_installed is undefined and not (is_debian_10 and not is_raspbian)
+    #when: monit_installed is undefined and not ((is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9))
 
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
 
-- name: Add 'monit' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: monit
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Monit
-    - option: description
-      value: '"Monit is a background service monitor which can correct problems, send email, restart services."'
-    - option: enabled
-      value: "{{ monit_enabled }}"
+  - name: Add 'monit' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: monit
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Monit
+      - option: description
+        value: '"Monit is a background service monitor which can correct problems, send email, restart services."'
+      - option: enabled
+        value: "{{ monit_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/mosquitto/tasks/main.yml
+++ b/roles/mosquitto/tasks/main.yml
@@ -19,26 +19,33 @@
     quiet: yes
 
 
-- name: Install Mosquitto if 'mosquitto_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: mosquitto_installed is undefined
+- block:
 
+  - name: Install Mosquitto if 'mosquitto_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: mosquitto_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'mosquitto' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: mosquitto
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Mosquitto service
+      - option: description
+        value: '"Mosquitto (uses the MQTT protocol) is a pub-sub broker for electronics projects and educational Internet of Things (IoT) experiments.  It''s designed for TCP/IP with remote locations where a ''small code footprint'' is required or bandwidth is limited.  See also: Node-RED"'
+      - option: mosquitto_install
+        value: "{{ mosquitto_install }}"
+      - option: mosquitto_enabled
+        value: "{{ mosquitto_enabled }}"
 
-- name: Add 'mosquitto' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: mosquitto
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Mosquitto service
-    - option: description
-      value: '"Mosquitto (uses the MQTT protocol) is a pub-sub broker for electronics projects and educational Internet of Things (IoT) experiments.  It''s designed for TCP/IP with remote locations where a ''small code footprint'' is required or bandwidth is limited.  See also: Node-RED"'
-    - option: mosquitto_install
-      value: "{{ mosquitto_install }}"
-    - option: mosquitto_enabled
-      value: "{{ mosquitto_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/munin/tasks/enable-or-disable.yml
+++ b/roles/munin/tasks/enable-or-disable.yml
@@ -1,3 +1,19 @@
+- name: Enable & Start 'munin-node' systemd service
+  systemd:
+    name: munin-node
+    daemon_reload: yes
+    enabled: yes
+    state: started
+  when: munin_enabled
+
+- name: Disable & Stop 'munin-node' systemd service
+  systemd:
+    name: munin-node
+    enabled: no
+    state: stopped
+  when: not munin_enabled
+
+
 - name: Enable http://box/munin via NGINX, by installing {{ nginx_conf_dir }}/munin24-nginx.conf from template
   template:
     src: munin24-nginx.conf.j2

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -19,42 +19,33 @@
     quiet: yes
 
 
-- name: Install Munin if 'munin_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: munin_installed is undefined
+- block:
 
+  - name: Install Munin if 'munin_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: munin_installed is undefined
 
-- name: Enable & Start 'munin-node' systemd service
-  systemd:
-    name: munin-node
-    daemon_reload: yes
-    enabled: yes
-    state: started
-  when: munin_enabled
+  - include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop 'munin-node' systemd service
-  systemd:
-    name: munin-node
-    enabled: no
-    state: stopped
-  when: not munin_enabled
+  - name: Add 'munin' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: munin
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Munin
+      - option: description
+        value: '"Munin is a networked resource monitoring tool that can help analyze resource trends and ''what just happened to kill our performance?'' problems."'
+      - option: munin_install
+        value: "{{ munin_install }}"
+      - option: munin_enabled
+        value: "{{ munin_enabled }}"
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  rescue:
 
-
-- name: Add 'munin' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: munin
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Munin
-    - option: description
-      value: '"Munin is a networked resource monitoring tool that can help analyze resource trends and ''what just happened to kill our performance?'' problems."'
-    - option: munin_install
-      value: "{{ munin_install }}"
-    - option: munin_enabled
-      value: "{{ munin_enabled }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -19,37 +19,44 @@
     quiet: yes
 
 
-- name: Install Nextcloud if 'nextcloud_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: nextcloud_installed is undefined
+- block:
 
+  - name: Install Nextcloud if 'nextcloud_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: nextcloud_installed is undefined
 
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  - name: Enable/Disable/Restart NGINX
+    include_tasks: nginx.yml
 
+  - name: Add 'nextcloud' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: Nextcloud
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Nextcloud
+      - option: description
+        value: '"Nextcloud is a local server-based facility for sharing files, photos, contacts, calendars, etc."'
+      - option: nextcloud_install
+        value: "{{ nextcloud_install }}"
+      - option: nextcloud_enabled
+        value: "{{ nextcloud_enabled }}"
+      - option: nextcloud_dl_url
+        value: "{{ nextcloud_dl_url }}"
+      - option: nextcloud_url
+        value: "{{ nextcloud_url }}"
+      - option: nextcloud_base_dir
+        value: "{{ nextcloud_base_dir }}"
+      - option: nextcloud_root_dir
+        value: "{{ nextcloud_root_dir }}"
+      - option: nextcloud_data_dir
+        value: "{{ nextcloud_data_dir }}"
 
-- name: Add 'nextcloud' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: Nextcloud
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Nextcloud
-    - option: description
-      value: '"Nextcloud is a local server-based facility for sharing files, photos, contacts, calendars, etc."'
-    - option: nextcloud_install
-      value: "{{ nextcloud_install }}"
-    - option: nextcloud_enabled
-      value: "{{ nextcloud_enabled }}"
-    - option: nextcloud_dl_url
-      value: "{{ nextcloud_dl_url }}"
-    - option: nextcloud_url
-      value: "{{ nextcloud_url }}"
-    - option: nextcloud_base_dir
-      value: "{{ nextcloud_base_dir }}"
-    - option: nextcloud_root_dir
-      value: "{{ nextcloud_root_dir }}"
-    - option: nextcloud_data_dir
-      value: "{{ nextcloud_data_dir }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -35,23 +35,31 @@
     var: nodejs_installed
 
 
-- name: Install Node.js if 'nodejs_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: nodejs_installed is undefined
+- block:
 
+  - name: Install Node.js if 'nodejs_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: nodejs_installed is undefined
 
-- name: Add 'nodejs' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: nodejs
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Node.js
-    - option: description
-      value: '"Node.js is a JavaScript runtime environment built on Chrome''s V8 JavaScript engine, that executes JavaScript code outside of a browser."'
-    - option: nodejs_install
-      value: "{{ nodejs_install }}"
-    - option: nodejs_enabled
-      value: "{{ nodejs_enabled }}"
+  - name: Add 'nodejs' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: nodejs
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Node.js
+      - option: description
+        value: '"Node.js is a JavaScript runtime environment built on Chrome''s V8 JavaScript engine, that executes JavaScript code outside of a browser."'
+      - option: nodejs_install
+        value: "{{ nodejs_install }}"
+      - option: nodejs_enabled
+        value: "{{ nodejs_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/nodered/tasks/main.yml
+++ b/roles/nodered/tasks/main.yml
@@ -19,26 +19,33 @@
     quiet: yes
 
 
-- name: Install Node-RED if nodered_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: nodered_installed is undefined
+- block:
 
+  - name: Install Node-RED if nodered_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: nodered_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'nodered' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: nodered
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Node-RED
+      - option: description
+        value: '"Node-RED is a flow-based development tool for visual programming developed originally by IBM for wiring together hardware devices, APIs and online services as part of the Internet of Things.  Node-RED provides a web browser-based flow editor, which can be used to create JavaScript functions."'
+      - option: nodered_install
+        value: "{{ nodered_install }}"
+      - option: nodered_enabled
+        value: "{{ nodered_enabled }}"
 
-- name: Add 'nodered' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: nodered
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Node-RED
-    - option: description
-      value: '"Node-RED is a flow-based development tool for visual programming developed originally by IBM for wiring together hardware devices, APIs and online services as part of the Internet of Things.  Node-RED provides a web browser-based flow editor, which can be used to create JavaScript functions."'
-    - option: nodered_install
-      value: "{{ nodered_install }}"
-    - option: nodered_enabled
-      value: "{{ nodered_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/osm-vector-maps/tasks/main.yml
+++ b/roles/osm-vector-maps/tasks/main.yml
@@ -11,28 +11,34 @@
     quiet: yes
 
 
-- name: Install OSM Vector Maps if 'osm_vector_maps_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: osm_vector_maps_installed is undefined
-  
+- block:
 
-- name: Enable/Disable/Reload NGINX for OSM, if nginx_enabled
-  include_tasks: nginx.yml
-  #when: nginx_enabled    # NGINX is mandatory starting with IIAB 7.2
+  - name: Install OSM Vector Maps if 'osm_vector_maps_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: osm_vector_maps_installed is undefined
 
+  - name: Enable/Disable/Reload NGINX for OSM, if nginx_enabled
+    include_tasks: nginx.yml
 
-- name: Add 'osm-vector-maps' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: osm-vector-maps
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: OSM Vector Maps
-    - option: description
-      value: '"OpenStreetMap is like Google Maps but better, for schools especially, as it works offline and avoids all the advertising.  Download detailed ''vector maps'' for an entire continent, or the entire world!  Also includes 10+ zoom levels of satellite imagery!"'
-    - option: osm_vector_maps_install
-      value: "{{ osm_vector_maps_install }}"
-    - option: osm_vector_maps_enabled
-      value: "{{ osm_vector_maps_enabled }}"
+  - name: Add 'osm-vector-maps' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: osm-vector-maps
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: OSM Vector Maps
+      - option: description
+        value: '"OpenStreetMap is like Google Maps but better, for schools especially, as it works offline and avoids all the advertising.  Download detailed ''vector maps'' for an entire continent, or the entire world!  Also includes 10+ zoom levels of satellite imagery!"'
+      - option: osm_vector_maps_install
+        value: "{{ osm_vector_maps_install }}"
+      - option: osm_vector_maps_enabled
+        value: "{{ osm_vector_maps_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/pbx/tasks/main.yml
+++ b/roles/pbx/tasks/main.yml
@@ -19,29 +19,38 @@
     quiet: yes
 
 
-- name: Install PBX if pbx_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: pbx_installed is undefined
+- block:
 
-- name: Install & Enable chan_dongle for Huawei USB modems - if asterisk_chan_dongle
-  include_tasks: chan_dongle.yml
-  when: asterisk_chan_dongle
+  - name: Install PBX if pbx_installed is not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: pbx_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - name: Install & Enable chan_dongle for Huawei USB modems - if asterisk_chan_dongle
+    include_tasks: chan_dongle.yml
+    when: asterisk_chan_dongle
+
+  - include_tasks: enable-or-disable.yml
 
 
-- name: Add 'pbx' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: pbx
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: PBX
-    - option: description
-      value: '"Full-featured PBX for rural telephony etc, that can integrate with GSM (mobile phone) networks.  Based on Asterisk (Voice over IP, SIP telephone numbers) and FreePBX (web-based GUI to administer it)."'
-    - option: pbx_install
-      value: "{{ pbx_install }}"
-    - option: pbx_enabled
-      value: "{{ pbx_enabled }}"
+  - name: Add 'pbx' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: pbx
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: PBX
+      - option: description
+        value: '"Full-featured PBX for rural telephony etc, that can integrate with GSM (mobile phone) networks.  Based on Asterisk (Voice over IP, SIP telephone numbers) and FreePBX (web-based GUI to administer it)."'
+      - option: pbx_install
+        value: "{{ pbx_install }}"
+      - option: pbx_enabled
+        value: "{{ pbx_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -19,29 +19,36 @@
     quiet: yes
 
 
-- name: "INCOMPLETE WITHOUT APACHE AS OF 2021-07-06: Install phpMyAdmin if 'phpmyadmin_installed' not defined, e.g. in {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: phpmyadmin_installed is undefined
+- block:
 
+  - name: "INCOMPLETE WITHOUT APACHE AS OF 2021-07-06: Install phpMyAdmin if 'phpmyadmin_installed' not defined, e.g. in {{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: phpmyadmin_installed is undefined
 
-- name: INCOMPLETE WITHOUT APACHE AS OF 2021-07-06
-  include_tasks: enable-or-disable.yml
+  - name: INCOMPLETE WITHOUT APACHE AS OF 2021-07-06
+    include_tasks: enable-or-disable.yml
 
+  - name: Add 'phpmyadmin' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: phpmyadmin
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: phpMyAdmin
+      - option: description
+        value: '"phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."'
+      - option: phpmyadmin_install
+        value: "{{ phpmyadmin_install }}"
+      - option: phpmyadmin_enabled
+        value: "{{ phpmyadmin_enabled }}"
+      - option: path
+        value: /opt/phpmyadmin
 
-- name: Add 'phpmyadmin' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: phpmyadmin
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: phpMyAdmin
-    - option: description
-      value: '"phpMyAdmin is an interface with a MySQL database written in PHP, and available to administer the database engine locally or across the network."'
-    - option: phpmyadmin_install
-      value: "{{ phpmyadmin_install }}"
-    - option: phpmyadmin_enabled
-      value: "{{ phpmyadmin_enabled }}"
-    - option: path
-      value: /opt/phpmyadmin
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/postgresql/tasks/enable-or-disable.yml
+++ b/roles/postgresql/tasks/enable-or-disable.yml
@@ -1,0 +1,14 @@
+- name: Enable & Start 'postgresql-iiab' systemd service, if postgresql_enabled
+  systemd:
+    name: postgresql-iiab
+    daemon_reload: yes
+    enabled: yes
+    state: started
+  when: postgresql_enabled
+
+- name: Disable & Stop 'postgresql-iiab' systemd service, if not postgresql_enabled
+  systemd:
+    name: postgresql-iiab
+    enabled: no
+    state: stopped
+  when: not postgresql_enabled

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -26,39 +26,33 @@
     var: postgresql_installed
 
 
-- name: Install PostgreSQL if 'postgresql_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: postgresql_installed is undefined
+- block:
 
+  - name: Install PostgreSQL if 'postgresql_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: postgresql_installed is undefined
 
-- name: Enable & Start 'postgresql-iiab' systemd service, if postgresql_enabled
-  systemd:
-    name: postgresql-iiab
-    daemon_reload: yes
-    enabled: yes
-    state: started
-  when: postgresql_enabled
+  - include_tasks: enable-or-disable.yml
 
-- name: Disable & Stop 'postgresql-iiab' systemd service, if not postgresql_enabled
-  systemd:
-    name: postgresql-iiab
-    enabled: no
-    state: stopped
-  when: not postgresql_enabled
+  - name: Add 'postgresql' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: postgresql
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: PostgreSQL
+      - option: description
+        value: '"PostgreSQL is a powerful, open source object-relational database system."'
+      - option: postgresql_install
+        value: "{{ postgresql_install }}"
+      - option: postgresql_enabled
+        value: "{{ postgresql_enabled }}"
 
+  rescue:
 
-- name: Add 'postgresql' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: postgresql
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: PostgreSQL
-    - option: description
-      value: '"PostgreSQL is a powerful, open source object-relational database system."'
-    - option: postgresql_install
-      value: "{{ postgresql_install }}"
-    - option: postgresql_enabled
-      value: "{{ postgresql_enabled }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -19,49 +19,56 @@
     quiet: yes
 
 
-- name: Install Transmission if 'transmission_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: transmission_installed is undefined
+- block:
 
+  - name: Install Transmission if 'transmission_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: transmission_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'transmission' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: transmission
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Transmission
+      - option: description
+        value: '"Transmission is a set of lightweight BitTorrent clients (in GUI, CLI and daemon form)."'
+      - option: transmission_install
+        value: "{{ transmission_install }}"
+      - option: transmission_enabled
+        value: "{{ transmission_enabled }}"
+      - option: transmission_download_dir
+        value: "{{ transmission_download_dir }}"
+      - option: transmission_user
+        value: "{{ transmission_user }}"
+      - option: transmission_group
+        value: "{{ transmission_group }}"
+      - option: transmission_http_port
+        value: "{{ transmission_http_port }}"
+      - option: transmission_url
+        value: "{{ transmission_url }}"
+      - option: transmission_peer_port
+        value: "{{ transmission_peer_port }}"
+      - option: transmission_provision
+        value: "{{ transmission_provision }}"
+      - option: transmission_kalite_version
+        value: "{{ transmission_kalite_version }}"
+      - option: transmission_kalite_languages
+        value: "{{ transmission_kalite_languages }}"
+      - option: transmission_username
+        value: "{{ transmission_username }}"
+      # 2020-04-14: better to redact passwords from /etc/iiab/iiab.ini etc, so iiab-diagnostics command doesn't publish these, etc
+      #- option: transmission_password
+      #  value: "{{ transmission_password }}"
 
-- name: Add 'transmission' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: transmission
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Transmission
-    - option: description
-      value: '"Transmission is a set of lightweight BitTorrent clients (in GUI, CLI and daemon form)."'
-    - option: transmission_install
-      value: "{{ transmission_install }}"
-    - option: transmission_enabled
-      value: "{{ transmission_enabled }}"
-    - option: transmission_download_dir
-      value: "{{ transmission_download_dir }}"
-    - option: transmission_user
-      value: "{{ transmission_user }}"
-    - option: transmission_group
-      value: "{{ transmission_group }}"
-    - option: transmission_http_port
-      value: "{{ transmission_http_port }}"
-    - option: transmission_url
-      value: "{{ transmission_url }}"
-    - option: transmission_peer_port
-      value: "{{ transmission_peer_port }}"
-    - option: transmission_provision
-      value: "{{ transmission_provision }}"
-    - option: transmission_kalite_version
-      value: "{{ transmission_kalite_version }}"
-    - option: transmission_kalite_languages
-      value: "{{ transmission_kalite_languages }}"
-    - option: transmission_username
-      value: "{{ transmission_username }}"
-    # 2020-04-14: better to redact passwords from /etc/iiab/iiab.ini etc, so iiab-diagnostics command doesn't publish these, etc
-    #- option: transmission_password
-    #  value: "{{ transmission_password }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/vnstat/tasks/main.yml
+++ b/roles/vnstat/tasks/main.yml
@@ -19,26 +19,33 @@
     quiet: yes
 
 
-- name: Install vnStat if 'vnstat_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: vnstat_installed is undefined
+- block:
 
+  - name: Install vnStat if 'vnstat_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: vnstat_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'vnstat' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: vnstat
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: vnStat
+      - option: description
+        value: '"vnStat is a console-based network traffic monitor for Linux and BSD that keeps a log of network traffic for the selected interface(s)."'
+      - option: vnstat_install
+        value: "{{ vnstat_install }}"
+      - option: vnstat_enabled
+        value: "{{ vnstat_enabled }}"
 
-- name: Add 'vnstat' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: vnstat
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: vnStat
-    - option: description
-      value: '"vnStat is a console-based network traffic monitor for Linux and BSD that keeps a log of network traffic for the selected interface(s)."'
-    - option: vnstat_install
-      value: "{{ vnstat_install }}"
-    - option: vnstat_enabled
-      value: "{{ vnstat_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -21,43 +21,52 @@
     quiet: yes
 
 
-- name: Provision MySQL DB for WordPress, if 'wordpress_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: setup.yml
-  when: wordpress_installed is undefined    # and not installing
+- block:
 
-- name: Install WordPress if 'wordpress_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: wordpress_installed is undefined
+  - name: Provision MySQL DB for WordPress, if 'wordpress_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: setup.yml
+    when: wordpress_installed is undefined    # and not installing
 
-
-- name: Enable/Disable/Restart NGINX
-  include_tasks: nginx.yml
+  - name: Install WordPress if 'wordpress_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: wordpress_installed is undefined
 
 
-- name: Add 'wordpress' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: wordpress
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: WordPress
-    - option: description
-      value: '"WordPress is a blog and web site management application."'
-    - option: wordpress_install
-      value: "{{ wordpress_install }}"
-    - option: wordpress_enabled
-      value: "{{ wordpress_enabled }}"
-    - option: wordpress_src
-      value: "{{ wordpress_src }}"
-    - option: wp_abs_path
-      value: "{{ wp_abs_path }}"
-    - option: wp_db_name
-      value: "{{ wp_db_name }}"
-    - option: wp_db_user
-      value: "{{ wp_db_user }}"
-    - option: wp_url
-      value: "{{ wp_url }}"
-    - option: wp_full_url
-      value: "{{ wp_full_url }}"
+  - name: Enable/Disable/Restart NGINX
+    include_tasks: nginx.yml
+
+
+  - name: Add 'wordpress' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: wordpress
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: WordPress
+      - option: description
+        value: '"WordPress is a blog and web site management application."'
+      - option: wordpress_install
+        value: "{{ wordpress_install }}"
+      - option: wordpress_enabled
+        value: "{{ wordpress_enabled }}"
+      - option: wordpress_src
+        value: "{{ wordpress_src }}"
+      - option: wp_abs_path
+        value: "{{ wp_abs_path }}"
+      - option: wp_db_name
+        value: "{{ wp_db_name }}"
+      - option: wp_db_user
+        value: "{{ wp_db_user }}"
+      - option: wp_url
+        value: "{{ wp_url }}"
+      - option: wp_full_url
+        value: "{{ wp_full_url }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -26,23 +26,31 @@
     var: yarn_installed
 
 
-- name: Install Yarn if 'yarn_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: yarn_installed is undefined
+- block:
 
+  - name: Install Yarn if 'yarn_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: yarn_installed is undefined
 
-- name: Add 'yarn' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: yarn
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Yarn
-    - option: description
-      value: '"Fast, reliable, and secure dependency management.  Comparable to npm.  Released by Facebook in October 2016."'
-    - option: yarn_install
-      value: "{{ yarn_install }}"
-    - option: yarn_enabled
-      value: "{{ yarn_enabled }}"
+  - name: Add 'yarn' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: yarn
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Yarn
+      - option: description
+        value: '"Fast, reliable, and secure dependency management.  Comparable to npm.  Released by Facebook in October 2016."'
+      - option: yarn_install
+        value: "{{ yarn_install }}"
+      - option: yarn_enabled
+        value: "{{ yarn_enabled }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error


### PR DESCRIPTION
2 [correction 3] subsidiary roles are included: (in addition to the 23 spelled out in Stage 6-to-9)

- roles/nodejs
- roles/postgresql
- [ roles/yarn ]

Other roles (beyond Stages 6-9) should also support variable `skip_role_on_error` in future.

This PR is a draft that still needs testing.  It builds on:

- PR #3255