### PR TITLE
Avoid bolting on libssl1.1, now that MongoDB can use libssl3 (at long last!) [e.g. on Ubuntu 22.04+ & Debian 12]

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -1,4 +1,5 @@
 # MongoDB Install Docs:
+# https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
 # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/
 # https://www.mongodb.com/docs/manual/installation/
 
@@ -78,6 +79,7 @@
 
 - block:
   - name: Add mongodb.org signing key (only 64-bit support available) for MongoDB version {{ mongodb_64bit_version }}
+    # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
     shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | gpg --dearmor > /usr/share/keyrings/mongodb.gpg
     #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | apt-key add -
     #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_64bit_version }}.asc | apt-key add -
@@ -90,7 +92,7 @@
 
   # 2023-01-19: MongoDB only offers x86_64 for Debian, AND IN ANY CASE all their
   # MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4,
-  # LIKE THEIR MongoDB 5.0 tested 2022-06-07 ~120 lines below.
+  # LIKE THEIR MongoDB 5.0 tested 2022-06-07 ~134 lines below.
   # -> DELETE THIS STANZA AFTER DEBIAN 12 IS SOLID -- USING UBUNTU REPO BELOW ?
   - name: Install mongodb-org's Debian bullseye source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_64bit_version }}, if x86_64 Debian < 12
     apt_repository:
@@ -106,9 +108,12 @@
     when: is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64"
     #when: is_debian and ansible_architecture == "x86_64"
 
-  # 2022-01-19: 64-bit RasPiOS likely not supported for now, as MongoDB 6.0's
-  # ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4, JUST LIKE THEIR
-  # MongoDB 5.0 (tested 2022-06-07 ~120 lines below).
+  # 2022-01-19: Tested on x86_64 VM's with Ubuntu 22.04 & Debian 12.  Based on
+  # MongoDB 6.0.3 (released 2022-11-15) instructions here:
+  # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
+  # WHEREAS 64-bit Raspberry Pi is likely NOT supported for now, as MongoDB 6.0
+  # IS ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4 (JUST LIKE THEIR
+  # MongoDB 5.0, tested 2022-06-07 ~113 lines below).
   - name: Otherwise, install mongodb-org's Ubuntu jammy source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
       repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_64bit_version }} multiverse

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -78,7 +78,8 @@
 
 - block:
   - name: Add mongodb.org signing key (only 64-bit support available) for MongoDB version {{ mongodb_64bit_version }}
-    shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | apt-key add -
+    shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | gpg --dearmor > /usr/share/keyrings/mongodb.gpg
+    #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | apt-key add -
     #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_64bit_version }}.asc | apt-key add -
     #args:
     #  warn: no
@@ -87,28 +88,36 @@
     # Supported parameters include: removes, strip_empty_ends, _raw_params,
     # _uses_shell, stdin_add_newline, creates, chdir, executable, argv, stdin."
 
-  # 2022-10-23: MongoDB only allows auto-install of Debian's x86_64, AND IN ANY
-  # CASE all their MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON
-  # ARM v8-A RPi 4, LIKE THEIR MongoDB 5.0 tested 2022-06-07 ~120 lines below.
-  # -> CAN THIS ENTIRE STANZA BE *DELETED* -- ALWAYS USING UBUNTU REPO BELOW ?
-  - name: Install mongodb-org's Debian bullseye source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_64bit_version }}
+  # 2023-01-19: MongoDB only offers x86_64 for Debian, AND IN ANY CASE all their
+  # MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4,
+  # LIKE THEIR MongoDB 5.0 tested 2022-06-07 ~120 lines below.
+  # -> DELETE THIS STANZA AFTER DEBIAN 12 IS SOLID -- USING UBUNTU REPO BELOW ?
+  - name: Install mongodb-org's Debian bullseye source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_64bit_version }}, if x86_64 Debian < 12
     apt_repository:
       # 2020-10-28 and 2022-06-09: https://repo.mongodb.org/apt/debian/dists/
       # supports only {Buster 10, Stretch 9, Jessie 8, Wheezy 7}.  So Bullseye
       # 11 and Bookworm 12 (testing branch) revert to buster for now:
       # 2022-09-27: Changed from 'buster' to 'bullseye' (i.e. Debian 11) as
       # this was recently added to https://repo.mongodb.org/apt/debian/dists/
-      repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
+      repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
+      #repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
       #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       #filename: mongodb-org
-    when: is_debian and ansible_architecture == "x86_64"
+    when: is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64"
+    #when: is_debian and ansible_architecture == "x86_64"
 
-  # 2022-10-23: RasPiOS Bullseye *MAY* FAIL when 'focal' changed to 'jammy' ?
-  - name: Otherwise install mongodb-org's Ubuntu focal source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
+  # 2022-01-19: 64-bit RasPiOS likely not supported for now, as MongoDB 6.0's
+  # ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4, JUST LIKE THEIR
+  # MongoDB 5.0 (tested 2022-06-07 ~120 lines below).
+  - name: Otherwise, install mongodb-org's Ubuntu jammy source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
-      repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_64bit_version }} multiverse
+      repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_64bit_version }} multiverse
+      #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_64bit_version }} multiverse
       #filename: mongodb-org
