### PR TITLE
iiab-diagnostics: Fix cat_cmd output + grep -B2 "SEE ERROR ABOVE" /opt/iiab/iiab/*.log + speed up prompt

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -88,18 +88,19 @@ function cat_dir() {
 function cat_cmd() {    # $1 = command + params, $2 = explanation
     echo "     $1  # $2"
     echo "=IIAB==========================================================================" >> $outfile
-    #cmd=$(echo "$1" | sed 's/\s.*$//')           # Keep command on left; Drop params on right (NOT NEC, 'command -v' does this!)
-    #pth=$(command -v $cmd | sed 's/[^/]*$//')    # Keep only path on left; Drop command & params on right
-    pthcmd=$(command -v $1)                                             # Use canonical path on left; Drop params on right
-    spc_params=$(echo "$1" | sed 's/^\s*\S*//;s/\s*$//;s/^\s\s*/ /')    # LTrim + drop original path + command on left; RTrim; Compress whitespace in between
+    cmd=$(echo "$1" | sed 's/^\s*\(\S*\)\s.*/\1/')    # Keep command on left; Drop params on right (NEC b/c 'command -v' interprets every word on the line!)
+    #pth=$(command -v $cmd | sed 's/[^/]*$//')        # Keep only path on left; Drop command & params on right
+    path_cmd=$(command -v $cmd)                                 # Use canonical path on left; Drop params on right
+    spc_params=$(echo "$1" | sed 's/^\s*\S*\s*/ /;s/\s*$//')    # Drop command on left; Keep a single space + params on right; RTrim
+    #spc_params=$(echo "$1" | sed 's/^\s*\S*//;s/\s*$//;s/^\s\s*/ /')    # LTrim + drop original path + command on left; RTrim; Compress whitespace in between
     #spc_params=$(echo "$1" | sed 's/^[[:blank:]]*[^[:blank:]]*//;s/[[:blank:]]*$//;s/^[[:blank:]][[:blank:]]*/ /')    # Equivalent (POSIX compliant)
     if [[ $2 == "" ]]; then
-	echo "COMMAND: $pthcmd$spc_params" >> $outfile
+	echo "COMMAND: $path_cmd$spc_params" >> $outfile
     else
-	echo "COMMAND: $pthcmd$spc_params    # $2" >> $outfile
+	echo "COMMAND: $path_cmd$spc_params    # $2" >> $outfile
     fi
     echo >> $outfile
-    if [[ $pthcmd == "" ]]; then
+    if [[ $path_cmd == "" ]]; then
         echo "COMMAND NOT FOUND: $1" >> $outfile
     else
         bash -c "$1" >> $outfile    # Works with | (pipes) and 'ls -l /lib/firmware/brcm/*43455*' etc!
@@ -254,7 +255,8 @@ echo -e "   $outfile\e[0m"
 #else
 echo
 echo -ne "\e[42;1mPublish it to a web pastebin? [Y/n]\e[0m "
-read ans < /dev/tty
+read -n 1 -r ans < /dev/tty
+echo
 #fi
 
 echo -e "\e[1m"

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -236,6 +236,7 @@ cat_cmd 'sudo iptables-save' 'Firewall rules'
 
 echo -e "\n  6. Log Files: (last 100 lines of each)\n"
 echo -e "\n\n\n\n6. LOG FILES (LAST 100 LINES OF EACH)\n" >> $outfile
+cat_cmd 'grep -B2 "SEE ERROR ABOVE" /opt/iiab/iiab/*.log'
 cat_tail /opt/iiab/iiab/iiab-install.log 100
 cat_tail /opt/iiab/iiab/iiab-configure.log 100
 cat_tail /opt/iiab/iiab/iiab-debug.log 100

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -88,10 +88,10 @@ function cat_dir() {
 function cat_cmd() {    # $1 = command + params, $2 = explanation
     echo "     $1  # $2"
     echo "=IIAB==========================================================================" >> $outfile
-    cmd=$(echo "$1" | sed 's/^\s*\(\S*\)\s.*/\1/')    # Keep command on left; Drop params on right (NEC b/c 'command -v' interprets every word on the line!)
-    #pth=$(command -v $cmd | sed 's/[^/]*$//')        # Keep only path on left; Drop command & params on right
-    path_cmd=$(command -v $cmd)                                 # Use canonical path on left; Drop params on right
-    spc_params=$(echo "$1" | sed 's/^\s*\S*\s*/ /;s/\s*$//')    # Drop command on left; Keep a single space + params on right; RTrim
+    cmd=$(echo "$1" | sed 's/^\s*\(\S\S*\)\b.*$/\1/')    # Keep command on left; Drop params on right (NEC b/c 'command -v' interprets every word on the line!)
+    #pth=$(command -v $cmd | sed 's/[^/]*$//')           # Keep only path on left; Drop command & params on right
+    path_cmd=$(command -v $cmd)                                   # Use canonical path on left (would drop params on right, but over-interpret each word as a cmd!)
+    spc_params=$(echo "$1" | sed 's/^\s*\S\S*\s*/ /;s/\s*$//')    # Drop command on left; Keep a single space + params on right; RTrim
     #spc_params=$(echo "$1" | sed 's/^\s*\S*//;s/\s*$//;s/^\s\s*/ /')    # LTrim + drop original path + command on left; RTrim; Compress whitespace in between
     #spc_params=$(echo "$1" | sed 's/^[[:blank:]]*[^[:blank:]]*//;s/[[:blank:]]*$//;s/^[[:blank:]][[:blank:]]*/ /')    # Equivalent (POSIX compliant)
     if [[ $2 == "" ]]; then
@@ -234,9 +234,9 @@ echo -e "\n\n\n\n5. FIREWALL RULES\n" >> $outfile
 #cat_file /usr/bin/iiab-gen-iptables
 cat_cmd 'sudo iptables-save' 'Firewall rules'
 
-echo -e "\n  6. Log Files: (last 100 lines of each)\n"
-echo -e "\n\n\n\n6. LOG FILES (LAST 100 LINES OF EACH)\n" >> $outfile
-cat_cmd 'grep -B2 "SEE ERROR ABOVE" /opt/iiab/iiab/*.log'
+echo -e "\n  6. Log Files: (e.g. last 100 lines of each)\n"
+echo -e "\n\n\n\n6. LOG FILES (e.g. LAST 100 LINES OF EACH)\n" >> $outfile
+cat_cmd 'grep -B2 "SEE ERROR ABOVE" /opt/iiab/iiab/*.log' 'for skip_role_on_error'
 cat_tail /opt/iiab/iiab/iiab-install.log 100
 cat_tail /opt/iiab/iiab/iiab-configure.log 100
 cat_tail /opt/iiab/iiab/iiab-debug.log 100
@@ -261,7 +261,8 @@ echo
 #fi
 
 echo -e "\e[1m"
-if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
+#if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
+if ! [[ $ans =~ ^[nN]$ ]]; then
     echo -ne "PUBLISHING TO URL... "
     #pastebinit -b dpaste.com < $outfile
     pastebinit -b sprunge.us < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -62,4 +62,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 119-244 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 120-246 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Building on:

- PR #3230
- PR #3255
- PR #3256