### PR TITLE
Try 'skip_role_on_error: True' in default_vars.yml for more uninterrupted installs of IIAB Apps ['./iiab-install --risky' if you want to live on the wild side, forcing it too to use 'skip_role_on_error: True']

### DIFF
--- a/iiab-from-cmdline.yml
+++ b/iiab-from-cmdline.yml
@@ -3,10 +3,10 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
-  - /etc/iiab/iiab_state.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
+    - /etc/iiab/iiab_state.yml
 
   roles:
     - { role: 0-init }

--- a/iiab-from-console.yml
+++ b/iiab-from-console.yml
@@ -3,10 +3,10 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
-  - /etc/iiab/iiab_state.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
+    - /etc/iiab/iiab_state.yml
 
   roles:
     - { role: 0-init }

--- a/iiab-install
+++ b/iiab-install
@@ -1,17 +1,57 @@
 #!/bin/bash -e
 # Running from a git repo
 # Add cmdline options for passing to ansible
-# Todo add proper shift to gobble up --debug --reinstall
 
 PLAYBOOK=iiab-stages.yml
 INVENTORY=ansible_hosts
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
-ARGS="--extra-vars {\"skip_role_on_error\":False"    # bash forces {...} to '{...}' for Ansible
+ARGS="--extra-vars {"    # Needs boolean not string so use JSON list.  bash forces {...} to '{...}' for Ansible
+
 CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
-OS=${OS//\"/}
+OS=${OS//\"/}    # Remove all '"'
 MIN_RPI_KERN=5.4.0        # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.11.6    # Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+MIN_ANSIBLE_VER=2.12.7    # Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+
+REINSTALL=false
+DEBUG=false
+SKIP_ROLE_ON_ERROR=false
+
+usage() {
+    echo -e "\n\e[1mUse './iiab-install' for regular installs, or to continue an install."
+    echo -e "Use './iiab-install --risky' to force 'skip_role_on_error: True'"
+    echo -e "Use './iiab-install --reinstall' to force running all Stages 0-9, followed by the Network Role."
+    echo -e "Use './iiab-install --debug' to run Stage 0, followed by Stages 3-9, followed by the Network Role."
+    echo -e "Use './iiab-configure' to run Stage 0, followed by Stages 4-9."
+    echo -e "Use './runrole' to run Stage 0, followed by a single Stage or Role."
+    echo -e "Use './iiab-network' to run Stage 0, followed by the Network Role.\e[0m\n"
+}
+
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash/14203146#14203146
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --reinstall)
+            REINSTALL=true
+            shift
+            ;;
+        --debug)
+            DEBUG=true
+            shift
+            ;;
+        -r|--risky)
+            SKIP_ROLE_ON_ERROR=true
+            shift
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+ARGS="$ARGS\"skip_role_on_error\":$SKIP_ROLE_ON_ERROR"    # Needs boolean not
+# string so use JSON list.  Ansible permits these boolean values: (refresher)
+# https://github.com/iiab/iiab/blob/master/roles/0-init/tasks/validate_vars.yml#L19-L43
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
 
@@ -27,11 +67,11 @@ if [ ! -f /etc/iiab/local_vars.yml ]; then
 
     echo -e "\nEXITING: /opt/iiab/iiab/iiab-install REQUIRES /etc/iiab/local_vars.yml\n" >&2
 
-    echo -e "(1) Please read http://wiki.laptop.org/go/IIAB/local_vars.yml to learn more" >&2
-    echo -e "(2) MIN/MEDIUM/BIG samples are included in /opt/iiab/iiab/vars" >&2
+    echo -e "(1) See http://FAQ.IIAB.IO -> What is local_vars.yml and how do I customize it?" >&2
+    echo -e "(2) SMALL/MEDIUM/LARGE samples are included in /opt/iiab/iiab/vars" >&2
     echo -e "(3) NO TIME FOR DETAILS?  RUN INTERNET-IN-A-BOX'S FRIENDLY 1-LINE INSTALLER:\n" >&2
 
-    echo -e '    http://download.iiab.io\n' >&2
+    echo -e '    https://download.iiab.io\n' >&2
 
     exit 1
 fi
@@ -54,16 +94,6 @@ echo -e "\nPlaced /etc/ansible/facts.d/local_facts.fact into position."
 if [ ! -f $PLAYBOOK ]; then
     echo "EXITING: IIAB Playbook ""$PLAYBOOK"" not found."
     echo "Please run './iiab-install' from /opt/iiab/iiab (top level of git repo)."
