### PR TITLE
Recommend ansible-core 2.14.0

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.13.5]
-GOOD_VER=2.13.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.14.0]
+GOOD_VER=2.14.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -34,6 +34,8 @@ GOOD_VER=2.13.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # https://www.ansible.com/blog/ansible-3.0.0-qa
 # https://github.com/ansible/ansible/tags
 # https://github.com/ansible/ansible/releases (OLD)
+# https://github.com/ansible/ansible/commits/stable-2.14
+# https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst
 # https://github.com/ansible/ansible/commits/stable-2.13
 # https://github.com/ansible/ansible/blob/stable-2.13/changelogs/CHANGELOG-v2.13.rst
 # https://github.com/ansible/ansible/commits/stable-2.12


### PR DESCRIPTION
FYI `pip install ansible-core==2.14.0rc2` from 6 days ago (https://pypi.org/project/ansible-core/2.14.0rc2/) worked on Ubuntu 22.10 (when the tiny PR's below were included) so Ansible 2.14.0's final release (when released in coming hours) should too.

Changelog:
https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst

Nitty-gritty:
https://github.com/ansible/ansible/commits/stable-2.14

Related:

- #3396
- PR #3417
- PR iiab/iiab-admin-console#516