-    when: not (is_debian and ansible_architecture == "x86_64")
+    when: not (is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64")
+    #when: is_ubuntu or is_debian and os_ver is version('debian-12', '>=')
+    #when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint and os_ver is version('linuxmint-12', '>=') or is_debian and os_ver is version('debian-12', '>=')
+    #when: not (is_debian and ansible_architecture == "x86_64")
 
   # 2022-10-23: Force-install MongoDB on Ubuntu 22.04+, Mint 21 & Debian 12;
   # as each includes libssl3 not libssl1.1 (#3190).  LATER REMOVE ALL 7 STANZAS
@@ -121,48 +130,52 @@
   # sudo apt-get install libssl1.1
   # rm /etc/apt/sources.list.d/focal-security.list
 
-  - name: Install source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+ x86_64 or Mint 21
-    apt_repository:
-      repo: deb http://security.ubuntu.com/ubuntu focal-security main
-      #filename: focal-security    # If filename focal-security.list is preferred
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "x86_64" or is_linuxmint_21
+  # 2023-01-19: libssl1.1 not longer nec on Ubuntu 22.04+ (and hopefully across
+  # the board, on Debian 12 etc too?!) since 2022-11-15:
+  # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
 
-  - name: Install source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if ubuntu 22.04+ aarch64
-    apt_repository:
-      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "aarch64"
+  # - name: Install source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+ x86_64 or Mint 21
+  #   apt_repository:
+  #     repo: deb http://security.ubuntu.com/ubuntu focal-security main
+  #     #filename: focal-security    # If filename focal-security.list is preferred
+  #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "x86_64" or is_linuxmint_21
 
-  - name: Install source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian 12
-    apt_repository:
-      repo: deb http://security.debian.org/debian-security bullseye-security main
-      #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
-    when: is_debian_12
+  # - name: Install source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if ubuntu 22.04+ aarch64
+  #   apt_repository:
+  #     repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
+  #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "aarch64"
 
-  - name: Install libssl1.1 if Ubuntu 22.04+ or Mint 21 or Debian 12 (required by MongoDB below)
-    package:
-      name: libssl1.1
-      state: present
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
+  # - name: Install source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian 12
+  #   apt_repository:
+  #     repo: deb http://security.debian.org/debian-security bullseye-security main
+  #     #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
+  #   when: is_debian_12
 
-  - name: Remove source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian 12
-    apt_repository:
-      repo: deb http://security.debian.org/debian-security bullseye-security main
-      #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
-      state: absent
-    when: is_debian_12
+  # - name: Install libssl1.1 if Ubuntu 22.04+ or Mint 21 or Debian 12 (required by MongoDB below)
+  #   package:
+  #     name: libssl1.1
+  #     state: present
+  #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
 
-  - name: Remove source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if ubuntu 22.04+ aarch64
-    apt_repository:
-      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
-      state: absent
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "aarch64"
+  # - name: Remove source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian 12
+  #   apt_repository:
+  #     repo: deb http://security.debian.org/debian-security bullseye-security main
+  #     #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
+  #     state: absent
+  #   when: is_debian_12
 
-  - name: Remove source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+ x86_64 or Mint 21
-    apt_repository:
-      repo: deb http://security.ubuntu.com/ubuntu focal-security main
-      state: absent
-      #filename: focal-security    # 100% IGNORED during repo deletion
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "x86_64" or is_linuxmint_21
+  # - name: Remove source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if ubuntu 22.04+ aarch64
+  #   apt_repository:
+  #     repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
+  #     state: absent
+  #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "aarch64"
+
+  # - name: Remove source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+ x86_64 or Mint 21
+  #   apt_repository:
+  #     repo: deb http://security.ubuntu.com/ubuntu focal-security main
+  #     state: absent
+  #     #filename: focal-security    # 100% IGNORED during repo deletion
+  # when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') and ansible_architecture == "x86_64" or is_linuxmint_21
 
   # # Debian 10 aarch64 might work below but is blocked in main.yml
   # - name: Use mongodb-org's Ubuntu focal repo for RasPiOS-aarch64

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -130,8 +130,9 @@
   # sudo apt-get install libssl1.1
   # rm /etc/apt/sources.list.d/focal-security.list
 
-  # 2023-01-19: libssl1.1 not longer nec on Ubuntu 22.04+ (and hopefully across
-  # the board, on Debian 12 etc too?!) since 2022-11-15:
+  # 2023-01-19: Retrofitting libssl1.1 onto Ubuntu 22.04+ and Debian 12 is no
+  # longer nec (certainly on x86_64, and hopefully sufficiently across the
+  # board?) as MongoDB can finally use libssl3 instead, since 2022-11-15:
   # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
 
   # - name: Install source/repo "deb http://security.ubuntu.com/ubuntu focal-security main" at /etc/apt/sources.list.d/security_ubuntu_com_ubuntu.list if Ubuntu 22.04+ x86_64 or Mint 21

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -113,7 +113,9 @@
   # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
   # WHEREAS 64-bit Raspberry Pi is likely NOT supported for now, as MongoDB 6.0
   # IS ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4 (JUST LIKE THEIR
-  # MongoDB 5.0, tested 2022-06-07 ~113 lines below).
+  # MongoDB 5.0, tested 2022-06-07 ~113 lines below).  Though MongoDB 6.0.3+ on
+  # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
+  # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
   - name: Otherwise, install mongodb-org's Ubuntu jammy source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
     apt_repository:
       repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_64bit_version }} multiverse


### PR DESCRIPTION
Tested successfully (using Sugarizer) on Ubuntu 22.04 and the latest daily build of Debian 12, in each case on x86_64 VM's.

Not every distro / hardware combination under the sun can be tested realistically, but more to follow.

Building on:

- https://github.com/iiab/iiab/issues/3190#issuecomment-1397745727
- #3399