-    exit 1
-fi
-
-if [ "$1" != "--debug" ] && [ "$1" != "--reinstall" ] && [ "$1" != "" ]; then
-    echo "Use './iiab-install' for regular installs, or to continue an install."
-    echo "Use './iiab-install --reinstall' to force running all Stages 0-9, followed by the Network Role."
-    echo "Use './iiab-install --debug' to run Stage 0, followed by Stages 3-9, followed by the Network Role."
-    echo "Use './iiab-configure' to run Stage 0, followed by Stages 4-9."
-    echo "Use './runrole' to run Stage 0, followed by a single Stage or Role."
-    echo "Use './iiab-network' to run Stage 0, followed by the Network Role."
     exit 1
 fi
 
@@ -125,28 +155,23 @@ if [ -f /etc/iiab/iiab.env ]; then
         fi
     fi
 
-    if [ "$1" == "--reinstall" ]; then
+    if $($REINSTALL); then
         STAGE=0
         #ARGS="$ARGS"" --extra-vars reinstall=True"
         ARGS="$ARGS,\"reinstall\":True"    # Needs boolean not string so use JSON list
         sed -i 's/^STAGE=.*/STAGE=0/' /etc/iiab/iiab.env
         echo "Wrote STAGE=0 (counter) to /etc/iiab/iiab.env"
-    elif [ "$STAGE" -ge 2 ] && [ "$1" == "--debug" ]; then
+    elif [ "$STAGE" -ge 2 ] && $($DEBUG); then
         STAGE=2
         sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
         echo "Wrote STAGE=2 (counter) to /etc/iiab/iiab.env"
     elif [ "$STAGE" -eq 9 ]; then
-        echo -e "\nEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done."
-        echo -e "Use './iiab-install --reinstall' to force running all Stages 0-9, followed by the Network Role."
-        echo -e "Use './iiab-install --debug' to run Stage 0, followed by Stages 3-9, followed by the Network Role."
-        echo -e "Use './iiab-configure' to run Stage 0, followed by Stages 4-9."
-        echo -e "Use './runrole' to run Stage 0, followed by a single Stage or Role."
-        echo -e "Use './iiab-network' to run Stage 0, followed by the Network Role.\n\n"
-
+        echo -e "\n\e[1mEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done."
+        usage
         exit 0    # Allows rerunning http://download.iiab.io/install.txt
     fi
 fi
-if [ "$STAGE" -lt 2 ] && [ "$1" == "--debug" ]; then
+if [ "$STAGE" -lt 2 ] && $($DEBUG); then
     echo -e "\n'--debug' *ignored* as STAGE (counter) < 2."
 fi
 

--- a/iiab-install
+++ b/iiab-install
@@ -166,7 +166,7 @@ if [ -f /etc/iiab/iiab.env ]; then
         sed -i 's/^STAGE=.*/STAGE=2/' /etc/iiab/iiab.env
         echo "Wrote STAGE=2 (counter) to /etc/iiab/iiab.env"
     elif [ "$STAGE" -eq 9 ]; then
-        echo -e "\n\e[1mEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done."
+        echo -e "\n\e[1mEXITING: STAGE (counter) in /etc/iiab/iiab.env shows Stage 9 Is Already Done.\e[0m"
         usage
         exit 0    # Allows rerunning http://download.iiab.io/install.txt
     fi

--- a/iiab-install
+++ b/iiab-install
@@ -6,7 +6,7 @@
 PLAYBOOK=iiab-stages.yml
 INVENTORY=ansible_hosts
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
-ARGS=""
+ARGS="--extra-vars {\"skip_role_on_error\":False"    # bash forces {...} to '{...}' for Ansible
 CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}
@@ -127,7 +127,8 @@ if [ -f /etc/iiab/iiab.env ]; then
 
     if [ "$1" == "--reinstall" ]; then
         STAGE=0
-        ARGS="$ARGS"" --extra-vars reinstall=True"
+        #ARGS="$ARGS"" --extra-vars reinstall=True"
+        ARGS="$ARGS,\"reinstall\":True"    # Needs boolean not string so use JSON list
         sed -i 's/^STAGE=.*/STAGE=0/' /etc/iiab/iiab.env
         echo "Wrote STAGE=0 (counter) to /etc/iiab/iiab.env"
     elif [ "$STAGE" -ge 2 ] && [ "$1" == "--debug" ]; then
@@ -168,6 +169,8 @@ export ANSIBLE_LOG_PATH="$CWD""/iiab-install.log"
 
 ansible -m setup -i $INVENTORY localhost --connection=local | grep python
 ansible -m setup -i $INVENTORY localhost --connection=local >> /dev/null    # So vars are recorded in /opt/iiab/iiab/iiab-install.log
-ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local
+ARGS="$ARGS}"
+echo -e "\nNOW RUN: ansible-playbook -i $INVENTORY $PLAYBOOK $ARGS --connection=local\n"
+ansible-playbook -i $INVENTORY $PLAYBOOK $ARGS --connection=local
 
 echo -e "./iiab-install $* COMPLETED IN $CWD\n\n"

