### PR TITLE
Highlight recent git tags (e.g. "8.0-preview-2" and "v0.5.5.9") in /usr/bin/iiab-summary, iiab-diagnostics etc [and remote URLs, branch names, PR count / commit count since tag...]

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -33,10 +33,10 @@
       value: "{{ ansible_local.local_facts.iiab_branch }}"
     - option: iiab_commit
       value: "{{ ansible_local.local_facts.iiab_commit }}"
+    - option: iiab_recent_tag
+      value: "{{ ansible_local.local_facts.iiab_recent_tag }}"
     - option: install_date
       value: "{{ ansible_date_time.iso8601 }}"
-    #- option: xo_model
-    #  value: "{{ xo_model }}"
     - option: rpi_model
       value: "{{ rpi_model }}"
     - option: devicetree_model

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -11,7 +11,6 @@
   set_fact:
     rpi_model: "{{ ansible_local.local_facts.rpi_model }}"
     devicetree_model: "{{ ansible_local.local_facts.devicetree_model }}"
-    #xo_model: "{{ ansible_local.local_facts.xo_model }}"
     iiab_stage: "{{ ansible_local.local_facts.stage }}"
 
 # 2020-10-29: Appears no longer nec (see 3 above ansible_local.local_facts.*)
@@ -78,6 +77,8 @@
       value: "{{ ansible_local.local_facts.iiab_branch }}"
     - option: runtime_commit
       value: "{{ ansible_local.local_facts.iiab_commit }}"
+    - option: iiab_recent_tag
+      value: "{{ ansible_local.local_facts.iiab_recent_tag }}"
     - option: runtime_date
       value: "{{ ansible_date_time.iso8601 }}"
     - option: ansible_version
@@ -102,10 +103,6 @@
       value: "{{ local_tz }}"
     - option: etc_localtime.stdout    # e.g. 'America/New_York' direct from symlink /etc/localtime -- or '' if /etc/localtime doesn't exist
       value: "{{ etc_localtime.stdout }}"
-    #- option: no_NM_reload
-    #  value: "{{ no_NM_reload }}"
-    #- option: is_F18
-    #  value: "{{ is_F18 }}"
     - option: FQDN_changed
       value: "{{ FQDN_changed }}"
 

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -23,11 +23,14 @@
     name: iiab-admin
   #when: iiab_admin_install    # Flag might be created in future?
 
-- name: Copy /opt/iiab/iiab/scripts/iiab-apps-to-be-installed to /usr/bin/
+- name: Copy iiab-summary & iiab-apps-to-be-installed from /opt/iiab/iiab/scripts/ to /usr/bin/
   copy:
-    src: "{{ iiab_dir }}/scripts/iiab-apps-to-be-installed"
+    src: "{{ iiab_dir }}/scripts/{{ item }}"
     dest: /usr/bin/
     mode: '0755'
+  with_items:
+    - iiab-summary
+    - iiab-apps-to-be-installed
 
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -10,10 +10,16 @@ YMDT=$(date +%F_%T_%Z)
 
 git config --global --add safe.directory /opt/iiab/iiab    # Nec below, if non-root
 HASH1=$(cd /opt/iiab/iiab; git log --pretty=format:'%H' -n 1)    # --pretty=format:'%h' (8 chars)
-TAG1=$(cd /opt/iiab/iiab; git describe --tags --abbrev=0)
+BRANCH1=$(cd /opt/iiab/iiab; git branch --show-current)
+REMOTE_URL1=$(cd /opt/iiab/iiab; git config remote.$(git config branch.$BRANCH1.remote).url)
+PR_COUNT1=$(cd /opt/iiab/iiab; git log "$(git describe --tags --abbrev=0)..HEAD" --oneline --grep='Merge pull request' | wc -l)
+TAG_COMMITS1=$(cd /opt/iiab/iiab; git describe --tags | sed 's/-[^-]*$//' | sed 's/-\([[:digit:]][[:digit:]]*\)$/ (\1 commits)/')
 git config --global --add safe.directory /opt/iiab/iiab-admin-console    # Nec below, if non-root
 HASH2=$(cd /opt/iiab/iiab-admin-console; git log --pretty=format:'%H' -n 1)
