### PR TITLE
pin ansible-core to 2.13.5

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -8,7 +8,7 @@
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
 CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.14.0]
-GOOD_VER=2.14.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+GOOD_VER=2.13.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -177,8 +177,8 @@ $APT_PATH/apt -y install python3-pip
 # https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
 # https://github.com/iiab/iiab/pull/3022
 pip3 config --global set global.no-cache-dir false
-echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
-pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+echo -e "\n\n'pip3 install --upgrade ansible-core==$GOOD_VER' will now run:\n"
+pip3 install --upgrade ansible-core==$GOOD_VER    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support


### PR DESCRIPTION
#3418 #3419 tested in build pipeline OS 2022-09-22-raspios-bullseye-armhf.img.xz
```
YOU ARE RUNNING: /opt/iiab/iiab/scripts/ansible (TO INSTALL ANSIBLE ETC)

RECOMMENDED PREREQUISITES:
(1) Verify you're online
(2) Remove all prior versions of Ansible using...
    'apt purge ansible-core'  and/or  'pip3 uninstall ansible-core'  and/or
    'apt purge ansible-base'  and/or  'pip3 uninstall ansible-base'  and/or
    'apt purge ansible'       and/or  'pip3 uninstall ansible'
(3) Remove all lines containing 'ansible' from...
    /etc/apt/sources.list and /etc/apt/sources.list.d/*

IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)
https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch

ANSIBLE NOT FOUND ON THIS COMPUTER -- LET'S TRY TO INSTALL IT!
(Internet-in-a-Box requests ansible-core 2.13.5 or higher)


apt update; apt install python3-pip    # Also installs 'python3-setuptools' and 'python3' etc
Hit:1 http://raspbian.raspberrypi.org/raspbian bullseye InRelease
Hit:2 http://archive.raspberrypi.org/debian bullseye InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3-pip is already the newest version (20.3.4-4+rpt1+deb11u1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Writing to /etc/pip.conf


'pip3 install --upgrade ansible-core==2.13.5' will now run:

Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting ansible-core==2.13.5
  Downloading https://www.piwheels.org/simple/ansible-core/ansible_core-2.13.5-py3-none-any.whl (2.1 MB)
     |████████████████████████████████| 2.1 MB 336 kB/s 
Requirement already satisfied: cryptography in /usr/lib/python3/dist-packages (from ansible-core==2.13.5) (3.3.2)
Collecting PyYAML>=5.1
  Downloading https://www.piwheels.org/simple/pyyaml/PyYAML-6.0-cp39-cp39-linux_armv7l.whl (45 kB)
     |████████████████████████████████| 45 kB 3.4 MB/s 
Collecting resolvelib<0.9.0,>=0.5.3
  Downloading https://www.piwheels.org/simple/resolvelib/resolvelib-0.8.1-py2.py3-none-any.whl (16 kB)
Collecting jinja2>=3.0.0
  Downloading https://www.piwheels.org/simple/jinja2/Jinja2-3.1.2-py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 5.1 MB/s 
Collecting packaging
  Downloading https://www.piwheels.org/simple/packaging/packaging-21.3-py3-none-any.whl (40 kB)
     |████████████████████████████████| 40 kB 3.1 MB/s 
Collecting MarkupSafe>=2.0
  Downloading https://www.piwheels.org/simple/markupsafe/MarkupSafe-2.1.1-cp39-cp39-linux_armv7l.whl (23 kB)
Collecting pyparsing!=3.0.5,>=2.0.2
  Downloading https://www.piwheels.org/simple/pyparsing/pyparsing-3.0.9-py3-none-any.whl (98 kB)
     |████████████████████████████████| 98 kB 352 kB/s 
Installing collected packages: pyparsing, MarkupSafe, resolvelib, PyYAML, packaging, jinja2, ansible-core
  Attempting uninstall: MarkupSafe
    Found existing installation: MarkupSafe 1.1.1
    Not uninstalling markupsafe at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'MarkupSafe'. No files were found to uninstall.
  Attempting uninstall: jinja2
    Found existing installation: Jinja2 2.11.3
    Not uninstalling jinja2 at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'Jinja2'. No files were found to uninstall.
Successfully installed MarkupSafe-2.1.1 PyYAML-6.0 ansible-core-2.13.5 jinja2-3.1.2 packaging-21.3 pyparsing-3.0.9 resolvelib-0.8.1


IIAB requires these ~4 Ansible Collections: (we upgrade them here if possible!)

Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/download/ansible-posix-1.4.0.tar.gz to /root/.ansible/tmp/ansible-local-98874q79drm7k/tmpc_lwrn5p/ansible-posix-1.4.0-1zcta7w7
Installing 'ansible.posix:1.4.0' to '/usr/share/ansible/collections/ansible_collections/ansible/posix'
Downloading https://galaxy.ansible.com/download/community-postgresql-2.3.0.tar.gz to /root/.ansible/tmp/ansible-local-98874q79drm7k/tmpc_lwrn5p/community-postgresql-2.3.0-00l19g5o
ansible.posix:1.4.0 was installed successfully
Installing 'community.postgresql:2.3.0' to '/usr/share/ansible/collections/ansible_collections/community/postgresql'
Downloading https://galaxy.ansible.com/download/community-mysql-3.5.1.tar.gz to /root/.ansible/tmp/ansible-local-98874q79drm7k/tmpc_lwrn5p/community-mysql-3.5.1-agrxi8nk
community.postgresql:2.3.0 was installed successfully
Installing 'community.mysql:3.5.1' to '/usr/share/ansible/collections/ansible_collections/community/mysql'
Downloading https://galaxy.ansible.com/download/community-general-6.0.0.tar.gz to /root/.ansible/tmp/ansible-local-98874q79drm7k/tmpc_lwrn5p/community-general-6.0.0-7g770ehx
community.mysql:3.5.1 was installed successfully
Installing 'community.general:6.0.0' to '/usr/share/ansible/collections/ansible_collections/community/general'
community.general:6.0.0 was installed successfully


SUCCESS!  PLEASE VERIFY ANSIBLE WITH COMMANDS LIKE:

    ansible --version
    pip3 show ansible-core
    apt -a list "ansible*"
    ansible-galaxy collection list

WARNING: Start a new Linux shell, if it changed from /usr/bin to /usr/local/bin
```