### PR TITLE
Debian 12 Bookworm uses PostgreSQL 15 (released 2022-10-13)

### DIFF
--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -18,6 +18,6 @@ mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
 php_version: 8.1
-postgresql_version: 14
+postgresql_version: 15
 systemd_location: /lib/systemd/system
 python_ver: "3.10"


### PR DESCRIPTION
Background;

- https://packages.debian.org/bookworm/postgresql
- https://www.postgresql.org/about/news/postgresql-15-released-2526/

Likely they'll also make the transition to Python 3.11 and PHP 8.2 before end of year...

Related:

- #3399