-TAG2=$(cd /opt/iiab/iiab-admin-console; git describe --tags --abbrev=0)
+BRANCH2=$(cd /opt/iiab/iiab-admin-console; git branch --show-current)
+REMOTE_URL2=$(cd /opt/iiab/iiab-admin-console; git config remote.$(git config branch.$BRANCH2.remote).url)
+PR_COUNT2=$(cd /opt/iiab/iiab-admin-console; git log "$(git describe --tags --abbrev=0)..HEAD" --oneline --grep='Merge pull request' | wc -l)
+TAG_COMMITS2=$(cd /opt/iiab/iiab-admin-console; git describe --tags | sed 's/-[^-]*$//' | sed 's/-\([[:digit:]][[:digit:]]*\)$/ (\1 commits)/')
 
 echo -e "\nGathers IIAB diagnostics into 1 file, to accelerate troubleshooting.  USAGE:"
 echo
@@ -124,12 +130,17 @@ echo -e "\nCompiling diagnostics..."
 echo -e "\n  0. Filename Header + Git Hashes + Raspberry Pi Model + OS"
 echo "This is: $outfile" >> $outfile
 echo >> $outfile
-echo -e "\n\n\n\n0. GIT HASHES/TAGS + RASPBERRY PI MODEL + OS" >> $outfile
+echo -e "\n\n\n\n0. GIT INFO + RASPBERRY PI MODEL + OS" >> $outfile
 echo >> $outfile
-echo "iiab commit:               $HASH1" >> $outfile
-echo "     recent git tag:       $TAG1" >> $outfile
-echo "iiab-admin-console commit: $HASH2" >> $outfile
-echo "     recent git tag:       $TAG2" >> $outfile
+echo "iiab commit:                       $HASH1" >> $outfile
+echo "     remote:                       $REMOTE_URL1" >> $outfile
+echo "     branch:                       $BRANCH1" >> $outfile
+printf "%4s merged PR's since recent tag: $TAG_COMMITS1\n" $PR_COUNT1 >> $outfile
+echo >> $outfile
+echo "iiab-admin-console commit:         $HASH2" >> $outfile
+echo "     remote:                       $REMOTE_URL2" >> $outfile
+echo "     branch:                       $BRANCH2" >> $outfile
+printf "%4s merged PR's since recent tag: $TAG_COMMITS2\n" $PR_COUNT2 >> $outfile
 echo >> $outfile
 cat_file /etc/iiab/pr-list-pulled
 cat_file /proc/device-tree/model    # Should be identical to /sys/firmware/devicetree/base/model

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -132,14 +132,14 @@ echo "This is: $outfile" >> $outfile
 echo >> $outfile
 echo -e "\n\n\n\n0. GIT INFO + RASPBERRY PI MODEL + OS" >> $outfile
 echo >> $outfile
-echo "iiab commit:                       $HASH1" >> $outfile
-echo "     remote:                       $REMOTE_URL1" >> $outfile
-echo "     branch:                       $BRANCH1" >> $outfile
+echo "iiab commit:               $HASH1" >> $outfile
+echo "     remote:               $REMOTE_URL1" >> $outfile
+echo "     branch:               $BRANCH1" >> $outfile
 printf "%4s merged PR's since recent tag: $TAG_COMMITS1\n" $PR_COUNT1 >> $outfile
 echo >> $outfile
-echo "iiab-admin-console commit:         $HASH2" >> $outfile
-echo "     remote:                       $REMOTE_URL2" >> $outfile
-echo "     branch:                       $BRANCH2" >> $outfile
+echo "iiab-admin-console commit: $HASH2" >> $outfile
+echo "     remote:               $REMOTE_URL2" >> $outfile
+echo "     branch:               $BRANCH2" >> $outfile
 printf "%4s merged PR's since recent tag: $TAG_COMMITS2\n" $PR_COUNT2 >> $outfile
 echo >> $outfile
 cat_file /etc/iiab/pr-list-pulled

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -163,6 +163,7 @@ cat_cmd 'dpkg --print-architecture' 'RaspiOS-on-PC shows: i386'
 cat_cmd 'dpkg --print-foreign-architectures' 'RaspiOS-on-PC shows: amd64'
 cat_cmd 'systemctl is-active display-manager.service' 'Graphical Desktop?'
 cat_cmd 'grep "^openvpn_" /etc/iiab/local_vars.yml'
+cat_cmd 'iiab-apps-to-be-installed' 'IIAB Apps to be installed'
 
 echo -e '\n\n  1. Files Specially Requested: (from "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n'
 echo -e '\n\n\n\n1. FILES SPECIALLY REQUESTED (FROM "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n' >> $outfile

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -4,15 +4,16 @@
 # PLEASE SEE /opt/iiab/iiab/scripts/iiab-diagnostics.README.md OR ONLINE HERE:
 # https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md
 
