### PR TITLE
iiab apps to be installed

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -32,11 +32,14 @@
 
 # Copies the latest/known version of iiab-diagnostics into /usr/bin (so it can
 # be run even if local source tree /opt/iiab/iiab is deleted to conserve disk).
-- name: Copy /opt/iiab/iiab/scripts/iiab-diagnostics to /usr/bin/
+- name: Copy iiab-summary & iiab-diagnostics from /opt/iiab/iiab/scripts/ to /usr/bin/
   copy:
-    src: "{{ iiab_dir }}/scripts/iiab-diagnostics"
+    src: "{{ iiab_dir }}/scripts/{{ item }}"
     dest: /usr/bin/
     mode: '0755'
+  with_items:
+    - iiab-summary
+    - iiab-diagnostics
 
 - name: Create globally-writable directory /etc/iiab/diag (0777) so non-root users can run 'iiab-diagnostics'
   file:

--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -23,15 +23,6 @@
     name: iiab-admin
   #when: iiab_admin_install    # Flag might be created in future?
 
-- name: Copy iiab-summary & iiab-apps-to-be-installed from /opt/iiab/iiab/scripts/ to /usr/bin/
-  copy:
-    src: "{{ iiab_dir }}/scripts/{{ item }}"
-    dest: /usr/bin/
-    mode: '0755'
-  with_items:
-    - iiab-summary
-    - iiab-apps-to-be-installed
-
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml
   #when: dnsmasq_install    # Flag might be used in future?

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -146,7 +146,6 @@ if [ -s /tmp/iiab-apps-to-be-installed ]; then
     echo >> $outfile
 fi
 
-
 echo -e '\n  1. Files Specially Requested: (from "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n'
 echo -e '\n\n\n\n1. FILES SPECIALLY REQUESTED (FROM "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n' >> $outfile
 for f in "$@"; do

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -163,7 +163,7 @@ cat_cmd 'dpkg --print-architecture' 'RaspiOS-on-PC shows: i386'
 cat_cmd 'dpkg --print-foreign-architectures' 'RaspiOS-on-PC shows: amd64'
 cat_cmd 'systemctl is-active display-manager.service' 'Graphical Desktop?'
 cat_cmd 'grep "^openvpn_" /etc/iiab/local_vars.yml'
-cat_cmd 'iiab-apps-to-be-installed' 'IIAB Apps to be installed'
+cat_cmd '/opt/iiab/iiab/scripts/iiab-apps-to-be-installed' 'IIAB Apps to be installed'
 
 echo -e '\n\n  1. Files Specially Requested: (from "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n'
 echo -e '\n\n\n\n1. FILES SPECIALLY REQUESTED (FROM "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n' >> $outfile


### PR DESCRIPTION
As iiab-apps-to-be-installed is a shared helper script, no real need for it it live in /usr/bin, as pointed out both parent scripts are resilient to missing commands. Always update parent scripts on the fly without a pass through 1-prep as these scripts are always in flux.  