### PR TITLE
venv refinements for consideration, to tighten up scripts/ansible, deferring install of pip unless truly nec

### DIFF
--- a/roles/6-generic-apps/tasks/main.yml
+++ b/roles/6-generic-apps/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: JUPYTERHUB
   include_role:
     name: jupyterhub
-  when: jupyterhub_install and ansible_machine is search("64")    # 2022-11-10: Avoid installing on 32-bit, until RasPiOS fixes Rust (PR #3421)
+  when: jupyterhub_install
 
 # UNMAINTAINED
 - name: LOKOLE

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -46,6 +46,7 @@
   package:
     name: python3-pip
     state: present
+  when: admin_console_install
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -42,9 +42,11 @@
     name: pbx
   when: pbx_install
 
-- name: "INSTALL python3-pip FOR ADMIN CONSOLE 'cmdsrv : Download speedtest-cli' -- SEE PR #3494 -- REMOVE THIS CODE LATER"
+- name: "INSTALL python3-pip FOR ADMIN CONSOLE 'cmdsrv : Download speedtest-cli' SEE PR #3494 -- INSTALL python3-jinja2 FOR ADMIN CONSOLE 'js-menu : Post process the downloaded menu defs' SEE PR #3496 -- REMOVE THIS CODE LATER"
   package:
-    name: python3-pip
+    name:
+      - python3-pip
+      - python3-jinja2
     state: present
   when: admin_console_install
 

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -42,6 +42,11 @@
     name: pbx
   when: pbx_install
 
+- name: "INSTALL python3-pip FOR ADMIN CONSOLE 'cmdsrv : Download speedtest-cli' -- SEE PR #3494 -- REMOVE THIS CODE LATER"
+  package:
+    name: python3-pip
+    state: present
+
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     path: "{{ iiab_env_file }}"

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: CALIBRE-WEB
   include_role:
     name: calibre-web
-  when: calibreweb_install and ansible_machine is search("64")    # 2022-11-10: Avoid installing on 32-bit, until RasPiOS fixes Rust (PR #3421)
+  when: calibreweb_install
 
 # KEEP NEAR THE VERY END as this installs dependencies from Debian's 'testing' branch!
 - name: CALIBRE

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -3,6 +3,8 @@
     name:
       - imagemagick
       - python3-venv
+      - python3-dev
+      - build-essential
     state: present
 
 - name: Allow ImageMagick to read PDFs, per /etc/ImageMagick-6/policy.xml, to create book cover thumbnails

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -1,9 +1,9 @@
-- name: "Install packages: imagemagick, python3-venv"
+- name: "Install packages: imagemagick, python3-venv, build-essential"
   package:
     name:
       - imagemagick
       - python3-venv
-      - python3-dev
+      #- python3-dev
       - build-essential
     state: present
 

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -15,7 +15,7 @@
     name:
       - python2
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
-      - virtualenv           # For Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
+      - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
   #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -2,11 +2,11 @@
 # https://github.com/iiab/iiab/blob/master/roles/www_base/templates/iiab-refresh-wiki-docs.sh#L51-L52
 
 
-- name: Install 14 packages for Lokole
+- name: Install 13 packages for Lokole
   apt:
     name:
       #- python3    # 2022-12-21: IIAB pre-req, see scripts/local_facts.fact
-      - python3-pip
+      #- python3-pip
       - python3-venv
       - python3-dev
       - python3-bcrypt    # 2019-10-14: Should work across modern Linux OS's

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -199,7 +199,7 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-echo -e "Create virtual envinronment for ansible"
+echo -e "Create virtual environment for ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "Place ansible on path using symlinks"

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -160,7 +160,7 @@ fi
 ###echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
 ###grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 
-#echo -e "\napt update; apt install python3-pip   # Also installs 'python3-setuptools' and 'python3' etc"
+#echo -e "\napt update; apt install python3-pip    # Also installs 'python3-setuptools' and 'python3' etc"
 #echo -e "https://github.com/iiab/iiab/blob/master/scripts/ansible.md\n"
 #$APT_PATH/apt update
 #$APT_PATH/apt -y install python3-pip
@@ -183,7 +183,7 @@ fi
 # cache system-wide before installing:
 # https://stackoverflow.com/questions/9510474/removing-pips-cache/61762308#61762308
 # https://github.com/iiab/iiab/pull/3022
-pip3 config --global set global.no-cache-dir false
+#pip3 config --global set global.no-cache-dir false
 
 #if ! uname -m | grep -q 64; then
     # echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
@@ -199,10 +199,10 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-echo -e "Create virtual environment for ansible"
+echo -e "Create virtual environment for Ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
-echo -e "Place ansible on path using symlinks"
+echo -e "Create symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
 cd /usr/local/ansible/bin
 for bin in $(ls ansible*); do
     ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -160,10 +160,10 @@ fi
 ###echo -e 'ENSURE ANSIBLE UPDATES CLEANLY: (then re-run this script to be sure!)\n'
 ###grep '^deb .*ansible' /etc/apt/sources.list /etc/apt/sources.list.d/*.list | grep -v '^/etc/apt/sources.list.d/iiab-ansible.list:' || true    # Override bash -e (instead of aborting at 1st error)
 
