### PR TITLE
Block iiab-install of JupyterHub & Calibre-Web on 32-bit OS's, til RasPiOS fixes Rust, wheels / cryptography

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: JUPYTERHUB
   include_role:
     name: jupyterhub
-  when: jupyterhub_install
+  when: jupyterhub_install and ansible_machine is search("64")    # 2022-11-10: Avoid installing on 32-bit, until RasPiOS fixes Rust (PR #3421)
 
 # UNMAINTAINED
 - name: LOKOLE

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: CALIBRE-WEB
   include_role:
     name: calibre-web
-  when: calibreweb_install
+  when: calibreweb_install and ansible_machine is search("64")    # 2022-11-10: Avoid installing on 32-bit, until RasPiOS fixes Rust (PR #3421)
 
 # KEEP NEAR THE VERY END as this installs dependencies from Debian's 'testing' branch!
 - name: CALIBRE


### PR DESCRIPTION
These 2 apps should probably not be running on ancient 32-bit "Zero W" machines in the first place!

(But Calibre-Web is part of  the MEDIUM-sized IIAB install, so this will help newcomers from getting tripped up installing something that they shouldn't...)

See:

- "Known Issues" at: https://github.com/iiab/iiab/wiki/IIAB-8.0-Release-Notes#known-issues
- @jvonau's suggestion at: https://github.com/iiab/iiab/pull/3421#issuecomment-1310597316
- https://github.com/iiab/iiab/pull/3459#issuecomment-1378928044