### PR TITLE
Somewhat higher PHP limits for Matomo — similar to Nextcloud, PBX, WordPress

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -52,13 +52,13 @@
 
 
 - debug:
-    msg: 'THE 5 ANSIBLE STANZAS BELOW ONLY RUN... when: moodle_install or nextcloud_install or pbx_install or wordpress_install'
+    msg: 'THE 5 ANSIBLE STANZAS BELOW ONLY RUN... when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install'
 
 - block:    # 5-STANZA BLOCK BEGINS
 
   # roles/nginx has installed pkg 'php{{ php_version }}-fpm' in 3-base-server
 
-  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
       path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
@@ -70,9 +70,9 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
-  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/cli/php.ini for lightweight use of WordPress/Nextcloud/PBX (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+  - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/cli/php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
     lineinfile:
       path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
@@ -84,7 +84,7 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: not nginx_high_php_limits and not moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   # WARNING: This might cause excess use of RAM/disk or other resources!
   # The first 5 values below were chosen by @ericnitschke and @kananigit on
@@ -98,7 +98,7 @@
   # regular operation it uses:     .../fpm/php.ini
   # And in the past it used:       .../apache2/php.ini
 
-  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for schools that use WordPress/Moodle/Nextcloud/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle or INTENSIVE use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
     lineinfile:
       path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
@@ -110,9 +110,9 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
-  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for schools that use WordPress/Moodle/Nextcloud/PBX intensively (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+  - name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for Moodle or INTENSIVE use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
     lineinfile:
       path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
       regexp: "{{ item.regexp }}"
@@ -124,14 +124,14 @@
       - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
       - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
       - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: moodle_install or nextcloud_install or pbx_install or wordpress_install
+    when: nginx_high_php_limits or moodle_install    # REMINDER: THIS ENTIRE 5-STANZA BLOCK IS ONLY INVOKED... when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
   - name: Restart 'php{{ php_version }}-fpm' systemd service
     systemd:
       name: php{{ php_version }}-fpm
       state: restarted
 
-  when: moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS.  COMPARE apache_allow_sudo conditionals below.
+  when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install    # 5-STANZA BLOCK ENDS.  COMPARE apache_allow_sudo conditionals below.
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -341,7 +341,7 @@ nmb_service: nmbd    # Could move to roles/samba/defaults/main.yml
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
@@ -584,6 +584,7 @@ awstats_enabled: True
 # Matomo is a web analytics alternative to Google Analytics, emphasizing privacy and data ownership.
 matomo_install: True
 matomo_enabled: True
+# If using Matomo intensively, investigate nginx_high_php_limits further above.
 
 # Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -209,7 +209,7 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
@@ -342,6 +342,7 @@ awstats_enabled: True
 # Matomo is a web analytics alternative to Google Analytics, emphasizing privacy and data ownership.
 matomo_install: True
 matomo_enabled: True
+# If using Matomo intensively, investigate nginx_high_php_limits further above.
 
 # Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -209,7 +209,7 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
@@ -342,6 +342,7 @@ awstats_enabled: True
 # Matomo is a web analytics alternative to Google Analytics, emphasizing privacy and data ownership.
 matomo_install: True
 matomo_enabled: True
+# If using Matomo intensively, investigate nginx_high_php_limits further above.
 
 # Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -209,7 +209,7 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
@@ -342,6 +342,7 @@ awstats_enabled: True
 # Matomo is a web analytics alternative to Google Analytics, emphasizing privacy and data ownership.
 matomo_install: True
 matomo_enabled: True
+# If using Matomo intensively, investigate nginx_high_php_limits further above.
 
 # Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -209,7 +209,7 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools that use WordPress/Nextcloud/Moodle/PBX intensively:
+# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
 nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
@@ -342,6 +342,7 @@ awstats_enabled: False
 # Matomo is a web analytics alternative to Google Analytics, emphasizing privacy and data ownership.
 matomo_install: False
 matomo_enabled: False
+# If using Matomo intensively, investigate nginx_high_php_limits further above.
 
 # Process supervision tool - from https://mmonit.com/monit/
 # 2020-09-22 WARNING: both vars are IGNORED on Debian 10 due to: iiab/iiab#1849


### PR DESCRIPTION
This PR is almost entirely documentation, to better acknowledge that Matomo depends on PHP.

@cwivagg with create a follow-up PR solving deeper issues relating to:

- #3441
- PR #3443

This PR was tested on Ubuntu 22.04 using all 3 "code paths" :

- `matomo_install: False`
- `matomo_install: True` with `nginx_high_php_limits: False`
- `matomo_install: True` with `nginx_high_php_limits: True`

Building on the original:

- #1762
- PR #3304