### PR TITLE
internetarchive/tasks/install.yml: Enforce Node.js <= 19.x

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -9,10 +9,10 @@
   include_role:
     name: nodejs
 
-- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 18.x
+- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 19.x
   assert:
-    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('18.x', '<=')
-    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 18.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('19.x', '<=')
+    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 19.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
     quiet: yes
 
 - name: "Set 'yarn_install: True' and 'yarn_enabled: True'"


### PR DESCRIPTION
Tested on Debian 12 Bookworm's latest daily build.

Related:

- PR #3186
- #3465