### PR TITLE
iiab-diagnostics: Display /etc/fstab as external disks get more popular

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -198,6 +198,7 @@ cat_cmd 'df -h' 'Disk usage'
 cat_cmd 'df -ah' 'Disk usage detail'
 cat_cmd 'lsblk' 'Partition mount points'
 cat_cmd 'blkid' 'Mount point details'
+cat_file /etc/fstab
 cat_cmd 'ip addr' 'Network interfaces'
 cat_cmd 'ifconfig' 'Network interfaces (old view)'
 cat_cmd 'ip route' 'Routing table'

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -68,4 +68,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-244 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-245 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Related:

- #3106 
- #3247
- #3350