### PR TITLE
Install Kolibri using PPA, which promises auto-upgrades (when you apt update?)

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -16,7 +16,8 @@
 # https://github.com/iiab/iiab/issues/1675
 # https://github.com/learningequality/kolibri/issues/5664
 
-kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest
+# 2022-07-30: UNCOMMENT THE FOLLOWING LINE TO TEST A PARTICULAR .deb INSTALL
+# kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest
 # 2019-11-21 issue #2045 - above URL had redirected to this broken Kolibri 0.12.9 release:
 # https://storage.googleapis.com/le-releases/downloads/kolibri/v0.12.9/kolibri_0.12.9-0ubuntu1_all.deb
 #

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -35,8 +35,35 @@
   apt:
     deb: "{{ kolibri_deb_url }}"    # https://learningequality.org/r/kolibri-deb-latest
   environment:
-    KOLIBRI_HOME: "{{ kolibri_home }}"    # these don't do a thing for now but
+    KOLIBRI_HOME: "{{ kolibri_home }}"    # These don't do a thing for now but
     KOLIBRI_USER: "{{ kolibri_user }}"    # both can't hurt & Might Help Later
+  when: kolibri_deb_url is defined
+
+- block:    # ELSE...
+
+  # https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html says:
+  # "When you use the PPA installation method, upgrades to newer versions
+  # will be automatic, provided there is internet access available."
+
+  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu)
+    apt_repository:
+      repo: ppa:learningequality/kolibri
+    when: is_ubuntu
+
+  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian)
+    apt_repository:
+      repo: ppa:learningequality/kolibri
+      codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
+    when: is_debian
+
+  - name: apt install kolibri (populates {{ kolibri_home }}, migrates database)    # i.e. /library/kolibri
+    apt:
+      name: kolibri
+    environment:
+      KOLIBRI_HOME: "{{ kolibri_home }}"    # These don't do a thing for now but
+      KOLIBRI_USER: "{{ kolibri_user }}"    # both can't hurt & Might Help Later
+
+  when: kolibri_deb_url is undefined
 
 - name: 'Install from template: /etc/systemd/system/kolibri.service'
   template:
@@ -52,20 +79,20 @@
 
 # 2019-10-01: Should no longer be nec, thanks to /etc/kolibri/daemon.conf
 #             containing KOLIBRI_HOME="/library/kolibri" (above)
-#- name: Run Kolibri migrations to begin populating {{ kolibri_home }}    # i.e. /library/kolibri
-#  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" manage migrate
-#  ignore_errors: yes
-#  become: yes
-#  become_user: "{{ kolibri_user }}"
-#  when: kolibri_provision
+# - name: Run Kolibri migrations to begin populating {{ kolibri_home }}    # i.e. /library/kolibri
+#   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" manage migrate
+#   ignore_errors: yes
+#   become: yes
+#   become_user: "{{ kolibri_user }}"
+#   when: kolibri_provision
 
 # 2020-01-05: Deprecated per https://github.com/iiab/iiab/issues/2103
-#- name: Set Kolibri default language ({{ kolibri_language }})
-#  shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
-#  ignore_errors: yes
-#  become: yes
-#  become_user: "{{ kolibri_user }}"
-#  when: kolibri_provision
+# - name: Set Kolibri default language ({{ kolibri_language }})
+#   shell: export KOLIBRI_HOME="{{ kolibri_home }}" && "{{ kolibri_exec_path }}" language setdefault "{{ kolibri_language }}"
+#   ignore_errors: yes
+#   become: yes
+#   become_user: "{{ kolibri_user }}"
+#   when: kolibri_provision
 
 - name: 'Provision Kolibri, while setting: facility name, admin acnt / password, preset type, and language'
   shell: >
@@ -91,9 +118,9 @@
 # 2019-10-07: Moved to roles/httpd/tasks/main.yml
 # 2019-09-29: roles/kiwix/tasks/kiwix_install.yml installs 4 Apache modules
 # for similar purposes (not all nec?)  Only 1 (proxy_http) is needed here.
-#- name: Enable Apache module proxy_http for http://box{{ kolibri_url }}    # i.e. http://box/kolibri
-#  apache2_module:
-#    name: proxy_http
+# - name: Enable Apache module proxy_http for http://box{{ kolibri_url }}    # i.e. http://box/kolibri
+#   apache2_module:
+#     name: proxy_http
 
 
 # RECORD Kolibri AS INSTALLED

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -291,7 +291,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True
 kolibri_enabled: True
-kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -291,7 +291,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True
 kolibri_enabled: True
-kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -291,7 +291,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -291,7 +291,7 @@ kalite_enabled: False
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bg-bg,bn-bd,de,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,hi-in,it,km,ko,mr,my,nyn,pt-br,sw-tz,te,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: False


### PR DESCRIPTION
1) This PR also lists 31 (not just 25) Kolibri languages for variable `kolibri_language` within those [local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) files that are designed to be human-readable documentation.  Building on;

   - PR #2826

2) And preserves Kolibri's legacy [.deb install method](https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html#install-from-a-deb-file) for both testing and emergency override purposes (if you manually specify `kolibri_deb_url` e.g. in roles/kolibri/defaults/main.yml) as discussed here:

   - #3217

3) Unfortunately different PPA logic was necessitated on Debian-like OS's (`codename: focal`) &mdash; as compared to Ubuntu-like OS's.  But both should work.  As outlined in official guidelines: https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html#install-from-ppa-repository

4) This PR was tested on 64-bit RasPiOS Lite on Raspberry Pi 4.

Tangentially related is Kolibri 0.15.6's recent fix of peer-importing of channels e.g. from nearby IIAB machines with URL's like http://box/kolibri :

- #3227