### PR TITLE
detected_network.yml: Disallow multi-line var second_gateway_found ~= exclude_devices (to avoid polluting /etc/iiab/iiab.ini)

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -142,7 +142,7 @@
   register: second_gateway_found
   changed_when: False
 
-- name: Fail intentionally and explain, if multiple secondary gateways are detected
+- name: If multiple secondary gateways are detected, fail intentionally and explain
   fail:
     msg: "IIAB currently DOES NOT SUPPORT multiple secondary gateways: {{ second_gateway_found.stdout }}"
   when: second_gateway_found.stdout_lines is defined and second_gateway_found.stdout_lines | length > 1

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -142,6 +142,10 @@
   register: second_gateway_found
   changed_when: False
 
+- assert:
+    that: second_gateway_found.stdout_lines | length == 1
+    fail_msg: "IIAB currently DOES NOT SUPPORT multiple secondary gateways."
+
 - name: Set exclude_devices if default gateway has been detected for {{ second_gateway_found.stdout }}
   set_fact:
     exclude_devices: "{{ second_gateway_found.stdout }}"

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -142,9 +142,10 @@
   register: second_gateway_found
   changed_when: False
 
-- assert:
-    that: second_gateway_found.stdout_lines | length == 1
-    fail_msg: "IIAB currently DOES NOT SUPPORT multiple secondary gateways."
+- name: Fail intentionally and explain, if multiple secondary gateways are detected
+  fail:
+    msg: "IIAB currently DOES NOT SUPPORT multiple secondary gateways: {{ second_gateway_found.stdout }}"
+  when: second_gateway_found.stdout_lines is defined and second_gateway_found.stdout_lines | length > 1
 
 - name: Set exclude_devices if default gateway has been detected for {{ second_gateway_found.stdout }}
   set_fact:


### PR DESCRIPTION
To keep `/etc/iiab/iiab.ini` from being polluted with multi-line variable artifacts like the following...

```
exclude_devices = none
wlp12s0
num_lan_interfaces = 1
```

...which prevented @EMG70 from running Admin Console earlier today, when he had 3 gateways (no doubt without realizing it) apparently including (1) his laptop's Ethernet (2) his laptop's internal WiFi (3) a USB WiFi dongle.  As confirmed by his Dell laptop's iiab-network.log (Line 9374) that is broken into 2 lines here:

```
2022-08-01 07:22:05,597 p=3352 u=root n=ansible | TASK [network : Set exclude_devices if default gateway has been detected for wlx1ca7705e063c
wlp12s0] ***
```

So this PR should help intercept problematic network attempts of this sort, e.g. when IIAB is being pushed too far into complex networking scenarios we're not ready to support at this time!

A bit of background:

- https://github.com/iiab/iiab/issues/815#issuecomment-884497515
- #3324
- https://github.com/iiab/iiab/pull/3329#issuecomment-1201162096
- https://github.com/iiab/iiab/pull/3329#issuecomment-1201163944