### PR TITLE
iiab-diagnostics: Highlight /etc/iiab/install-flags sequence

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -145,6 +145,7 @@ if [ -s /tmp/iiab-apps-to-be-installed ]; then
     cat /tmp/iiab-apps-to-be-installed >> $outfile
     echo >> $outfile
 fi
+cat_cmd 'ls -ltr /etc/iiab/install-flags' 'IIAB install flags'
 
 echo -e '\n  1. Files Specially Requested: (from "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n'
 echo -e '\n\n\n1. FILES SPECIALLY REQUESTED (FROM "iiab-diagnostics PATH/FILE1 PATH/FILE2")\n' >> $outfile


### PR DESCRIPTION
Thanks @deldesir for making this need more clear.

Tested on Ubuntu 23.04 latest daily build.