### PR TITLE
Force 'pip install ansible-core' on Python 3.11+ for Ubuntu 23.04 (Lunar Lobster) & Debian 12 (Bookworm)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -186,15 +186,15 @@ if uname -m | grep -q 64; then
     # https://github.com/iiab/iiab/pull/3022
     pip3 config --global set global.no-cache-dir false
     echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
-    pip3 install --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+    pip3 install --break-system-packages --upgrade ansible-core    # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 else
 #    echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
 #    $APT_PATH/apt -y --allow-downgrades install ansible-core
     pip3 config --global set global.no-cache-dir false
     echo -e "\n\n'pip3 install cryptography==37.0.4' will now run:\n"
-    pip3 install cryptography==37.0.4 # latest compatible with ansible-core available via piwheels.org
+    pip3 install --break-system-packages cryptography==37.0.4 # latest compatible with ansible-core available via piwheels.org
     echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"
-    pip3 install --upgrade ansible-core # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+    pip3 install --break-system-packages --upgrade ansible-core # ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
 fi
 
 # (Re)running collection installs appears safe, with --force-with-deps to force


### PR DESCRIPTION
Tested on the latest Ubuntu 23.04 pre-release, which recently (just like Debian 12!) jumped to Python 3.11.2.

A more future-proof solution can be considered later in 2023 as (different?) norms evolve for installing `ansible-core` on these new OS's.  e.g. possibly a venv with official instructions at https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#pip-install as they evolve.  Or some other solution perhaps.  In any case, this interim approach works, and is good enough for now.

Aside: Both aforementioned OS's underwent beta-like freezes earlier today, so should be expected shortly in coming months.

Background / Context:

- https://github.com/iiab/iiab/issues/3399#issuecomment-1457315944
- [PEP 668](https://peps.python.org/pep-0668/) – Marking Python base environments as “externally managed”

Building on:

- PR #3459
- PR #3484