### PR TITLE
Download kiwix.apk ("redirect to latest") instead of kiwix-3.5.0.apk

### DIFF
--- a/roles/kiwix/tasks/kiwix-apk.yml
+++ b/roles/kiwix/tasks/kiwix-apk.yml
@@ -6,7 +6,7 @@
 
 - name: Download kiwix.apk to {{ doc_root }}{{ kiwix_apk_url }}
   get_url:
-    url: "{{ kiwix_apk_src }}"    # e.g. https://download.kiwix.org/release/kiwix-android/kiwix-3.5.0.apk formerly kiwix.apk
+    url: "{{ kiwix_apk_src }}"    # e.g. https://download.kiwix.org/release/kiwix-android/kiwix.apk formerly kiwix-3.5.0.apk
     dest: "{{ doc_root }}{{ kiwix_apk_url }}"
     timeout: "{{ download_timeout }}"
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -486,7 +486,7 @@ kiwix_port: 3000
 iiab_zim_path: "{{ content_base }}/zims"    # /library/zims
 kiwix_incl_apk: False
 kiwix_apk_url: /software/kiwix
-kiwix_apk_src: https://download.kiwix.org/release/kiwix-android/kiwix-3.5.0.apk
+kiwix_apk_src: https://download.kiwix.org/release/kiwix-android/kiwix.apk
 
 # 2020-09-24: BOTH VALUES BELOW ARE IGNORED as PostgreSQL is installed on
 # demand as a dependency -- by Moodle &/or Pathagar


### PR DESCRIPTION
Hoping that Kiwix keeps URL https://download.kiwix.org/release/kiwix-android/kiwix.apk updated in future.

As discussed on:

- PR #3310