### PR TITLE
Better description of current configuration when networking is disabled

### DIFF
--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -1,4 +1,8 @@
 #!/bin/bash
+{% if not network_enabled %}
+echo -e "Networking role disabled\n"
+echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
+{% else %}
 sed -i -e "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=False/" {{ iiab_env_file }}
 systemctl disable hostapd
 systemctl stop hostapd
@@ -35,4 +39,5 @@ echo -e "\nPlease reboot to enable upstream WiFi access.\n"
 exit 0
 {% endif %}
 #wifi_up_down
+{% endif %}
 {% endif %}

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -1,4 +1,8 @@
 #!/bin/bash
+{% if not network_enabled %}
+echo -e "Networking role disabled\n"
+echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
+{% else %}
 {% if not can_be_ap %}
 echo -e "\nUH-OH: Your Wi-Fi firmware doesn't support AP mode, according to 'iw list'\n"
 echo -e "If you add Wi-Fi hardware, run 'cd /opt/iiab/iiab' then 'sudo ./iiab-network'\n"
@@ -43,5 +47,6 @@ echo -e "\nPlease reboot to activate hostapd feature.\n"
 exit 0
 {% endif %}
 #wifi_up_down
+{% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
### Fixes bug:
Correct message displayed to user when network_enabled is set to False
### Description of changes proposed in this pull request:
Reflect true state of configuration
### Smoke-tested on which OS or OS's:
RasPiOS
### Mention a team member @username e.g. to help with code review:
