### PR TITLE
22.04 & Mint 21: Avoid Sugarizer+Moodle initially (TEMPORARY)

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: MOODLE
   include_role:
     name: moodle
-  when: moodle_install    # and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: moodle_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
 
 - name: OSM-VECTOR-MAPS
   include_role:
@@ -43,7 +43,7 @@
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install    # and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: sugarizer_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:

--- a/vars/linuxmint-21.yml
+++ b/vars/linuxmint-21.yml
@@ -2,7 +2,7 @@
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_ubuntu: True    # Opposite of is_debian for now
-is_ubuntu_22: True
+is_ubuntu_2204: True
 is_linuxmint: True
 is_linuxmint_21: True
 


### PR DESCRIPTION
Less confusion for newcomers chomping at the bit for Ubuntu 22.04+ and (imminent) Mint 21 Beta.

This responds to @jvonau's suggestion (below) and also means we're better prepared for the masses when Ubuntu 22.04.1 is released around early August (at which point Ubuntu will officially recommend upgrades from 20.04).

Ref:

- PR #3189
- PR https://github.com/iiab/iiab/pull/3262#issuecomment-1165810271