### PR TITLE
2-common/tasks/packages.yml: Debian 12 needs 'apt install cron'

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -1,10 +1,11 @@
 # 2022-03-16: 'apt show <pkg> | grep Size' revealed download sizes, on 64-bit RasPiOS with desktop.
 
-- name: "Install 16 common packages: acpid, bzip2, curl, gawk, htop, i2c-tools, logrotate, plocate, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
+- name: "Install 17 common packages: acpid, bzip2, cron, curl, gawk, htop, i2c-tools, logrotate, plocate, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:
     name:
       - acpid              #   55kB download: Daemon for ACPI (power mgmt) events
       - bzip2              #   47kB download: RasPiOS installs this regardless -- 2021-04-26: Prob not used, but can't hurt?
+      - cron               #   98kB download: RasPiOS installs this regardless -- 2022-10-13: Debian 12 needs this added (for now?)
       - curl               #  254kB download: RasPiOS installs this regardless -- Used to install roles/nodejs and roles/nodered
       #- etckeeper         #   54kB download: "nobody is really using etckeeper and it's bloating the filesystem every time apt runs" per @jvonau at https://github.com/iiab/iiab/issues/1146
       #- exfat-fuse        #   28kB download: 2021-07-27: Should no longer be nec with 5.4+ kernels, so let's try commenting it out


### PR DESCRIPTION
Resolves several issues mentioned here:

- #3399