### PR TITLE
Set WiFi firmware in /lib/firmware/cypress due to RasPiOS & Ubuntu changes

### DIFF
--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -1,23 +1,36 @@
-- name: Back up 4 OS-provided WiFi firmware files (or symlinks) to /lib/firmware/brcm/*.orig
-  copy:
-    src: /lib/firmware/brcm/{{ item }}
-    dest: /lib/firmware/brcm/{{ item }}.orig
+# 2023-02-24: MONITOR FIRMWARE UPDATES in 3 places especially:
+#
+# 1. apt changelog firmware-brcm80211
+#    https://github.com/RPi-Distro/firmware-nonfree
+#    http://archive.raspberrypi.org/debian/dists/bullseye/main/binary-arm64/Packages
+#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_*
+# 2. apt changelog linux-firmware-raspi
+#    https://packages.ubuntu.com/search?keywords=linux-firmware-raspi
+# 3. https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml
+
+#- name: Back up 4 OS-provided WiFi firmware files (incl symlink contents) to /lib/firmware/cypress/*.orig
+- name: Back up 4 OS-provided WiFi firmware files (or preserve symlinks) to /lib/firmware/cypress/*.orig
+  # copy:
+  #   src: /lib/firmware/cypress/{{ item }}
+  #   dest: /lib/firmware/cypress/{{ item }}.orig
+  #   local_follow: False    # FAILS TO PRESERVE LINKS (ansible/ansible#74777) e.g. /lib/firmware/cypress/cyfmac43455-sdio.bin -> /etc/alternatives/cyfmac43455-sdio.bin -> ...
+  command: cp -P /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig
   with_items:
-    - brcmfmac43430-sdio.bin
-    - brcmfmac43430-sdio.clm_blob
-    - brcmfmac43455-sdio.bin
-    - brcmfmac43455-sdio.clm_blob
-  ignore_errors: yes
+    - cyfmac43430-sdio.bin
+    - cyfmac43430-sdio.clm_blob
+    - cyfmac43455-sdio.bin
+    - cyfmac43455-sdio.clm_blob
+  #ignore_errors: yes
 
 - name: Download higher-capacity firmwares (for RPi internal WiFi, per https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and https://github.com/iiab/iiab/issues/2853)
   get_url:
     url: "{{ iiab_download_url }}/{{ item }}"
-    dest: /lib/firmware/brcm/
+    dest: /lib/firmware/cypress/
     timeout: "{{ download_timeout }}"
   with_items:
-    - brcmfmac43455-sdio.bin_2021-11-30_minimal                # 19 -- from https://github.com/RPi-Distro/firmware-nonfree/blob/feeeda21e930c2e182484e8e1269b61cca2a8451/debian/config/brcm80211/cypress/cyfmac43455-sdio-minimal.bin
+    - brcmfmac43455-sdio.bin_2021-11-30_minimal                # 19 -- SAME AS RASPIOS & UBUNTU'S https://github.com/RPi-Distro/firmware-nonfree/blob/feeeda21e930c2e182484e8e1269b61cca2a8451/debian/config/brcm80211/cypress/cyfmac43455-sdio-minimal.bin
     - brcmfmac43455-sdio.bin_2021-10-05_3rd-trial-minimal      # 24 -- from https://github.com/iiab/iiab/issues/2853#issuecomment-934293015
-    - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi               # Works w/ both above -- from https://github.com/RPi-Distro/firmware-nonfree/blob/dc406650e840705957f8403efeacf71d2d7543b3/debian/config/brcm80211/cypress/cyfmac43455-sdio.clm_blob
+    - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi               # Works w/ both above -- SAME AS RASPIOS & UBUNTU'S https://github.com/RPi-Distro/firmware-nonfree/blob/dc406650e840705957f8403efeacf71d2d7543b3/debian/config/brcm80211/cypress/cyfmac43455-sdio.clm_blob
     - brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1    # 32 -- from https://github.com/iiab/iiab/issues/823#issuecomment-662285202
     - brcmfmac43455-sdio.clm_blob_2018-02-26_rpi
     - brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65             # 30 -- from https://github.com/iiab/iiab/issues/823#issuecomment-662285202

--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -9,18 +9,18 @@
 # 3. https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml
 
 #- name: Back up 4 OS-provided WiFi firmware files (incl symlink contents) to /lib/firmware/cypress/*.orig
-- name: Back up 4 OS-provided WiFi firmware files (or preserve symlinks) to /lib/firmware/cypress/*.orig
+- name: Back up 4 OS-provided WiFi firmware files (or replicate symlinks) to /lib/firmware/cypress/*.orig -- NOTE that "doubly timestamped" copies (incl any symlinks' contents!) are ALSO made by iiab-check-firmware -- as firmware install completes
   # copy:
   #   src: /lib/firmware/cypress/{{ item }}
   #   dest: /lib/firmware/cypress/{{ item }}.orig
-  #   local_follow: False    # FAILS TO PRESERVE LINKS (ansible/ansible#74777) e.g. /lib/firmware/cypress/cyfmac43455-sdio.bin -> /etc/alternatives/cyfmac43455-sdio.bin -> ...
-  command: cp -P /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig
+  #   #local_follow: False    # FAILS TO PRESERVE LINKS (ansible/ansible#74777) e.g. /lib/firmware/cypress/cyfmac43455-sdio.bin -> /etc/alternatives/cyfmac43455-sdio.bin -> ...
+  command: cp -P /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig    # "cp -P" == "cp --no-dereference" sufficient to replicate these symlinks and files ("cp -d" & "cp -a" are incrementally stronger, but so far unnec)
   with_items:
     - cyfmac43430-sdio.bin
     - cyfmac43430-sdio.clm_blob
     - cyfmac43455-sdio.bin
     - cyfmac43455-sdio.clm_blob
-  #ignore_errors: yes
+  #ignore_errors: yes    # 2023-02-25: Let's INTENTIONALLY surface any errors, e.g. if any future RasPiOS or Ubuntu-on-Rpi lack some of the above 4 files/links?
 
 - name: Download higher-capacity firmwares (for RPi internal WiFi, per https://github.com/iiab/iiab/issues/823#issuecomment-662285202 and https://github.com/iiab/iiab/issues/2853)
   get_url:

--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -2,22 +2,22 @@
 #
 # 1. apt changelog firmware-brcm80211
 #    https://github.com/RPi-Distro/firmware-nonfree -> debian/config/brcm80211 (brcm, cypress)
-#    http://archive.raspberrypi.org/debian/dists/bullseye/main/binary-arm64/Packages (1.1MB text file, look inside for summary of latest firmware-brcm80211)
-#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/ -> firmware-brcm80211_* e.g.:
+#    https://archive.raspberrypi.org/debian/dists/bullseye/main/binary-arm64/Packages (1.1MB text file, look inside for summary of latest firmware-brcm80211)
+#    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/ -> firmware-brcm80211_* e.g.:
 #    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt11_all.deb from 2021-01-25
 #    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20210315-3+rpt4_all.deb from 2021-12-06
-#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20221012-1~bpo11+1+rpt1_all.deb from 2022-11-17
+#    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20221012-1~bpo11+1+rpt1_all.deb from 2022-11-17
 # 2. apt changelog linux-firmware-raspi
 #    https://packages.ubuntu.com/search?keywords=linux-firmware-raspi
 # 3. https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml
 
 #- name: Back up 4 OS-provided WiFi firmware files (incl symlink contents) to /lib/firmware/cypress/*.orig
-- name: Back up 4 OS-provided WiFi firmware files (or replicate symlinks) to /lib/firmware/cypress/*.orig -- NOTE that "doubly timestamped" copies (incl any symlinks' contents!) are ALSO made by iiab-check-firmware -- as firmware install completes
+- name: Back up 4 OS-provided WiFi firmware files (replicate any symlinks) to /lib/firmware/cypress/*.orig -- /usr/bin/iiab-check-firmware will later do similar (e.g. as firmware install completes) -- moving 2-or-4 of these to <ORIGINAL FILENAME>.YYYY-MM-DD-HH:MM:SS ("doubly timestamping" to preserve BOTH last-modif & moving date)
   # copy:
   #   src: /lib/firmware/cypress/{{ item }}
   #   dest: /lib/firmware/cypress/{{ item }}.orig
   #   #local_follow: False    # FAILS TO PRESERVE LINKS (ansible/ansible#74777) e.g. /lib/firmware/cypress/cyfmac43455-sdio.bin -> /etc/alternatives/cyfmac43455-sdio.bin -> ...
-  command: cp -P /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig    # "cp -P" == "cp --no-dereference" sufficient to replicate these symlinks and files ("cp -d" & "cp -a" are incrementally stronger, but so far unnec)
+  command: cp -a /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig    # "cp -P" == "cp --no-dereference" sufficient to replicate these symlinks and files ("cp -d" & "cp -a" are incrementally stronger, and so probably can't hurt)
   with_items:
     - cyfmac43430-sdio.bin
     - cyfmac43430-sdio.clm_blob

--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -1,9 +1,12 @@
-# 2023-02-24: MONITOR FIRMWARE UPDATES in 3 places especially:
+# 2023-02-25: MONITOR FIRMWARE UPDATES in 3 places especially...
 #
 # 1. apt changelog firmware-brcm80211
-#    https://github.com/RPi-Distro/firmware-nonfree
-#    http://archive.raspberrypi.org/debian/dists/bullseye/main/binary-arm64/Packages
-#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_*
+#    https://github.com/RPi-Distro/firmware-nonfree -> debian/config/brcm80211 (brcm, cypress)
+#    http://archive.raspberrypi.org/debian/dists/bullseye/main/binary-arm64/Packages (1.1MB text file, look inside for summary of latest firmware-brcm80211)
+#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/ -> firmware-brcm80211_* e.g.:
+#    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt11_all.deb from 2021-01-25
+#    https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20210315-3+rpt4_all.deb from 2021-12-06
+#    http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20221012-1~bpo11+1+rpt1_all.deb from 2022-11-17
 # 2. apt changelog linux-firmware-raspi
 #    https://packages.ubuntu.com/search?keywords=linux-firmware-raspi
 # 3. https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -4,61 +4,69 @@
 
 
 # Set 2 symlinks for RPi 3 B+ and 4 (43455)
+# COMPARE: update-alternatives --display cyfmac43455-sdio.bin
+# https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml#L3-L6
 
-- name: Populate rpi3bplus_rpi4_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/brcm)
+- name: Populate rpi3bplus_rpi4_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/cypress)
   set_fact:
     rpi3bplus_rpi4_wifi_firmwares:    # Dictionary keys (left side) are always strings, e.g. "19"
       os:
-        - brcmfmac43455-sdio.bin.orig
-        - brcmfmac43455-sdio.clm_blob.orig
+        - cyfmac43455-sdio.bin.orig             # 2023-02-25: 7.45.241 from 2021-11-01 on Ubuntu 22.04.2 too (cyfmac43455-sdio-standard.bin)
+        - cyfmac43455-sdio.clm_blob.orig        # On Ubuntu 22.04.2 too (brcmfmac43455-sdio.clm_blob_2021-11-17_rpi)
+      ub:
+        - cyfmac43455-sdio.bin.distrib          # 2023-02-25: STALE 7.45.234 from 2021-04-15; on Ubuntu 22.04.2 NOT RasPiOS
+        - cyfmac43455-sdio.clm_blob.distrib     # 4.7K instead of 2.7K w/ above "os"
       19:
-        - brcmfmac43455-sdio.bin_2021-11-30_minimal
-        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi
+        - brcmfmac43455-sdio.bin_2021-11-30_minimal     # On Ubuntu 22.04.2 too (cyfmac43455-sdio-minimal.bin)
+        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi    # On Ubuntu 22.04.2 too (cyfmac43455-sdio.clm_blob)
       24:
         - brcmfmac43455-sdio.bin_2021-10-05_3rd-trial-minimal
-        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi
+        - brcmfmac43455-sdio.clm_blob_2021-11-17_rpi    # On Ubuntu 22.04.2 too (cyfmac43455-sdio.clm_blob)
       32:
         - brcmfmac43455-sdio.bin_2015-03-01_7.45.18.0_ub19.10.1
-        - brcmfmac43455-sdio.clm_blob_2018-02-26_rpi
+        - brcmfmac43455-sdio.clm_blob_2018-02-26_rpi    # 14K instead of 2.7K w/ above "os"
 
-- name: Symlink /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+- name: Symlink /lib/firmware/cypress/cyfmac43455-sdio.bin.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
   file:
     src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][0] }}"
-    path: /lib/firmware/brcm/brcmfmac43455-sdio.bin.iiab
+    path: /lib/firmware/cypress/cyfmac43455-sdio.bin.iiab
     state: link
     force: yes
 
-- name: Symlink /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
+- name: Symlink /lib/firmware/cypress/cyfmac43455-sdio.clm_blob.iiab -> {{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }} (as rpi3bplus_rpi4_wifi_firmware is "{{ rpi3bplus_rpi4_wifi_firmware }}")
   file:
     src: "{{ rpi3bplus_rpi4_wifi_firmwares[rpi3bplus_rpi4_wifi_firmware][1] }}"
-    path: /lib/firmware/brcm/brcmfmac43455-sdio.clm_blob.iiab
+    path: /lib/firmware/cypress/cyfmac43455-sdio.clm_blob.iiab
     state: link
     force: yes
 
 
 # Set 2 symlinks for RPi Zero W and 3 (43430)
 
-- name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/brcm)
+- name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/cypress)
   set_fact:
     rpizerow_rpi3_wifi_firmwares:
       os:
-        - brcmfmac43430-sdio.bin.orig
-        - brcmfmac43430-sdio.clm_blob.orig
+        - cyfmac43430-sdio.bin.orig            # 2023-02-25: 7.45.98 from 2021-07-19 on Ubuntu 22.04.2 too
+        - cyfmac43430-sdio.clm_blob.orig       # On Ubuntu 22.04.2 too
+      ub:
+        - cyfmac43430-sdio.bin.distrib         # 2023-02-25: STALE 7.45.98.118 from 2021-03-30; on Ubuntu 22.04.2 NOT RasPiOS
+        - cyfmac43430-sdio.clm_blob.distrib    # Identical to above 4.7K cyfmac43430-sdio.clm_blob
       30:
         - brcmfmac43430-sdio.bin_2018-09-11_7.45.98.65
-        - brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65
+        - brcmfmac43430-sdio.clm_blob_2018-09-11_7.45.98.65    # 14K instead of 4.7K w/ above "os" & "ub"
 
-- name: Symlink /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+- name: Symlink /lib/firmware/cypress/cyfmac43430-sdio.bin.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
   file:
     src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][0] }}"
-    path: /lib/firmware/brcm/brcmfmac43430-sdio.bin.iiab
+    path: /lib/firmware/cypress/cyfmac43430-sdio.bin.iiab
     state: link
     force: yes
 
-- name: Symlink /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
+- name: Symlink /lib/firmware/cypress/cyfmac43430-sdio.clm_blob.iiab -> {{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }} (as rpizerow_rpi3_wifi_firmware is "{{ rpizerow_rpi3_wifi_firmware }}")
   file:
     src: "{{ rpizerow_rpi3_wifi_firmwares[rpizerow_rpi3_wifi_firmware][1] }}"
-    path: /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob.iiab
+    path: /lib/firmware/cypress/cyfmac43430-sdio.clm_blob.iiab
     state: link
     force: yes
 

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -81,7 +81,7 @@
     - { src: 'iiab-check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
     - { src: 'iiab-firmware-warn.sh', dest: '/etc/profile.d/', mode: '0644' }
 
-- name: Enable & (Re)Start iiab-check-firmware.service (also runs on each boot)
+- name: Enable & (Re)Start iiab-check-firmware.service (also runs on each boot) -- creating our 2-or-4 key simlink chains e.g. /lib/firmware/cypress/X.{bin|blob} -> /lib/firmware/cypress/X.{bin|blob}.iiab -> CHOSEN-FIRMWARE-FILE-OR-LINK
   systemd:
     name: iiab-check-firmware.service
     daemon_reload: yes

--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -81,7 +81,7 @@
     - { src: 'iiab-check-firmware.service', dest: '/etc/systemd/system/', mode: '0644' }
     - { src: 'iiab-firmware-warn.sh', dest: '/etc/profile.d/', mode: '0644' }
 
-- name: Enable & (Re)Start iiab-check-firmware.service (also runs on each boot) -- creating our 2-or-4 key simlink chains e.g. /lib/firmware/cypress/X.{bin|blob} -> /lib/firmware/cypress/X.{bin|blob}.iiab -> CHOSEN-FIRMWARE-FILE-OR-LINK
+- name: Enable & (Re)Start iiab-check-firmware.service (also runs on each boot) -- finalizing 2-or-4 symlink chains e.g. /lib/firmware/cypress/X.{bin|blob} -> /lib/firmware/cypress/X.{bin|blob}.iiab -> CHOSEN-FIRMWARE-FILE-OR-LINK
   systemd:
     name: iiab-check-firmware.service
     daemon_reload: yes

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -3,18 +3,22 @@
 # client devices that can access your Raspberry Pi's internal WiFi hotspot.
 
 # If IIAB's already installed, you should then run 'cd /opt/iiab/iiab' and
-# then 'sudo ./runrole firmware' (do run iiab-check-firmware for more tips!)
+# then 'sudo ./runrole firmware' (DO RUN iiab-check-firmware FOR MORE TIPS!)
 
-# BACKGROUND AS OF 2022-01-10:
-# https://github.com/iiab/iiab/issues/823#issuecomment-662285202
-# https://github.com/iiab/iiab/issues/2853#issuecomment-957836892
-# https://github.com/iiab/iiab/pull/3103
-# https://github.com/RPi-Distro/firmware-nonfree/tree/bullseye/debian/config/brcm80211 (brcm, cypress)
-# https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt11_all.deb from 2021-01-25
-# https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20210315-3+rpt4_all.deb from 2021-12-06
-
+# 2018-2023 Background & Progress:
+#
+# Raspberry Pi 3 used to support 32 WiFi connections but is now limited to [4-10]
+#     https://github.com/iiab/iiab/issues/823#issuecomment-662285202
+# Opinions about Pi 4B/3B+ WiFi features [practical AP firmware for schools!]
+#     https://github.com/iiab/iiab/issues/2853#issuecomment-957836892
+# RPi WiFi hotspot firmware reliability fix, incl new/better choices for 3B+ & 4
+#     https://github.com/iiab/iiab/pull/3103
+# Set WiFi firmware in /lib/firmware/cypress due to RasPiOS & Ubuntu changes
+#     https://github.com/iiab/iiab/pull/3482
 # RISK: What USB 3.0 stick/drive patterns degrade a Raspberry Pi's 2.4GHz WiFi?
-# https://github.com/iiab/iiab/issues/2638
+#     https://github.com/iiab/iiab/issues/2638
+
+# ► SEE "MONITOR FIRMWARE UPDATES in 3 places especially" in tasks/download.yml ◄
 
 - name: Install firmware (for RPi internal WiFi)
   include_tasks: install.yml

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -14,29 +14,29 @@ iiab_var_value() {
 }
 
 link_fw() {
-    if [[ $(readlink /lib/firmware/brcm/$1) != $1.iiab ]] ; then
-	echo
-	mv /lib/firmware/brcm/$1 /lib/firmware/brcm/$1.$(date +%F-%T)
-	ln -s $1.iiab /lib/firmware/brcm/$1
-	echo -e "\e[1mSymlinked /lib/firmware/brcm/$1 -> $1.iiab\e[0m"
-	touch /tmp/.fw_modified
+    if [[ $(readlink /lib/firmware/cypress/$1) != $1.iiab ]] ; then
+        echo
+        mv /lib/firmware/cypress/$1 /lib/firmware/cypress/$1.$(date +%F-%T)
+        ln -s $1.iiab /lib/firmware/cypress/$1
+        echo -e "\e[1mSymlinked /lib/firmware/cypress/$1 -> $1.iiab\e[0m"
+        touch /tmp/.fw_modified
     fi
 }
 
 if [[ $(iiab_var_value rpi3bplus_rpi4_wifi_firmware) != "os" ]] ; then
-    link_fw brcmfmac43455-sdio.bin
-    link_fw brcmfmac43455-sdio.clm_blob
+    link_fw cyfmac43455-sdio.bin
+    link_fw cyfmac43455-sdio.clm_blob
 fi
 
 if [[ $(iiab_var_value rpizerow_rpi3_wifi_firmware) != "os" ]] ; then
-    link_fw brcmfmac43430-sdio.bin
-    link_fw brcmfmac43430-sdio.clm_blob
+    link_fw cyfmac43430-sdio.bin
+    link_fw cyfmac43430-sdio.clm_blob
 fi
 
 if [ -f /tmp/.fw_modified ]; then
     bash /etc/profile.d/iiab-firmware-warn.sh
 else
-    echo -e "\n\e[1mWiFi Firmware links in /lib/firmware/brcm appear \e[92mCORRECT\e[0m\e[1m, per iiab/iiab#2853.\e[0m"
+    echo -e "\n\e[1mWiFi Firmware links in /lib/firmware/cypress appear \e[92mCORRECT\e[0m\e[1m, per iiab/iiab#2853.\e[0m"
     echo
     echo -e "\e[100;1m(No reboot appears necessary!)\e[0m"
     echo

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# The 1st time /usr/bin/iiab-check-firmware runs (at the end of
+# firmware/tasks/install.yml) 2-4 lynchpin top links are put in place,
+# finalizing symlink chains like:
+#
+#     /lib/firmware/cypress/X.{bin|blob} ->
+#     /lib/firmware/cypress/X.{bin|blob}.iiab ->
+#     CHOSEN-FIRMWARE-FILE-OR-LINK
+#
+# Also backing up top-of-chain originals (file or link!) by moving these to:
+#
+#     /lib/firmware/cypress/<ORIGINAL FILENAME>.YYYY-MM-DD-HH:MM:SS
+#
+# NOTE these are "doubly timestamped" to preserve BOTH last-modif & moving date.
+
 # 2023-02-25: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
 # https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
@@ -16,7 +30,7 @@ iiab_var_value() {
 link_fw() {
     if [[ $(readlink /lib/firmware/cypress/$1) != $1.iiab ]] ; then
         echo
-        mv /lib/firmware/cypress/$1 /lib/firmware/cypress/$1.$(date +%F-%T)    # i.e. "doubly timestamping" to preserve BOTH last-modif & moving date
+        mv /lib/firmware/cypress/$1 /lib/firmware/cypress/$1.$(date +%F-%T)
         ln -s $1.iiab /lib/firmware/cypress/$1
         echo -e "\e[1mSymlinked /lib/firmware/cypress/$1 -> $1.iiab\e[0m"
         touch /tmp/.fw_modified

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
+# 2023-02-25: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
 # https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
-# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
+# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L23-L39
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN
 
 iiab_var_value() {
@@ -16,7 +16,7 @@ iiab_var_value() {
 link_fw() {
     if [[ $(readlink /lib/firmware/cypress/$1) != $1.iiab ]] ; then
         echo
-        mv /lib/firmware/cypress/$1 /lib/firmware/cypress/$1.$(date +%F-%T)
+        mv /lib/firmware/cypress/$1 /lib/firmware/cypress/$1.$(date +%F-%T)    # i.e. "doubly timestamping" to preserve BOTH last-modif & moving date
         ln -s $1.iiab /lib/firmware/cypress/$1
         echo -e "\e[1mSymlinked /lib/firmware/cypress/$1 -> $1.iiab\e[0m"
         touch /tmp/.fw_modified
@@ -36,7 +36,7 @@ fi
 if [ -f /tmp/.fw_modified ]; then
     bash /etc/profile.d/iiab-firmware-warn.sh
 else
-    echo -e "\n\e[1mWiFi Firmware links in /lib/firmware/cypress appear \e[92mCORRECT\e[0m\e[1m, per iiab/iiab#2853.\e[0m"
+    echo -e "\n\e[1mWiFi Firmware links in /lib/firmware/cypress appear \e[92mCORRECT\e[0m\e[1m, per iiab/iiab#3482\e[0m"
     echo
     echo -e "\e[100;1m(No reboot appears necessary!)\e[0m"
     echo

--- a/roles/firmware/templates/iiab-firmware-warn.sh
+++ b/roles/firmware/templates/iiab-firmware-warn.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f /tmp/.fw_modified ]; then
-    echo -e "\n\e[41;1mWiFi Firmware link(s) modified, per iiab/iiab#2853: PLEASE REBOOT!\e[0m"
+    echo -e "\n\e[41;1mWiFi Firmware link(s) modified, per iiab/iiab#3482: PLEASE REBOOT!\e[0m"
     echo
     echo -e "If you want this warning to stop, reboot to remove /tmp/.fw_modified\n"
 fi

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -34,11 +34,11 @@ IPTABLES=/usr/sbin/iptables
 IPTABLES_DATA=/etc/sysconfig/iptables
 {% endif %}
 
-# 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
+# 2023-02-25: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
 # https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
-# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
+# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L23-L39
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN
 
 # "awk '{print $2}'" almost works, but: (1) Fails to remove outer quotes, and

--- a/roles/openvpn/templates/iiab-support
+++ b/roles/openvpn/templates/iiab-support
@@ -10,11 +10,11 @@ DEBUG=false    # Using /usr/bin/true or /usr/bin/false
 PLAYBOOK="install-support.yml"
 INVENTORY="ansible_hosts"
 
-# 2021-08-18: bash scripts using default_vars.yml &/or local_vars.yml
+# 2023-02-25: bash scripts using default_vars.yml &/or local_vars.yml
 # https://github.com/iiab/iiab-factory/blob/master/iiab
 # https://github.com/iiab/iiab/blob/master/roles/firmware/templates/iiab-check-firmware#L10-14
 # https://github.com/iiab/iiab/blob/master/roles/network/templates/gateway/iiab-gen-iptables#L48-L52
-# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L25-L34
+# https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-install-map-region#L23-L39
 # https://github.com/iiab/iiab/blob/master/roles/openvpn/templates/iiab-support READS AND WRITES, INCL NON-BOOLEAN
 
 # PARSE local_vars.yml JUST AS Ansible & /etc/openvpn/scripts/announcer DO:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -131,9 +131,10 @@ hostapd_enabled: True
 
 # Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
 # internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
-# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+# 32 on older OS's from 2020) using EXACTLY 1 of the 5 lines below:
 #
 #rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+#rpi3bplus_rpi4_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.234
 rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 #rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
 #rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
@@ -143,7 +144,8 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
 # internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98
+#rpizerow_rpi3_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.98.118
 #rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -74,9 +74,10 @@ hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
 
 # Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
 # internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
-# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+# 32 on older OS's from 2020) using EXACTLY 1 of the 5 lines below:
 #
 #rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+#rpi3bplus_rpi4_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.234
 rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 #rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
 #rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
@@ -86,7 +87,8 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
 # internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98
+#rpizerow_rpi3_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.98.118
 #rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -74,9 +74,10 @@ hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
 
 # Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
 # internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
-# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+# 32 on older OS's from 2020) using EXACTLY 1 of the 5 lines below:
 #
 #rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+#rpi3bplus_rpi4_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.234
 rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 #rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
 #rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
@@ -86,7 +87,8 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
 # internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98
+#rpizerow_rpi3_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.98.118
 #rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -74,9 +74,10 @@ hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
 
 # Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
 # internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
-# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+# 32 on older OS's from 2020) using EXACTLY 1 of the 5 lines below:
 #
 #rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+#rpi3bplus_rpi4_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.234
 rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 #rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
 #rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
@@ -86,7 +87,8 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
 # internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98
+#rpizerow_rpi3_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.98.118
 #rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -74,9 +74,10 @@ hostapd_password: changeme    # espec if WiFi firmware patched below?  #2696
 
 # Raspberry Pi 3 B+ and 4 OS's don't allow more than ~4 students to use the
 # internal WiFi hotspot.  Increase this to 19 or 24 student WiFi devices (or
-# 32 on older OS's from 2020) using EXACTLY 1 of the 4 lines below:
+# 32 on older OS's from 2020) using EXACTLY 1 of the 5 lines below:
 #
 #rpi3bplus_rpi4_wifi_firmware: os    # Use your OS's WiFi firmware e.g. 7.45.241
+#rpi3bplus_rpi4_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.234
 rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 #rpi3bplus_rpi4_wifi_firmware: 24    # REQUIRES "wifi_up_down: False" BELOW!
 #rpi3bplus_rpi4_wifi_firmware: 32    # UNRELIABLE (INTERMITTENT) with 2021+ OS's
@@ -86,7 +87,8 @@ rpi3bplus_rpi4_wifi_firmware: 19     # SEE: github.com/iiab/iiab/issues/2853
 # Raspberry Pi Zero W and 3 OS's don't allow more than ~10 students to use the
 # internal WiFi hotspot.  Or try increasing this to 30 student WiFi devices:
 #
-rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98.118
+rpizerow_rpi3_wifi_firmware: os     # Use yr OS WiFi firmware e.g. 7.45.98
+#rpizerow_rpi3_wifi_firmware: ub    # Ubuntu-only OLD firmware e.g. 7.45.98.118
 #rpizerow_rpi3_wifi_firmware: 30    # Or firmware 7.45.98.65 from 2018-09-28
 
 wifi_up_down: True    # AP+STA mode: Uses "ap0" WiFi adapter for upstream WiFi


### PR DESCRIPTION
This PR restores IIAB implementers' ability to select WiFi firmware on most Raspberry Pi's.

This is necessary because Raspberry Pi OS (and Ubuntu now too) have recently changed how WiFi firmware is selected for 43430 and 43455 chips (i.e. the Broadcom/Cypress/Infineon WiFi/Bluetooth chip used in most Raspberry Pi's).

Specifically, selecting a preferred WiFi firmware in directory `/lib/firmware/brcm` is no longer workable — with Raspberry Pi's that use these 2 chips — as can be seen from these newer (OS-provided) symlinks here:

```
root@box:/lib/firmware/brcm# ls -l brcm*rasp* | grep '\.\.' | cut -d' ' -f 9-
brcmfmac43430-sdio.raspberrypi,3-model-b.bin -> ../cypress/cyfmac43430-sdio.bin
brcmfmac43430-sdio.raspberrypi,3-model-b.clm_blob -> ../cypress/cyfmac43430-sdio.clm_blob
brcmfmac43430-sdio.raspberrypi,model-zero-w.bin -> ../cypress/cyfmac43430-sdio.bin
brcmfmac43430-sdio.raspberrypi,model-zero-w.clm_blob -> ../cypress/cyfmac43430-sdio.clm_blob
brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin -> ../cypress/cyfmac43455-sdio.bin
brcmfmac43455-sdio.raspberrypi,3-model-a-plus.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin -> ../cypress/cyfmac43455-sdio.bin
brcmfmac43455-sdio.raspberrypi,3-model-b-plus.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
brcmfmac43455-sdio.raspberrypi,4-model-b.bin -> ../cypress/cyfmac43455-sdio.bin
brcmfmac43455-sdio.raspberrypi,4-model-b.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
```

Distinct from the "10 above" symlinks (that lead to directory `/lib/firmware/cypress`) — most of the rest (of the other 18) still use `/lib/firmware/brcm` interestingly — at least for now:

```
root@box:/lib/firmware/brcm# ls -l *rasp*
lrwxrwxrwx 1 root root 27 Dec 19 12:31 BCM43430A1.raspberrypi,model-zero-2-w.hcd -> ../synaptics/SYN43430A1.hcd
lrwxrwxrwx 1 root root 27 Dec 19 12:31 BCM43430B0.raspberrypi,model-zero-2-w.hcd -> ../synaptics/SYN43430B0.hcd
lrwxrwxrwx 1 root root 31 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,3-model-b.bin -> ../cypress/cyfmac43430-sdio.bin
lrwxrwxrwx 1 root root 36 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,3-model-b.clm_blob -> ../cypress/cyfmac43430-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,3-model-b.txt -> brcmfmac43430-sdio.txt
lrwxrwxrwx 1 root root 31 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,model-zero-w.bin -> ../cypress/cyfmac43430-sdio.bin
lrwxrwxrwx 1 root root 36 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,model-zero-w.clm_blob -> ../cypress/cyfmac43430-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43430-sdio.raspberrypi,model-zero-w.txt -> brcmfmac43430-sdio.txt
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43436-sdio.raspberrypi,model-zero-2-w.bin -> brcmfmac43436-sdio.bin
lrwxrwxrwx 1 root root 27 Oct 31 10:31 brcmfmac43436-sdio.raspberrypi,model-zero-2-w.clm_blob -> brcmfmac43436-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43436-sdio.raspberrypi,model-zero-2-w.txt -> brcmfmac43436-sdio.txt
lrwxrwxrwx 1 root root 23 Oct 31 10:31 brcmfmac43436s-sdio.raspberrypi,model-zero-2-w.bin -> brcmfmac43436s-sdio.bin
lrwxrwxrwx 1 root root 23 Oct 31 10:31 brcmfmac43436s-sdio.raspberrypi,model-zero-2-w.txt -> brcmfmac43436s-sdio.txt
lrwxrwxrwx 1 root root 31 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin -> ../cypress/cyfmac43455-sdio.bin
lrwxrwxrwx 1 root root 36 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-a-plus.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-a-plus.txt -> brcmfmac43455-sdio.txt
lrwxrwxrwx 1 root root 31 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin -> ../cypress/cyfmac43455-sdio.bin
lrwxrwxrwx 1 root root 36 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-b-plus.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt -> brcmfmac43455-sdio.txt
lrwxrwxrwx 1 root root 31 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,4-model-b.bin -> ../cypress/cyfmac43455-sdio.bin
lrwxrwxrwx 1 root root 36 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,4-model-b.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43455-sdio.raspberrypi,4-model-b.txt -> brcmfmac43455-sdio.txt
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,400.bin -> brcmfmac43456-sdio.bin
lrwxrwxrwx 1 root root 27 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,400.clm_blob -> brcmfmac43456-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,400.txt -> brcmfmac43456-sdio.txt
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,4-compute-module.bin -> brcmfmac43456-sdio.bin
lrwxrwxrwx 1 root root 27 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,4-compute-module.clm_blob -> brcmfmac43456-sdio.clm_blob
lrwxrwxrwx 1 root root 22 Oct 31 10:31 brcmfmac43456-sdio.raspberrypi,4-compute-module.txt -> brcmfmac43456-sdio.txt
```

This PR is tested on 64-bit Raspberry Pi OS to resolve the problem, and spot-checked quickly on 64-bit Ubuntu 22.04.2 (also on Raspberry Pi 4).

Building on:

- PR #3103