-IIAB_RELEASE=`cat /etc/iiab/iiab.env | grep IIAB_RELEASE | cut -d'=' -f2`
-OS_VER=`cat /etc/iiab/iiab.env | grep OS_VER | cut -d'=' -f2`
+IIAB_RELEASE=$(cat /etc/iiab/iiab.env | grep IIAB_RELEASE | cut -d'=' -f2)
+OS_VER=$(cat /etc/iiab/iiab.env | grep OS_VER | cut -d'=' -f2)
 YMDT=$(date +%F_%T_%Z)
 
-#HASH=`cd /opt/iiab/iiab; git log --pretty=format:'%h' -n 1`
 git config --global --add safe.directory /opt/iiab/iiab    # Nec below, if non-root
-HASH1=`cd /opt/iiab/iiab; git log --pretty=format:'%H' -n 1`
+HASH1=$(cd /opt/iiab/iiab; git log --pretty=format:'%H' -n 1)    # --pretty=format:'%h' (8 chars)
+TAG1=$(cd /opt/iiab/iiab; git describe --tags --abbrev=0)
 git config --global --add safe.directory /opt/iiab/iiab-admin-console    # Nec below, if non-root
-HASH2=`cd /opt/iiab/iiab-admin-console; git log --pretty=format:'%H' -n 1`
+HASH2=$(cd /opt/iiab/iiab-admin-console; git log --pretty=format:'%H' -n 1)
+TAG2=$(cd /opt/iiab/iiab-admin-console; git describe --tags --abbrev=0)
 
 echo -e "\nGathers IIAB diagnostics into 1 file, to accelerate troubleshooting.  USAGE:"
 echo
@@ -123,10 +124,12 @@ echo -e "\nCompiling diagnostics..."
 echo -e "\n  0. Filename Header + Git Hashes + Raspberry Pi Model + OS"
 echo "This is: $outfile" >> $outfile
 echo >> $outfile
-echo -e "\n\n\n\n0. GIT HASHES + RASPBERRY PI MODEL + OS" >> $outfile
+echo -e "\n\n\n\n0. GIT HASHES/TAGS + RASPBERRY PI MODEL + OS" >> $outfile
 echo >> $outfile
 echo "iiab commit:               $HASH1" >> $outfile
+echo "     recent git tag:       $TAG1" >> $outfile
 echo "iiab-admin-console commit: $HASH2" >> $outfile
+echo "     recent git tag:       $TAG2" >> $outfile
 echo >> $outfile
 cat_file /etc/iiab/pr-list-pulled
 cat_file /proc/device-tree/model    # Should be identical to /sys/firmware/devicetree/base/model

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -68,4 +68,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-260 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-261 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -62,4 +62,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 121-249 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-260 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -62,4 +62,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 120-246 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 121-249 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -1,10 +1,16 @@
 ## Objective
 
-To streamline troubleshooting of remote Internet-in-a-Box (IIAB) installations, we bundle up common machine/software diagnostics, all together in 1 human-readable small file, that can be easily circulated online AND offline.  Just FYI Raspberry Pi OS's [/usr/bin/raspinfo](https://github.com/raspberrypi/utils/blob/master/raspinfo/raspinfo) serves a very similar purpose, but we do not include that program's 700-to-800 line output at present.
+To streamline troubleshooting of remote Internet-in-a-Box (IIAB) installations, we bundle up common machine/software diagnostics, all together in 1 human-readable file of about 2000 lines, that can be easily circulated online AND offline.
 
-Passwords (including Wi-Fi passwords) are auto-redacted from this file, to protect your community confidentiality.
+Just FYI Raspberry Pi OS's [/usr/bin/raspinfo](https://github.com/raspberrypi/utils/blob/master/raspinfo/raspinfo) serves a very similar purpose, but we do not include that program's 700-to-800 line output at present.
 
