### PR TITLE
(1) ansible-core 2.14.0 fails to install on 32-bit ARM OS's (2) Some 32-bit RPi OS's end up upgrading to the older ansible-core 2.11.x

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,8 +10,8 @@ ARGS="--extra-vars {"    # Needs boolean not string so use JSON list.  bash forc
 CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}    # Remove all '"'
-MIN_RPI_KERN=5.4.0        # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.12.7    # Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+MIN_RPI_KERN=5.4.0         # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
+MIN_ANSIBLE_VER=2.11.12    # 2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
 
 REINSTALL=false
 DEBUG=false


### PR DESCRIPTION
Thanks @deldesir for surfacing this bug, on Raspberry Pi OS Lite (64-bit??) on a Raspberry Pi 3 Model B Rev 1.2

I've confirmed with 32-bit Raspberry Pi OS with desktop (32-bit) on an identical CPU to his.

@deldesir please explain more if you discover more details in coming days, Thanks!

Related:

- PR #3418