### PR TITLE
iiab-diagnostics: sudo ufw status verbose

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -229,6 +229,7 @@ echo -e "\n  5. Firewall Rules:\n"
 echo -e "\n\n\n5. FIREWALL RULES\n" >> $outfile
 #cat_file /usr/bin/iiab-gen-iptables
 cat_cmd 'sudo iptables-save' 'Firewall rules'
+cat_cmd 'sudo ufw status verbose' 'Firewall status & rules'
 
 echo -e "\n  6. Log Files: (e.g. last 100 lines of each)\n"
 echo -e "\n\n\n6. LOG FILES (e.g. LAST 100 LINES OF EACH)\n" >> $outfile

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -68,4 +68,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-242 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-243 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Highlight [ufw firewall status (verbose view)](https://linuxhint.com/ufw_list_rules/) in [iiab-diagnostics](https://github.com/iiab/iiab/blob/master/scripts/iiab-diagnostics.README.md) to help with OS's / operators who've accidentally and unintentionally blocked SSH access.