### PR TITLE
Record branch's actual Git remote (URL) to iiab.ini (in 2 places) + cleaner /usr/bin/iiab-summary when Admin Console is missing

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -29,6 +29,8 @@
       value: "{{ ansible_architecture }}"
     - option: iiab_base_ver
       value: "{{ iiab_base_ver }}"
+    - option: iiab_remote
+      value: "{{ ansible_local.local_facts.iiab_remote }}"
     - option: iiab_branch
       value: "{{ ansible_local.local_facts.iiab_branch }}"
     - option: iiab_commit

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -73,6 +73,8 @@
       value: "{{ iiab_base_ver }}"
     - option: iiab_revision
       value: "{{ iiab_revision }}"
+    - option: iiab_remote
+      value: "{{ ansible_local.local_facts.iiab_remote }}"
     - option: runtime_branch
       value: "{{ ansible_local.local_facts.iiab_branch }}"
     - option: runtime_commit

--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -34,9 +34,13 @@ if [ -f /etc/iiab/pr-list-pulled ]; then
     cat /etc/iiab/pr-list-pulled
 fi
 echo
-echo -e "iiab-admin-console: $SHORT_HASH2, $PR_COUNT2 PR's / $COMMITS2 commits since tag $TAG2"
-echo -e "    \e[1m\"$COMMIT_MSG2\"\e[0m"
-echo "    $REMOTE_URL2   branch: $BRANCH2"
+if [ -d /opt/iiab/iiab-admin-console ]; then
+    echo -e "iiab-admin-console: $SHORT_HASH2, $PR_COUNT2 PR's / $COMMITS2 commits since tag $TAG2"
+    echo -e "    \e[1m\"$COMMIT_MSG2\"\e[0m"
+    echo "    $REMOTE_URL2   branch: $BRANCH2"
+else
+    echo "    WARNING: Directory /opt/iiab/iiab-admin-console does not exist!"
+fi
 echo
 if [ -f /etc/rpi-issue ]; then
     cat /etc/rpi-issue

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -12,6 +12,7 @@
 STAGE=0
 OS="none"
 VERSION_ID="none"    # This var's combined with the above, before being output
+IIAB_REMOTE="none"
 IIAB_BRANCH="none"
 IIAB_COMMIT="none"
 IIAB_RECENT_TAG="none"
@@ -86,9 +87,12 @@ case $OS_VER in
         ;;
 esac
 
-# These next 3 help indicate what version of IIAB
+# These next 4 help indicate what version of IIAB
 tmp=$(git rev-parse --abbrev-ref HEAD) &&
     IIAB_BRANCH=$tmp
+
+tmp=$(git config remote.$(git config branch.$IIAB_BRANCH.remote).url) &&
+    IIAB_REMOTE=$tmp
 
 tmp=$(git rev-parse --verify HEAD) &&
     IIAB_COMMIT=$tmp
@@ -141,6 +145,7 @@ cat <<EOF
 "dhcpcd"                  : "$DHCPCD",
 "network_manager"         : "$NETWORK_MANAGER",
 "systemd_networkd"        : "$SYSTEMD_NETWORKD",
+"iiab_remote"             : "$IIAB_REMOTE",
 "iiab_branch"             : "$IIAB_BRANCH",
 "iiab_commit"             : "$IIAB_COMMIT",
 "iiab_recent_tag"         : "$IIAB_RECENT_TAG",

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -3,7 +3,7 @@
 # Higher-level purpose explained at the bottom of:
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
 
-# 2020-10-27: Most of the 12 variables require a command[*] to be run to
+# 2020-10-27: Most of the 13 variables require a command[*] to be run to
 # establish the var's value.  WE DISPLAY ALL ERRORS / DIAGNOSTICS AND CONTINUE.
 #
 # [*] DOESN'T MATTER WHAT COMMAND: so long as it fails with Return Code != 0


### PR DESCRIPTION
Addresses:

- https://github.com/iiab/iiab/issues/3266#issuecomment-1170161056

Building on:

- #3267