### PR TITLE
@jvonau's PR #3273 with obsolete groovy (Ubuntu 20.10) code block commented out & clarified [drop ping altogether, and vars internet_available & gw_active]

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -27,9 +27,6 @@
 # hostapd_enabled: True
 # Above set in /opt/iiab/iiab/vars/default_vars.yml
 
-# 2022-06-29: Legacy vars no longer used by roles/0-init
-gw_active: False                # 2021-07-30: Not used propgrammatically
-discovered_wan_iface: none      # 2021-07-30: Very broadly used!
 
 hostapd_wait: 10
 host_wireless_n: False
@@ -67,7 +64,8 @@ can_be_ap: False
 exclude_devices: none
 device_gw: none
 prior_gw_device: unset
-
+# 2022-06-29: Legacy vars no longer used by roles/0-init
+discovered_wan_iface: none      # 2021-07-30: Very broadly used!
 iiab_wan_iface: none
 iiab_lan_iface: none
 discovered_lan_iface: none

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -8,41 +8,6 @@
     discovered_wan_iface: "{{ ansible_default_ipv4.alias }}"
   when: ansible_default_ipv4.gateway is defined
 
-- name: "Verify gateway active: ping -c4 {{ ansible_default_ipv4.gateway }} -- using ansible_default_ipv4.gateway"
-  shell: ping -c4 "{{ ansible_default_ipv4.gateway }}" | grep icmp_seq=4 | wc -l
-  register: gw_active_test
-  when: discovered_wan_iface != "none"
-
-- name: "If gateway responded, set 'gw_active: True' and 'iiab_wan_iface: {{ discovered_wan_iface }}' -- using discovered_wan_iface"
-  set_fact:
-    iiab_wan_iface: "{{ discovered_wan_iface }}"    # Same as code on Line 70 !
-    gw_active: True
-  when: discovered_wan_iface != "none" and gw_active_test.stdout == "1"
-
-
-# Similar to roles/www_options/tasks/main.yml prereq for iiab-refresh-wiki-docs
-- name: 'Test for Internet access, using: {{ iiab_download_url }}/heart-beat.txt'
-  get_url:
-    url: "{{ iiab_download_url }}/heart-beat.txt"
-    dest: /tmp/heart-beat.txt
-    #timeout: "{{ download_timeout }}"
-    # @jvonau recommends: 100sec is too much (keep 10sec default)
-  ignore_errors: True
-  #async: 10
-  #poll: 2
-  register: internet_access_test
-
-- name: "Set 'internet_available: True' if above download succeeded AND not disregard_network"
-  set_fact:
-    internet_available: True    # Initialized to 'False' in 0-init/defaults/main.yml
-  when: not internet_access_test.failed and not disregard_network
-
-- name: Remove downloaded Internet test file /tmp/heart-beat.txt
-  file:
-    path: /tmp/heart-beat.txt
-    state: absent
-
-
 # so this works
 - name: Interface count
   shell: ls /sys/class/net | grep -v {{ virtual_network_devices }} | wc | awk '{print $1}'
@@ -284,10 +249,6 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
-    - option: gw_active
-      value: "{{ gw_active }}"
-    - option: internet_available
-      value: "{{ internet_available }}"
     - option: has_ifcfg_gw
       value: "{{ has_ifcfg_gw }}"
     - option: prior_gateway_device

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -64,7 +64,7 @@
     url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
     dest: /usr/bin/networkd-dispatcher
     timeout: "{{ download_timeout }}"
-  when: internet_available and fix_dispatcher and ansible_distribution_release == "groovy"
+  when: iiab_stage|int < 9 and fix_dispatcher and ansible_distribution_release == "groovy"
   # 2021-08-29 context from @jvonau: Fix is 'Groovy' specific, 21.04 and later
   # should have the fix baked into a newer apt package installed by default.
 

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -59,14 +59,22 @@
   with_items:
     - "{{ netplan.stdout_lines }}"
 
