### PR TITLE
calibre-web - compiler and header files only when needed

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -3,9 +3,16 @@
     name:
       - imagemagick
       - python3-venv
-      #- python3-dev
-      - build-essential    # 2023-03-18: Needed (e.g. on Ubuntu 22.04) now that scripts/ansible no longer installs python3-pip
     state: present
+
+# https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
+- name: "Install packages: python3-dev, gcc to compile 'netifaces'"
+  package:
+    name:
+      - python3-dev # header files
+      - gcc         # compiler
+    state: present
+  when: python_version is version('3.10', '>=')
 
 - name: Allow ImageMagick to read PDFs, per /etc/ImageMagick-6/policy.xml, to create book cover thumbnails
   lineinfile:
@@ -44,7 +51,7 @@
 #  ignore_errors: True
 ##
 # Implementing this with Ansible command module for now.
-- name: Download Calibre-Web dependencies (using pip) into python3 virtual environment {{ calibreweb_venv_path }}
+- name: Download Calibre-Web dependencies from 'requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }}
   pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
@@ -95,6 +102,14 @@
     backup: yes
   when: not appdb.stat.exists
 
+# https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
+#- name: "Uninstall packages: python3-dev, gcc used to compile 'netifaces'"
+#  package:
+#    name:
+#      - python3-dev # header files
+#      - gcc         # compiler
+#    state: absent
+#  when: python_version is version('3.10', '>=')
 
 # RECORD Calibre-Web AS INSTALLED
 


### PR DESCRIPTION
### Fixes bug:
Installs a smaller subset of what build-essential installs
### Description of changes proposed in this pull request:
install only what is needed to compile 'netifaces' on python3.10 or greater
### Smoke-tested on which OS or OS's:
22.04 VM

2 passes to get the dependencies correct
```
Start-Date: 2023-03-19  21:28:36
Commandline: /usr/bin/apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install gcc=4:11.2.0-1ubuntu1
Requested-By: ubuntu (1000)
Install: manpages-dev:amd64 (5.10-1ubuntu1, automatic), gcc-11:amd64 (11.3.0-1ubuntu1~22.04, automatic), libtsan0:amd64 (11.3.0-1ubuntu1~22.04, automatic), cpp:amd64 (4:11.2.0-1ubuntu1, automatic), gcc:amd64 (4:11.2.0-1ubuntu1), libcc1-0:amd64 (12.1.0-2ubuntu1~22.04, automatic), libmpc3:amd64 (1.2.1-2build1, automatic), libasan6:amd64 (11.3.0-1ubuntu1~22.04, automatic), libnsl-dev:amd64 (1.3.0-2build2, automatic), rpcsvc-proto:amd64 (1.4.2-0ubuntu6, automatic), libcrypt-dev:amd64 (1:4.4.27-1, automatic), cpp-11:amd64 (11.3.0-1ubuntu1~22.04, automatic), libitm1:amd64 (12.1.0-2ubuntu1~22.04, automatic), libc-dev-bin:amd64 (2.35-0ubuntu3.1, automatic), libc-devtools:amd64 (2.35-0ubuntu3.1, automatic), libisl23:amd64 (0.24-2build1, automatic), libc6-dev:amd64 (2.35-0ubuntu3.1, automatic), libquadmath0:amd64 (12.1.0-2ubuntu1~22.04, automatic), libubsan1:amd64 (12.1.0-2ubuntu1~22.04, automatic), liblsan0:amd64 (12.1.0-2ubuntu1~22.04, automatic), gcc-11-base:amd64 (11.3.0-1ubuntu1~22.04, automatic), libtirpc-dev:amd64 (1.3.2-2ubuntu0.1, automatic), libgcc-11-dev:amd64 (11.3.0-1ubuntu1~22.04, automatic), libatomic1:amd64 (12.1.0-2ubuntu1~22.04, automatic), linux-libc-dev:amd64 (5.15.0-67.74, automatic)
End-Date: 2023-03-19  21:28:41

Start-Date: 2023-03-19  21:31:25
Commandline: /usr/bin/apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install python3-dev=3.10.6-1~22.04
Requested-By: ubuntu (1000)
Install: libpython3-dev:amd64 (3.10.6-1~22.04, automatic), zlib1g-dev:amd64 (1:1.2.11.dfsg-2ubuntu9.2, automatic), python3-dev:amd64 (3.10.6-1~22.04), libpython3.10-dev:amd64 (3.10.6-1~22.04.2, automatic), python3.10-dev:amd64 (3.10.6-1~22.04.2, automatic), libjs-jquery:amd64 (3.6.0+dfsg+~3.5.13-1, automatic), libexpat1-dev:amd64 (2.4.7-1ubuntu0.2, automatic), libjs-sphinxdoc:amd64 (4.3.2-1, automatic), javascript-common:amd64 (11+nmu1, automatic), libjs-underscore:amd64 (1.13.2~dfsg-2, automatic)
End-Date: 2023-03-19  21:31:26
```
On a side note is upstream even aware the project is uninstallable via pip on U-22.04 without having the required compilers installed?