### PR TITLE
plocate: Faster & smaller than locate & mlocate

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -15,7 +15,8 @@
       - logrotate          #   67kB download: RasPiOS installs this regardless
       #- lynx              #  505kB download: Installed by 1-prep's roles/iiab-admin/tasks/main.yml
       #- make              #  376kB download: 2021-07-27: Currently used by roles/pbx and no other roles
-      - mlocate            #   92kB download
+      #- mlocate           #   92kB download
+      - plocate            #   97kB download: Faster & smaller than locate & mlocate
       #- ntfs-3g           #  379kB download: RasPiOS installs this regardless -- 2021-07-31: But this should no longer be nec with 5.4+ kernels, similar to exfat packages above -- however, see also this symlink warning: https://superuser.com/questions/1050544/mount-with-kernel-ntfs-and-not-ntfs-3g -- and upcoming kernel 5.15 improvements: https://www.phoronix.com/scan.php?page=news_item&px=New-NTFS-Likely-For-Linux-5.15
       #- openssh-server    #  318kB download: RasPiOS installs this regardless -- this is also installed by 1-prep's roles/sshd/tasks/main.yml to cover all OS's
       - pandoc             #   19kB download: For /usr/bin/iiab-refresh-wiki-docs


### PR DESCRIPTION
plocate is a drop-in replacement for mlocate.

If some distros or our favorite "Linux fundamentalist obsessives" (of every possible kind, friendly & non-friendly ;) have already installed locate or mlocate, this should still work (generally...)

Of course I've not tested every single OS variant &mdash; but if important corners cases arise later we can address those in due course.