### PR TITLE
sugarizer-server-1.5.0

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -13,7 +13,7 @@ sugarizer_dir_version: sugarizer-1.6.0    # WAS: sugarizer-1.0, sugarizer-master
 sugarizer_git_version: v1.6.0             # WAS: v1.0.1, master, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
-sugarizer_server_dir_version: sugarizer-server-1.4.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0, sugarizer-server-1.1.1, sugarizer-server-1.2.0, sugarizer-server-1.3.0
-sugarizer_server_git_version: v1.4.0                    # WAS: v1.0.1, master, dev, f27bf6acd56aba6d99116ef471ca713b0f0dfed3, v1.1.0, v1.1.1, v1.2.0, v1.3.0
+sugarizer_server_dir_version: sugarizer-server-1.5.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0, sugarizer-server-1.1.1, sugarizer-server-1.2.0, sugarizer-server-1.3.0, sugarizer-server-1.4.0
+sugarizer_server_git_version: v1.5.0                    # WAS: v1.0.1, master, dev, f27bf6acd56aba6d99116ef471ca713b0f0dfed3, v1.1.0, v1.1.1, v1.2.0, v1.3.0, v1.4.0
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer-server/commits/dev
 #                 AND https://github.com/llaske/sugarizer-server/releases

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -61,7 +61,7 @@
 # CLARIF: during repeat runs of "./runrole sugarizer", this git sync shows
 # "changed" (whereas above git sync shows "ok").  Reason: "npm install"
 # (below) modifies /opt/iiab/sugarizer-server/node_modules
-- name: Clone llaske/sugarizer-server ({{ sugarizer_server_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_server_dir_version }} (~9 MB initially, ~195+ MB later)
+- name: Clone llaske/sugarizer-server ({{ sugarizer_server_git_version }} branch/version) from GitHub to /opt/iiab/{{ sugarizer_server_dir_version }} (~16 MB initially, ~227+ MB later)
   git:
     repo: https://github.com/llaske/sugarizer-server
     dest: "{{ iiab_base }}/{{ sugarizer_server_dir_version }}"


### PR DESCRIPTION
MongoDB minimal version is now 3.2+

Further detail:
https://github.com/llaske/sugarizer-server/releases/tag/v1.5.0

Related:

- PR #3099
- PR #3214
- PE #3238
- PR #3241
- PR #3469