### PR TITLE
Force string python_ver: "3.10" in ubuntu-2204.yml & ubuntu-2210.yml [also update debian-12.yml "Bookworm"]

### DIFF
--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -23,7 +23,7 @@ mysql_service: mariadb
 apache_log: /var/log/apache2/access.log
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 8.0
-postgresql_version: 13
+php_version: 8.1
+postgresql_version: 14
 systemd_location: /lib/systemd/system
-python_ver: 3.9
+python_ver: "3.10"

--- a/vars/ubuntu-2204.yml
+++ b/vars/ubuntu-2204.yml
@@ -26,4 +26,4 @@ sshd_service: ssh
 php_version: 8.1
 postgresql_version: 14
 systemd_location: /lib/systemd/system
-python_ver: 3.10
+python_ver: "3.10"

--- a/vars/ubuntu-2210.yml
+++ b/vars/ubuntu-2210.yml
@@ -26,4 +26,4 @@ sshd_service: ssh
 php_version: 8.1
 postgresql_version: 14
 systemd_location: /lib/systemd/system
-python_ver: 3.10
+python_ver: "3.10"


### PR DESCRIPTION
Addresses bug:

- https://github.com/iiab/iiab/pull/3259#issuecomment-1160816010