### PR TITLE
remoteit/tasks/install.yml: Remove "IIAB_LIKE=Ubuntu" after workaround, for Ansible OS detection

### DIFF
--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -76,6 +76,15 @@
 - name: Install remote.it Device Package for your CPU/OS, using https://downloads.remote.it/remoteit/install_agent.sh
   shell: curl -L https://downloads.remote.it/remoteit/install_agent.sh | sh
 
+# 2022-06-29: Ansible misinterprets "IIAB_LIKE=Ubuntu" (interpreting the entire
+# OS as Ubuntu instead of Mint, on later Ansible runs) so let's remove line now.
+- name: If Linux Mint, remove above "IIAB_LIKE=Ubuntu" from /etc/os-release (for Ansible's sloppy OS recognition logic)
+  lineinfile:
+    path: /etc/os-release
+    line: IIAB_LIKE=Ubuntu
+    state: absent
+  when: is_linuxmint
+
 
 - name: "'rm /etc/remoteit/registration' (empty file used just above)"
   file:


### PR DESCRIPTION
Resolves:

- #3268

I will test this to further verify.

Building on:

- PR #3201
- PR #3202