### PR TITLE
Preliminary support for Ubuntu 23.04 Lunar Lobster

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -28,7 +28,7 @@
     virtualenv_command: /usr/bin/virtualenv
     virtualenv_python: python2.7
     extra_args: "--no-use-pep517 --no-cache-dir --no-python-version-warning"
-  when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
+  #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
   # long form of (is_debian_11+ or is_ubuntu_20+)
 
 - name: Use pip to install ka-lite-static to {{ kalite_venv }}
@@ -63,7 +63,7 @@
     path: "{{ kalite_venv }}/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py"    # /usr/local/kalite/venv
     regexp: 'a-zA-Z0-9'
     replace: 'a-zA-Z0-9\-'
-  when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
+  #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
   # JV: why not just is_ubuntu_20? AH: to make this work on Ubuntu 21+ and ideally Debian/RasPiOS 11+ too?
 
@@ -72,7 +72,7 @@
     path: "{{ kalite_venv }}/local/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py"
     regexp: 'a-zA-Z0-9'
     replace: 'a-zA-Z0-9\-'
-  when: is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19
+  #when: is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 - name: Create dir {{ kalite_root }}

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -20,7 +20,7 @@
   #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
-- name: Use pip to pin setuptools to 44 in {{ kalite_venv }} if Raspbian/Debian > 10 or Ubuntu > 19
+- name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # if Raspbian/Debian > 10 or Ubuntu > 19
   pip:
     name: setuptools==44
     virtualenv: "{{ kalite_venv }}"    # /usr/local/kalite/venv
@@ -58,7 +58,7 @@
 #     dest: "/etc/{{ apache_conf_dir }}"    # apache2/sites-available on debuntu
 #   when: apache_installed is defined
 
-- name: Fix KA Lite bug in regex parsing ifconfig output (ifcfg/parser.py) for @m-anish's network names that contain dashes, if Raspbian/Debian > 10 or Ubuntu > 19
+- name: Fix KA Lite bug in regex parsing ifconfig output (ifcfg/parser.py) for @m-anish's network names that contain dashes    # if Raspbian/Debian > 10 or Ubuntu > 19
   replace:
     path: "{{ kalite_venv }}/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py"    # /usr/local/kalite/venv
     regexp: 'a-zA-Z0-9'
@@ -67,13 +67,13 @@
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
   # JV: why not just is_ubuntu_20? AH: to make this work on Ubuntu 21+ and ideally Debian/RasPiOS 11+ too?
 
-- name: Fix KA Lite bug in regex parsing ifconfig output (ifcfg/parser.py) for @m-anish's network names that contain dashes, if Raspbian/Debian < 11 or Ubuntu < 20
-  replace:
-    path: "{{ kalite_venv }}/local/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py"
-    regexp: 'a-zA-Z0-9'
-    replace: 'a-zA-Z0-9\-'
-  #when: is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19
-  # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
+# - name: Fix KA Lite bug in regex parsing ifconfig output (ifcfg/parser.py) for @m-anish's network names that contain dashes, if Raspbian/Debian < 11 or Ubuntu < 20
+#   replace:
+#     path: "{{ kalite_venv }}/local/lib/python2.7/site-packages/kalite/packages/dist/ifcfg/parser.py"
+#     regexp: 'a-zA-Z0-9'
+#     replace: 'a-zA-Z0-9\-'
+#   when: is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19
+#   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 - name: Create dir {{ kalite_root }}
   file:

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -41,7 +41,8 @@
 
   - name: Install Monit if 'monit_installed' not defined, e.g. in {{ iiab_state_file }} AND not Debian 10    # /etc/iiab/iiab_state.yml
     include_tasks: install.yml
-    when: monit_installed is undefined and not (is_debian_10 and not is_raspbian)
+    when: monit_installed is undefined
+    #when: monit_installed is undefined and not (is_debian_10 and not is_raspbian)
     #when: monit_installed is undefined and not ((is_debian and not is_raspbian) and (not is_debian_8) and (not is_debian_9))
 
 

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -1,9 +1,9 @@
-- name: Create a user for avahi (debuntu)
+- name: Create user 'avahi'
   user:
     name: avahi
     createhome: no
     shell: /bin/false
-  when: is_debuntu
+  #when: is_debuntu
 
 - name: Install avahi announce config file /etc/avahi/services/schoolserver.service
   template:
@@ -20,24 +20,24 @@
   # IF >= 2, Admin Console $gui_port from 0-init determines which port (http-or-https) is opened here:
   # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L133-L138
 
-- name: Find avahi_ver for clean copy of ssh.service (not debuntu)
-  shell: "ls /usr/share/doc/ | grep avahi | head -n1"
-  register: avahi_ver
-  ignore_errors: True
-  changed_when: False
-  # when: not is_debuntu    # would cause failures 6 lines below
+# - name: Find avahi_ver for clean copy of ssh.service (not debuntu)
+#   shell: "ls /usr/share/doc/ | grep avahi | head -n1"
+#   register: avahi_ver
+#   ignore_errors: True
+#   changed_when: False
+#   # when: not is_debuntu    # would cause failures 6 lines below
 
