### PR TITLE
Put vars/<OS-VER>.yml files on a diet, moving stale vars to default_vars.yml or roles/X/defaults

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -57,5 +57,6 @@ kiwix_url: /kiwix
 kiwix_url_plus_slash: "{{ kiwix_url }}/"    # /kiwix/
 kiwix_path: "{{ iiab_base }}/kiwix"         # /opt/iiab/kiwix
 
+systemctl_program: /bin/systemctl
 kiwix_nginx_timeout: 600
 kiwix_threads: 4

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -1,0 +1,10 @@
+# sshd_install: True    # Required by OpenVPN
+# sshd_enabled: True
+
+# sshd_port: 22    # Not fully functional.  SEE: roles/sshd/tasks/install.yml
+
+# All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
+# If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
+
+sshd_package: openssh-server
+sshd_service: ssh

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,23 +1,20 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_debian: True    # Opposite of is_ubuntu for now
 is_debian_11: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "7.4"
 # postgresql_version: 13
 # python_version: "3.9"

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,23 +1,20 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_debian: True    # Opposite of is_ubuntu for now
 is_debian_12: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "8.1"
 # postgresql_version: 15
 # python_version: "3.10"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -272,6 +272,7 @@ pi_swap_file_size: 1024
 # THESE 2 LEGACY VARS ARE PRESERVED BUT HAVE NO EFFECT:
 mysql_install: True
 mysql_enabled: True
+mysql_service: mariadb
 
 # 2020-09-24: NGINX is MANDATORY but still evolving - please see:
 # https://github.com/iiab/iiab/blob/master/roles/nginx/README.md
@@ -300,6 +301,8 @@ squid_install: False
 squid_enabled: False    # Enabling this ~= 'iiab_gateway_enabled: True' (ABOVE)
 gw_squid_whitelist: False    # Works with HTTP sites, not HTTPS sites !
 gw_block_https: False
+proxy: squid         # Admin Console uses
+proxy_user: proxy    # Could move to roles/network/defaults/main.yml
 
 # UNMAINTAINED as of July 2021
 # DansGuardian REQUIRES Squid (above) be installed & enabled.
@@ -320,6 +323,7 @@ iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
 # Kolibri can export & import channels to USB sticks/drive:
 usb_lib_umask0000_for_kolibri: True
+systemd_location: /lib/systemd/system    # 2-common iiab-startup also uses
 
 # Common UNIX Printing System (CUPS)
 cups_install: False
@@ -332,6 +336,8 @@ samba_enabled: False
 samba_udp_ports: 137:138
 samba_tcp_mports: 139,445
 shared_dir : "{{ content_base }}/public"    # /library/public
+smb_service: smbd    # Admin Console uses
+nmb_service: nmbd    # Could move to roles/samba/defaults/main.yml
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
@@ -346,6 +352,8 @@ nginx_high_php_limits: False
 
 # Make this True to enable http://box/js-menu/menu-files/services/power_off.php
 apache_allow_sudo: False
+apache_service: apache2
+apache_user: www-data    # Admin Console uses
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
 nodocs: False

--- a/vars/linuxmint-21.yml
+++ b/vars/linuxmint-21.yml
@@ -1,4 +1,4 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_ubuntu: True    # Opposite of is_debian for now
@@ -6,20 +6,17 @@ is_ubuntu_2204: True
 is_linuxmint: True
 is_linuxmint_21: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "8.1"
 # postgresql_version: 14
 # python_version: "3.10"

--- a/vars/raspbian-11.yml
+++ b/vars/raspbian-11.yml
@@ -1,4 +1,4 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_debian: True    # Opposite of is_ubuntu for now
@@ -6,20 +6,17 @@ is_debian_11: True
 is_raspbian: True
 is_raspbian_11: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: ssh
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: ssh
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "7.4"
 # postgresql_version: 13
 # python_version: "3.9"

--- a/vars/ubuntu-2204.yml
+++ b/vars/ubuntu-2204.yml
@@ -1,23 +1,20 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_2204: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "8.1"
 # postgresql_version: 14
 # python_version: "3.10"

--- a/vars/ubuntu-2210.yml
+++ b/vars/ubuntu-2210.yml
@@ -1,23 +1,20 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_2210: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "8.1"
 # postgresql_version: 14
 # python_version: "3.10"

--- a/vars/ubuntu-2304.yml
+++ b/vars/ubuntu-2304.yml
@@ -1,23 +1,20 @@
-# Every is_<OS> var is initially set to 'False' at the bottom of
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
 is_ubuntu: True    # Opposite of is_debian for now
 is_ubuntu_2304: True
 
-proxy: squid
-proxy_user: proxy
-apache_service: apache2
-apache_user: www-data
-apache_conf_dir: apache2/sites-available
-apache_log_dir: /var/log/apache2
-apache_log: /var/log/apache2/access.log
-smb_service: smbd
-nmb_service: nmbd
-systemctl_program: /bin/systemctl
-mysql_service: mariadb
-sshd_package: openssh-server
-sshd_service: ssh
-systemd_location: /lib/systemd/system
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
 # php_version: "8.1"
 # postgresql_version: 14
 # python_version: "3.10"


### PR DESCRIPTION
This PR tightens up inflationary bitrot in `/opt/iiab/iiab/vars/<OS_VER>.yml` files.

As explained within: https://github.com/iiab/iiab/pull/3439#issuecomment-1362282710

Tested with a LARGE-sized IIAB install on Ubuntu 22.04

Building on:

- PR #3438
- PR #3439