### PR TITLE
Auto-install latest/official kiwix-tools + tighten up code

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -21,14 +21,27 @@
 # - index = directory for legacy *.zim.idx's
 kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 
-# 3 lines below specify which version(s) of kiwix-tools to download from...
-# https://download.iiab.io/packages/ ...as originally obtained from...
-# https://download.kiwix.org/release/kiwix-tools/ ...or sometimes...
-# https://download.kiwix.org/nightly/
+kiwix_base_url: https://download.kiwix.org/release/kiwix-tools/
+#kiwix_base_url: https://download.kiwix.org/nightly/2022-10-04/
+#kiwix_base_url: "{{ iiab_download_url }}/"    # https://download.iiab.io/packages/
 
-kiwix_version_armhf: kiwix-tools_linux-armhf-3.3.0-1
-kiwix_version_linux64: kiwix-tools_linux-x86_64-3.3.0-1
-kiwix_version_i686: kiwix-tools_linux-i586-3.3.0-1
+kiwix_arch_dict:
+  #i386:
+  i686: i586
+  x86_64: x86_64
+  armv6l: armhf
+  armv7l: armhf
+  aarch64: armhf
+
+# ansible_architecture can also work:
+# https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837
+kiwix_arch: "{{ kiwix_arch_dict[ansible_machine] | default('unsupported') }}"
+
+# Latest official kiwix-tools release, per Kiwix permalink redirects:
+# https://www.kiwix.org/en/downloads/kiwix-serve/
+# https://github.com/kiwix/container-images/issues/236
+kiwix_tar_gz: "kiwix-tools_linux-{{ kiwix_arch }}.tar.gz"
+#kiwix_tar_gz: "kiwix-tools_linux-{{ kiwix_arch }}-3.3.0-1.tar.gz"    # Version can be hard-coded if you prefer (as was done til 2022-10-04)
 
 # kiwix_src_file_i686: "kiwix-linux-i686.tar.bz2"
 # v0.9 for i686 published May 2014 ("use it to test legacy ZIM content")

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -33,8 +33,10 @@ kiwix_arch_dict:
   armv7l: armhf
   aarch64: armhf
 
-# ansible_architecture can also work:
+# ansible_architecture might also work, if not quite as well:
 # https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837
+# CLAIM: 'ansible_machine might be "i686", whereas ansible_architecture on the same host would be "i386"'
+# https://stackoverflow.com/questions/44713880/how-do-i-make-decision-based-on-arch-in-ansible-playbooks/44714226#44714226
 kiwix_arch: "{{ kiwix_arch_dict[ansible_machine] | default('unsupported') }}"
 
 # Latest official kiwix-tools release, per Kiwix permalink redirects:

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -23,7 +23,7 @@ kiwix_library_xml: "{{ iiab_zim_path }}/library.xml"
 
 kiwix_base_url: https://download.kiwix.org/release/kiwix-tools/
 #kiwix_base_url: https://download.kiwix.org/nightly/2022-10-04/
-#kiwix_base_url: "{{ iiab_download_url }}/"    # https://download.iiab.io/packages/
+#kiwix_base_url: "{{ iiab_download_url }}/"    # e.g. https://download.iiab.io/packages/
 
 kiwix_arch_dict:
   #i386:

--- a/roles/kiwix/tasks/enable-or-disable.yml
+++ b/roles/kiwix/tasks/enable-or-disable.yml
@@ -13,7 +13,7 @@
   systemd:
     name: kiwix-serve
     enabled: yes
-    state: started    # Not needed...but can't hurt
+    state: started
   when: kiwix_enabled
 
 
@@ -28,15 +28,15 @@
          # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
     line: "0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
     dest: /etc/crontab
-  when: kiwix_enabled and is_debuntu
+  when: kiwix_enabled
 
-- name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
-# *  *  *  *  * user-name  command to be executed
-  lineinfile:
-         # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
-    line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
-    dest: /etc/crontab
-  when: kiwix_enabled and is_redhat
+# - name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
+# # *  *  *  *  * user-name  command to be executed
+#   lineinfile:
+#          # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
+#     line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
+#     dest: /etc/crontab
+#   when: kiwix_enabled and is_redhat
 
 
 - name: Enable/Disable/Restart NGINX

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -1,42 +1,22 @@
-# 0. SET CPU ARCHITECTURE
+# 0. VERIFY CPU/OS ARCHITECTURE SUPPORTED
 