--- a/iiab-network.yml
+++ b/iiab-network.yml
@@ -3,10 +3,10 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
-  - /etc/iiab/iiab_state.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
+    - /etc/iiab/iiab_state.yml
 
   roles:
     - { role: 0-init }

--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -3,11 +3,11 @@
   become: yes
 
   vars_files:
-  - roles/0-init/defaults/main.yml
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
-  - /etc/iiab/iiab_state.yml
+    - roles/0-init/defaults/main.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
+    - /etc/iiab/iiab_state.yml
 
   tasks:
 

--- a/install-support.yml.unused
+++ b/install-support.yml.unused
@@ -2,9 +2,9 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
 
   roles:
     - { role: 0-init }

--- a/run-one-role.yml
+++ b/run-one-role.yml
@@ -3,10 +3,10 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
-  - /etc/iiab/iiab_state.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
+    - /etc/iiab/iiab_state.yml
 
   roles:
     - { role: 0-init }

--- a/runrole
+++ b/runrole
@@ -8,7 +8,8 @@ INSTALL=false
 ENABLED=false
 REINSTALL=false
 CWD=`pwd`
-ARGS="--extra-vars {"    # bash forces {...} to '{...}' for Ansible, SEE BOTTOM
+#ARGS="--extra-vars {"
+ARGS="--extra-vars {\"skip_role_on_error\":False,"    # bash forces {...} to '{...}' for Ansible, SEE BOTTOM (IFS-like issue)
 INVENTORY=ansible_hosts
 PLAYBOOK=run-one-role.yml
 
@@ -44,7 +45,7 @@ fi
 #fi
 
 if [ "$1" == "--reinstall" ]; then
-    ARGS="$ARGS\"reinstall\":True," # Needs boolean not string so use JSON list
+    ARGS="$ARGS\"reinstall\":True,"    # Needs boolean not string so use JSON list
     REINSTALL=true
     shift
 fi
@@ -110,7 +111,7 @@ else
    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
 fi
 
-ARGS="$ARGS\"role_to_run\":\"$1\"}"    # $1 works like \"$1\" if str validated
+ARGS="$ARGS\"role_to_run\":\"$1\"}"    # $1 works like \"$1\" if str type validated
 CMD="ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local $ARGS"
 echo -e "\e[1mbash will now run this, adding single quotes around the {...} curly braces:\e[0m\n\n$CMD\n"
 ansible -m setup -i $INVENTORY localhost --connection=local | grep python

--- a/runroles-base.yml
+++ b/runroles-base.yml
@@ -3,9 +3,9 @@
   become: yes
 
   vars_files:
-  - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver }}.yml
-  - /etc/iiab/local_vars.yml
+    - vars/default_vars.yml
+    - vars/{{ ansible_local.local_facts.os_ver }}.yml
+    - /etc/iiab/local_vars.yml
 
   roles:
     - { role: 0-init }

--- a/test.yml
+++ b/test.yml
@@ -5,11 +5,11 @@
   become: yes    # Optional privilege escalation
 
   #vars_files:
-  #- roles/0-init/defaults/main.yml
-  #- vars/default_vars.yml
-  #- vars/{{ ansible_local.local_facts.os_ver }}.yml
-  #- /etc/iiab/local_vars.yml
-  #- /etc/iiab/iiab_state.yml
+  #  - roles/0-init/defaults/main.yml
+  #  - vars/default_vars.yml
+  #  - vars/{{ ansible_local.local_facts.os_ver }}.yml
+  #  - /etc/iiab/local_vars.yml
+  #  - /etc/iiab/iiab_state.yml
 
   #roles:
   #  - { role: 0-init }

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -16,6 +16,10 @@
 iiab_base_ver: 8.0
 iiab_revision: 0
 
+# 2022-06-23: ./iiab-install (with 'sudo iiab') follow the traditional linear
+# install path, intentionally overriding this value, until "SOFTWARE INSTALL IS
+# COMPLETE".  But you can run './iiab-install --risky' if you truly need
+# iiab-install to run with 'skip_role_on_error: True' (PRs #3255, #3256, #3262)
 skip_role_on_error: True
 
 iiab_etc_path: /etc/iiab

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -16,7 +16,7 @@
 iiab_base_ver: 8.0
 iiab_revision: 0
 
-skip_role_on_error: False
+skip_role_on_error: True
 
 iiab_etc_path: /etc/iiab
 


### PR DESCRIPTION
This PR sets `skip_role_on_error: True` in /opt/iiab/iiab/vars/default_vars.yml, causing ./runroles and Admin Console (e.g. preset learning bouquets, etc) to install IIAB Apps in a more uninterrupted way.

For now this will not affect ./iiab-install and ./runrole, as they are manually overriding this to `skip_role_on_error: False` for the moment.

Related:

- #3242
- #3244
- PR #3255
- PR #3256
- PR #3257