### PR TITLE
kolibri/tasks/install.yml: PPA special cases for Mint 20 (focal) + Mint 21 (jammy)

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -45,16 +45,38 @@
   # "When you use the PPA installation method, upgrades to newer versions
   # will be automatic, provided there is internet access available."
 
-  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu)
+  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu and not is_linuxmint)
     apt_repository:
       repo: ppa:learningequality/kolibri
-    when: is_ubuntu
+    when: is_ubuntu and not is_linuxmint
 
-  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian)
+  # 2022-08-19: 'add-apt-repository ppa:learningequality/kolibri' works at CLI on
+  # Mint 21 (creating /etc/apt/sources.list.d/learningequality-kolibri-jammy.list)
+  # BUT equivalent Ansible command (STANZA ABOVE) failed with error...
+  # "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/learningequality/kolibri/ubuntu vanessa Release' does not have a Release file."
+  # ...so for now we special case Mint, similar to Debian (BOTH STANZAS BELOW!)
+
+  # 2022-08-19: https://github.com/learningequality/kolibri/issues/9647 also asks
+  # about the warning below, arising no matter if codename is 'focal' or 'jammy'
+  # with Kolibri 0.15.6 on Mint 21 -- if you run '/usr/bin/kolibri --version':
+  #
+  # /usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
+  # warnings.warn(
+
+  # 2022-08-19: 'apt-key list' & 'apt-key del 3194 DD81' are useful if you also
+  # want to clear out Kolibri's key from the DEPRECATED /etc/apt/trusted.gpg
+
+  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'jammy' (if is_linuxmint_21)
+    apt_repository:
+      repo: ppa:learningequality/kolibri
+      codename: jammy    # CONSOLIDATE THIS STANZA WITH UBUNTU ABOVE IN FUTURE?
+    when: is_linuxmint_21
+
+  - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian or is_linuxmint_20)
     apt_repository:
       repo: ppa:learningequality/kolibri
       codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
-    when: is_debian
+    when: is_debian or is_linuxmint_20
 
   - name: apt install kolibri (populates {{ kolibri_home }}, migrates database)    # i.e. /library/kolibri
     apt:


### PR DESCRIPTION
Currently one can hack around this Kolibri install bug by putting `kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest` into [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) on Mint.

But this PR solves Kolibri's PPA configuration complexity in a _hopefully/increasingly_ sane way :smiley_cat: 

This PR is tested repeatedly on Linux Mint 21.

Building on:

- learningequality/kolibri#3217
- PR learningequality/kolibri#3327

Somewhat related:

- learningequality/kolibri#9634
- learningequality/kolibri-installer-debian#114