-- name: "Initialize 'kiwix_src_dir: False' just in case CPU architecture is not supported"
-  set_fact:
-    kiwix_src_dir: False
-
-- name: "Set fact 'kiwix_src_dir: {{ kiwix_version_armhf }}' (armv6l or armv71 or aarch64)"
-  set_fact:
-    kiwix_src_dir: "{{ kiwix_version_armhf }}"
-  when: ansible_machine == "armv6l" or ansible_machine == "armv7l" or ansible_machine == "aarch64"
-
-- name: "Set fact 'kiwix_src_dir: {{ kiwix_version_linux64 }}' (x86_64)"
-  set_fact:
-    kiwix_src_dir: "{{ kiwix_version_linux64 }}"
-  when: ansible_machine == "x86_64"
-
-- name: "Set fact 'kiwix_src_dir: {{ kiwix_version_i686 }}' (i686)"
-  set_fact:
-    kiwix_src_dir: "{{ kiwix_version_i686 }}"
-  when: ansible_machine == "i686"
-# COMMENT OUT LINE ABOVE TO TEST i686 CODE PATH ON X86_64 (WORKS NOV 2017)
-
-- name: Force Ansible to exit (FAIL) if kiwix-tools appears unavailable for your architecture ({{ ansible_machine }})
+- name: Force Ansible to exit (FAIL) if kiwix-tools appears unavailable for your CPU/OS architecture ({{ ansible_machine }})
   fail:
-    msg: "WARNING: kiwix-tools SOFTWARE APPEARS UNAVAILABLE FOR YOUR {{ ansible_machine }} OS/ARCHITECTURE."
-  when: not kiwix_src_dir
-
-- name: "Set fact 'kiwix_src_file: {{ kiwix_src_dir }}.tar.gz'"
-  set_fact:
-    kiwix_src_file: "{{ kiwix_src_dir }}.tar.gz"
+    msg: "WARNING: kiwix-tools SOFTWARE APPEARS UNAVAILABLE FOR YOUR {{ ansible_machine }} CPU/OS ARCHITECTURE."
+  when: kiwix_arch == "unsupported"
 
 
 # 1. PUT IN PLACE: /opt/iiab/downloads/kiwix-tools_linux-*.tar.gz, essential dirs, and test.zim if nec (library.xml is created later, by enable-or-disable.yml)
 
-- name: Download {{ iiab_download_url }}/{{ kiwix_src_file }} to /opt/iiab/downloads
+# 2022-10-04: get_url might be removed in future (unarchive below can handle
+# everything!)  Conversely: (1) unarchive doesn't support timeout (2) one day
+# /opt/iiab/downloads might have practical value beyond hoarding (unlikely!)
+- name: Download {{ kiwix_base_url }}{{ kiwix_tar_gz }} to /opt/iiab/downloads
   get_url:
-    url: "{{ iiab_download_url }}/{{ kiwix_src_file }}"    # https://download.iiab.io/packages
-    dest: "{{ downloads_dir }}/{{ kiwix_src_file }}"    # /opt/iiab/downloads
+    url: "{{ kiwix_base_url }}{{ kiwix_tar_gz }}"    # e.g. https://download.kiwix.org/release/kiwix-tools/ + kiwix-tools_linux-x86_64.tar.gz
+    dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
     timeout: "{{ download_timeout }}"
+  register: kiwix_dl    # Kiwix URL redirects to a longer filename, including the actual kiwix-tools version (placed in kiwix_dl.dest with its path, for unarchive ~28 lines below)
 
 - name: "Create dirs, including parent dirs: {{ kiwix_path }}/bin (executables), {{ iiab_zim_path }}/content (ZIM files), {{ iiab_zim_path }}/index (legacy indexes) (by default 0755)"
   file:
@@ -63,13 +43,11 @@
 
 # 2. INSTALL KIWIX-TOOLS EXECUTABLES
 
