### PR TITLE
Fix hostapd for Raspberry Pi Zero W (systemd unit files, so it doesn't start too early!)

### DIFF
--- a/roles/network/templates/hostapd/hostapd.legacy.j2
+++ b/roles/network/templates/hostapd/hostapd.legacy.j2
@@ -1,5 +1,9 @@
 [Unit]
 Description=Hostapd IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
+# https://unix.stackexchange.com/questions/257888/systemd-wait-for-network-interface-to-be-up-before-running-service/417839#417839
+# 2022-08-22: #3352 Raspberry Pi Zero W requires 2 lines below...
+BindsTo=sys-subsystem-net-devices-{{ discovered_wireless_iface }}.device
+After=sys-subsystem-net-devices-{{ discovered_wireless_iface }}.device
 Before=network.target
 Wants=network-pre.target
 

--- a/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
+++ b/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
@@ -1,6 +1,10 @@
 [Unit]
 Description=IIAB ap0 clone wifi device
 Wants=network-pre.target
+# https://unix.stackexchange.com/questions/257888/systemd-wait-for-network-interface-to-be-up-before-running-service/417839#417839
+# 2022-08-22: #3352 Raspberry Pi Zero W requires 2 lines below...
+BindsTo=sys-subsystem-net-devices-{{ discovered_wireless_iface }}.device
+After=sys-subsystem-net-devices-{{ discovered_wireless_iface }}.device
 After=network-pre.target
 Before=dhcpcd.service
 Before=wpa_supplicant.service


### PR DESCRIPTION
This was extensively tested to fix hostapd on Raspberry Pi Zero W's running 32-bit Raspberry Pi OS Lite on and after 2022-08-22:

- #3352

Earlier today @jvonau recommended this change be merged without delay.

Before we go ahead however, this PR should really be re-tested using new "2022-09-06" version(s) of Raspberry Pi OS &mdash; for example:

- 32-bit RasPiOS Lite on Zero W
- 64-bit RasPiOS Lite on Zero 2 W

Tangentially related:

- PR #3179