### PR TITLE
Put Kiwix var {{ systemctl_program }} to rest — simple is almost always better

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -57,6 +57,5 @@ kiwix_url: /kiwix
 kiwix_url_plus_slash: "{{ kiwix_url }}/"    # /kiwix/
 kiwix_path: "{{ iiab_base }}/kiwix"         # /opt/iiab/kiwix
 
-systemctl_program: /bin/systemctl
 kiwix_nginx_timeout: 600
 kiwix_threads: 4

--- a/roles/kiwix/tasks/enable-or-disable.yml
+++ b/roles/kiwix/tasks/enable-or-disable.yml
@@ -17,18 +17,34 @@
   when: kiwix_enabled
 
 
-# TO DO: BOTH CRON ENTRIES BELOW *SHOULD* BE DELETED "when: not kiwix_enabled"
-
 # In the past kiwix-serve did not stay running, so we'd been doing this hourly.
 # @mgautierfr & others suggest kiwix-serve might be auto-restarted w/o cron in
 # future, whenever service fails, if this really catches all cases??
 # https://github.com/iiab/iiab/issues/484#issuecomment-342151726
-- name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
-  lineinfile:
-         # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
-    line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
-    dest: /etc/crontab
+
+- name: Set cron to restart kiwix-serve 4AM daily, if kiwix_enabled
+  cron:
+    name: kiwix-serve daily restart
+    minute: "0"
+    hour: "4"
+    job: /usr/bin/systemctl restart kiwix-serve.service
+    user: root
+    cron_file: kiwix-serve_daily    # i.e. /etc/cron.d/kiwix-serve_daily instead of /var/spool/cron/crontabs/root
   when: kiwix_enabled
+
+- name: Remove 4AM daily cron, if not kiwix_enabled
+  cron:
+    name: kiwix-serve daily restart
+    cron_file: kiwix-serve_daily
+    state: absent
+  when: not kiwix_enabled
+
+# - name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
+#   lineinfile:
+#          # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
+#     line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
+#     dest: /etc/crontab
+#   when: kiwix_enabled
 
 # - name: Make a crontab entry to restart kiwix-serve at 4AM (redhat)
 # # *  *  *  *  * user-name  command to be executed

--- a/roles/kiwix/tasks/enable-or-disable.yml
+++ b/roles/kiwix/tasks/enable-or-disable.yml
@@ -29,7 +29,7 @@
     hour: "4"
     job: /usr/bin/systemctl restart kiwix-serve.service
     user: root
-    cron_file: kiwix-serve_daily    # i.e. /etc/cron.d/kiwix-serve_daily instead of /var/spool/cron/crontabs/root
+    cron_file: kiwix-serve_daily    # i.e. /etc/cron.d/kiwix-serve_daily instead of /var/spool/cron/crontabs/root or /etc/crontab
   when: kiwix_enabled
 
 - name: Remove 4AM daily cron, if not kiwix_enabled

--- a/roles/kiwix/tasks/enable-or-disable.yml
+++ b/roles/kiwix/tasks/enable-or-disable.yml
@@ -26,7 +26,7 @@
 - name: Make a crontab entry to restart kiwix-serve at 4AM (debuntu)
   lineinfile:
          # mn hr dy mo day-of-week[Sunday=0] username command-to-be-executed
-    line: "0  4  *  *  * root /bin/systemctl restart kiwix-serve.service"
+    line: "0  4  *  *  * root /usr/bin/systemctl restart kiwix-serve.service"
     dest: /etc/crontab
   when: kiwix_enabled
 

--- a/roles/kiwix/templates/iiab-make-kiwix-lib
+++ b/roles/kiwix/templates/iiab-make-kiwix-lib
@@ -25,12 +25,12 @@ if flock -n -e 200; then :
   else
     /usr/bin/iiab-make-kiwix-lib.py -f # force rebuild of library.xml
   fi
-  {{ systemctl_program }} stop kiwix-serve
+  /usr/bin/systemctl stop kiwix-serve
   if [ -f $KIWIXLIB ]; then
     rm $KIWIXLIB
   fi
   mv $KIWIXLIB.tmp $KIWIXLIB
-  {{ systemctl_program }} start kiwix-serve
+  /usr/bin/systemctl start kiwix-serve
 else
   echo "Can't get wait lock for iiab-make-kiwix-lib.py";
   exit 1;


### PR DESCRIPTION
Unclear that systemctl really needs a full path but it can't hurt.

Tested on Ubuntu 23.04's latest daily, with this PR using canonical path `/usr/bin/systemctl` to be consistent with command-line usage.

Building on:

- PR #3440
- #3444