-- name: Unarchive {{ kiwix_src_file }} to /tmp    # e.g. kiwix-tools_linux-armhf-3.1.2-3.tar.gz
+- name: Unarchive {{ kiwix_dl.dest }} to {{ kiwix_path }}/bin -- use '--strip-components=1' to remove tarball's top-level dir during unpacking
   unarchive:
-    src: "{{ downloads_dir }}/{{ kiwix_src_file }}"
-    dest: /tmp
-
-- name: Move /tmp/{{ kiwix_src_dir }}/* to permanent location {{ kiwix_path }}/bin
-  shell: "mv /tmp/{{ kiwix_src_dir }}/* {{ kiwix_path }}/bin/"    # /opt/iiab/kiwix
+    src: "{{ kiwix_dl.dest }}"    # See ~28 lines above, e.g. /opt/iiab/downloads/kiwix-tools_linux-x86_64-3.3.0-1.tar.gz
+    dest: "{{ kiwix_path }}/bin"    # /opt/iiab/kiwix/bin
+    extra_opts: --strip-components=1
 
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU
@@ -103,7 +81,6 @@
   systemd:
     daemon_reload: yes
 
-# install kiwix app
 - name: Install Kiwix Android app
   include_tasks: kiwix-apk.yml
   when: kiwix_incl_apk

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -6,25 +6,34 @@
   when: kiwix_arch == "unsupported"
 
 
-# 1. PUT IN PLACE: /opt/iiab/downloads/kiwix-tools_linux-*.tar.gz, essential dirs, and test.zim if nec (library.xml is created later, by enable-or-disable.yml)
+# 1. PUT IN PLACE: /opt/iiab/downloads/kiwix-tools_linux-*.tar.gz, move /opt/iiab/kiwix/bin aside if nec, create essential dirs, and test.zim if nec (library.xml is created later, by enable-or-disable.yml)
 
 # 2022-10-04: get_url might be removed in future (unarchive below can handle
 # everything!)  Conversely: (1) unarchive doesn't support timeout (2) one day
 # /opt/iiab/downloads might have practical value beyond hoarding (unlikely!)
-- name: Download {{ kiwix_base_url }}{{ kiwix_tar_gz }} to /opt/iiab/downloads
+- name: Download {{ kiwix_base_url }}{{ kiwix_tar_gz }} into /opt/iiab/downloads (ACTUAL filename should include kiwix-tools version, or nightly build date)
   get_url:
     url: "{{ kiwix_base_url }}{{ kiwix_tar_gz }}"    # e.g. https://download.kiwix.org/release/kiwix-tools/ + kiwix-tools_linux-x86_64.tar.gz
     dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
-    #force: yes    # Implied b/c dest is a dir! (to recover from incomplete downloads, etc)
+    #force: yes    # Already implied b/c dest is a dir! (to recover from incomplete downloads, etc)
     timeout: "{{ download_timeout }}"
-  register: kiwix_dl    # Kiwix URL redirects to a longer filename, including the actual kiwix-tools version (placed in kiwix_dl.dest with its path, for unarchive ~28 lines below)
+  register: kiwix_dl    # PATH /opt/iiab/downloads + ACTUAL filename put in kiwix_dl.dest, for unarchive ~28 lines below
+
+- name: Does {{ kiwix_path }}/bin already exist? (as a directory, symlink or file)
+  stat:
+    path: "{{ kiwix_path }}/bin"    # /opt/iiab/kiwix
+  register: kiwix_bin
+
+- name: If so, move {{ kiwix_path }}/bin to {{ kiwix_path }}/bin.DATE_TIME_TZ
+  shell: "mv {{ kiwix_path }}/bin {{ kiwix_path }}/bin.$(date +%F_%T_%Z)"
+  when: kiwix_bin.stat.exists
 
 - name: "Create dirs, including parent dirs: {{ kiwix_path }}/bin (executables), {{ iiab_zim_path }}/content (ZIM files), {{ iiab_zim_path }}/index (legacy indexes) (by default 0755)"
   file:
     path: "{{ item }}"
     state: directory
   with_items:
-    - "{{ kiwix_path }}/bin"           # /opt/iiab/kiwix
+    - "{{ kiwix_path }}/bin"
     - "{{ iiab_zim_path }}/content"    # /library/zims
     - "{{ iiab_zim_path }}/index"
 
@@ -47,7 +56,7 @@
 - name: Unarchive {{ kiwix_dl.dest }} to {{ kiwix_path }}/bin -- untar with '--strip-components=1' to chop tarball's top-level dir from path
   unarchive:
     src: "{{ kiwix_dl.dest }}"    # See ~28 lines above, e.g. /opt/iiab/downloads/kiwix-tools_linux-x86_64-3.3.0-1.tar.gz
-    dest: "{{ kiwix_path }}/bin"    # /opt/iiab/kiwix/bin
+    dest: "{{ kiwix_path }}/bin"
     extra_opts: --strip-components=1
 
 

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -15,6 +15,7 @@
   get_url:
     url: "{{ kiwix_base_url }}{{ kiwix_tar_gz }}"    # e.g. https://download.kiwix.org/release/kiwix-tools/ + kiwix-tools_linux-x86_64.tar.gz
     dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
+    #force: yes    # Implied b/c dest is a dir! (to recover from incomplete downloads, etc)
     timeout: "{{ download_timeout }}"
   register: kiwix_dl    # Kiwix URL redirects to a longer filename, including the actual kiwix-tools version (placed in kiwix_dl.dest with its path, for unarchive ~28 lines below)
 

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -44,7 +44,7 @@
 
 # 2. INSTALL KIWIX-TOOLS EXECUTABLES
 
-- name: Unarchive {{ kiwix_dl.dest }} to {{ kiwix_path }}/bin -- use '--strip-components=1' to remove tarball's top-level dir during unpacking
+- name: Unarchive {{ kiwix_dl.dest }} to {{ kiwix_path }}/bin -- untar with '--strip-components=1' to chop tarball's top-level dir from path
   unarchive:
     src: "{{ kiwix_dl.dest }}"    # See ~28 lines above, e.g. /opt/iiab/downloads/kiwix-tools_linux-x86_64-3.3.0-1.tar.gz
     dest: "{{ kiwix_path }}/bin"    # /opt/iiab/kiwix/bin

--- a/roles/kiwix/tasks/main.yml
+++ b/roles/kiwix/tasks/main.yml
@@ -42,6 +42,8 @@
         value: "{{ kiwix_install }}"
       - option: kiwix_enabled
         value: "{{ kiwix_enabled }}"
+      - option: kiwix_tar_gz
+        value: "{{ kiwix_tar_gz }}"
       - option: kiwix_url
         value: "{{ kiwix_url }}"
       - option: kiwix_url_plus_slash


### PR DESCRIPTION
Instead of IIAB having to hard-code and host a new version of [kiwix-tools](https://github.com/kiwix/kiwix-tools) every month or so:

1. This makes installing the lastest/official kiwix-tools release automatic, based on Kiwix's permalink redirects:
   - https://www.kiwix.org/en/downloads/kiwix-serve/
   - kiwix/k8s#50
2. Bonus it's now easier to quickly update to the very latest official kiwix-tools release (if any IIAB implementer wants that pre-flight / pre-deployment).  It's now as easy as running:
   ```
   cd /opt/iiab/iiab
   sudo ./runrole --reinstall kiwix
   ```
3. Specific versions of kiwix-tools can now be hard-coded even more easily than in the past, by hand editing `/opt/iiab/iiab/roles/kiwix/defaults/main.yml` that explains your options much more clearly &mdash; e.g. during regression testing (progress testing!) comparing different versions of kiwix-tools, etc.

RECAP: As usual, this installs kiwix-tools' 3 executables {kiwix-manage, kiwix-search, kiwix-serve} into /opt/iiab/kiwix/bin but does it in a more compact and automated way than in the past.

Tested on Ubuntu 22.10 (pre-release).

Not a big deal, but a Caveat: downloading of kiwix-tools will occasionally now take a bit longer (e.g. sometimes a full minute) as Kiwix download mirrors can be quite scattershot.  These inconsistent results appear to be luck of the draw (very random) from my experience, probably based Kiwix's "round robin" mirror server rotation that's quite a familiar issue over recent years.

Building on:

- PR #3235 
- PR #3344