### PR TITLE
network/tasks/detected_network.yml: can_be_ap grep failed on absence of regex

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -113,6 +113,7 @@
   shell: iw list | grep '^[[:space:]]*\* AP$'
   register: look_for_ap
   when: discovered_wireless_iface != "none"
+  failed_when: False    # Hides red errors (stronger than 'ignore_errors: yes') -- otherwise Ansible will fail if grep returns '1' on absence of regex!
 
 - name: Set can_be_ap if 'iw list' output contains suitable '* AP'
   set_fact:


### PR DESCRIPTION
Emergency patch to help those whose laptops don't even mention AP at all in the output of `iw list`

Building on:

- #3057
- PR #3070 
- PR #3222