### PR TITLE
Refine remote.it operations, now that connectd systemd service is gone, and considering 3 valid states for /etc/remoteit/registration

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -2,7 +2,7 @@
 
 Remote.it can be a [great way](https://docs.remote.it/introduction/get-started/readme) to remotely support an Internet-in-a-Box (IIAB).
 
-As of [April 2022](https://remote.it/pricing/), 5 IIAB devices can be managed for free, and an unlimited number can be managed for $6/month.
+As of [October 2022](https://remote.it/pricing/), 5 IIAB devices can be managed for free, and an unlimited number can be managed for $10/month.
 
 For other approaches, please see [FAQ.IIAB.IO](https://wiki.iiab.io/go/FAQ) -> "How can I remotely manage my Internet-in-a-Box?"
 

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -7,7 +7,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# # 2022-03-31: https://remote.it/download/ offers 4 relevant "Device Packages"
+# # 2022-03-31: https://remote.it/download/ offered 4 relevant "Device Packages"
 # # 1) Raspberry Pi (ARM)    = armhf.rpi
 # # 2) Raspberry Pi (ARM64)  = arm64.rpi
 # # 3) Debian Linux (ARM64)  = arm64
@@ -32,23 +32,26 @@
 # # # Example...         https://downloads.remote.it/remoteit/v4.14.1/remoteit-4.14.1.armhf.rpi.deb
 
 
-# 2022-03-31: https://remote.it/download/ offers 4 relevant "CLI" installs:
-# 1) Debian Linux (ARM v6) OR Raspberry Pi (ARM)   = armv6
-# 2) Debian Linux (ARM v7)                         = armv7
-# 3) Debian Linux (ARM64)  OR Raspberry Pi (ARM64) = arm64
+# 2022-10-09: https://remote.it/download/ offers 4 relevant "CLI" installs:
+# 1) Debian Linux (ARM v6) OR Raspberry Pi (ARM)   = armv6 -> arm-v6
+# 2) Debian Linux (ARM v7)                         = armv7 -> arm-v7
+# 3) Debian Linux (ARM64)  OR Raspberry Pi (ARM64) = arm64 -> aarch64
 # 4) Debian Linux (x86_64)                         = x86_64
 
-# See https://docs.remote.it/software/cli/overview to refine URL below:
-cli_suffixes:
-  armv6: armv6
-  armv6l: armv6
-  armv7: armv7
-  armv7l: armv7
-  armv8: arm64
-  aarch64: arm64
+# SEE https://www.remote.it/download-list
+#     https://www.remote.it/download-list?products=cli to refine arch/URL below
+# BUT https://docs.remote.it/software/cli/overview can be useful OR stale :/
+remoteit_arch_dict:
+  armv6: arm-v6
+  armv6l: arm-v6
+  armv7: arm-v7
+  armv7l: arm-v7
+  armv8: aarch64
+  aarch64: aarch64
   x86_64: x86_64
-remoteit_cli_suffix: "{{ cli_suffixes[ansible_architecture] | default('unknown') }}"
-remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit_linux_{{ remoteit_cli_suffix }}
+remoteit_arch: "{{ remoteit_arch_dict[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
+remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit.{{ remoteit_arch }}-linux
+
 
 # OPTION #1: Run 'sudo iiab-remoteit' after IIAB is installed.
 

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -17,6 +17,18 @@
   when: remoteit_license_key is defined
 
 
+- name: Does empty file /etc/remoteit/registration exist?
+  stat:
+    path: /etc/remoteit/registration
+  register: remoteit_reg
+
+- name: Remove empty file /etc/remoteit/registration if remoteit_enabled
+  file:
+    path: /etc/remoteit/registration
+    state: absent
+  when: remoteit_enabled and remoteit_reg.stat.exists and remoteit_reg.stat.size == 0
+
+
 # 2022-04-07 FYI: connectd (below) never deletes /etc/remoteit/registration
 
 - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -22,40 +22,43 @@
     path: /etc/remoteit/registration
   register: remoteit_reg
 
-- name: Remove empty file /etc/remoteit/registration if remoteit_enabled
+- name: Remove empty file /etc/remoteit/registration if remoteit_enabled, so claim code can be generated
   file:
     path: /etc/remoteit/registration
     state: absent
   when: remoteit_enabled and remoteit_reg.stat.exists and remoteit_reg.stat.size == 0
 
 
-# 2022-04-07 FYI: connectd (below) never deletes /etc/remoteit/registration
+# 2022-10-09: refresh.sh is equivalent to their old connectd "parent" systemd
+# service, that they removed from 4.15.2 device packages on 2022-09-07.
+# (Either way, the job below never deletes /etc/remoteit/registration)
 
-- name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
-  systemd:
-    name: connectd
-    daemon_reload: yes
-    enabled: yes
-    state: restarted
+- name: 'Run /usr/share/remoteit/refresh.sh to put a claim code in /etc/remoteit/config.json (if you don't already have a license key in /etc/remoteit/registration) -- FYI this spawns 2 "child" services/daemons: schannel & e.g. remoteit@80:00:01:7F:7E:00:56:36.service'
+  command: /usr/share/remoteit/refresh.sh
   when: remoteit_enabled
 
-- name: Enable remote.it daemon schannel ("Remote tcp command service") -- try to avoid contention with connectd which auto-spawns it as nec (just above)
+# - name: Enable & Restart remote.it "parent" service connectd, which exits after spawning 2 "child" services/daemons below
+#   systemd:
+#     name: connectd
+#     daemon_reload: yes
+#     enabled: yes
+#     state: restarted
+#   when: remoteit_enabled
+
+# 2022-10-09: refresh.sh (above) now takes care of this too
+# - name: Enable remote.it daemon schannel ("Remote tcp command service") -- try to avoid contention with connectd which auto-spawns it as nec (just above)
+#   systemd:
+#     name: schannel
+#     enabled: yes
+#     state: started
+#   when: remoteit_enabled
+
+
+- name: Disable & Stop remote.it service schannel
   systemd:
     name: schannel
-    enabled: yes
-    state: started
-  when: remoteit_enabled
-
-
-- name: Disable & Stop remote.it services {connectd, schannel}
-  systemd:
-    name: "{{ item }}"
     enabled: no
     state: stopped
-  with_items:
-    - connectd
-    - schannel
-  ignore_errors: yes
   when: not remoteit_enabled
 
 - name: Stop & Disable "Remote tcp connection services" remoteit@* found in /etc/systemd/system/multi-user.target.wants/ e.g. remoteit@80:00:01:7F:7E:00:56:36.service

--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -33,7 +33,7 @@
 # service, that they removed from 4.15.2 device packages on 2022-09-07.
 # (Either way, the job below never deletes /etc/remoteit/registration)
 
-- name: 'Run /usr/share/remoteit/refresh.sh to put a claim code in /etc/remoteit/config.json (if you don't already have a license key in /etc/remoteit/registration) -- FYI this spawns 2 "child" services/daemons: schannel & e.g. remoteit@80:00:01:7F:7E:00:56:36.service'
+- name: 'Run /usr/share/remoteit/refresh.sh to put a claim code in /etc/remoteit/config.json (if you don''t already have a license key in /etc/remoteit/registration) -- FYI this spawns 2 "child" services/daemons: schannel & e.g. remoteit@80:00:01:7F:7E:00:56:36.service'
   command: /usr/share/remoteit/refresh.sh
   when: remoteit_enabled
 

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -47,7 +47,7 @@
     state: directory
     path: /etc/remoteit
 
-- name: "'touch /etc/remoteit/registration' to block generation of claim code below, also speeding things up a bit"
+- name: "'touch /etc/remoteit/registration' (might contain a remoteit_license_key) to prevent generation of claim code below; also speeding things up a bit"
   file:
     state: touch
     path: /etc/remoteit/registration
@@ -86,11 +86,13 @@
   when: is_linuxmint
 
 
-- name: "'rm /etc/remoteit/registration' (empty file used just above)"
-  file:
-    state: absent
-    path: /etc/remoteit/registration
-  ignore_errors: yes    # In case a future version of install_agent.sh deletes it for us
+# 2022-10-09: Let's keep the file (empty or not!)  If it exists with size zero
+# bytes, enable-or-disable.yml or /usr/bin/iiab-remoteit delete it later as nec.
+# - name: "'rm /etc/remoteit/registration' (empty file used just above)"
+#   file:
+#     state: absent
+#     path: /etc/remoteit/registration
+#   ignore_errors: yes    # In case a future version of install_agent.sh deletes it for us
 
 
 - name: Install /usr/bin/iiab-remoteit from template -- so IIAB operators can quickly enable remote.it AND generate a new remote.it claim code (in /etc/remoteit/config.json) -- optionally downloading + installing the very latest Device Package (like the 2 steps above)

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -108,10 +108,10 @@
     mode: 0755
 
 
-- name: Fail if architecture remoteit_cli_suffix == "unknown"
+- name: Fail if architecture remoteit_arch == "unknown"
   fail:
     msg: "Could not find a remote.it CLI binary for CPU architecture \"{{ ansible_architecture }}\""
-  when: remoteit_cli_suffix == "unknown"
+  when: remoteit_arch == "unknown"
 
 - name: Download OPTIONAL {{ remoteit_cli_url }} (CLI) to /usr/bin/remoteit (755)
   get_url:

--- a/roles/remoteit/tasks/main.yml
+++ b/roles/remoteit/tasks/main.yml
@@ -11,31 +11,39 @@
     quiet: yes
 
 
-- name: Install remoteit if 'remoteit_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: remoteit_installed is undefined
+- block:
 
+  - name: Install remoteit if 'remoteit_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: remoteit_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
-# - name: Extract claim code from /etc/remoteit/config.json if it exists
-#   shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
-#   register: remoteit_claim_code
+  # - name: Extract claim code from /etc/remoteit/config.json if it exists
+  #   shell: grep claim /etc/remoteit/config.json | rev | cut -d\" -f2 | rev
+  #   register: remoteit_claim_code
 
-- name: Add 'remoteit' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: remoteit
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: remote.it
-    - option: description
-      value: '"https://remote.it can help you remotely maintain an IIAB.  Some benefits include: crossing multiple NATs/firewalls using a single TCP port, without requiring router port forwarding, and reducing your network''s vulnerability."'
-    - option: remoteit_install
-      value: "{{ remoteit_install }}"
-    - option: remoteit_enabled
-      value: "{{ remoteit_enabled }}"
-    # - option: remoteit_claim_code
-    #   value: "{{ remoteit_claim_code.stdout }}"
+  - name: Add 'remoteit' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: remoteit
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: remote.it
+      - option: description
+        value: '"https://remote.it can help you remotely maintain an IIAB.  Some benefits include: crossing multiple NATs/firewalls using a single TCP port, without requiring router port forwarding, and reducing your network''s vulnerability."'
+      - option: remoteit_install
+        value: "{{ remoteit_install }}"
+      - option: remoteit_enabled
+        value: "{{ remoteit_enabled }}"
+      # - option: remoteit_claim_code
+      #   value: "{{ remoteit_claim_code.stdout }}"
+
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -58,9 +58,9 @@ if [ -f /etc/remoteit/config.json ]; then
     if [[ $ans =~ ^[nN]$ ]]; then    # Nearly the same as Lines 142-189
         echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
 
-        systemctl enable connectd
-        systemctl restart connectd
-        systemctl enable schannel
+        /usr/share/remoteit/refresh.sh    # Just like connectd systemd service
+        # prior to 4.15.2 (its new remoteit-refresh.service is insufficient, as
+        # it's not installed initially, by their curl script install_agent.sh)
 
         if grep -q '^remoteit_enabled:' /etc/iiab/local_vars.yml; then
             sed -i "s/^remoteit_enabled:.*/remoteit_enabled: True/" /etc/iiab/local_vars.yml
@@ -123,9 +123,7 @@ else
     # regardless whether /etc/remoteit/registration exists and what it contains,
     # and regardless whether /etc/remoteit/config.json contains a claim code.
 
-    echo -e "In a few seconds, all 3 {connectd, schannel, remoteit@...} should be enabled!\n"
-
-    systemctl stop connectd    # "Safer" (though it's generally exited already!)
+    echo -e "In a few seconds, both services {schannel, remoteit@...} should be enabled!\n"
 
     #if [ ! -f /etc/remoteit/registration ] && [ -f /etc/remoteit/config.json ]; then
     if [ -f /etc/remoteit/config.json ]; then
@@ -139,20 +137,18 @@ else
         echo -e "/etc/remoteit/config.json moved aside, for fresh device registration.\n"
     fi
 
-    systemctl start connectd    # Registration logic (use license key or
-    # generate claim code) then kickstart 2 "child" services below.
-    # FYI running /usr/share/remoteit/refresh.sh appears to do the exact same
-    # thing (as bouncing service connectd).
+    /usr/share/remoteit/refresh.sh    # Registration logic (use license key or
+    # generate claim code) then kickstart 2 "child" services below.  In the
+    # past, we bounced the connectd service which did the same, and we enabled
+    # services {connectd, schannel} like enable-or-disable.yml used to do too.
 
-    systemctl enable connectd    # 2 enable lines, like enable-or-disable.yml
+    # schannel.service - Remote tcp command service
+    # remoteit@80:00:01:7F:7E:00:56:36.service - Remote tcp connection service
 
-    # schannel = "Remote tcp command service" started by connectd above if nec
-    systemctl enable schannel    # 2 enable lines, like enable-or-disable.yml
-
-    # "Remote tcp connection service" appears a few seconds after connectd is
-    # started above.  Auto-enabled when spawned by connectd, SO NOT NEC HERE:
+    # Both above appear a few seconds after refresh.sh is run, MANUAL NOT NEC:
     # systemctl enable $(ls /etc/systemd/system/multi-user.target.wants/ | grep remoteit@*)
-    # These systemd service names e.g. remoteit@80:00:01:7F:7E:00:56:36.service
+
+    # FYI systemd service names like remoteit@80:00:01:7F:7E:00:56:36.service
     # change, e.g. when a new claim code is generated, and more arise when the
     # IIAB device is registered to a remote.it account (#3166), etc.
 fi

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -55,7 +55,7 @@ if [ -f /etc/remoteit/config.json ]; then
     read -n 1 -r ans < /dev/tty    # Prompt for a single character
     echo; echo
 
-    if [[ $ans = "n" || $ans = "N" ]]; then    # Nearly the same as Lines 142-189
+    if [[ $ans =~ ^[nN]$ ]]; then    # Nearly the same as Lines 142-189
         echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
 
         systemctl enable connectd
@@ -88,7 +88,7 @@ echo -en "\e[1m\nOptionally purge + install latest remote.it Device Package? [y/
 read -n 1 -r ans < /dev/tty    # Prompt for a single character
 echo; echo
 
-if [[ $ans = "y" || $ans = "Y" ]]; then
+if [[ $ans =~ ^[yY]$ ]]; then
     # Full apt path avoids problematic /usr/local/bin/apt on Linux Mint
     /usr/bin/apt -y purge "remoteit*" || true
 

--- a/roles/remoteit/templates/iiab-remoteit
+++ b/roles/remoteit/templates/iiab-remoteit
@@ -55,7 +55,7 @@ if [ -f /etc/remoteit/config.json ]; then
     read -n 1 -r ans < /dev/tty    # Prompt for a single character
     echo; echo
 
-    if [[ $ans =~ ^[nN]$ ]]; then    # Nearly the same as Lines 142-189
+    if [[ $ans =~ ^[nN]$ ]]; then    # Nearly the same as Lines 140-185
         echo -e "Let's try to enable remote.it, with your existing /etc/remoteit/config.json...\n"
 
         /usr/share/remoteit/refresh.sh    # Just like connectd systemd service

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -17,9 +17,9 @@ fi
 # 3 sections below should be equivalent to -- and much faster than:
 # https://github.com/iiab/iiab/tree/master/roles/remoteit/tasks/enable-or-disable.yml
 
-# remote.it "parent" service
-systemctl stop connectd || true    # connectd may not exist.  See PR #3363
-systemctl disable connectd || true
+# remote.it "parent" service no longer part of Device Package 4.15.2 on 2022-09-07
+#systemctl stop connectd
+#systemctl disable connectd
 
 # "Remote tcp command service"
 systemctl stop schannel

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -18,7 +18,7 @@ fi
 # https://github.com/iiab/iiab/tree/master/roles/remoteit/tasks/enable-or-disable.yml
 
 # remote.it "parent" service
-systemctl stop connectd || true    # connectd may no longer exist. See PR #3363
+systemctl stop connectd || true    # connectd may not exist.  See PR #3363
 systemctl disable connectd || true
 
 # "Remote tcp command service"

--- a/roles/remoteit/templates/iiab-remoteit-off
+++ b/roles/remoteit/templates/iiab-remoteit-off
@@ -18,8 +18,8 @@ fi
 # https://github.com/iiab/iiab/tree/master/roles/remoteit/tasks/enable-or-disable.yml
 
 # remote.it "parent" service
-systemctl stop connectd
-systemctl disable connectd
+systemctl stop connectd || true    # connectd may no longer exist. See PR #3363
+systemctl disable connectd || true
 
 # "Remote tcp command service"
 systemctl stop schannel


### PR DESCRIPTION
remote.it Device Packages 4.15.2 removed their **connectd** "parent" systemd service as of 2022-09-07.  So instead of bouncing their connectd service, going forward, we'll instead run `/usr/share/remoteit/refresh.sh` which should generally do the exact same thing.

This PR aims for a cleaner all-around solution to remote.it frailties.

Recognizing that `/etc/remoteit/config.json` may or may not exist a priori (with or without a claim code) and that `/etc/remoteif/registration` can be in any one of 3 states {doesn't exist, is empty to block registration handshake, OR contains a [presumably valid!] remoteit_license_key} ...until remote.it is enabled by either...

- `sudo /usr/bin/iiab-remoteit`

Or...

- `./runrole remoteit` which runs `roles/remoteit/tasks/enable-or-disable.yml` (after you set `remoteit_enabled: True` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?))

Needs testing in coming days!

Building on:

- PR #3161
- PR #3363