### PR TITLE
Straw Man 1-prep/templates/iiab-expand-rootfs.service based on 2020's PR #2522 + /usr/sbin/iiab-expand-rootfs "bash -xe" exit-on-error (to defer deleting /.expand-rootfs)

### DIFF
--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
 
 # Expand rootfs partition to its maximum size, if /.expand-rootfs exists.
 # Used by /etc/systemd/system/iiab-expand-rootfs.service on IIAB boot.

--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -15,6 +15,7 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
         # 2022-02-17: Uses do_expand_rootfs() from:
         # https://github.com/RPi-Distro/raspi-config/blob/master/raspi-config
         raspi-config --expand-rootfs    # REQUIRES A REBOOT
+        rm -f /.expand-rootfs /.resize-rootfs
         reboot                          # In future, we might warn interactive users?
     else                                # REQUIRES NO REBOOT; BEWARE iiab-expand-rootfs.service RACE CONDITION WITH fsck (PR #2522 & #3325)
         # 2022-03-15: Borrows from above raspi-config URL's do_expand_rootfs()
@@ -54,7 +55,7 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
         # # Resize partition
         # growpart /dev/$root_dev $root_part_no
         # resize2fs /dev/$root_part
+        
+        rm -f /.expand-rootfs /.resize-rootfs
     fi
-
-    rm -f /.expand-rootfs /.resize-rootfs
 fi

--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -15,6 +15,7 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
         # 2022-02-17: Uses do_expand_rootfs() from:
         # https://github.com/RPi-Distro/raspi-config/blob/master/raspi-config
         raspi-config --expand-rootfs    # REQUIRES A REBOOT
+        reboot                          # In future, we might warn interactive users?
     else                                # REQUIRES NO REBOOT; BEWARE iiab-expand-rootfs.service RACE CONDITION WITH fsck (PR #2522 & #3325)
         # 2022-03-15: Borrows from above raspi-config URL's do_expand_rootfs()
         ROOT_PART="$(findmnt / -o SOURCE -n)"    # e.g. /dev/sda2 or /dev/mmcblk0p2

--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -16,7 +16,7 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
         # https://github.com/RPi-Distro/raspi-config/blob/master/raspi-config
         raspi-config --expand-rootfs    # REQUIRES A REBOOT
         rm -f /.expand-rootfs /.resize-rootfs
-        reboot                          # In future, we might warn interactive users?
+        reboot                          # In future, we might warn interactive users that a reboot is coming?
     else                                # REQUIRES NO REBOOT; BEWARE iiab-expand-rootfs.service RACE CONDITION WITH fsck (PR #2522 & #3325)
         # 2022-03-15: Borrows from above raspi-config URL's do_expand_rootfs()
         ROOT_PART="$(findmnt / -o SOURCE -n)"    # e.g. /dev/sda2 or /dev/mmcblk0p2

--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -33,7 +33,9 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
 
         # Expand partition
         growpart $ROOT_DEV $ROOT_PART_NUM || true    # raspi-config instead uses fdisk.  WARNING: growpart RC 2 is more severe than RC 1, and should possibly be handled separately in future?
+        rc=$?    # Make Return Code visible, for 'bash -x'
         resize2fs $ROOT_PART
+        rc=$?    # Make RC visible (as above)
 
         # 2022-03-15: Legacy code below worked with Raspberry Pi microSD cards
         # but *not* with USB boot drives, internal spinning disks/SSD's, etc.

--- a/roles/1-prep/templates/iiab-expand-rootfs
+++ b/roles/1-prep/templates/iiab-expand-rootfs
@@ -32,7 +32,7 @@ if [ -f /.expand-rootfs ] || [ -f /.resize-rootfs ]; then
         fi
 
         # Expand partition
-        growpart $ROOT_DEV $ROOT_PART_NUM    # raspi-config instead uses fdisk
+        growpart $ROOT_DEV $ROOT_PART_NUM || true    # raspi-config instead uses fdisk.  WARNING: growpart RC 2 is more severe than RC 1, and should possibly be handled separately in future?
         resize2fs $ROOT_PART
 
         # 2022-03-15: Legacy code below worked with Raspberry Pi microSD cards

