### PR TITLE
Create ubuntu-2304.yml, as daily builds are now available for testing (via Multipass etc)

### DIFF
--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -92,7 +92,7 @@
     state: directory
     path: "{{ nextcloud_root_dir }}"    # /library/www/nextcloud
 
-- name: Unarchive {{ nextcloud_dl_url }} (~138 MB) to {{ nextcloud_root_dir }} (~507 MB initially, 531+ MB later, {{ apache_user }}:{{ apache_user }})
+- name: Unarchive {{ nextcloud_dl_url }} (~138 MB) to {{ nextcloud_root_dir }} (~519 MB initially, {{ apache_user }}:{{ apache_user }})
   unarchive:
     remote_src: yes    # Overwrite even if "already exists on the target"
     src: "{{ nextcloud_dl_url }}"

--- a/vars/ubuntu-2304.yml
+++ b/vars/ubuntu-2304.yml
@@ -1,0 +1,23 @@
+# Every is_<OS> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
+is_ubuntu_2304: True
+
+proxy: squid
+proxy_user: proxy
+apache_service: apache2
+apache_user: www-data
+apache_conf_dir: apache2/sites-available
+apache_log_dir: /var/log/apache2
+apache_log: /var/log/apache2/access.log
+smb_service: smbd
+nmb_service: nmbd
+systemctl_program: /bin/systemctl
+mysql_service: mariadb
+sshd_package: openssh-server
+sshd_service: ssh
+php_version: "8.1"
+postgresql_version: 14
+systemd_location: /lib/systemd/system
+python_ver: "3.10"


### PR DESCRIPTION
e.g. if you run `multipass launch 23.04`

This pre-release OS (Ubuntu 23.04) should make the transition to Python 3.11 around January 5.

Likewise it will probably make the transition from PHP 8.1 to 8.2 sometime early in 2023.

This PR builds on:

- PR #3415