### PR TITLE
Revert jammy to focal for MongoDB 5.0.5 collateral on arm64/aarch64

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -17,7 +17,7 @@ iset_suffixes:
   armv6l: arm-6
   armv7l: arm-6    # "arm-7" used to work, but no longer since 2019-04-20's Gitea 1.8.0: https://github.com/iiab/iiab/issues/1673 https://github.com/iiab/iiab/pull/1713 -- 2019-07-31: ARM7 support will return at some point, according to: https://github.com/go-gitea/gitea/pull/7037#issuecomment-516735216 (what about ARM8 support for RPi 4?)
 
-gitea_iset_suffix: "{{ iset_suffixes[ansible_architecture] | default('unknown') }}"
+gitea_iset_suffix: "{{ iset_suffixes[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
 
 gitea_download_url: "https://dl.gitea.io/gitea/{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_iset_suffix }}"
 gitea_integrity_url: "{{ gitea_download_url }}.asc"

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -20,7 +20,18 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mongodb_64bit_version: 6.0    # 2022-10-23: 4.4 fails on Debian 12 x86_64:
+mongodb_arch_dict:
+  armv6l: unsupported    # WAS: 3.0
+  armv7l: unsupported    # WAS: 3.0
+  aarch64: 5.0
+  i386: unsupported
+  x86_64: 6.0
+
+mongodb_version: "{{ mongodb_arch_dict[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
+
+#mongodb_arm64_version: 5.0    # 2023-02-24: MongoDB 6.0.4 fails to install on
+#                              # 64-bit RasPiOS 11, as it doesn't offer libssl3.
+#mongodb_amd64_version: 6.0    # 2022-10-23: 4.4 fails on Debian 12 x86_64:
 # "No package matching 'mongodb-org' is available".  5.0+ fail on "pre-2011"
 # CPU's w/o AVX, and on RPi due to MongoDB compiling these for v8.2-A (RPi 4 is
 # ARM v8-A).  SO IIAB ALWAYS OVERLAYS andyfelong.com's 5.0.5 IF 5.0+ SPECIFIED.

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -16,6 +16,9 @@
 # CLARIF: mongodb_stretch_3_0_14_core.zip IS IN FACT 3.0.14 (core) BUT...
 #         mongodb_stretch_3_0_14_tools.zip IS REALLY 3.0.15 (tools)
 
+# 2023-02-24: ALL 54 LINES BELOW (e.g. for 32-bit RasPiOS) MAY NEED TO BE
+# REMOVED SOON, due to Sugarizer Server 1.5.0's new MongoDB 3.2+ REQUIREMENT:
+# https://github.com/iiab/iiab/pull/3478#issuecomment-1444395170
 - block:
   - name: Create dir /tmp/mongodb-3.0.1x (aarch32)
     file:
@@ -71,18 +74,18 @@
   # end block
   when: not (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
 
-# 32-bit OS's are handled above: this should handle aarch32 including 32-bit
+# 32-bit OS's [WERE] handled above: this should handle aarch32 including 32-bit
 # Ubuntu from https://ubuntu.com/download/raspberry-pi but Ubuntu 20.04+ and
 # 22.04+ 32-bit might fail untested, and 32-bit Intel might puke as this was
 # orginally deployed for Raspbian.  (Haven't seen bootable 32-bit Intel
 # installers for a while now.)  64-bit OS's proceed below.
 
 - block:
-  - name: Add mongodb.org signing key (only 64-bit support available) for MongoDB version {{ mongodb_64bit_version }}
+  - name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }}
     # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
-    shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | gpg --dearmor > /usr/share/keyrings/mongodb.gpg
-    #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_64bit_version }}.asc | apt-key add -
-    #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_64bit_version }}.asc | apt-key add -
+    shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /usr/share/keyrings/mongodb.gpg
+    #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | apt-key add -
+    #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_version }}.asc | apt-key add -
     #args:
     #  warn: no
     # Ansible 2.14 ERROR:
