### PR TITLE
iiab-diagnostics: Report /lib/firmware/cypress/* not brcm

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -110,10 +110,10 @@ function cat_cmd() {    # $1 = command + params, $2 = explanation
     if [[ $path_cmd == "" ]]; then
         echo "COMMAND NOT FOUND: $1" >> $outfile
     else
-        bash -c "$1" >> $outfile    # Works with | (pipes) and 'ls -l /lib/firmware/brcm/*43455*' etc!
-	#(exec $1 >> $outfile)      # Works with | (pipes) and 'ls -l /lib/firmware/brcm/*43455*' etc!  Subshell needed (parens) as exec then exits entire shell.
+        bash -c "$1" >> $outfile    # Works with | (pipes) and 'ls -l /lib/firmware/cypress/*43455*' etc!
+	#(exec $1 >> $outfile)      # Works with | (pipes) and 'ls -l /lib/firmware/cypress/*43455*' etc!  Subshell needed (parens) as exec then exits entire shell.
 	#eval $1 >> $outfile              # Should be identical to below, i.e. insufficient -- "eval" combine ARGs into a single string.
-        #$(echo "eval $1") >> $outfile    # "eval" works with | (pipes) per https://stackoverflow.com/a/7184782 BUT globbing like 'ls -l /lib/firmware/brcm/*43455*' FAILS to output lines w/ filenames that contain spaces (ugly IFS issues!)
+        #$(echo "eval $1") >> $outfile    # "eval" works with | (pipes) per https://stackoverflow.com/a/7184782 BUT globbing like 'ls -l /lib/firmware/cypress/*43455*' FAILS to output lines w/ filenames that contain spaces (ugly IFS issues!)
     fi
     echo >> $outfile
 }
@@ -221,8 +221,8 @@ cat_cmd 'ps -AH' 'Process hierarchy: staging of hostapd & wpa_supplicant?'
 #cat_cmd 'dmesg | grep brcm' 'Diagnostic messages: RPi Wi-Fi firmware'
 cat_cmd 'dmesg | grep -i -e 80211 -e 802\.11 -e wireless -e wifi -e wlan -e broadcom -e brcm -e bcm -e realtek | head -100' 'Wi-Fi firmware/driver msgs'
 cat_cmd 'lspci -nn' 'Devices on PCI buses'
-cat_cmd 'ls -l /lib/firmware/brcm/*43430*' 'RPi Zero W & 3 WiFi firmware'
-cat_cmd 'ls -l /lib/firmware/brcm/*43455*' 'RPi 3 B+ & 4 WiFi firmware'
+cat_cmd 'ls -l /lib/firmware/cypress/*43430*' 'RPi Zero W & 3 WiFi firmware'
+cat_cmd 'ls -l /lib/firmware/cypress/*43455*' 'RPi 3 B+ & 4 WiFi firmware'
 cat_cmd 'env' 'Environment variables'
 cat_cmd '/opt/iiab/kiwix/bin/kiwix-serve --version' 'kiwix-tools'
 cat_cmd 'journalctl -t IIAB-CMDSRV' 'Admin Console CMDSRV log'


### PR DESCRIPTION
Follow-up to:

- PR #3482
