### PR TITLE
Install the new MediaWiki 1.39.0 LTS

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: 1.38    # "1.35" also works
-mediawiki_minor_version: 4
+mediawiki_major_version: 1.39    # "1.35" also works
+mediawiki_minor_version: 0
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Announcement / details:

- https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/NBLSFOQLZKVXWIB3NBHDZ7XGCZB6UXG7/
- https://www.mediawiki.org/wiki/MediaWiki_1.39
- https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/REL1_39/RELEASE-NOTES-1.39

Building on:

- PR #3386