### PR TITLE
Update matomo-nginx.conf.j2 ["fix the error private directories are accessible"]

### DIFF
--- a/roles/matomo/templates/matomo-nginx.conf.j2
+++ b/roles/matomo/templates/matomo-nginx.conf.j2
@@ -1,3 +1,5 @@
+location ~ ^/matomo/(config|tmp|core|lang) { deny all; return 403; }
+
 location ~ ^/matomo(.*)\.php(.*)$ {
     alias /library/www/matomo$1.php$2;    # /library/www/matomo
     proxy_set_header X-Real-IP  $remote_addr;
@@ -10,7 +12,6 @@ location ~ ^/matomo(.*)\.php(.*)$ {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param SCRIPT_NAME     $fastcgi_script_name;
     fastcgi_param PATH_INFO       $2;
-    location ~ ^/matomo/(config|tmp|core|lang) { deny all; return 403; }
 }
 
 location ~ ^/matomo(/)? {

--- a/roles/matomo/templates/matomo-nginx.conf.j2
+++ b/roles/matomo/templates/matomo-nginx.conf.j2
@@ -10,6 +10,7 @@ location ~ ^/matomo(.*)\.php(.*)$ {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param SCRIPT_NAME     $fastcgi_script_name;
     fastcgi_param PATH_INFO       $2;
+    location ~ ^/matomo/(config|tmp|core|lang) { deny all; return 403; }
 }
 
 location ~ ^/matomo(/)? {


### PR DESCRIPTION
### Fixes bug:

Security problems noted in https://github.com/iiab/iiab/issues/3441.

### Description of changes proposed in this pull request:

Adds a line in the nginx config for Matomo barring browser access to any files in several recommended directories. This is the preferred fix method according to Matomo's docs ([link](https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/), see "Nginx web server", or scroll your eyes to the next section "Other web server" to save yourself a click on seeing what their Nginx conf is doing).

### Smoke-tested on which OS or OS's:

multipass 22.04 Small Matomo install

### Mention a team member @username e.g. to help with code review:

@holta 