### PR TITLE
Live w/ red errors to set can_be_ap ('failed_when: False' was too strong) + WiFi firmware questions w/ Linux Mint (Broadcom or Realtek)

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -108,12 +108,12 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout|int }}"
 
-- name: Run 'iw list' to check for Access Point capability
-  #command: iw list | grep -v AP: | grep AP | wc -l # False positives 'EAP' etc
+- name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface != "none"
+  # shell: iw list | grep -v AP: | grep AP | wc -l  # False positives 'EAP' etc
   shell: iw list | grep '^[[:space:]]*\* AP$'
   register: look_for_ap
-  when: discovered_wireless_iface != "none"
-  failed_when: False    # Hides red errors (stronger than 'ignore_errors: yes') -- otherwise Ansible will fail if grep returns '1' on absence of regex!
+  when: discovered_wireless_iface != "none"    # Line not nec (but can't hurt?)
+  ignore_errors: yes    # 'failed_when: False' hides red errors, but is too strong (renders useless the look_for_ap.failed test below!)
 
 - name: Set can_be_ap if 'iw list' output contains suitable '* AP'
   set_fact:


### PR DESCRIPTION
In short, this PR was overkill:

- PR #3323

As confirmed by @EMG70's:

- https://github.com/iiab/iiab/issues/3324#issuecomment-1200546459

This Ansible stanza regrettably introduces many different code paths for what should really be a dead simple `grep -q` existence test.

In any case, they're now fixed and tested, and we live with Ansible's artificially-added complexity in this case.