### PR TITLE
Several updates to make Matomo experience cleaner

### DIFF
--- a/roles/matomo/README.adoc
+++ b/roles/matomo/README.adoc
@@ -41,13 +41,6 @@ Log in to your IIAB's full Matomo URL, e.g. http://box.lan/matomo, as arranged a
 
 Take a look at Matomo's official guides to further set this up: https://matomo.org/guides/
 
-WARNING: If your IIAB URL is *not* http://box.lan, you may run into a big orange warning from Matomo that it has been configured to run from a different address. Here are the steps to fix this problem.
-
-1. Copy the IP address listed in the box below "How do I fix this problem and how do I log in again?" For example, I see `trusted_hosts[] = "192.168.64.10"`, so I copy `"192.168.64.10"`.
-2. Run `sudo nano /library/www/matomo/config/config.ini.php` to edit Matomo's config file.
-3. Paste or type the IP address from Step 1 to replace `"box.lan"` in the `trusted_hosts` line, which should be about line 13. When I'm done, my line 13 says `trusted_hosts[] = "192.168.64.10"` instead of `trusted_hosts[] = "box.lan"`.
-4. Refresh the Matomo homepage and the warning should be gone.
-5. Optionally, see the https://forum.matomo.org/t/trusted-hostname/11963[advanced tips] in https://forum.matomo.org/[Matomo's Forum].
 
 WARNING: Matomo won't show any traffic statistics until after 1 day or reboot (which are the events that trigger the log scraper!)
 
@@ -64,6 +57,9 @@ Below the *Visitors* button is a second button, *Behavior*. Click on the *Pages*
 1. If your Internet-in-a-Box setup is without power and Internet access, it may not be able to keep time correctly. This is okay! But it means that the time-of-visit information in Matomo will not be correct.
 
 2. One thing Matomo can't track correctly is navigation within KA Lite (Khan Academy) pages. If your users are spending a lot of time here, it won't be visible in the Matomo statistics.
+
+3. Time Zones: The Matomo installer's default behavior in "Configure Matomo to track IIAB" is to pick up the system time zone when none is supplied. If this doesn't work, you can set the time zone to whatever you prefer from the Matomo home page. In testing, Matomo picked up the system time zone on a regular Multipass Ubuntu instance. However, it was unable to do so on a VirtualBox Ubuntu instance. Thus, we provide a fallback behavior "Fallback Configure Matomo to track IIAB" that picks an arbitrary time zone. The fallback fires only when the form with an empty time zone is submitted and returns a 200 status code instead of 302, indicating that form submission failed.
+
 
 == Credits
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -10,6 +10,17 @@
 # TASK [matomo : HTTP Get Welcome] ***************************************************************************************************************************************
 # fatal: [127.0.0.1]: FAILED! => {"cache_control": "private, no-cache, no-store", "changed": false, "connection": "close", "content_type": "text/html; charset=utf-8", "date": "Wed, 15 Jun 2022 05:07:41 GMT", "elapsed": 0, "expires": "Thu, 19 Nov 1981 08:52:00 GMT", "msg": "Status code was 500 and not [200]: HTTP Error 500: Internal Server Error", "pragma": "no-cache", "redirected": false, "server": "nginx/1.18.0 (Ubuntu)", "set_cookie": "MATOMO_SESSID=psak3aem27vrdrt8t2f016600f; path=/; HttpOnly; SameSite=Lax", "status": 500, "transfer_encoding": "chunked", "url": "http://box.lan/matomo/index.php?action=welcome", "x_matomo_request_id": "fbfd2"}
 
+# https://matomo.org/faq/on-premise/matomo-requirements/
+- name: Install Matomo's recommended PHP extensions
+  package:
+    name:
+      - php{{ php_version }}-curl
+      - php{{ php_version }}-gd
+      - php{{ php_version }}-cli
+      - php{{ php_version }}-mysql
+      - php{{ php_version }}-xml
+      - php{{ php_version }}-mbstring
+
 - name: Start MariaDB
   #action: service name=mysql state=started
   systemd:

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -211,6 +211,11 @@
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
 
+- name: Don't Check for Trusted Host
+  ansible.builtin.lineinfile:
+    path: "{{ matomo_path }}/matomo/config/config.ini.php"
+    line: enable_trusted_host_check=0
+    insertafter: "[General]"
 
 # RECORD Matomo AS INSTALLED
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -214,8 +214,8 @@
 - name: Don't Check for Trusted Host
   ansible.builtin.lineinfile:
     path: "{{ matomo_path }}/matomo/config/config.ini.php"
-    line: enable_trusted_host_check=0
-    insertafter: "[General]"
+    line: "enable_trusted_host_check=0"
+    insertafter: "^\[General\]$"
 
 # RECORD Matomo AS INSTALLED
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -214,7 +214,7 @@
 - name: Don't Check for Trusted Host
   ansible.builtin.lineinfile:
     path: "{{ matomo_path }}/matomo/config/config.ini.php"
-    line: "enable_trusted_host_check=0"
+    line: "enable_trusted_host_check\=0"
     insertafter: "^\[General\]$"
 
 # RECORD Matomo AS INSTALLED

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -212,10 +212,11 @@
     group: "{{ apache_user }}"
 
 - name: Don't Check for Trusted Host
-  ansible.builtin.lineinfile:
+  ini_file:
     path: "{{ matomo_path }}/matomo/config/config.ini.php"
-    line: "enable_trusted_host_check\=0"
-    insertafter: "^\[General\]$"
+    section: General
+    option: enable_trusted_host_check
+    value: 0
 
 # RECORD Matomo AS INSTALLED
 

--- a/roles/matomo/templates/matomo-nginx.conf.j2
+++ b/roles/matomo/templates/matomo-nginx.conf.j2
@@ -12,6 +12,6 @@ location ~ ^/matomo(.*)\.php(.*)$ {
     fastcgi_param PATH_INFO       $2;
 }
 
-location ~ ^/matomo/ {
+location ~ ^/matomo(/)? {
     root /library/www;
 }


### PR DESCRIPTION
Several updates to make Matomo experience cleaner

### Description of changes proposed in this pull request:

* Avoid trusted host check so users can get to the Matomo website more easily.
* Remove documentation for users to circumvent the trusted host check since it is no longer necessary.
* Add documentation about the time zone and how we got here.
* Add PHP dependencies.
* Fix the <host>/matomo URL (as opposed to <host>/matomo/ which already worked).

### Smoke-tested on which OS or OS's:

Ubuntu 22.04 size 0 and 1 installs (with Matomo enabled).

### Mention a team member @username e.g. to help with code review:

@holta 