--- a/roles/1-prep/templates/iiab-expand-rootfs.service
+++ b/roles/1-prep/templates/iiab-expand-rootfs.service
@@ -8,6 +8,7 @@ Before=dphys-swapfile.service
 Environment=TERM=linux
 Type=oneshot
 ExecStart=/usr/sbin/iiab-expand-rootfs
+TimeoutSec=infinity
 # "Standard output type syslog is obsolete"
 # StandardError=syslog
 # WHEREAS StandardError=journal is the default, per https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=

--- a/roles/1-prep/templates/iiab-expand-rootfs.service
+++ b/roles/1-prep/templates/iiab-expand-rootfs.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Root Filesystem Auto-Expander
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=dphys-swapfile.service
 
 [Service]
 Environment=TERM=linux
@@ -8,7 +11,7 @@ ExecStart=/usr/sbin/iiab-expand-rootfs
 # "Standard output type syslog is obsolete"
 # StandardError=syslog
 # WHEREAS StandardError=journal is the default, per https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=
-RemainAfterExit=no
+RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=local-fs.target

--- a/roles/1-prep/templates/iiab-expand-rootfs.service
+++ b/roles/1-prep/templates/iiab-expand-rootfs.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Root Filesystem Auto-Expander
 DefaultDependencies=no
+# 2022-08-08: IIAB's 4 core OS's have 'After=systemd-fsck-root.service' WITHIN
+# systemd-remount-fs.service, allowing us to avoid #3325 race condition w/ fsck
 After=systemd-remount-fs.service
 # 2022-08-08: While dphys-swapfile.service doesn't exist on Ubuntu, Mint
 # and pure Debian, the following line may still serve a purpose on RasPiOS:

--- a/roles/1-prep/templates/iiab-expand-rootfs.service
+++ b/roles/1-prep/templates/iiab-expand-rootfs.service
@@ -2,6 +2,8 @@
 Description=Root Filesystem Auto-Expander
 DefaultDependencies=no
 After=systemd-remount-fs.service
+# 2022-08-08: While dphys-swapfile.service doesn't exist on Ubuntu, Mint
+# and pure Debian, the following line may still serve a purpose on RasPiOS:
 Before=dphys-swapfile.service
 
 [Service]

--- a/roles/1-prep/templates/iiab-expand-rootfs.service
+++ b/roles/1-prep/templates/iiab-expand-rootfs.service
@@ -10,6 +10,8 @@ Before=dphys-swapfile.service
 Environment=TERM=linux
 Type=oneshot
 ExecStart=/usr/sbin/iiab-expand-rootfs
+# 2022-08-08: By default, systemd dangerously kills rootfs expansion after just
+# 90s (1TB microSD cards take ~8 min to expand).  Let's remove the time limit:
 TimeoutSec=infinity
 # "Standard output type syslog is obsolete"
 # StandardError=syslog


### PR DESCRIPTION
1) To move the state-of-the-art forward, this is just a Straw Man PR to build on and evolve @jvonau and @tim-moody's #2522 discussion 2 years ago and similar work:

   - #723
   - PR #2465
   - #2517
   - PR #2522
   - PR #3137
   - #3147
   - #3159 
   - PR #3160
   - #3325
   - #3336
   - #3339

2) The race condition between iiab-expand-rootfs.service and fsck would appear to be the most serious problem (#3325).

3) Other resiliency improvements can certainly also be added where they prove effective.

4) Personally...I'm not at all in favor of `systemctl disable iiab-expand-rootfs.service` after rootfs has expanded (e.g. near the bottom of [/usr/sbin/iiab-expand-rootfs](https://github.com/iiab/iiab/blob/master/roles/1-prep/templates/iiab-expand-rootfs)).

   The reason is that grassroots communities should retain the full freedom to touch `/.expand-rootfs` at absolutely anytime &mdash; to expand their own regional/spontaneous/generative/remix IIAB disk images &mdash; even when (especially when) their community tooling (and skills!) remain comparatively primitive.