### PR TITLE
Force-install libssl1.1 if MongoDB needed on Ubuntu >= 22.04 (for Sugarizer)

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -81,15 +81,14 @@ fi
 
 echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
 
-mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22 (for PR #3318 netwarn pop-ups, asking you to run iiab-network)
+mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22
+echo -e "/etc/iiab/install-flags directory created/verified."
+echo -e "(e.g. for PR #3318 netwarn pop-ups, asking you to run iiab-network)\n"
 
 echo -e "local_facts.fact DIAGNOSTICS... (A FEW LINES OF ERRORS/WARNINGS BELOW ARE OK!)\n"
-
 scripts/local_facts.fact    # Exit & advise, if OS not supported.
 
-if [ ! -f /etc/ansible/facts.d/local_facts.fact ]; then
-    mkdir -p /etc/ansible/facts.d
-fi
+mkdir -p /etc/ansible/facts.d
 cp scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 echo -e "\nPlaced /etc/ansible/facts.d/local_facts.fact into position."
 

--- a/iiab-install
+++ b/iiab-install
@@ -81,16 +81,16 @@ fi
 
 echo -e "\n\n./iiab-install $* BEGUN IN $CWD\n"
 
-mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22
-echo -e "/etc/iiab/install-flags directory created/verified."
-echo -e "(e.g. for PR #3318 netwarn pop-ups, asking you to run iiab-network)\n"
-
 echo -e "local_facts.fact DIAGNOSTICS... (A FEW LINES OF ERRORS/WARNINGS BELOW ARE OK!)\n"
 scripts/local_facts.fact    # Exit & advise, if OS not supported.
 
 mkdir -p /etc/ansible/facts.d
 cp scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
-echo -e "\nPlaced /etc/ansible/facts.d/local_facts.fact into position."
+echo -e "\nPlaced /etc/ansible/facts.d/local_facts.fact into position.\n"
+
+mkdir -p /etc/iiab/install-flags    # MANDATORY since 2022-07-22
+echo -e "/etc/iiab/install-flags directory created/verified."
+echo -e "(e.g. for PR #3318 netwarn pop-ups, asking you to run iiab-network)\n"
 
 if [ ! -f $PLAYBOOK ]; then
     echo "EXITING: IIAB Playbook ""$PLAYBOOK"" not found."

--- a/iiab-setup
+++ b/iiab-setup
@@ -10,7 +10,8 @@ apt -y install git curl nano gawk wget pastebinit
 cd /opt/iiab/iiab
 scripts/ansible
 
-mkdir -p /etc/iiab/install-flags
+# 2022-09-27: iiab-install now handles this
+#mkdir -p /etc/iiab/install-flags
 
 if [ ! -f /etc/iiab/local_vars.yml ]; then
   cp /opt/iiab/iiab/vars/local_vars_none.yml /etc/iiab/local_vars.yml

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -9,9 +9,10 @@
 # https://github.com/iiab/iiab/blob/master/vars/default_vars.yml
 - name: "Ansible just ran /etc/ansible/facts.d/local_facts.fact to set 11 vars -- here we extract 3 of those -- rpi_model: {{ ansible_local.local_facts.rpi_model }}, devicetree_model: {{ ansible_local.local_facts.devicetree_model }}, iiab_stage: {{ ansible_local.local_facts.stage }}"
   set_fact:
+    iiab_stage: "{{ ansible_local.local_facts.stage }}"
     rpi_model: "{{ ansible_local.local_facts.rpi_model }}"
     devicetree_model: "{{ ansible_local.local_facts.devicetree_model }}"
-    iiab_stage: "{{ ansible_local.local_facts.stage }}"
+    os_ver: "{{ ansible_local.local_facts.os_ver }}"
 
 # Initialize /etc/iiab/iiab.ini writing the 'location' and 'version' sections
 # once and only once, to preserve the install date and git hash.
@@ -92,6 +93,8 @@
       value: "{{ rpi_model }}"
     - option: devicetree_model
       value: "{{ devicetree_model }}"
+    - option: os_ver
+      value: "{{ os_ver }}"
     - option: first_run
       value: "{{ first_run }}"
     - option: local_tz    # e.g. 'EDT' (summer) or 'EST' (winter) after Ansible interprets symlink /etc/localtime -- or 'UTC' if /etc/localtime doesn't exist

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: sugarizer_install
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -20,8 +20,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mongodb_64bit_version: 4.4    # 5.0 also works as of 2022-06-09, but can fail on
-# "pre-2011" CPU's lacking AVX.  VERIFY both X.Y versions exist (+ work!) below:
+mongodb_64bit_version: 4.4    # 5.0 and 6.0 also work as of 2022-09-27, but fail
+# on "pre-2011" CPU's w/o AVX.  VERIFY both X.Y versions exist (+ work!) below:
 #
 # 1) https://www.mongodb.org/static/pgp/server-X.Y.asc ~= https://pgp.mongodb.com
 # 2) http://repo.mongodb.org/apt/debian &/OR https://repo.mongodb.org/apt/ubuntu

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -92,7 +92,6 @@
       # this was recently added to https://repo.mongodb.org/apt/debian/dists/
       repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
       #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
-      state: present
       filename: mongodb-org
     when: is_debian and ansible_architecture == "x86_64"
 
@@ -100,22 +99,47 @@
   - name: Otherwise install mongodb-org's Ubuntu focal source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_64bit_version }} multiverse
-      state: present
       filename: mongodb-org
     when: not (is_debian and ansible_architecture == "x86_64")
+
+  # 2022-09-27: Workaround to install MongoDB on Ubuntu 22.04+, which include
+  # libssl3 instead of libssl1.1 -- https://github.com/iiab/iiab/issues/3190
+  # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931
+  # https://askubuntu.com/questions/1403619/mongodb-install-fails-on-ubuntu-22-04-depends-on-libssl1-1-but-it-is-not-insta/1403683#1403683
+  # echo "deb http://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+  # sudo apt-get update
+  # sudo apt-get install libssl1.1
+  # rm /etc/apt/sources.list.d/focal-security.list
+
+  - name: Install source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+
+    apt_repository:
+      repo: deb http://security.ubuntu.com/ubuntu focal-security main
+      #filename: focal-security    # If filename focal-security.list is preferred
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
+
+  - name: Install libssl1.1 if Ubuntu 22.04+ (required by MongoDB below)
+    package:
+      name: libssl1.1
+      state: present
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
+
+  - name: Remove source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+
+    apt_repository:
+      repo: deb http://security.ubuntu.com/ubuntu focal-security main
+      state: absent
+      #filename: focal-security    # 100% IGNORED during repo deletion
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
 
   # # Debian 10 aarch64 might work below but is blocked in main.yml
   # - name: Use mongodb-org's Ubuntu focal repo for RasPiOS-aarch64
   #   apt_repository:
   #     repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
-  #     state: present
   #     filename: mongodb-org
   #   when: is_raspbian and ansible_architecture == "aarch64"
 
   # - name: Use mongodb-org's Ubuntu focal repo for Linux Mint - 64bit only
   #   apt_repository:
   #     repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
-  #     state: present
   #     filename: mongodb-org
   #   when: is_linuxmint
 
@@ -126,7 +150,6 @@
   #     # so other Ubuntu's like groovy 20.10 need to revert to recent LTS repo:
   #     repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse
   #     #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse
-  #     state: present
   #     filename: mongodb-org
   #   when: is_ubuntu and not is_linuxmint
 

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -83,17 +83,20 @@
     args:
       warn: false
 
-  - name: Install mongodb-org's Debian buster source/repo (we only use x86_64 i.e. arm64) for MongoDB version {{ mongodb_64bit_version }}
+  - name: Install mongodb-org's Debian bullseye source/repo (we only use x86_64 i.e. arm64) for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
       # 2020-10-28 and 2022-06-09: https://repo.mongodb.org/apt/debian/dists/
       # supports only {Buster 10, Stretch 9, Jessie 8, Wheezy 7}.  So Bullseye
       # 11 and Bookworm 12 (testing branch) revert to buster for now:
-      repo: deb https://repo.mongodb.org/apt/debian buster/mongodb-org/{{ mongodb_64bit_version }} main
+      # 2022-09-27: Changed from 'buster' to 'bullseye' (i.e. Debian 11) as
+      # this was recently added to https://repo.mongodb.org/apt/debian/dists/
+      repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
       #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       state: present
       filename: mongodb-org
     when: is_debian and ansible_architecture == "x86_64"
 
+  # 2022-09-27: Soon to change from 'focal' to 'jammy'
   - name: Otherwise install mongodb-org's Ubuntu focal source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
       repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_64bit_version }} multiverse

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -29,7 +29,7 @@
 - debug:
     var: rpi_model    # 0-init sets it from ansible_local.local_facts.rpi_model
 - debug:
-    var: ansible_local.local_facts.os_ver   # Like OS_VER in /etc/iiab/iiab.env
+    var: os_ver    # Equivalent to ansible_local.local_facts.os_ver and OS_VER in /etc/iiab/iiab.env
 - debug:
     var: is_debian
 - debug:


### PR DESCRIPTION
Resolves:

- #3190 

For those communities wanting Sugarizer on Ubuntu 22.04+

Tested on the latest daily build of Ubuntu 22.10 (server version not desktop version).

Refs:

- PR #3099
- PR #3189
- PR #3241
- PR #3262
- PR #3265