### PR TITLE
Closed Issue: revert to using pip for ansible on 32bit RasPiOS [& ongoing issues w/ wheels, cryptography, rust]

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -129,8 +129,8 @@ fi
 ###     > /etc/apt/sources.list.d/iiab-ansible.list
 
 # 2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
-echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu focal main" \
-     > /etc/apt/sources.list.d/iiab-ansible.list
+#echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu focal main" \
+#     > /etc/apt/sources.list.d/iiab-ansible.list
 
 # In future we might instead consider 'add-apt-repository ppa:ansible/ansible'
 # or 'apt-add-repository ppa:ansible/bionic/ansible' etc, e.g. for streamlined
@@ -152,7 +152,7 @@ echo "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.la
 #chmod 644 /usr/share/keyrings/iiab-ansible-keyring.gpg
 
 # 2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, until upstream wheels -> cryptography is fixed (PR #3421)
-cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
+#cp /opt/iiab/iiab/scripts/iiab-ansible-keyring.gpg /usr/share/keyrings/iiab-ansible-keyring.gpg
 
 ###echo -e 'PPA source "deb [signed-by=/usr/share/keyrings/iiab-ansible-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu '$CODENAME' main"'
 ###echo -e "successfully saved to /etc/apt/sources.list.d/iiab-ansible.list\n"
@@ -188,8 +188,13 @@ if uname -m | grep -q 64; then
     echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
     pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 else
-    echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
-    $APT_PATH/apt -y --allow-downgrades install ansible-core
+#    echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
+#    $APT_PATH/apt -y --allow-downgrades install ansible-core
+    pip3 config --global set global.no-cache-dir false
+    echo -e "\n\n'pip3 install cryptography==37.0.4' will now run:\n"
+    pip3 install cryptography==37.0.4 # latest compatible with ansible-core available via piwheels.org
+    echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
+    pip3 install --upgrade ansible-core # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 fi
 
 # (Re)running collection installs appears safe, with --force-with-deps to force


### PR DESCRIPTION
### Fixes bug:
Stops polluting /etc/apt/sources.list.d/ and /usr/share/keyrings/ with files that are never used to install ansible while using "pip3 install". ie Ubuntu and RasPiOS-64bit
### Description of changes proposed in this pull request:
Restores "pip3 install" for RasPiOS-32-bit
### Smoke-tested on which OS or OS's:
Ref: Slimmed down version of #3456