@@ -94,15 +97,15 @@
   # MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4,
   # LIKE THEIR MongoDB 5.0 tested 2022-06-07 ~137 lines below.  Tested on Deb 11.
   # -> DELETE THIS STANZA AFTER DEBIAN 12 IS SOLID -- USING UBUNTU REPO BELOW ?
-  - name: Install mongodb-org's Debian bullseye source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_64bit_version }}, if x86_64 Debian < 12
+  - name: Install mongodb-org's Debian bullseye source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_version }}, if x86_64 Debian < 12
     apt_repository:
       # 2020-10-28 and 2022-06-09: https://repo.mongodb.org/apt/debian/dists/
       # supports only {Buster 10, Stretch 9, Jessie 8, Wheezy 7}.  So Bullseye
       # 11 and Bookworm 12 (testing branch) revert to buster for now:
       # 2022-09-27: Changed from 'buster' to 'bullseye' (i.e. Debian 11) as
       # this was recently added to https://repo.mongodb.org/apt/debian/dists/
-      repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
-      #repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_64bit_version }} main
+      repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_version }} main
+      #repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_version }} main
       #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       #filename: mongodb-org
     when: is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64"
@@ -117,10 +120,10 @@
   # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
   # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
   # So IIAB overlays MongoDB 5.0.5 64-bit RPi binaries for now (~141 LINES BELOW!)
-  - name: Otherwise, install mongodb-org's Ubuntu jammy source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_64bit_version }}
+  - name: Otherwise, install mongodb-org's Ubuntu focal source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_version }}
     apt_repository:
-      repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_64bit_version }} multiverse
-      #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_64bit_version }} multiverse
+      repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
+      #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
       #filename: mongodb-org
     when: not (is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64")
     #when: is_ubuntu or is_debian and os_ver is version('debian-12', '>=')
@@ -250,16 +253,16 @@
   # https://andyfelong.com/downloads/raspbian_mongodb_5.0.5.gz
   # https://andyfelong.com/2021/08/mongodb-4-4-under-raspberry-pi-os-64-bit-raspbian64/
 
-  - name: If hardware is Raspberry Pi and mongodb_64bit_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
+  - name: If hardware is Raspberry Pi and mongodb_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
     command: apt-mark hold mongodb-org mongodb-org-server
-    when: rpi_model != "none" and mongodb_64bit_version is version('5.0', '>=')
+    when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
 
-  - name: If hardware is Raspberry Pi and mongodb_64bit_version >= 5.0, unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
+  - name: If hardware is Raspberry Pi and mongodb_version >= 5.0, unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
     unarchive:
       remote_src: yes
       src: "{{ iiab_download_url }}/raspbian_mongodb_5.0.5.gz"
       dest: /usr/bin
-    when: rpi_model != "none" and mongodb_64bit_version is version('5.0', '>=')
+    when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
 
   # end block
   when: ansible_architecture == "aarch64" or ansible_architecture == "x86_64"


### PR DESCRIPTION
This is not just a fix &mdash; it should also make IIAB's MongoDB install process more future-proof:

0) CLARIF that https://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/ is useless on Raspberry Pi.

1) CLARIF that we use https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/5.0/ on 64-bit Raspberry Pi **merely as a convenience** to automate install of COLLATERAL e.g. MongoDB user, config files, log file and systemd unit file.

   Essentially as a shortcut to put in place the 4+ grungy details explained under https://andyfelong.com/2021/08/mongodb-4-4-under-raspberry-pi-os-64-bit-raspbian64/ **> Install and use** here:

   - Create the mongodb user
   - Create the configuration file:  `/etc/mongod.conf`
   - Create the log file and data directory. Change owner and group.
   - Create the systemctl service [unit] file to stop/start mongod process

2) Whereas the lynchpin (actual working MongoDB 5.0.5 for 64-bit Raspberry Pi binaries!) are provided by https://andyfelong.com/2021/08/mongodb-4-4-under-raspberry-pi-os-64-bit-raspbian64/

Finally, this was tested on the very latest (just released) 64-bit RasPiOS 2023-02-21, with Sugarizer 1.6.0 and the just-released Sugarizer Server 1.5.0:

- PR #3478

Building on:

- PR #3469