### PR TITLE
mongodb/tasks/install.yml: Force libssl1.1 on is_linuxmint_21 too (for Sugarizer)

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -115,20 +115,20 @@
     apt_repository:
       repo: deb http://security.ubuntu.com/ubuntu focal-security main
       #filename: focal-security    # If filename focal-security.list is preferred
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21
 
   - name: Install libssl1.1 if Ubuntu 22.04+ (required by MongoDB below)
     package:
       name: libssl1.1
       state: present
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21
 
   - name: Remove source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+
     apt_repository:
       repo: deb http://security.ubuntu.com/ubuntu focal-security main
       state: absent
       #filename: focal-security    # 100% IGNORED during repo deletion
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=')
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21
 
   # # Debian 10 aarch64 might work below but is blocked in main.yml
   # - name: Use mongodb-org's Ubuntu focal repo for RasPiOS-aarch64


### PR DESCRIPTION
Tested on Mint 21.

Building on:

- PR #3380