### PR TITLE
Use the new 'gitea_version: 1.17' instead of 1.16

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -9,7 +9,7 @@
 
 # Info needed to install Gitea:
 
-gitea_version: 1.16    # 2022-01-30: Grabs latest point release from this branch.  Rather than hardcoding (e.g. 1.14.5) every few weeks.
+gitea_version: 1.17    # 2022-01-30: Grabs latest point release from this branch.  Rather than hardcoding (e.g. 1.14.5) every few weeks.
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases/tag/v1.17.0

Building on:

- PR #3112