### PR TITLE
Install Moodle dev pre-release (e.g. 4.2dev for now) IFF PHP >= 8.3

### DIFF
--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -49,21 +49,21 @@
   when: php_settings_done is undefined
 
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.2"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.3"
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
     version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022)
-  when: php_version is version('8.2', '>=')
+  when: php_version is version('8.3', '>=')
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.2
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.3
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
     version: "{{ moodle_version }}"    # e.g. MOODLE_401_STABLE (Moodle 4.1)
-  when: php_version is version('8.2', '<')
+  when: php_version is version('8.3', '<')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:


### PR DESCRIPTION
Thanks to testing of Moodle 4.1.1 LTS on PHP 8.2.1 on Debian 12 Bookworm's latest daily build :heavy_check_mark:

It works great, which is very positive news.

Related:

- https://download.moodle.org/releases/development/
- PR #2832
- #2864
- PR #3382
- #3399
- PR #3430