-- name: Replace networkd-dispatcher #2585 for "groovy"
-  get_url:
-    url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
-    dest: /usr/bin/networkd-dispatcher
-    timeout: "{{ download_timeout }}"
-  when: iiab_stage|int < 9 and fix_dispatcher and ansible_distribution_release == "groovy"
-  # 2021-08-29 context from @jvonau: Fix is 'Groovy' specific, 21.04 and later
-  # should have the fix baked into a newer apt package installed by default.
+# 2022-06-30: Ubuntu Groovy (20.10) is ancient history but this code might now
+# help Linux Mint ?
+#
+# 2022-05-29: @jvonau wrote on #3106 "networkd-dispatcher has a traceback,
+# I suspect the cause is the same as found #2645, need to confirm the package
+# version installed with apt list networkd-dispatcher before suggesting the
+# workaround be extended to LinuxMint"
+#
+# - name: Replace networkd-dispatcher #2585 for "groovy"
+#   get_url:
+#     url: https://gitlab.com/craftyguy/networkd-dispatcher/-/raw/2.1/networkd-dispatcher
+#     dest: /usr/bin/networkd-dispatcher
+#     timeout: "{{ download_timeout }}"
+#   when: iiab_stage|int < 9 and fix_dispatcher and ansible_distribution_release == "groovy"
+#   # 2021-08-29 context from @jvonau: Fix is 'Groovy' specific, 21.04 and later
+#   # should have the fix baked into a newer apt package installed by default.
 
 #- name: Supply netplan template
 #  template:

--- a/roles/vnstat/tasks/install.yml
+++ b/roles/vnstat/tasks/install.yml
@@ -1,5 +1,5 @@
 # Similar code block in roles/network/tasks/detected_network.yml
-- name: "Setting iiab_wan_iface to {{ ansible_default_ipv4.alias }}' -- using ansible_default_ipv4.alias if detected"
+- name: "Setting iiab_wan_iface to '{{ ansible_default_ipv4.alias }}' -- using ansible_default_ipv4.alias if detected"
   set_fact:
     iiab_wan_iface: "{{ ansible_default_ipv4.alias }}"
   when: ansible_default_ipv4.gateway is defined

--- a/roles/vnstat/tasks/install.yml
+++ b/roles/vnstat/tasks/install.yml
@@ -1,18 +1,8 @@
 # Similar code block in roles/network/tasks/detected_network.yml
-- name: "If above ansible_default_ipv4.gateway is defined, set WAN candidate 'discovered_wan_iface: {{ ansible_default_ipv4.alias }}' -- using ansible_default_ipv4.alias"
+- name: "Setting iiab_wan_iface to {{ ansible_default_ipv4.alias }}' -- using ansible_default_ipv4.alias if detected"
   set_fact:
-    discovered_wan_iface: "{{ ansible_default_ipv4.alias }}"
+    iiab_wan_iface: "{{ ansible_default_ipv4.alias }}"
   when: ansible_default_ipv4.gateway is defined
-
-- name: "Verify gateway active: ping -c4 {{ ansible_default_ipv4.gateway }} -- using ansible_default_ipv4.gateway"
-  shell: ping -c4 "{{ ansible_default_ipv4.gateway }}" | grep icmp_seq=4 | wc -l
-  register: gw_active_test
-  when: discovered_wan_iface != "none"
-
-- name: "If gateway responded, set 'iiab_wan_iface: {{ discovered_wan_iface }}' -- using discovered_wan_iface"
-  set_fact:
-    iiab_wan_iface: "{{ discovered_wan_iface }}"
-  when: discovered_wan_iface != "none" and gw_active_test.stdout == "1"
 
 
 - name: Install 'vnstat' package

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -154,7 +154,7 @@
   when: not apache_allow_sudo
 
 
-# internet_available var moved to roles/network/tasks/detected_network.yml
+# 2022-06-30: internet_available var removed
 - name: 'Test for Internet access, using: {{ iiab_download_url }}/heart-beat.txt'
   get_url:
     url: "{{ iiab_download_url }}/heart-beat.txt"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -97,9 +97,6 @@ js_menu_install: True
 # NETWORK role (/opt/iiab/iiab/roles/network).  SEE ALSO:
 # https://github.com/iiab/iiab/blob/master/roles/network/defaults/main.yml
 
-# The following variable may be useful in debugging:
-disregard_network: False    # Use cache, or error out if cache does not exist.
-
 iiab_hostname: box
 iiab_domain: lan
 lan_ip: 172.18.96.1


### PR DESCRIPTION
Testing ongoing using a LARGE-sized IIAB install on Ubuntu Server 22.04, currently in Stage 8 (10.8.0.14).

Related:

- PR #2972
- PR #3272
- PR #3273 