### PR TITLE
Add Haitian Creole (Kreyòl) as Kolibri's 32nd languages

### DIFF
--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -289,7 +289,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True
 kolibri_enabled: True
-kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -289,7 +289,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True
 kolibri_enabled: True
-kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -289,7 +289,7 @@ kalite_enabled: True
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -289,7 +289,7 @@ kalite_enabled: False
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
+kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: False


### PR DESCRIPTION
Thanks to:

- https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/utils/i18n.py#L59
- https://github.com/learningequality/kolibri/pull/10150
- https://github.com/learningequality/kolibri/releases/tag/v0.15.12

Its [PPA](https://itsfoss.com/ppa-guide/) is now live for upgrades from Kolibri 0.15.11 to 0.15.12 — but not quite yet available for new installs here:

- https://learningequality.org/download/
- https://learningequality.org/r/kolibri-deb-latest

(Those 2 should appear soon in the coming ~24h or so!)

Just FYI Haitian Creole (ht) hasn't yet appeared near the bottom of `i18n.py` in their `develop` branch below — but that will hopefully happen soon as Kolibri 0.16 will arrive in coming months:

- https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py

Building on:

- PR #3327
- 0b83307