### PR TITLE
Encourage pre-release testing of Moodle 4.1 LTS if PHP >= 8.1

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: MOODLE
   include_role:
     name: moodle
-  when: moodle_install and not is_ubuntu_2204 and not is_ubuntu_2210    # TEMPORARY
+  when: moodle_install
 
 - name: OSM-VECTOR-MAPS
   include_role:

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -7,7 +7,12 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-moodle_version: 400
+
+# 2022-09-27: Currently testing Moodle's master branch is mandatory if your
+# OS PHP >= 8.1 -- see moodle/tasks/install.yml for detail!
+# (Any moodle_version setting below applies IF-AND-ONLY-IF your OS PHP < 8.1)
+#moodle_version: master              # Try Moodle's "weekly" 4.1dev pre-release, even if OS PHP < 8.1
+moodle_version: MOODLE_400_STABLE    # Use Moodle 4.0
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -43,14 +43,21 @@
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
-- name: Download (clone) {{ moodle_repo_url }} to {{ moodle_base }} (~370 MB initially, ~390 MB later)
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} >= 8.1"
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
-    version: "MOODLE_{{ moodle_version }}_STABLE"
-    #version: master   # TEMPORARY DURING MAY 2018 TESTING, installed 3.5beta+ = https://download.moodle.org/releases/development/
-  #ignore_errors: yes
+    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022)
+  when: php_version is version('8.1', '>=')
+
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} < 8.1
+  git:
+    repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
+    dest: "{{ moodle_base }}"        # /opt/iiab/moodle
+    depth: 1
+    version: "{{ moodle_version }}"    # e.g. master or MOODLE_400_STABLE
+  when: php_version is version('8.1', '<')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:


### PR DESCRIPTION
Until Moodle 4.1 LTS is released in about 6 weeks (on "Monday 2022-11-14") this PR nudges everyone trying to install Moodle onto an OS with PHP 8.1-or-higher (e.g. Ubuntu 22.04, 22.10, Mint 21) to immediately try Moodle's weekly dev build.

This makes quality-focused volunteering even far simpler, than was summarized earlier today here:

- #3381

Refs:

- PR #2832
- #3182 
- PR #3184
- PR #3189 
- PR #3262 
- PR #3265