-Finally, the ``pastebinit`` command can then be used to auto-upload this file, creating a short URL that makes it much easier to circulate among [volunteers](http://internet-in-a-box.org/pages/contributing.html).
+For a more concise "instant" summary of any IIAB machine (about 20-25 lines) try this command instead: [/usr/bin/iiab-summary](iiab-summary)
+
+## What `iiab-diagnostics` does
+
+Passwords (including Wi-Fi passwords) are auto-redacted as the output file is generated, to protect your community confidentiality.
+
+Finally, the ``pastebinit`` command can be used to auto-upload the output file (human-readable, approx 2000 lines) creating a short URL that makes it much easier to circulate among [volunteers](https://internet-in-a-box.org/contributing.html).
 
 But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 

--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Intentionally very concise summary of IIAB details.
+# Can evolve for int'l community needs, alongside the much longer:
+# https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md
+
+git config --global --add safe.directory /opt/iiab/iiab    # Nec below, if non-root
+cd /opt/iiab/iiab
+SHORT_HASH1=$(git log --pretty=format:'%h' -n 1)    # --pretty=format:'%H' (all 40 chars)
+TAG1=$(git describe --tags --abbrev=0)
+COMMITS1=$(git log "$TAG1..HEAD" --oneline | wc -l)
+PR_COUNT1=$(git log "$TAG1..HEAD" --oneline --grep='Merge pull request' | wc -l)
+COMMIT_MSG1=$(git log --format=%B -1 | head -1)
+BRANCH1=$(git branch --show-current)
+REMOTE_URL1=$(git config remote.$(git config branch.$BRANCH1.remote).url)
+
+git config --global --add safe.directory /opt/iiab/iiab-admin-console    # Nec below, if non-root
+cd /opt/iiab/iiab-admin-console
+SHORT_HASH2=$(git log --pretty=format:'%h' -n 1)    # --pretty=format:'%H' (all 40 chars)
+TAG2=$(git describe --tags --abbrev=0)
+COMMITS2=$(git log "$TAG2..HEAD" --oneline | wc -l)
+PR_COUNT2=$(git log "$TAG2..HEAD" --oneline --grep='Merge pull request' | wc -l)
+COMMIT_MSG2=$(git log --format=%B -1 | head -1)
+BRANCH2=$(git branch --show-current)
+REMOTE_URL2=$(git config remote.$(git config branch.$BRANCH2.remote).url)
+
+echo "$(grep install_date /etc/iiab/iiab.ini)   Current TZ: $(date +%Z)"
+echo
+echo -e "iiab: $SHORT_HASH1, $PR_COUNT1 PR's / $COMMITS1 commits since tag $TAG1"
+echo -e "    \e[1m\"$COMMIT_MSG1\"\e[0m"
+echo "    $REMOTE_URL1   branch: $BRANCH1"
+if [ -f /etc/iiab/pr-list-pulled ]; then
+    echo
+    cat /etc/iiab/pr-list-pulled
+fi
+echo
+echo -e "iiab-admin-console: $SHORT_HASH2, $PR_COUNT2 PR's / $COMMITS2 commits since tag $TAG2"
+echo -e "    \e[1m\"$COMMIT_MSG2\"\e[0m"
+echo "    $REMOTE_URL2   branch: $BRANCH2"
+echo
+if [ -f /etc/rpi-issue ]; then
+    cat /etc/rpi-issue
+    echo "/etc/debian-version: $(cat /etc/debian_version)"
+else
+    echo "$(cat /etc/issue.net)   $(cat /etc/debian_version)"
+fi
+echo "display-manager? $(systemctl is-active display-manager.service)   Arch1: $(dpkg --print-architecture)   Arch2: $(dpkg --print-foreign-architectures)"
+uname -rvp
+echo "$(lscpu | grep '^Model name:' | sed 's/^Model name:\s*//')   $(lscpu | grep '^CPU(s):' | tr -s ' ')   "$(free -m | tail -2 | tr -s ' ' | cut -d' ' -f1-2)
+if [ -f /proc/device-tree/model ]; then
+    cat /proc/device-tree/model ; echo    # MORE RPi DETAIL: tail -4 /proc/cpuinfo
+fi
+if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
+    echo "Temp(s): "$(cat /sys/class/thermal/thermal_zone*/temp)    # Prettier if avail: vcgencmd measure_temp
+fi
+#if command -v landscape-sysinfo > /dev/null; then    # Slow, Ubuntu Server only
+#    landscape-sysinfo --sysinfo-plugins=Disk,Temperature,Load    # Like: uptime -p
+#fi
+echo
+echo "$(df -h /)                ZIMs: $(ls /library/zims/content/ | wc -l) OER2Go: $(ls /library/www/html/modules/ | wc -l)"
+echo
+echo $(ip -o link show | awk -F': ' '{print $2}')    # Better order than: ls -rt /sys/class/net
+grep "^openvpn_enabled:" /etc/iiab/local_vars.yml
+grep "^openvpn_handle:" /etc/iiab/local_vars.yml
+hostname -I
+echo

--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -57,7 +57,7 @@ fi
 #    landscape-sysinfo --sysinfo-plugins=Disk,Temperature,Load    # Like: uptime -p
 #fi
 echo
-echo "$(df -h /)                ZIMs: $(ls /library/zims/content/ | wc -l) OER2Go: $(ls /library/www/html/modules/ | wc -l)"
+echo "$(df -h /)      ZIMs: $(ls /library/zims/content/ | wc -l) OER2Go: $(ls /library/www/html/modules/ | wc -l) Apps2B: $(iiab-apps-to-be-installed | wc -l)"
 echo
 echo $(ip -o link show | awk -F': ' '{print $2}')    # Better order than: ls -rt /sys/class/net
 grep "^openvpn_enabled:" /etc/iiab/local_vars.yml

--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -51,7 +51,7 @@ if [ -f /proc/device-tree/model ]; then
     cat /proc/device-tree/model ; echo    # MORE RPi DETAIL: tail -4 /proc/cpuinfo
 fi
 if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
-    echo "Temp(s): "$(cat /sys/class/thermal/thermal_zone*/temp)    # Prettier if avail: vcgencmd measure_temp
+    echo "Temperature(s): "$(cat /sys/class/thermal/thermal_zone*/temp)    # Prettier if avail: vcgencmd measure_temp
 fi
 #if command -v landscape-sysinfo > /dev/null; then    # Slow, Ubuntu Server only
 #    landscape-sysinfo --sysinfo-plugins=Disk,Temperature,Load    # Like: uptime -p

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -3,7 +3,7 @@
 # Higher-level purpose explained at the bottom of:
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
 
-# 2020-10-27: Most of the 11 variables require a command[*] to be run to
+# 2020-10-27: Most of the 12 variables require a command[*] to be run to
 # establish the var's value.  WE DISPLAY ALL ERRORS / DIAGNOSTICS AND CONTINUE.
 #
 # [*] DOESN'T MATTER WHAT COMMAND: so long as it fails with Return Code != 0
@@ -14,7 +14,7 @@ OS="none"
 VERSION_ID="none"    # This var's combined with the above, before being output
 IIAB_BRANCH="none"
 IIAB_COMMIT="none"
-#XO_MODEL="none"
+IIAB_RECENT_TAG="none"
 RPI_MODEL="none"
 DEVICETREE_MODEL="none"
 ANSIBLE_VERSION="none"
@@ -86,15 +86,15 @@ case $OS_VER in
         ;;
 esac
 
-# These next 2 help indicate what version of IIAB
+# These next 3 help indicate what version of IIAB
 tmp=$(git rev-parse --abbrev-ref HEAD) &&
     IIAB_BRANCH=$tmp
 
 tmp=$(git rev-parse --verify HEAD) &&
     IIAB_COMMIT=$tmp
 
-#tmp=$(cat /proc/device-tree/mfg-data/MN) &&
-#    XO_MODEL=$tmp
+tmp=$(git describe --tags --abbrev=0) &&
+    IIAB_RECENT_TAG=$tmp
 
 grep -iq raspberry /proc/device-tree/model &&
     RPI_MODEL=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0')
@@ -143,11 +143,10 @@ cat <<EOF
 "systemd_networkd"        : "$SYSTEMD_NETWORKD",
 "iiab_branch"             : "$IIAB_BRANCH",
 "iiab_commit"             : "$IIAB_COMMIT",
+"iiab_recent_tag"         : "$IIAB_RECENT_TAG",
 "rpi_model"               : "$RPI_MODEL",
 "devicetree_model"        : "$DEVICETREE_MODEL",
 "ansible_version"         : "$ANSIBLE_VERSION",
 "os"                      : "$OS",
 "os_ver"                  : "$OS_VER"}
 EOF
-
-#"xo_model"                : "$XO_MODEL",


### PR DESCRIPTION
Uses `git describe --tags --abbrev=0` to record "most recent" Git tag(s) like "8.0-preview-2" and "v0.5.5.9" to various places &mdash; e.g. /etc/iiab/iiab.ini and [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md) pastebin.

Ref:

- #3266