### PR TITLE
Calibre web optional

### DIFF
--- a/roles/calibre-web/defaults/main.yml
+++ b/roles/calibre-web/defaults/main.yml
@@ -14,6 +14,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
+calibreweb_optional_install: False
+
 calibreweb_version: master    # WAS: master, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 0.6.8, 0.6.9
 
 calibreweb_venv_path: /usr/local/calibre-web-py3

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -131,6 +131,7 @@
         - python3-dev # header files
         - gcc         # compiler
         - libldap-dev # lber.h
+        - libsasl2-dev # sasl.h
 
   - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
     pip:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -102,15 +102,6 @@
     backup: yes
   when: not appdb.stat.exists
 
-# https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
-#- name: "Uninstall packages: python3-dev, gcc used to compile 'netifaces'"
-#  package:
-#    name:
-#      - python3-dev # header files
-#      - gcc         # compiler
-#    state: absent
-#  when: python_version is version('3.10', '>=')
-
 
 # RECORD Calibre-Web AS INSTALLED
 
@@ -147,3 +138,15 @@
       regexp: '^calibreweb_optional_installed'
       line: 'calibreweb_optional_installed: True'
   when: calibreweb_optional_install
+
+# https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
+#- name: "Uninstall packages: python3-dev, gcc used to compile 'netifaces'"
+#  package:
+#    name:
+#      - python3-dev # header files
+#      - gcc         # compiler
+#      - libldap-dev # lber.h
+#      - libsasl2-dev # sasl.h
+#      - g++ # compiler
+#    state: absent
+

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -3,17 +3,17 @@
     name:
       - imagemagick
       - python3-venv
+      - python3-netifaces
     state: present
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
-- name: "Install packages: python3-dev, gcc to compile 'netifaces'"
-  package:
-    name:
-      - python3-dev # header files
-      - gcc         # compiler
-    state: present
-  when: python_version is version('3.10', '>=')
-
+#- name: "Install packages: python3-dev, gcc to compile 'netifaces'"
+#  package:
+#    name:
+#      - python3-dev # header files
+#      - gcc         # compiler
+#    state: present
+#  when: python_version is version('3.10', '>=')
 - name: Allow ImageMagick to read PDFs, per /etc/ImageMagick-6/policy.xml, to create book cover thumbnails
   lineinfile:
     path: /etc/ImageMagick-6/policy.xml
@@ -56,7 +56,8 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
-    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
+    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+
 # VIRTUALENV EXAMPLE COMMANDS:
 # cd /usr/local/calibre-web-py3
 # source bin/activate
@@ -149,4 +150,3 @@
 #      - libsasl2-dev # sasl.h
 #      - g++ # compiler
 #    state: absent
-

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -56,7 +56,7 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
-    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+    virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
 
 # VIRTUALENV EXAMPLE COMMANDS:
 # cd /usr/local/calibre-web-py3
@@ -116,29 +116,37 @@
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'
 
-#- block:
-#  - name: "Install packages for optional-requirements.txt"
-#    package:
-#      name:
+- block:
+  - name: "Install packages for optional-requirements.txt"
+    package:
+      name:
+        - python3-ldap
+#        - python3-chardet
 #        - python3-dev # header files
 #        - gcc         # compiler
 #        - libldap-dev # lber.h
 #        - libsasl2-dev # sasl.h
 #        - g++ # compiler
 
-#  - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
-#    pip:
-#      requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
-#      virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
-#      virtualenv_site_packages: no
-#      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+  - name: "Update optional-requirements.txt"
+    lineinfile:
+      path: "{{ calibreweb_venv_path }}/optional-requirements.txt"
+      regexp: '^cchardet'
+      line: 'faust-cchardet>=2.1.18'
 
-#  - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
-#    lineinfile:
-#      path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-#      regexp: '^calibreweb_optional_installed'
-#      line: 'calibreweb_optional_installed: True'
-#  when: calibreweb_optional_install
+  - name: "Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked"
+    pip:
+      requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
+      virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
+      virtualenv_site_packages: no
+      virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
+
+  - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
+    lineinfile:
+      path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+      regexp: '^calibreweb_optional_installed'
+      line: 'calibreweb_optional_installed: True'
+  when: calibreweb_optional_install
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
 #- name: "Uninstall devel packages and compilers

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -128,11 +128,12 @@
 #        - libsasl2-dev # sasl.h
 #        - g++ # compiler
 
