### PR TITLE
Modernize install of Kolibri PPA for Ubuntu 22.04+ (e.g. 23.04, 23.10, etc)

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -61,15 +61,17 @@
       gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
       gpg --yes --output /usr/share/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
 
-  - name: Add signed Kolibri PPA 'jammy' (if Ubuntu 22.04 or 22.10 or Mint 21 or Debian 12)
+  - name: Add signed Kolibri PPA 'jammy' (if Ubuntu 22.04+ or Mint 21 or Debian 12)
     apt_repository:
       repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
-    when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
+    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
+    #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
 
   - name: Add signed Kolibri PPA 'focal' (if other/older OS's)
     apt_repository:
       repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu focal main"
-    when: not (is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12)
+    when: not (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12)
+    #when: not (is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12)
 
   # - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu and not is_linuxmint)
   #   apt_repository:


### PR DESCRIPTION
Thanks to:

```
when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
```

Much like roles/mongodb: https://github.com/iiab/iiab/blob/33f1989c7bb3ddf7ddab8d780fea570c24395dc2/roles/mongodb/tasks/install.yml#L120-L161

Tested on Ubuntu 22.10

Related:

- #3343
- PR #3356
- PR #3380