### PR TITLE
Install new Moodle 4.1 LTS, or 4.2dev if OS PHP >= 8.2

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -8,15 +8,15 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# 2022-09-27: Currently testing Moodle's master branch is mandatory if your
-# OS PHP >= 8.1 -- see moodle/tasks/install.yml for detail!
-# (Any moodle_version setting below applies IF-AND-ONLY-IF your OS PHP < 8.1)
-#moodle_version: master              # Try Moodle's "weekly" 4.1dev pre-release, even if OS PHP < 8.1
-moodle_version: MOODLE_400_STABLE    # Use Moodle 4.0
+# 2022-11-27: Currently testing Moodle's master branch is mandatory if your
+# OS PHP >= 8.2, see moodle/tasks/install.yml for detail!  OR, *IF* your
+# OS PHP < 8.2, then {{ moodle_version }} will be attempted:
+moodle_version: MOODLE_401_STABLE    # Moodle 4.1 LTS
+#moodle_version: master              # e.g. to try Moodle's "weekly" 4.2dev pre-release *EVEN IF* OS PHP < 8.2
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 
-moodle_base: "{{ iiab_base }}/moodle"    # /opt/iiab
+moodle_base: "{{ iiab_base }}/moodle"       # /opt/iiab
 moodle_data: "{{ content_base }}/moodle"    # /library
 
 moodle_db_name: moodle

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -43,21 +43,21 @@
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} >= 8.1"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} >= 8.2"
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
     version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022)
-  when: php_version is version('8.1', '>=')
+  when: php_version is version('8.2', '>=')
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} < 8.1
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} < 8.2
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
-    version: "{{ moodle_version }}"    # e.g. master or MOODLE_400_STABLE
-  when: php_version is version('8.1', '<')
+    version: "{{ moodle_version }}"    # e.g. MOODLE_401_STABLE (Moodle 4.1)
+  when: php_version is version('8.2', '<')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -43,15 +43,15 @@
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} >= 8.2"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.2"
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
-    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022)
+    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022)
   when: php_version is version('8.2', '>=')
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~370 MB initially, ~390 MB later) if OS PHP {{ php_version }} < 8.2
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.2
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle


### PR DESCRIPTION
Tested on Ubuntu Server 22.04

For official release of Moodle 4.1 LTS, whose official announcement should be tomorrow (2022-11-28).

Building on:

- #3047 
- PR #3189
- #3190
- PR #3255
- PR #3265
- #3381
- PR #3382
- PR #3415

Tangentionally related:

- #2864