-  - name: "Update optional-requirements.txt"
-    lineinfile:
-      path: "{{ calibreweb_venv_path }}/optional-requirements.txt"
-      regexp: '^cchardet'
-      line: 'faust-cchardet>=2.1.18'
+# https://github.com/janeczku/calibre-web/pull/2725
+#  - name: "Update optional-requirements.txt"
+#    lineinfile:
+#      path: "{{ calibreweb_venv_path }}/optional-requirements.txt"
+#      regexp: '^cchardet'
+#      line: 'faust-cchardet>=2.1.18'
 
   - name: "Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked"
     pip:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -116,7 +116,7 @@
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'
 
-- block:
+#- block:
 #  - name: "Install packages for optional-requirements.txt"
 #    package:
 #      name:
@@ -126,19 +126,19 @@
 #        - libsasl2-dev # sasl.h
 #        - g++ # compiler
 
-  - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
-    pip:
-      requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
-      virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
-      virtualenv_site_packages: no
-      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+#  - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
+#    pip:
+#      requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
+#      virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
+#      virtualenv_site_packages: no
+#      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
 
-  - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
-    lineinfile:
-      path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-      regexp: '^calibreweb_optional_installed'
-      line: 'calibreweb_optional_installed: True'
-  when: calibreweb_optional_install
+#  - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
+#    lineinfile:
+#      path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+#      regexp: '^calibreweb_optional_installed'
+#      line: 'calibreweb_optional_installed: True'
+#  when: calibreweb_optional_install
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
 #- name: "Uninstall devel packages and compilers

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -132,6 +132,7 @@
         - gcc         # compiler
         - libldap-dev # lber.h
         - libsasl2-dev # sasl.h
+        - g++ # compiler
 
   - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
     pip:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -123,3 +123,25 @@
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^calibreweb_installed'
     line: 'calibreweb_installed: True'
+
+- block:
+  - name: "Install packages for optional-requirements.txt"
+    package:
+      name:
+        - python3-dev # header files
+        - gcc         # compiler
+        - libldap-dev # lber.h
+
+  - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
+    pip:
+      requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
+      virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
+      virtualenv_site_packages: no
+      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
+
+  - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
+    lineinfile:
+      path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+      regexp: '^calibreweb_optional_installed'
+      line: 'calibreweb_optional_installed: True'
+  when: calibreweb_optional_install

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -1,4 +1,4 @@
-- name: "Install packages: imagemagick, python3-venv"
+- name: "Install packages: imagemagick, python3-venv, python3-netifaces"
   package:
     name:
       - imagemagick
@@ -117,21 +117,21 @@
     line: 'calibreweb_installed: True'
 
 - block:
-  - name: "Install packages for optional-requirements.txt"
-    package:
-      name:
-        - python3-dev # header files
-        - gcc         # compiler
-        - libldap-dev # lber.h
-        - libsasl2-dev # sasl.h
-        - g++ # compiler
+#  - name: "Install packages for optional-requirements.txt"
+#    package:
+#      name:
+#        - python3-dev # header files
+#        - gcc         # compiler
+#        - libldap-dev # lber.h
+#        - libsasl2-dev # sasl.h
+#        - g++ # compiler
 
   - name: Download Calibre-Web dependencies from 'optional-requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }} when asked
     pip:
       requirements: "{{ calibreweb_venv_path }}/optional-requirements.txt"
       virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
       virtualenv_site_packages: no
-      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
+      virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
 
   - name: "Add 'calibreweb_optional_installed: True' to {{ iiab_state_file }}"
     lineinfile:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -140,7 +140,7 @@
   when: calibreweb_optional_install
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
-#- name: "Uninstall packages: python3-dev, gcc used to compile 'netifaces'"
+#- name: "Uninstall devel packages and compilers
 #  package:
 #    name:
 #      - python3-dev # header files

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -41,7 +41,9 @@
 
 
 # February 2020: See @m-anish's PR #2119 and follow-up PR #2258.
-# 2021-07-06: If you're running Nextcloud 22+ in production, carefully check the latest required AND recommended prereqs:
+# 2023-03-21: Check the latest required AND recommended prereqs below.
+# e.g. Nextcloud 26 now allows installation on PHP 8.2:
+# https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html
 # https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # https://docs.nextcloud.com/server/25/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 # https://docs.nextcloud.com/server/24/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation


### PR DESCRIPTION
### Fixes bug:
none new feature Edit: now a refinement in the install process to make use of an available wheel. 
### Description of changes proposed in this pull request:
new feature to install Calibre-web's optional addons Edit: uses --system-site-packages to find the deb based python package from the system as the upstream doesn't provide a current wheel. 
### Smoke-tested on which OS or OS's:
U-22.04 VM This was more an demo of how to declare explicit dependencies without tossing the kitchen sink at the problem. Each package containing the needed header files was added until the install was successful.
### Mention a team member @username e.g. to help with code review:
