### PR TITLE
/usr/bin/iiab-apps-to-be-installed: Quick scan to see what's asked for but not yet installed

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -38,7 +38,7 @@
 
 # Copies the latest/known version of iiab-diagnostics into /usr/bin (so it can
 # be run even if local source tree /opt/iiab/iiab is deleted to conserve disk).
-- name: Copy /opt/iiab/iiab/scripts/iiab-diagnostics to /usr/bin/iiab-diagnostics
+- name: Copy /opt/iiab/iiab/scripts/iiab-diagnostics to /usr/bin/
   copy:
     src: "{{ iiab_dir }}/scripts/iiab-diagnostics"
     dest: /usr/bin/

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -23,6 +23,12 @@
     name: iiab-admin
   #when: iiab_admin_install    # Flag might be created in future?
 
+- name: Copy /opt/iiab/iiab/scripts/iiab-apps-to-be-installed to /usr/bin/
+  copy:
+    src: "{{ iiab_dir }}/scripts/iiab-apps-to-be-installed"
+    dest: /usr/bin/
+    mode: '0755'
+
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml
   #when: dnsmasq_install    # Flag might be used in future?

--- a/scripts/iiab-apps-to-be-installed
+++ b/scripts/iiab-apps-to-be-installed
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Lists IIAB Apps set to install BUT not yet installed (according to /etc/iiab/iiab_state.yml)
+
+iiab_var_value() {
+    v1=$(grep "^$1:\s" /opt/iiab/iiab/vars/default_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    v2=$(grep "^$1:\s" /etc/iiab/local_vars.yml | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    [[ $v2 != "" ]] && echo $v2 || echo $v1    # [ "$v2" ] ALSO WORKS
+}
+
+# 2022-06-18: 40 apps (list not quite complete)
+#grep -l _installed: /opt/iiab/iiab/roles/*/tasks/install.yml | cut -d/ -f6 > /tmp/iiab-apps-list
+
+# 2022-06-18: 46 apps (list incorrect) -- adds these 6: iiab_admin, minetest, network (HAS NO _installed VAR), pylibs, www_base, www_options
+#grep -l _installed: /opt/iiab/iiab/roles/*/tasks/* | cut -d/ -f6 | sort | uniq > /tmp/iiab-apps-list
+
+# 2022-06-18: 50 apps (list long but ok!) -- adds these 10: dansguardian, dhcpd, iiab_admin, minetest, named, pylibs, squid, wondershaper, www_base, www_options
+grep -hro '[A-Za-z_][A-Za-z_]*_installed: True' --exclude-dir=0-DEPRECATED-ROLES /opt/iiab/iiab/roles | sed 's/_installed: True$//' | sort | uniq > /tmp/iiab-apps-list
+
+while read app; do
+    if [ $app == "calibre-web" ]; then
+        app=calibreweb
+    elif [ $app == "osm-vector-maps" ]; then
+        app=osm_vector_maps
+    fi
+
+    # echo ${app}_install: $(iiab_var_value ${app}_install)
+
+    if [[ $(iiab_var_value ${app}_install) =~ ^[Tt]rue$ ]] && ! grep -q "${app}_installed: True" /etc/iiab/iiab_state.yml; then
+        echo $app
+    fi
+done < /tmp/iiab-apps-list


### PR DESCRIPTION
`/usr/bin/iiab-apps-to-be-installed` is a command-line convenience for testers/devs primarily:

It intentionally scans the status of most all apps/services/roles (even a few ugly duckling stepchildren) to help with debugging &mdash; giving you a list of those apps that were requested to be installed, but are not yet recorded as installed.

Example: `bluetooth_install: True` is a very common setting in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) and [default_vars.yml](https://github.com/iiab/iiab-admin-console/blob/master/vars/default_vars.yml), yet it rarely results in `bluetooth_installed: True` in /etc/iiab/iiab_state.yml (unless your hardware is Raspberry Pi!)

Summary: Whatever the reason for the app/service/role not having been fully installed, you can run `iiab-apps-to-be-installed` to quickly surface all such discrepancies, so you can immediately take action (or ignore these "to be installed" discrepancies, as you choose!)

Tested on Ubuntu 20.04

Refs:

- PR #3255
- PR #3256