### PR TITLE
Til wheels / cryptography fixed: ansible-core 2.12.10+ PPA on 32-bit RasPiOS

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -128,6 +128,10 @@ fi
 ###echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $CODENAME main" \
 ###     > /etc/apt/sources.list.d/iiab-ansible.list
 
+# 2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
+echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu focal main" \
+     > /etc/apt/sources.list.d/iiab-ansible.list
+
 # In future we might instead consider 'add-apt-repository ppa:ansible/ansible'
 # or 'apt-add-repository ppa:ansible/bionic/ansible' etc, e.g. for streamlined
 # removal using 'apt-add-repository -r' -- however that currently requires
@@ -146,6 +150,9 @@ fi
 #apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
 ###cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
 #chmod 644 /usr/share/keyrings/iiab-ansible-keyring.gpg
+
+# 2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
+cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
 
 ###echo -e 'PPA source "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu '$CODENAME' main"'
 ###echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
@@ -172,13 +179,18 @@ $APT_PATH/apt -y install python3-pip
 
 #$APT_PATH/apt -y --allow-downgrades install ansible-core
 
-# 2021-10-30: Using pip is messy, leaving behind cached files, so turn off pip
-# cache system-wide before installing:
-# https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
-# https://github.com/iiab/iiab/pull/3022
-pip3 config --global set global.no-cache-dir false
-echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
-pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+if uname -m | grep -q 64; then
+    # 2021-10-30: Using pip is messy, leaving behind cached files, so turn off pip
+    # cache system-wide before installing:
+    # https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
+    # https://github.com/iiab/iiab/pull/3022
+    pip3 config --global set global.no-cache-dir false
+    echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
+    pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+else
+    echo "2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
+    $APT_PATH/apt -y --allow-downgrades install ansible-core
+fi
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -128,7 +128,7 @@ fi
 ###echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $CODENAME main" \
 ###     > /etc/apt/sources.list.d/iiab-ansible.list
 
-# 2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
+# 2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
 echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu focal main" \
      > /etc/apt/sources.list.d/iiab-ansible.list
 
@@ -151,7 +151,7 @@ echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.la
 ###cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
 #chmod 644 /usr/share/keyrings/iiab-ansible-keyring.gpg
 
-# 2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
+# 2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
 cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
 
 ###echo -e 'PPA source "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu '$CODENAME' main"'
@@ -188,7 +188,7 @@ if uname -m | grep -q 64; then
     echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
     pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 else
-    echo "2022-11-09: ansible-core 2.12.10 PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
+    echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
     $APT_PATH/apt -y --allow-downgrades install ansible-core
 fi
 


### PR DESCRIPTION
All ansible-base and ansible-core versions failed to pip install on 32-bit Raspberry Pi OS Lite according to my tests on RPi 4.  Despite this being a new problem since around mid-August 2022, all versions of 32-bit RasPiOS from 2022 (not just the 2022-09-22 release) now suffer from this same problem.

Examples of the many failures, due to wheels / cryptography being missing:

```
pip3 install ansible-base=2.10.9
pip3 install ansible-core=2.11.12
pip3 install ansible-core=2.12.10
pip3 install ansible-core=2.13.6
pip3 install ansible-core=2.14.0
```

So this PR installs ansible-core 2.12.10 on 32-bit RasPiOS Lite using our original PPA method, well-tested with IIAB installs over many years.

It's quite likely this PR can be reverted in coming months, if/when the wheels / cryptography glitch (which arose around mid-August 2022) is hopefully solved upstream:

- piwheels/piwheels#322
  - PR piwheels/piwheels#328
  - piwheels/packages#329
- pyca/cryptography#7651
- ansible/ansible#79358
- PR #3419
- PR #3420
- https://launchpad.net/~ansible/+archive/ubuntu/ansible (ansible-core PPA's / .deb files from Ubuntu)
- PR #3459

We should entirely avoid mucking around with Ansible internals & dependencies, leaving that job to those upstream.  But just FYI this PR ends up putting the original `cryptography 3.3.2` in place, just as if `pip3 install ansible-core==2.12.10` was still working:

```
# pip3 show cryptography

Name: cryptography
Version: 3.3.2
Summary: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
Home-page: https://github.com/pyca/cryptography
Author: The cryptography developers
Author-email: cryptography-dev@python.org
License: BSD or Apache License, Version 2.0
Location: /usr/lib/python3/dist-packages
Requires:
Required-by: requests-kerberos
```