### PR TITLE
Copy Node-RED's default settings.js from /usr/lib/... OR /usr/local/lib/…

### DIFF
--- a/roles/nodered/tasks/settings.yml
+++ b/roles/nodered/tasks/settings.yml
@@ -39,7 +39,7 @@
 #- name: Run 'node-red admin init' as user '{{ nodered_linux_user }}' to create /home/{{ nodered_linux_user }}/.node-red/settings.js
 #  command: runuser -u {{ nodered_linux_user }} node-red admin init
 
-# 2022-10-13: These 9 lines can likely be removed later in 2023 or 2024?
+# 2022-10-13: These 9 lines (OLD WAY) might be removable by ~2024?  PR #3402
 - name: "OLD WAY: Copy /usr/lib/node_modules/node-red/settings.js to /home/{{ nodered_linux_user }}/.node-red/settings.js"
   copy:
     remote_src: yes

--- a/roles/nodered/tasks/settings.yml
+++ b/roles/nodered/tasks/settings.yml
@@ -39,7 +39,8 @@
 #- name: Run 'node-red admin init' as user '{{ nodered_linux_user }}' to create /home/{{ nodered_linux_user }}/.node-red/settings.js
 #  command: runuser -u {{ nodered_linux_user }} node-red admin init
 
-- name: Copy /usr/lib/node_modules/node-red/settings.js to /home/{{ nodered_linux_user }}/.node-red/settings.js
+# 2022-10-13: These 9 lines can likely be removed later in 2023 or 2024?
+- name: "OLD WAY: Copy /usr/lib/node_modules/node-red/settings.js to /home/{{ nodered_linux_user }}/.node-red/settings.js"
   copy:
     remote_src: yes
     src: /usr/lib/node_modules/node-red/settings.js
@@ -47,6 +48,17 @@
     owner: "{{ nodered_linux_user }}"
     group: "{{ nodered_linux_user }}"
     #mode: preserve    # Implied (and required) w/ remote_src, since Ansible 2.6
+  ignore_errors: yes
+
+- name: "NEW WAY: Copy /usr/local/lib/node_modules/node-red/settings.js to /home/{{ nodered_linux_user }}/.node-red/settings.js"
+  copy:
+    remote_src: yes
+    src: /usr/local/lib/node_modules/node-red/settings.js
+    dest: /home/{{ nodered_linux_user }}/.node-red/settings.js
+    owner: "{{ nodered_linux_user }}"
+    group: "{{ nodered_linux_user }}"
+    #mode: preserve    # Implied (and required) w/ remote_src, since Ansible 2.6
+  ignore_errors: yes
 
 
 - name: Splice username and password into /home/{{ nodered_linux_user }}/.node-red/settings.js


### PR DESCRIPTION
Fixes:

- #3401 

Tested on the latest pre-release of Ubuntu Server 22.10

It's possible (but not certain!) this patch might no longer be necessary by/around 2024 &mdash; if conflicting path norms across different distros later converge (maybe) on one of these two paths.

(e.g. `/usr/local/lib/node_modules/node-red/settings.js` hypothetically, that being the newer of the two paths?)

FINALLY: Bright red Ansible output is used on purpose (`ignore_errors: yes`) to draw attention to this pattern so it can be monitored over the coming year or so.

Related:

- PR #3248