-echo -e "\napt update; apt install python3-pip    # Also installs 'python3-setuptools' and 'python3' etc"
+#echo -e "\napt update; apt install python3-pip   # Also installs 'python3-setuptools' and 'python3' etc"
 #echo -e "https://github.com/iiab/iiab/blob/master/scripts/ansible.md\n"
-$APT_PATH/apt update
-$APT_PATH/apt -y install python3-pip
+#$APT_PATH/apt update
+#$APT_PATH/apt -y install python3-pip
 
 # 2021-07-29:
 # 'python3-packaging' dropped for now
@@ -185,15 +185,28 @@ $APT_PATH/apt -y install python3-pip
 # https://github.com/iiab/iiab/pull/3022
 pip3 config --global set global.no-cache-dir false
 
-if ! uname -m | grep -q 64; then
+#if ! uname -m | grep -q 64; then
     # echo "2022-11-09: ansible-core 2.12.10+ PPA works on 32-bit RasPiOS, using /etc/apt/sources.list.d/iiab-ansible.list, until upstream wheels -> cryptography is fixed (PR #3421)"
     # $APT_PATH/apt -y --allow-downgrades install ansible-core
-    echo -e "\n\n'pip3 install cryptography==39.0.2' will now run:\n"
-    pip3 install --break-system-packages cryptography==39.0.2 || pip3 install cryptography==39.0.2    # PR #3459 https://www.piwheels.org/project/cryptography/ -- WAS 37.0.4 which as of 2023-01-06 was the "latest compatible with ansible-core available via piwheels.org"
-fi
+#    echo -e "\n\n'pip3 install cryptography==39.0.2' will now run:\n"
+#    pip3 install --break-system-packages cryptography==39.0.2 || pip3 install cryptography==39.0.2    # PR #3459 https://www.piwheels.org/project/cryptography/ -- WAS 37.0.4 which as of 2023-01-06 was the "latest compatible with ansible-core available via piwheels.org"
+#fi
 
-echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"                                   # REMINDER: ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
-pip3 install --break-system-packages --upgrade ansible-core || pip3 install --upgrade ansible-core    # PR #3493: Revert to old syntax if pip < 23.0.1, as flag --break-system-packages (for Python 3.11+ / PEP 668) is brand new in Feb 2023: https://github.com/pypa/pip/pull/11780
+#echo -e "\n\n'pip3 install --upgrade ansible-core' will now run:\n"                                   # REMINDER: ansible-core 2.12 (released 2021-11-08) requires Python >= 3.8
+#pip3 install --break-system-packages --upgrade ansible-core || pip3 install --upgrade ansible-core    # PR #3493: Revert to old syntax if pip < 23.0.1, as flag --break-system-packages (for Python 3.11+ / PEP 668) is brand new in Feb 2023: https://github.com/pypa/pip/pull/11780
+
+echo -e "\napt update; apt install python3-venv"
+$APT_PATH/apt update
+$APT_PATH/apt -y install python3-venv
+
+echo -e "Create virtual envinronment for ansible"
+python3 -m venv /usr/local/ansible
+/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
+echo -e "Place ansible on path using symlinks"
+cd /usr/local/ansible/bin
+for bin in $(ls ansible*); do
+    ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin
+done
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -199,10 +199,10 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-echo -e "Create virtual environment for Ansible"
+echo -e "\nCreate virtual environment for Ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
-echo -e "Create symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
+echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
 cd /usr/local/ansible/bin
 for bin in $(ls ansible*); do
     ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -229,6 +229,7 @@ ansible-galaxy collection install --force-with-deps \
 
 echo -e "\n\nSUCCESS!  PLEASE VERIFY ANSIBLE WITH COMMANDS LIKE:\n"
 echo -e "    ansible --version"
+echo -e "    /usr/local/ansible/bin/pip3 show ansible-core"
 echo -e "    pip3 show ansible-core"
 echo -e '    apt -a list "ansible*"'
 echo -e "    ansible-galaxy collection list\n"


### PR DESCRIPTION
Building on @jvonau's:

- PR #3494

Tested with individual installs of {Calibre-Web, JupyterHub, Lokole} which do not install `pip` ~= `pip3` (thanks to this PR).
Whereas a 4th IIAB App (KA Lite) still does necessitate installing `pip` ~= `pip3`.

Finally, a stub is included in 9-local-addons/tasks/main.yml to force the install of `pip` ~= `pip3` for Admin Console.  For now anyway (this stub should later be removed).

Tested on Ubuntu 22.04.

Open Questions:

- Do these approaches work on 32-bit RasPiOS?  (That OS has had many issues with `piwheels` and `pip install cryptography` in recent months.)  Some background here:
  - PR #3459 
  - #3479
- Might there be other IIAB Apps that directly depend on `pip` ~= `pip3`, aside from the above 4?
- If this overall approach of tightening up & speeding up scripts/ansible is a good one, is completely eliminating pip3's cache optimization below Ok?  https://github.com/iiab/iiab/blob/00aa5d5a264d126160d3991fb6f62a9e4091aed1/scripts/ansible#L182-L186
  - PR #3022

_ADDENDUM - this PR also reverts the well-intended (but flawed) and in any case no-longer-necessary:_

- PR #3422

Ansible Context:

- PR #3484
- PR #3493