### PR TITLE
iiab-install: mkdir -p /etc/iiab/install-flags

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -81,6 +81,8 @@ fi
 
 echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
 
+mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22 (PR #3318 netwarn pop-ups, asking you to run iiab-network)
+
 echo -e "local_facts.fact DIAGNOSTICS... (A FEW LINES OF ERRORS/WARNINGS BELOW ARE OK!)\n"
 
 scripts/local_facts.fact    # Exit & advise, if OS not supported.

--- a/iiab-install
+++ b/iiab-install
@@ -81,7 +81,7 @@ fi
 
 echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
 
-mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22 (PR #3318 netwarn pop-ups, asking you to run iiab-network)
+mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22 (for PR #3318 netwarn pop-ups, asking you to run iiab-network)
 
 echo -e "local_facts.fact DIAGNOSTICS... (A FEW LINES OF ERRORS/WARNINGS BELOW ARE OK!)\n"
 


### PR DESCRIPTION
Makes directory [/etc/iiab/install-flags](https://github.com/iiab/iiab-factory/blob/63d5041ec3f009186ddbef931f37c9576d3e102d/iiab#L75) more mandatory, resolving:

- #3366

Tangentially related:

- PR #3369