### PR TITLE
3379 [Restart iiab-clone-wifi if ap0 device (for AP+STA mode) not detected by Ansible]

### DIFF
--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -64,8 +64,8 @@
 - name: Clone wifi if needed
   systemd:
     name: iiab-clone-wifi
-    state: started
-  when: wifi_up_down and discovered_wireless_iface != "none"
+    state: restarted
+  when: wifi_up_down and discovered_wireless_iface != "none" and ansible_ap0 is undefined
 
 - name: Restart the networking service if appropriate
   systemd:

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -54,8 +54,8 @@
 - name: Clone wifi if needed
   systemd:
     name: iiab-clone-wifi
-    state: started
-  when: wifi_up_down and discovered_wireless_iface != "none"
+    state: restarted
+  when: wifi_up_down and discovered_wireless_iface != "none" and ansible_ap0 is undefined
 
 - name: Enable & Restart systemd-networkd.service
   systemd:


### PR DESCRIPTION
…#3379

### Fixes bug:
noted in 
### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
