### PR TITLE
Store actual System TZ (not Ansible's ambiguous TZ abbreviations) into fpm/php.ini & cli/php.ini — for Matomo etc

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -54,8 +54,9 @@
   include_tasks: validate_vars.yml
   when: not (rpi_model | regex_search('\\bW\\b'))    # Ansible require double backslashes, e.g. with \b "word boundary" anchors: https://www.regular-expressions.info/wordboundaries.html https://stackoverflow.com/questions/56869119/ansible-regular-expression-to-match-a-string-and-extract-the-line/56869801#56869801
 
-- name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"
-  include_tasks: tz.yml
+# 2022-12-30: Functionality moved to www_options/tasks/php-settings.yml
+# - name: "Time Zone / TZ: Set symlink /etc/localtime to UTC if it doesn't exist?"
+#   include_tasks: tz.yml
 
 - name: Set hostname / domain (etc) in various places
   include_tasks: hostname.yml
@@ -103,10 +104,10 @@
       value: "{{ php_version }}"
     - option: first_run
       value: "{{ first_run }}"
-    - option: local_tz    # e.g. 'EDT' (summer) or 'EST' (winter) after Ansible interprets symlink /etc/localtime -- or 'UTC' if /etc/localtime doesn't exist
-      value: "{{ local_tz }}"
-    - option: etc_localtime.stdout    # e.g. 'America/New_York' direct from symlink /etc/localtime -- or '' if /etc/localtime doesn't exist
-      value: "{{ etc_localtime.stdout }}"
+    # - option: local_tz    # e.g. 'EDT' (summer) or 'EST' (winter) after Ansible interprets symlink /etc/localtime -- or 'UTC' if /etc/localtime doesn't exist
+    #   value: "{{ local_tz }}"
+    # - option: etc_localtime.stdout    # e.g. 'America/New_York' direct from symlink /etc/localtime -- or '' if /etc/localtime doesn't exist
+    #   value: "{{ etc_localtime.stdout }}"
     - option: FQDN_changed
       value: "{{ FQDN_changed }}"
 

--- a/roles/0-init/tasks/tz.yml.unused
+++ b/roles/0-init/tasks/tz.yml.unused
@@ -1,20 +1,4 @@
-# 2022-12-30: FYI ansible_date_time.tz provides TZ ABBREVIATIONS (equivalent
-# to 'date +%Z' output) which leads to serious ambiguity -- and not just (A)
-# seasonal EST/EDT ambiguities, or (B) floods of geographic synonyms for the
-# very same time zone!  More Seriously: (C) both commands above output "IST"
-# for both Israel Standard Time (+0200) AND India Standard Time (+0530).  Etc!
-#
-# While Ansible provides 2 other vars that (slightly) help disambiguate
-# (ansible_date_time.tz_dst and ansible_date_time.tz_offset), there's a far
-# better way -- which is to read the System TZ directly from Linux:
-#
-# timedatectl show -p "Timezone" --value
-#
-# This takes care of essentially everything (e.g. output "America/New_York")
-# by checking (1) symlink /etc/localtime then (2) text file /etc/timezone
-# then (3) if neither exist, "UTC" is declated (correctly!)  One drawback:
-# timedatectl if not easily usable within chroot environments.
-
+# 2022-12-30: Functionality moved to www_options/tasks/php-settings.yml
 
 - name: "'local_tz: {{ local_tz }}' was set by ansible_date_time.tz in /opt/iiab/iiab/vars/default_vars.yml -- e.g. if Ansible finds symlink /etc/localtime -> ../usr/share/zoneinfo/America/New_York -- it will simplify that to 'EDT' (in the summer) or 'EST' (in the winter)"
   command: echo

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -23,9 +23,9 @@
       - php{{ php_version }}-xml
       - php{{ php_version }}-mbstring
 
-- name: "Run roles/www_options/tasks/set-php-limits.yml with 'nginx_high_php_limits: False' by default"
-  include_tasks: roles/www_options/tasks/set-php-limits.yml
-  when: set_php_limits_done is undefined
+- name: "Run roles/www_options/tasks/php-settings.yml with 'nginx_high_php_limits: False' by default"
+  include_tasks: roles/www_options/tasks/php-settings.yml
+  when: php_settings_done is undefined
 
 
 - name: Start MariaDB

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -44,9 +44,9 @@
       - php{{ php_version }}-zip         # 2021-06-27: Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx_dependencies.yml, wordpress/tasks/install.yml
     state: present
 
-- name: "Run roles/www_options/tasks/set-php-limits.yml with 'nginx_high_php_limits: True' by default"
-  include_tasks: roles/www_options/tasks/set-php-limits.yml
-  when: set_php_limits_done is undefined
+- name: "Run roles/www_options/tasks/php-settings.yml with 'nginx_high_php_limits: True' by default"
+  include_tasks: roles/www_options/tasks/php-settings.yml
+  when: php_settings_done is undefined
 
 
 - name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.2"

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -86,9 +86,9 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
-- name: "Run roles/www_options/tasks/set-php-limits.yml with 'nginx_high_php_limits: False' by default"
-  include_tasks: roles/www_options/tasks/set-php-limits.yml
-  when: set_php_limits_done is undefined
+- name: "Run roles/www_options/tasks/php-settings.yml with 'nginx_high_php_limits: False' by default"
+  include_tasks: roles/www_options/tasks/php-settings.yml
+  when: php_settings_done is undefined
 
 
 - name: Create dir {{ nextcloud_root_dir }} (by default 755 dirs & 644 files)

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -62,9 +62,9 @@
 #     state: present
 #   when: php_version is version('8.0', '<')
 
-- name: "Run roles/www_options/tasks/set-php-limits.yml with 'nginx_high_php_limits: False' by default"
-  include_tasks: roles/www_options/tasks/set-php-limits.yml
-  when: set_php_limits_done is undefined
+- name: "Run roles/www_options/tasks/php-settings.yml with 'nginx_high_php_limits: False' by default"
+  include_tasks: roles/www_options/tasks/php-settings.yml
+  when: php_settings_done is undefined
 
 - name: FreePBX - Install and configure Apache - if pbx_use_apache
   include_tasks: apache.yml

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -39,9 +39,9 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
-- name: "Run roles/www_options/tasks/set-php-limits.yml with 'nginx_high_php_limits: False' by default"
-  include_tasks: roles/www_options/tasks/set-php-limits.yml
-  when: set_php_limits_done is undefined
+- name: "Run roles/www_options/tasks/php-settings.yml with 'nginx_high_php_limits: False' by default"
+  include_tasks: roles/www_options/tasks/php-settings.yml
+  when: php_settings_done is undefined
 
 
 - name: Delete {{ downloads_dir }}/wordpress.tar.gz if it exists

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -51,11 +51,11 @@
   when: lxde_pi_autostart_present.stat.exists and chromium_present.stat.exists
 
 
-# 2022-12-29: set-php-limits.yml is ALSO attempted (on demand) by every
+# 2022-12-29: php-settings.yml is ALSO attempted (on demand) by every
 # <ROLE>/tasks/install.yml that needs it (Matomo, Moodle, Nextcloud, PBX,
 # WordPress) so './runrole <ROLE>' and similar are fully self-sufficient!
-- name: "Run set-php-limits.yml -- allows post-install toggling of nginx_high_php_limits in /etc/iiab/local_vars.yml -- if you run './runrole www_options'"
-  include_tasks: set-php-limits.yml
+- name: "Run php-settings.yml -- allows post-install toggling of nginx_high_php_limits in /etc/iiab/local_vars.yml -- if you run './runrole www_options'"
+  include_tasks: php-settings.yml
   when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
 

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -1,4 +1,4 @@
-# 2022-12-29: This file (set-php-limits.yml) is ALSO invoked on demand, by:
+# 2022-12-29: This file (php-settings.yml) is ALSO invoked on demand, by:
 #
 # roles/matomo/tasks/install.yml
 # roles/moodle/tasks/install.yml
@@ -11,6 +11,38 @@
 #
 # But in this case, explanatory comments (inserted by lineinfile below) offer
 # important context to implementers modifying both php.ini files after the fact.
+
+
+# 2022-12-30: FYI ansible_date_time.tz provides TZ ABBREVIATIONS (equivalent
+# to 'date +%Z' output) which leads to serious ambiguity -- and not just (A)
+# seasonal EST/EDT ambiguities, or (B) floods of geographic synonyms for the
+# very same time zone!  More Seriously: (C) both commands above output "IST"
+# for both Israel Standard Time (+0200) AND India Standard Time (+0530).  Etc!
+#
+# While Ansible provides 2 other vars that (slightly) help disambiguate
+# (ansible_date_time.tz_dst and ansible_date_time.tz_offset), there's a far
+# better way -- which is to read the System TZ directly from Linux:
+#
+# timedatectl show -p Timezone --value
+#
+# This takes care of essentially everything (e.g. output "America/New_York")
+# by checking (1) symlink /etc/localtime then (2) text file /etc/timezone
+# then (3) if neither exist, "UTC" is declated (correctly!)  One drawback:
+# timedatectl if not easily usable within chroot environments.
+
+- name: Extract Time Zone from symlink /etc/localtime &/or text file /etc/timezone (or lack thereof!)
+  command: timedatectl show -p "Timezone" --value
+  register: tz_cli
+
+- name: Store 'date.timezone = {{ tz_cli.stdout }}' (from above) in /etc/php/{{ php_version }}/fpm/php.ini and /etc/php/{{ php_version }}/cli/php.ini
+  ini_file:
+    path: "{{ item }}"
+    section: Date
+    option: date.timezone
+    value: "{{ tz_cli.stdout }}"    # e.g. America/New_York or UTC
+  with_items:
+    - /etc/php/{{ php_version }}/fpm/php.ini
+    - /etc/php/{{ php_version }}/cli/php.ini
 
 
 # WARNING: 'nginx_high_php_limits: True' (especially!) might cause excess use of
@@ -89,9 +121,9 @@
     name: php{{ php_version }}-fpm
     state: restarted
 
-- name: "Set 'set_php_limits_done: True' so set-php-limits.yml runs just once (per Ansible run)"
+- name: "Set 'php_settings_done: True' so php-settings.yml runs just once (per Ansible run)"
   set_fact:
-    set_php_limits_done: True
+    php_settings_done: True
 
 
 # - debug:

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -6,12 +6,6 @@
 # roles/pbx/tasks/freepbx.yml
 # roles/wordpress/tasks/install.yml
 
-# Ansible's ini_file would normally be best, to tweak .ini files:
-# https://docs.ansible.com/ansible/latest/collections/community/general/ini_file_module.html
-#
-# But in this case, explanatory comments (inserted by lineinfile below) offer
-# important context to implementers modifying both php.ini files after the fact.
-
 
 # 2022-12-30: FYI ansible_date_time.tz provides TZ ABBREVIATIONS (equivalent
 # to 'date +%Z' output) which leads to serious ambiguity -- and not just (A)
@@ -26,9 +20,9 @@
 # timedatectl show -p Timezone --value
 #
 # This takes care of essentially everything (e.g. output "America/New_York")
-# by checking (1) symlink /etc/localtime then (2) text file /etc/timezone
-# then (3) if neither exist, "UTC" is declated (correctly!)  One drawback:
-# timedatectl if not easily usable within chroot environments.
+# by checking (1) symlink /etc/localtime then (2) text file /etc/timezone if
+# nec, then (3) if neither exist, "UTC" is declated (correctly!)  Potential
+# drawback: timedatectl is not easily usable within chroot environments.
 
 - name: Extract Time Zone from symlink /etc/localtime &/or text file /etc/timezone (or lack thereof!)
   command: timedatectl show -p "Timezone" --value
@@ -114,6 +108,13 @@
     - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
   when: nginx_high_php_limits or moodle_install
+
+
+# To tweak .ini files, Ansible's ini_file is normally better than lineinfile:
+# https://docs.ansible.com/ansible/latest/collections/community/general/ini_file_module.html
+#
+# But for the 6 * 4 above, explanatory comments (inserted by lineinfile) offer
+# important context to implementers modifying both php.ini files after the fact.
 
 
 - name: Restart 'php{{ php_version }}-fpm' systemd service

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -72,9 +72,6 @@ admin_console_group: iiab-admin    # This group & sudo log in to Admin Console.
 # Obtain a password hash - OLD WAY:
 #    python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 
-# Time Zone (php used to need timezone set).  SEE: roles/0-init/tasks/tz.yml
-local_tz: "{{ ansible_date_time.tz }}"
-
 # Set these to False if you do not want to install/enable IIAB Admin Console
 admin_console_install: True
 admin_console_enabled: True
@@ -346,7 +343,7 @@ nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
 # REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/set-php-limits.yml
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf
 
@@ -505,7 +502,7 @@ postgresql_enabled: False
 moodle_install: False
 moodle_enabled: False
 # FYI 'nginx_high_php_limits: True' (explained above) is mandated with Moodle,
-# as auto-enacted by roles/www_options/tasks/set-php-limits.yml
+# as auto-enacted by roles/www_options/tasks/php-settings.yml
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -214,7 +214,7 @@ nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
 # REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/set-php-limits.yml
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf
 
@@ -297,7 +297,7 @@ kiwix_enabled: True
 moodle_install: True
 moodle_enabled: True
 # FYI 'nginx_high_php_limits: True' (explained above) is mandated with Moodle,
-# as auto-enacted by roles/www_options/tasks/set-php-limits.yml
+# as auto-enacted by roles/www_options/tasks/php-settings.yml
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -214,7 +214,7 @@ nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
 # REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/set-php-limits.yml
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf
 
@@ -297,7 +297,7 @@ kiwix_enabled: True
 moodle_install: False
 moodle_enabled: False
 # FYI 'nginx_high_php_limits: True' (explained above) is mandated with Moodle,
-# as auto-enacted by roles/www_options/tasks/set-php-limits.yml
+# as auto-enacted by roles/www_options/tasks/php-settings.yml
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -214,7 +214,7 @@ nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
 # REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/set-php-limits.yml
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf
 
@@ -297,7 +297,7 @@ kiwix_enabled: True
 moodle_install: False
 moodle_enabled: False
 # FYI 'nginx_high_php_limits: True' (explained above) is mandated with Moodle,
-# as auto-enacted by roles/www_options/tasks/set-php-limits.yml
+# as auto-enacted by roles/www_options/tasks/php-settings.yml
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -214,7 +214,7 @@ nginx_high_php_limits: False
 # WARNING: Enabling this might cause excess use of RAM/disk or other resources!
 # roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
 # REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
-# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/set-php-limits.yml
+# https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf
 
@@ -297,7 +297,7 @@ kiwix_enabled: False
 moodle_install: False
 moodle_enabled: False
 # FYI 'nginx_high_php_limits: True' (explained above) is mandated with Moodle,
-# as auto-enacted by roles/www_options/tasks/set-php-limits.yml
+# as auto-enacted by roles/www_options/tasks/php-settings.yml
 
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps


### PR DESCRIPTION
@cwivagg this PR should finally fix the Time Zone in Matomo (as well as providing better TZ hygiene for all of IIAB's PHP-based apps).  LMK please if you discover quirks on VirtualBox or anywhere!

It works by bypassing Ansible's unhelpful TZ abbreviation mechanisms {`ansible_date_time.tz`, `ansible_date_time.tz_dst`, `ansible_date_time.tz_offset`} and instead using Linux's TZ directly (e.g. `America/New_York`, from symlink /etc/localtime and/or text file /etc/timezone &mdash; or the absence of both &mdash; which in fact means time zone `UTC`).

Thanks to the very hard work from many.  Including @jvonau, @cwivagg and others..

FYI this PR also documents, clarifies and cleans up, e.g.:

- Renaming www_options/tasks/set-php-limits.tml to www_options/tasks/php-settings.yml
- Renaming flag var set_php_limits_done to php_settings_done

This PR was tested quite extensively on Debian 12's latest daily.  It builds on:

- #69
- #1147
- #1762
- PR #2886
- #2953
- PR #3148
- PR #3304
- PR #3447
- PR #3448
- PR #3449
- PR #3452
