### PR TITLE
awstats.schoolserver.conf.j2: Set AllowFullYearView=3 not 2

### DIFF
--- a/roles/awstats/templates/awstats.schoolserver.conf.j2
+++ b/roles/awstats/templates/awstats.schoolserver.conf.j2
@@ -261,7 +261,7 @@ AllowToUpdateStatsFromBrowser=1
 #  3 - Possible on CLI and CGI
 # Default: 2
 #
-AllowFullYearView=2
+AllowFullYearView=3
 
 
 


### PR DESCRIPTION
This PR essentially fixes AWStats's full year view, by setting /etc/awstats/awstats.schoolserver.conf to a far more useful default.

Allowing folks to bypass this ugly error/warning when they select "- Year -" at the bottom of the dropdown where you pick a month:

```
Error: Full year view has not been allowed from a browser (AllowFullYearView should be set to 3).

Setup ('/etc/awstats/awstats.conf' file, web server or permissions) may be wrong.
Check config file, permissions and AWStats documentation (in 'docs' directory).
```

Tested on Raspberry Pi OS Lite on RPi 4.
