### PR TITLE
0-init: Skip validate_vars.yml on Zero W & Zero 2 W (slow Raspberry Pi's)

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml
-  when: not (rpi_model | regex_search('\bW\b'))
+  when: not (rpi_model | regex_search('\\bW\\b'))    # Ansible require double backslashes, e.g. with \b "word boundary" anchors: https://www.regular-expressions.info/wordboundaries.html https://stackoverflow.com/questions/56869119/ansible-regular-expression-to-match-a-string-and-extract-the-line/56869801#56869801
 
 - name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"
   include_tasks: tz.yml

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -51,6 +51,7 @@
 
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml
+  when: not (rpi_model | regex_search('\bW\b'))
 
 - name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"
   include_tasks: tz.yml


### PR DESCRIPTION
Personally I would never run Ansible on a Raspberry Pi Zero W.

As moving the microSD card to an RPi 4 is more than 10X faster.

But for those who must, this PR (needs testing) is an option.

Related:

- https://github.com/iiab/iiab/pull/3379#issuecomment-1264773836