### PR TITLE
Published Password warnings work better with 'sudo -n'

### DIFF
--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # sets field2 to "" if sudo -s fails to read /etc/shadow
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # sets field2 to "" if sudo -s fails to read /etc/shadow
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # Sets field2 to "" if sudo -s fails to read /etc/shadow
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2)
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-lxde-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(grep "^$1:" /etc/shadow | cut -d: -f2)
+    field2=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2)
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
@@ -16,7 +16,8 @@
 check_user_pwd() {
     #[ $(id -un) = "root" ] || return 2
     #[ $(id -un) = "root" ] || [ $(id -un) = "iiab-admin" ] || return 2
-    [ -r /etc/shadow ] || return 2    # FORCE ERROR if /etc/shadow not readable
+
+    #[ -r /etc/shadow ] || return 2   # FORCE ERROR if /etc/shadow not readable
     # *BUT* overall bash script still returns exit code 0 ("success").
 
     #id -u $1 > /dev/null 2>&1 || return 2    # Not needed if return 1 is good
@@ -25,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(grep "^$1:" /etc/shadow | cut -d: -f2)
+    field2=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2) || return 2    # TRY TO FORCE ERROR if /etc/shadow not readable even with sudo
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # sets field2 to "" if sudo -s fails to read /etc/shadow
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # Sets field2 to "" if sudo -s fails to read /etc/shadow
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2) || return 2    # TRY TO FORCE ERROR if /etc/shadow not readable even with sudo
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2)    # sets field2 to "" if sudo -s fails to read /etc/shadow
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
+++ b/roles/iiab-admin/templates/sshpwd-profile-iiab.sh.j2
@@ -26,7 +26,7 @@ check_user_pwd() {
 
     # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
     # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
-    field2=$(sudo grep "^$1:" /etc/shadow | cut -d: -f2) || return 2    # TRY TO FORCE ERROR if /etc/shadow not readable even with sudo
+    field2=$(sudo -n grep "^$1:" /etc/shadow | cut -d: -f2) || return 2    # TRY TO FORCE ERROR if /etc/shadow not readable even with sudo
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds


### PR DESCRIPTION
This fix was tested to restore both IIAB's graphical popup and the command-line reminders.

Thanks to @jvonau who uncovered this silent omission/regression &mdash; exacerbated by increasingly strict security in recent versions of Raspberry Pi OS.