### PR TITLE
scripts/local_facts.fact: Stop supporting Ubuntu 21.10 (Impish Indri)

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,6 +64,7 @@ OS_VER="$OS-$VERSION_ID"
     #"ubuntu-18"    | \
     #"ubuntu-19"    | \
     #"ubuntu-2104"  | \
+    #"ubuntu-2210"  | \
     #"centos-7"     | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
@@ -78,7 +79,6 @@ case $OS_VER in
     "ubuntu-2004"  | \
     "ubuntu-2110"  | \
     "ubuntu-2204"  | \
-    "ubuntu-2210"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
     "raspbian-11")

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,7 +64,7 @@ OS_VER="$OS-$VERSION_ID"
     #"ubuntu-18"    | \
     #"ubuntu-19"    | \
     #"ubuntu-2104"  | \
-    #"ubuntu-2210"  | \
+    #"ubuntu-2110"  | \
     #"centos-7"     | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
@@ -77,8 +77,8 @@ case $OS_VER in
     "debian-11"    | \
     "debian-12"    | \
     "ubuntu-2004"  | \
-    "ubuntu-2110"  | \
     "ubuntu-2204"  | \
+    "ubuntu-2210"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
     "raspbian-11")


### PR DESCRIPTION
This should have been done in April when Ubuntu 22.04 (Jammy Jellyfish) was released months ago.

IIAB supports too many OS's and needs to tighten up focus on teachers/kids/clinics/communities (rather than "geek distractions").

Aside: Ubuntu [21.10] is officially end-of-life'd the day after tomorrow.

- #3307