### PR TITLE
Set default for use in netplan.yml and wording

### DIFF
--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -3,7 +3,7 @@
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml    # Invoked by 1-prep (so full path needed)
 
-- name: Install package networkd-dispatcher (OS's other than RasPiOS and LinuxMint)
+- name: Install package networkd-dispatcher (OS's other than RasPiOS and Linux Mint)
   package:
     name: networkd-dispatcher    # 15kB download: Dispatcher service for systemd-networkd connection status changes
     state: present

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -3,7 +3,7 @@
 - name: Install dnsmasq -- configure LATER in 'network', after Stage 9
   include_tasks: roles/network/tasks/dnsmasq.yml    # Invoked by 1-prep (so full path needed)
 
-- name: Install package networkd-dispatcher (OS's other than RasPiOS)
+- name: Install package networkd-dispatcher (OS's other than RasPiOS and LinuxMint)
   package:
     name: networkd-dispatcher    # 15kB download: Dispatcher service for systemd-networkd connection status changes
     state: present

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -4,8 +4,9 @@
   register: netplan
   #ignore_errors: True # pre 17.10 doesn't use netplan
 
-# 2022-07-23
-- name: Default to False
+# 2022-07-23: PR #3319 "Ubuntu variants [all] use NetworkManager as the backend
+# for use with netplan and ship with systemd-networkd present but disabled"
+- name: "Force default 'systemd_networkd_active: False' -- nec b/c network/default/main.yml is omitted when 1-prep directly invokes network/tasks/install.yml"
   set_fact:
     systemd_networkd_active: False
 

--- a/roles/network/tasks/netplan.yml
+++ b/roles/network/tasks/netplan.yml
@@ -4,6 +4,11 @@
   register: netplan
   #ignore_errors: True # pre 17.10 doesn't use netplan
 
+# 2022-07-23
+- name: Default to False
+  set_fact:
+    systemd_networkd_active: False
+
 # 2022-07-22: Copied from detected_network.yml (REMOVE DUPLICATE CODE LATER?!)
 - name: "Set 'systemd_networkd_active: True' if local_facts.systemd_networkd confirms"
   set_fact:

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -71,7 +71,7 @@
     enabled: yes
     masked: no
 
-- name: Enable & Restart networkd-dispatcher.service
+- name: Enable & Restart networkd-dispatcher.service except for LinuxMint
   systemd:
     name: networkd-dispatcher
     state: restarted

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -71,7 +71,7 @@
     enabled: yes
     masked: no
 
-- name: Enable & Restart networkd-dispatcher.service except for LinuxMint
+- name: Enable & Restart networkd-dispatcher.service except for Linux Mint
   systemd:
     name: networkd-dispatcher
     state: restarted


### PR DESCRIPTION
### Fixes bug:
Default to False or perhaps move the `when: ansible_local.local_facts.systemd_networkd == "enabled" or ansible_local.local_facts.systemd_networkd == "enabled-runtime"` to replace `when: systemd_networkd_active`
### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
