### PR TITLE
remoteit/tasks/enable-or-disable.yml: Don't fail if svc(s) missing

### DIFF
--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -43,6 +43,7 @@
   with_items:
     - connectd
     - schannel
+  ignore_errors: yes
   when: not remoteit_enabled
 
 - name: Stop & Disable "Remote tcp connection services" remoteit@* found in /etc/systemd/system/multi-user.target.wants/ e.g. remoteit@80:00:01:7F:7E:00:56:36.service


### PR DESCRIPTION
This PR allows `remoteit_enabled: False` to be enforced without failing, e.g. after remote.it ["Device Package" 4.15.2 (released yesterday)](https://www.remote.it/download) is installed by apt.

Just FYI:

1) Most IIAB users/operators won't know to `touch /etc/remoteit/registration` prior to running `apt dist-upgrade` (or, equivalently `apt install remoteit`) and so apt will visually provide them a remote.it "Claim Code" (whether they want it or not!)

2) They should however then (if they choose!) retain the option of running the following, to turn off remote.it services:

   ```
   cd /opt/iiab/iiab
   ./runrole remoteit
   ```

Building on:

- PR #3161