-- name: Grab a clean copy of ssh.service (not debuntu)
-  copy:
-    src: '/usr/share/doc/{{ avahi_ver.stdout }}/ssh.service'
-    dest: /etc/avahi/services/
-  when: avahi_ver.stdout != "" and not is_debuntu
+# - name: Grab a clean copy of ssh.service (not debuntu)
+#   copy:
+#     src: '/usr/share/doc/{{ avahi_ver.stdout }}/ssh.service'
+#     dest: /etc/avahi/services/
+#   when: avahi_ver.stdout != "" and not is_debuntu
 
-- name: Grab a clean copy of ssh.service (debuntu)
+- name: Grab a clean copy of ssh.service
   copy:
     src: /usr/share/doc/avahi-daemon/examples/ssh.service
     dest: /etc/avahi/services/
-  when: is_debuntu
+  #when: is_debuntu
 
 - name: Set ssh port for avahi
   lineinfile:

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -53,14 +53,16 @@
   template:
     dest: /etc/network/interfaces.d/patch_auto
     src: network/debian-auto.j2
-  when: iiab_wan_iface != "none" and is_debian and not is_debian_8
+  when: iiab_wan_iface != "none" and is_debian
+  #when: iiab_wan_iface != "none" and is_debian and not is_debian_8
 
 - name: Clearing out /etc/network/interfaces for static addresses (debian-9+)
   lineinfile:
     state: absent
     path: /etc/network/interfaces
     regexp: "{{ iiab_wan_iface }}"
-  when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian and not is_debian_8
+  when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian
+  #when: wan_ip != "dhcp" and iiab_wan_iface != "none" and is_debian and not is_debian_8
 
 #- include_tasks: down-debian.yml
 

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -60,13 +60,14 @@
 
 - name: Check /etc/network/interfaces for gateway
   shell: grep {{ device_gw }} /etc/network/interfaces | wc -l
-  when: is_debuntu
+  #when: is_debuntu
   register: wan_file
 
 - name: Setting wan_in_interfaces
   set_fact:
     wan_in_interfaces: True
-  when: is_debuntu and (wan_file.stdout|int > 0)
+  when: wan_file.stdout|int > 0
+  #when: is_debuntu and (wan_file.stdout|int > 0)
 
 # WIRELESS -- if any wireless is detected as gateway, it becomes WAN
 - name: Look for any wireless interfaces
@@ -220,7 +221,8 @@
 - name: For Debian, always use bridging
   set_fact:
     iiab_lan_iface: br0
-  when: num_lan_interfaces|int >= 1 and is_debuntu
+  when: num_lan_interfaces|int >= 1
+  #when: num_lan_interfaces|int >= 1 and is_debuntu
 
 - name: WiFi is on the LAN - use bridging
   set_fact:

--- a/roles/network/tasks/dhcpd.yml.unused
+++ b/roles/network/tasks/dhcpd.yml.unused
@@ -28,7 +28,8 @@
     name: "{{ dhcp_service }}6"
     enabled: no
     state: stopped
-  when: is_ubuntu and not is_ubuntu_16
+  when: is_ubuntu
+  #when: is_ubuntu and not is_ubuntu_16
   #when: is_ubuntu_18
 
 - name: Install systemd unit file to /etc/systemd/system/dhcpd.service

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -76,11 +76,13 @@
 
   - name: NetworkManager in use
     include_tasks: NM-debian.yml
-    when: is_debuntu and network_manager_active
+    when: network_manager_active
+    #when: is_debuntu and network_manager_active
 
   - name: systemd-networkd in use
     include_tasks: sysd-netd-debian.yml
-    when: is_debuntu and systemd_networkd_active
+    when: systemd_networkd_active
+    #when: is_debuntu and systemd_networkd_active
 
   - name: Raspbian can use dhcpcd only with no N-M or SYS-NETD active
     include_tasks: rpi_debian.yml
@@ -88,7 +90,8 @@
 
   - name: Not RPi, Not NetworkManager, Not systemd-networkd in use
     include_tasks: debian.yml
-    when: (not is_raspbian and not network_manager_active and not systemd_networkd_active and is_debuntu) or is_ubuntu_16
+    when: not is_raspbian and not network_manager_active and not systemd_networkd_active
+    #when: (not is_raspbian and not network_manager_active and not systemd_networkd_active and is_debuntu) or is_ubuntu_16
   #### end network layout
 
   - name: Restart services

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -40,7 +40,8 @@
   template:
     dest: /etc/systemd/network/IIAB-Static.network
     src: network/systemd-static-net.j2
-  when: wan_ip != "dhcp" and ( is_ubuntu_16 or not network_manager_active )
+  when: wan_ip != "dhcp" and not network_manager_active
+  #when: wan_ip != "dhcp" and ( is_ubuntu_16 or not network_manager_active )
 
 - name: Create networkd-dispatcher diagnostic hook for recording network events
   template:

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -79,6 +79,7 @@ case $OS_VER in
     "ubuntu-2004"  | \
     "ubuntu-2204"  | \
     "ubuntu-2210"  | \
