### PR TITLE
BUG FIX: use a virtual env for ansible

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -2,11 +2,11 @@
 # https://github.com/iiab/iiab/blob/master/roles/www_base/templates/iiab-refresh-wiki-docs.sh#L51-L52
 
 
-- name: Install 14 packages for Lokole
+- name: Install 13 packages for Lokole
   apt:
     name:
       #- python3    # 2022-12-21: IIAB pre-req, see scripts/local_facts.fact
-      - python3-pip
+      #- python3-pip
       - python3-venv
       - python3-dev
       - python3-bcrypt    # 2019-10-14: Should work across modern Linux OS's

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -199,7 +199,7 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-echo -e "Create virtual envinronment for ansible"
+echo -e "Create virtual environment for ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "Place ansible on path using symlinks"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -160,10 +160,10 @@ fi
 ###echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
 ###grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 
-echo -e "\napt update; apt install python3-pip    # Also installs 'python3-setuptools' and 'python3' etc"
+#echo -e "\napt update; apt install python3-pip   # Also installs 'python3-setuptools' and 'python3' etc"
 #echo -e "https://github.com/iiab/iiab/blob/master/scripts/ansible.md\n"
-$APT_PATH/apt update
-$APT_PATH/apt -y install python3-pip
+#$APT_PATH/apt update
+#$APT_PATH/apt -y install python3-pip
 
 # 2021-07-29:
 # 'python3-packaging' dropped for now
@@ -185,15 +185,28 @@ $APT_PATH/apt -y install python3-pip
 # https://github.com/iiab/iiab/pull/3022
 pip3 config --global set global.no-cache-dir false
 
-if ! uname -m | grep -q 64; then
+#if ! uname -m | grep -q 64; then
     # echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
     # $APT_PATH/apt -y --allow-downgrades install ansible-core
-    echo -e "\n\n'pip3 install cryptography==39.0.2' will now run:\n"
-    pip3 install --break-system-packages cryptography==39.0.2 || pip3 install cryptography==39.0.2    # PR #3459 https://www.piwheels.org/project/cryptography/ -- WAS 37.0.4 which as of 2023-01-06 was the "latest compatible with ansible-core available via piwheels.org"
-fi
+#    echo -e "\n\n'pip3 install cryptography==39.0.2' will now run:\n"
+#    pip3 install --break-system-packages cryptography==39.0.2 || pip3 install cryptography==39.0.2    # PR #3459 https://www.piwheels.org/project/cryptography/ -- WAS 37.0.4 which as of 2023-01-06 was the "latest compatible with ansible-core available via piwheels.org"
+#fi
 
-echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"                                   # REMINDER: ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
-pip3 install --break-system-packages --upgrade ansible-core || pip3 install --upgrade ansible-core    # PR #3493: Revert to old syntax if pip < 23.0.1, as flag --break-system-packages (for Python 3.11+ / PEP 668) is brand new in Feb 2023: https://github.com/pypa/pip/pull/11780
+#echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"                                   # REMINDER: ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+#pip3 install --break-system-packages --upgrade ansible-core || pip3 install --upgrade ansible-core    # PR #3493: Revert to old syntax if pip < 23.0.1, as flag --break-system-packages (for Python 3.11+ / PEP 668) is brand new in Feb 2023: https://github.com/pypa/pip/pull/11780
+
+echo -e "\napt update; apt install python3-venv"
+$APT_PATH/apt update
+$APT_PATH/apt -y install python3-venv
+
+echo -e "Create virtual envinronment for ansible"
+python3 -m venv /usr/local/ansible
+/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
+echo -e "Place ansible on path using symlinks"
+cd /usr/local/ansible/bin
+for bin in $(ls ansible*); do
+    ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin
+done
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -199,10 +199,10 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-echo -e "Create virtual environment for ansible"
+echo -e "\nCreate virtual environment for ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
-echo -e "Place ansible on path using symlinks"
+echo -e "\nPlace ansible on path using symlinks"
 cd /usr/local/ansible/bin
 for bin in $(ls ansible*); do
     ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -183,7 +183,7 @@ fi
 # cache system-wide before installing:
 # https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
 # https://github.com/iiab/iiab/pull/3022
-pip3 config --global set global.no-cache-dir false
+#pip3 config --global set global.no-cache-dir false
 
 #if ! uname -m | grep -q 64; then
     # echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"


### PR DESCRIPTION
### Fixes bug:
The dangerous use of '--break-system-packages'
### Description of changes proposed in this pull request:
https://github.com/iiab/iiab/issues/3399#issuecomment-1457315944 Switch to using a virtual environment to store ansible libraries 
Ref: https://salsa.debian.org/cpython-team/python3/-/blob/master/debian/README.venv
### Smoke-tested on which OS or OS's:
lightly tested on U-23.04 VM

