### PR TITLE
roles/osm-vector-maps: Download three 25-48MB files from new repo iiab/maps-assets

### DIFF
--- a/roles/osm-vector-maps/defaults/main.yml
+++ b/roles/osm-vector-maps/defaults/main.yml
@@ -8,18 +8,20 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# Pulls in ~38 files thx to @jvonau's #3192 -- change these 2 during testing:
+# Pulls in ~37 files thx to @jvonau's #3192 -- change these 2 during testing:
 osm_repo_url: https://raw.githubusercontent.com/iiab/maps
 maps_branch: master    # Quotes not required
 #osm_repo_url: https://raw.githubusercontent.com/georgejhunt/maps
 #maps_branch: maps7.3
 
 # 2022-04-30 -- Bluehost (timmoody.com) has become extremely slow!
-#map_installer_url: https://timmoody.com/iiab-files/maps
-map_installer_url: https://download.iiab.io/content/OSM/vector-tiles
+#maps_assets_url: https://timmoody.com/iiab-files/maps
+#maps_assets_url: https://download.iiab.io/content/OSM/vector-tiles
+maps_assets_url: https://raw.githubusercontent.com/iiab/maps-assets/main
 
-installer_planet: planet_z0-z6_2020.mbtiles
-installer_satellite: satellite_z0-z6_2020.mbtiles
+# cities1000.sqlite                                  # 26MB
+installer_planet: planet_z0-z6_2020.mbtiles          # 48MB
+installer_satellite: satellite_z0-z6_2020.mbtiles    # 25MB
 
 
 # 2022-04-30 WIP -- CLI approach to installing larger .mbtiles OSM "continents" a.k.a. regions:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -20,9 +20,9 @@
     - "{{ vector_map_path }}/viewer/tiles"
     - "{{ vector_map_path }}/installer"
 
-- name: Download 26MB {{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite to {{ vector_map_path }}/viewer/
+- name: Download 26MB {{ maps_assets_url }}/cities1000.sqlite to {{ vector_map_path }}/viewer/
   get_url:
-    url: "{{ osm_repo_url }}/{{ maps_branch }}/2020/cities1000.sqlite"    # e.g. https://raw.githubusercontent.com/iiab/maps + / + master + ...
+    url: "{{ maps_assets_url }}/cities1000.sqlite"    # e.g. https://raw.githubusercontent.com/iiab/maps-assets/main
     dest: "{{ vector_map_path }}/viewer/"
     timeout: "{{ download_timeout }}"
 
@@ -77,9 +77,9 @@
     - tileserver.php
 
 
-- name: Download 48MB {{ map_installer_url }}/{{ installer_planet }} to {{ vector_map_path }}/installer/ -- for map installer
+- name: Download 48MB {{ maps_assets_url }}/{{ installer_planet }} to {{ vector_map_path }}/installer/ -- for map installer
   get_url:
-    url: "{{ map_installer_url }}/{{ installer_planet }}"    # e.g. https://download.iiab.io/content/OSM/vector-tiles + / + planet_z0-z6_2020.mbtiles
+    url: "{{ maps_assets_url }}/{{ installer_planet }}"    # e.g. planet_z0-z6_2020.mbtiles
     dest: "{{ vector_map_path }}/installer/"
     timeout: "{{ download_timeout }}"
 
@@ -95,9 +95,9 @@
     path: "{{ vector_map_path }}/viewer/tiles/{{ installer_planet }}"
     state: link
 
-- name: Download 25MB {{ map_installer_url }}/{{ installer_satellite }} to {{ vector_map_path }}/viewer/tiles/ -- basic satellite photos
+- name: Download 25MB {{ maps_assets_url }}/{{ installer_satellite }} to {{ vector_map_path }}/viewer/tiles/ -- basic satellite photos
   get_url:
-    url: "{{ map_installer_url }}/{{ installer_satellite }}"    # e.g. satellite_z0-z6_2020.mbtiles
+    url: "{{ maps_assets_url }}/{{ installer_satellite }}"    # e.g. satellite_z0-z6_2020.mbtiles
     dest: "{{ vector_map_path }}/viewer/tiles/"
     timeout: "{{ download_timeout }}"
 


### PR DESCRIPTION
Thanks to phone input from @georgejhunt earlier this morning, who recommended organizing/consolidating in this way.

This PR works with new repo: https://github.com/iiab/maps-assets

To try to reduce the git bloat on repo https://github.com/iiab/maps that should only contain code and smaller configuration/catalog files.

(To that end, the 26MB https://github.com/iiab/maps/blob/master/2020/cities1000.sqlite will be deleted in coming days, after this transition is complete.)