+    "ubuntu-2304"  | \
     "linuxmint-20" | \
     "linuxmint-21" | \
     "raspbian-11")

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -17,7 +17,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.4
+php_version: "7.4"
 postgresql_version: 13
 systemd_location: /lib/systemd/system
-python_ver: 3.9
+python_ver: "3.9"

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -17,7 +17,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 8.1
+php_version: "8.1"
 postgresql_version: 15
 systemd_location: /lib/systemd/system
 python_ver: "3.10"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -755,15 +755,16 @@ pbx_http_port: 83
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)
 
 is_ubuntu: False    # Covers: Ubuntu, Linux Mint
+is_ubuntu_2304: False
 is_ubuntu_2210: False
 is_ubuntu_2204: False
-is_ubuntu_2110: False
-is_ubuntu_2104: False
+#is_ubuntu_2110: False
+#is_ubuntu_2104: False
 is_ubuntu_2004: False
-is_ubuntu_19: False
-is_ubuntu_18: False
-is_ubuntu_17: False
-is_ubuntu_16: False
+#is_ubuntu_19: False
+#is_ubuntu_18: False
+#is_ubuntu_17: False
+#is_ubuntu_16: False
 
 is_linuxmint: False    # Subset of is_ubuntu
 is_linuxmint_21: False
@@ -772,22 +773,22 @@ is_linuxmint_20: False
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
 is_debian_12: False
 is_debian_11: False
-is_debian_10: False
-is_debian_9: False
-is_debian_8: False
+#is_debian_10: False
+#is_debian_9: False
+#is_debian_8: False
 
 is_raspbian: False    # Covers both: RPi HW + non-RPi HW versions of Raspberry Pi OS (Raspbian)
 is_raspbian_11: False
-is_raspbian_10: False
-is_raspbian_9: False
-is_raspbian_8: False
+#is_raspbian_10: False
+#is_raspbian_9: False
+#is_raspbian_8: False
 
-is_redhat: False    # Not well supported as of 2019, see: https://github.com/iiab/iiab/issues/1434
-is_centos: False
-is_centos_7: False
-is_fedora: False
-is_fedora_22: False
-is_fedora_18: False
+#is_redhat: False    # Unsupported as of 2019, see: https://github.com/iiab/iiab/issues/1434
+#is_centos: False
+#is_centos_7: False
+#is_fedora: False
+#is_fedora_22: False
+#is_fedora_18: False
 
 # How This Works:
 #

--- a/vars/linuxmint-20.yml
+++ b/vars/linuxmint-20.yml
@@ -19,7 +19,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.4
+php_version: "7.4"
 postgresql_version: 12
 systemd_location: /lib/systemd/system
-python_ver: 3.8
+python_ver: "3.8"

--- a/vars/linuxmint-21.yml
+++ b/vars/linuxmint-21.yml
@@ -19,7 +19,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 8.1
+php_version: "8.1"
 postgresql_version: 14
 systemd_location: /lib/systemd/system
 python_ver: "3.10"

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -19,10 +19,10 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: ssh
 sshd_service: ssh
-php_version: 7.4
+php_version: "7.4"
 postgresql_version: 13
 systemd_location: /lib/systemd/system
-python_ver: 3.9
+python_ver: "3.9"
 
 # Minetest for RPi
 minetest_server_bin: /library/games/minetest/bin/minetestserver

--- a/vars/ubuntu-2004.yml
+++ b/vars/ubuntu-2004.yml
@@ -17,7 +17,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 7.4
+php_version: "7.4"
 postgresql_version: 12
 systemd_location: /lib/systemd/system
-python_ver: 3.8
+python_ver: "3.8"

--- a/vars/ubuntu-2204.yml
+++ b/vars/ubuntu-2204.yml
@@ -17,7 +17,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 8.1
+php_version: "8.1"
 postgresql_version: 14
 systemd_location: /lib/systemd/system
 python_ver: "3.10"

--- a/vars/ubuntu-2210.yml
+++ b/vars/ubuntu-2210.yml
@@ -17,7 +17,7 @@ systemctl_program: /bin/systemctl
 mysql_service: mariadb
 sshd_package: openssh-server
 sshd_service: ssh
-php_version: 8.1
+php_version: "8.1"
 postgresql_version: 14
 systemd_location: /lib/systemd/system
 python_ver: "3.10"


### PR DESCRIPTION
FYI Ubuntu 20.04 will be desupported later in November, as its 3-year anniversary approaches.

Supporting 4 different versions of Ubuntu balkanizes community focus, while damaging both software and support quality.

People who volunteer many 100s of hours of their lives monitoring the security and reliability of IIAB and its dozen of apps (and documenting this, to serve others) should not be stretched too thin.

Tangentially related:

- #3189
- PR #3413