### PR TITLE
MongoDB: Use jammy repo on amd64 (unless Debian 11)

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -85,7 +85,7 @@
 
 
 - debug:
-    msg: 15-STANZA BLOCK BELOW, RUNS *IF* 64-BIT -- i.e. ansible_architecture == "aarch64" or ansible_architecture == "x86_64"
+    msg: 16-STANZA BLOCK BELOW, RUNS *IF* 64-BIT -- i.e. ansible_architecture == "aarch64" or ansible_architecture == "x86_64"
 
 - block:
   - name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }}
@@ -116,7 +116,11 @@
       #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
       #filename: mongodb-org
     when: is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64"
-    #when: is_debian and ansible_architecture == "x86_64"
+
+  - name: Install mongodb-org's Ubuntu jammy source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_version }}, if other x86_64 OS
+    apt_repository:
+      repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_version }} multiverse
+    when: not (is_debian and os_ver is version('debian-12', '<')) and ansible_architecture == "x86_64"
 
   # 2023-01-19: Tested on x86_64 VM's with Ubuntu 22.04 & Debian 12.  Based on
   # MongoDB 6.0.3 (released 2022-11-15) instructions here:
@@ -127,12 +131,13 @@
   # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
   # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
   # So IIAB overlays MongoDB 5.0.5 64-bit RPi binaries for now (~141 LINES BELOW!)
-  - name: Otherwise, install mongodb-org's Ubuntu focal source/repo [ arch=amd64,arm64 ] for MongoDB version {{ mongodb_version }}
+  - name: Otherwise, install mongodb-org's Ubuntu focal source/repo [ arch=arm64 ] for MongoDB version {{ mongodb_version }}
     apt_repository:
-      repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
+      repo: deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
+      #repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
       #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
       #filename: mongodb-org
-    when: not (is_debian and os_ver is version('debian-12', '<') and ansible_architecture == "x86_64")
+    when: not ansible_architecture == "x86_64"
     #when: is_ubuntu or is_debian and os_ver is version('debian-12', '>=')
     #when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint and os_ver is version('linuxmint-12', '>=') or is_debian and os_ver is version('debian-12', '>=')
     #when: not (is_debian and ansible_architecture == "x86_64")
@@ -320,7 +325,7 @@
   when: ansible_architecture == "aarch64" or ansible_architecture == "x86_64"
 
 - debug:
-    msg: 15-STANZA BLOCK ABOVE, RAN *IF* 64-BIT -- i.e. ansible_architecture == "aarch64" or ansible_architecture == "x86_64"    # ansible_machine is a bit safer than ansible_architecture (see kiwix/defaults/main.yml)
+    msg: 16-STANZA BLOCK ABOVE, RAN *IF* 64-BIT -- i.e. ansible_architecture == "aarch64" or ansible_architecture == "x86_64"    # ansible_machine is a bit safer than ansible_architecture (see kiwix/defaults/main.yml)
 
 
 # 2. CONFIGURE MongoDB FOR IIAB


### PR DESCRIPTION
Tested on Debian 12 Bookworm on amd64 == x86_64.

Building on and improving upon:

- PR #3481
- PR #3483

Related:

- #3399