### PR TITLE
Fix for Issue #3441

### DIFF
--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -180,13 +180,6 @@
     body_format: form-urlencoded
     status_code: 302
 
-- name: Set Matomo Directory Permissions
-  file:
-    path: "{{ matomo_path }}/matomo"
-    recurse: yes
-    owner: "{{ apache_user }}"    # e.g. www-data
-    group: "{{ apache_user }}"
-
 - name: Start Collecting Matomo Data
   cron:
     name: "MatomoDataIngestionOnReboot"
@@ -204,14 +197,19 @@
     user: root
     cron_file: "matomo_daily"
 
+- name: Set Permissions for token.php
+  copy:
+    content: ""
+    dest: "{{ matomo_path }}/matomo/tmp/cache/token.php"
+    group: "{{ apache_user }}"
+    owner: "{{ apache_user }}"
 
-- name: Start Collecting Matomo Data
-  cron:
-    name: "MatomoDataIngestionOnReboot2"
-    special_time: reboot
-    job: "sudo touch /library/www/matomo/tmp/cache/token.php && sudo mkdir /library/www/matomo/tmp/cache/tracker && sudo chown -R www-data:www-data /library/www/matomo"
-    user: root
-    cron_file: "matomo_reboot2"
+- name: Set Permissions for tracker Directory
+  file:
+    path: "{{ matomo_path }}/matomo/tmp/cache/tracker"
+    state: directory
+    owner: "{{ apache_user }}"
+    group: "{{ apache_user }}"
 
 # RECORD Matomo AS INSTALLED
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -205,6 +205,14 @@
     cron_file: "matomo_daily"
 
 
+- name: Start Collecting Matomo Data
+  cron:
+    name: "MatomoDataIngestionOnReboot2"
+    special_time: reboot
+    job: "sudo chown -R www-data:www-data /library/www/matomo"
+    user: root
+    cron_file: "matomo_reboot2"
+
 # RECORD Matomo AS INSTALLED
 
 - name: "Set 'matomo_installed: True'"

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -209,7 +209,7 @@
   cron:
     name: "MatomoDataIngestionOnReboot2"
     special_time: reboot
-    job: "sudo chown -R www-data:www-data /library/www/matomo"
+    job: "sudo touch /library/www/matomo/tmp/cache/token.php && sudo mkdir /library/www/matomo/tmp/cache/tracker && sudo chown -R www-data:www-data /library/www/matomo"
     user: root
     cron_file: "matomo_reboot2"
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -180,6 +180,13 @@
     body_format: form-urlencoded
     status_code: 302
 
+- name: Set Matomo Directory Permissions
+  file:
+    path: "{{ matomo_path }}/matomo"
+    recurse: yes
+    owner: "{{ apache_user }}"    # e.g. www-data
+    group: "{{ apache_user }}"
+
 - name: Start Collecting Matomo Data
   cron:
     name: "MatomoDataIngestionOnReboot"


### PR DESCRIPTION
### Fixes bug:

[Going to Matomo takes user to error page.](https://github.com/iiab/iiab/issues/3441)

### Description of changes proposed in this pull request:

Add a file and a directory that aren't created until someone browses to Matomo (apparently).

### Smoke-tested on which OS or OS's:

Just Ubuntu 22.04. These changes should cause no new issues. There are a couple known issues with Ubuntu 23.04 and Debian 12 (?) that will be fixed by future changes.

### Mention a team member @username e.g. to help with code review:

@holta 