### PR TITLE
use --system-site-packages and install package to omit building 'netifaces' wheel [Calibre-Web]

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -22,6 +22,11 @@
     line: '  <policy domain="coder" rights="read" pattern="PDF" />'
     state: present
 
+- name: Remove previous virtual environment {{ calibreweb_venv_path }}
+  file:
+    path: "{{ calibreweb_venv_path }}"
+    state: absent
+
 - name: "Create 3 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_venv_path }}, {{ calibreweb_config }} (all set to {{ calibreweb_user }}:{{ apache_user }}) (default to 0755)"
   file:
     state: directory

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -61,7 +61,7 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
-    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+    virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
 
 # VIRTUALENV EXAMPLE COMMANDS:
 # cd /usr/local/calibre-web-py3

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -1,19 +1,19 @@
-- name: "Install packages: imagemagick, python3-venv"
+- name: "Install packages: imagemagick, python3-venv, python3-netifaces"
   package:
     name:
       - imagemagick
       - python3-venv
+      - python3-netifaces
     state: present
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
-- name: "Install packages: python3-dev, gcc to compile 'netifaces'"
-  package:
-    name:
-      - python3-dev # header files
-      - gcc         # compiler
-    state: present
-  when: python_version is version('3.10', '>=')
-
+#- name: "Install packages: python3-dev, gcc to compile 'netifaces'"
+#  package:
+#    name:
+#      - python3-dev # header files
+#      - gcc         # compiler
+#    state: present
+#  when: python_version is version('3.10', '>=')
 - name: Allow ImageMagick to read PDFs, per /etc/ImageMagick-6/policy.xml, to create book cover thumbnails
   lineinfile:
     path: /etc/ImageMagick-6/policy.xml
@@ -56,7 +56,8 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     virtualenv_site_packages: no
-    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
+    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }} --system-site-packages
+
 # VIRTUALENV EXAMPLE COMMANDS:
 # cd /usr/local/calibre-web-py3
 # source bin/activate
@@ -101,15 +102,6 @@
     group: "{{ apache_user }}"         # www-data on debuntu
     backup: yes
   when: not appdb.stat.exists
-
-# https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
-#- name: "Uninstall packages: python3-dev, gcc used to compile 'netifaces'"
-#  package:
-#    name:
-#      - python3-dev # header files
-#      - gcc         # compiler
-#    state: absent
-#  when: python_version is version('3.10', '>=')
 
 
 # RECORD Calibre-Web AS INSTALLED


### PR DESCRIPTION
Smaller subset of #3500 without optional-requirements.txt

This works because the wheel is provided by apt, the OS package manager, and with --system-site-packages has access to the system's preinstalled wheels when creating the virtual environment. Normally --system-site-packages would be omitted and the packages would be pulled down from pypi but 'netifaces' doesn't have the latest wheels for python3.10+ but the OS does.