### PR TITLE
Move 2 vars kolibri/defaults to default_vars.yml + Cleaner kolibri homedir in /etc/passwd

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -9,7 +9,7 @@
 # kolibri_user: kolibri    # Whereas a vanilla install of Kolibri auto-identifies
 # and saves a 'desktop-like' user like {iiab-admin, pi} to /etc/kolibri/username
 # (generally the user with lowest UID >= 1000) to allow access to USB devices:
-# https://kolibri.readthedocs.io/en/latest/install.html#changing-the-owner-of-kolibri-system-service
+# https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html#changing-the-owner-of-kolibri-system-service
 # https://github.com/learningequality/kolibri-installer-debian/issues/115
 
 # kolibri_http_port: 8009

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -3,10 +3,20 @@
 
 # kolibri_language: en    # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 
+# Kolibri folder to store its data and configuration files.
+# kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
+
+# kolibri_user: kolibri    # Whereas a vanilla install of Kolibri auto-identifies
+# and saves a 'desktop-like' user like {iiab-admin, pi} to /etc/kolibri/username
+# (generally the user with lowest UID >= 1000) to allow access to USB devices:
+# https://kolibri.readthedocs.io/en/latest/install.html#changing-the-owner-of-kolibri-system-service
+# https://github.com/learningequality/kolibri-installer-debian/issues/115
+
 # kolibri_http_port: 8009
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
+
 
 # 2019-09-27: Pinning to a particular version is unfortunately NOT supported
 # with our new apt approach (.deb installer) at this time.
@@ -30,18 +40,10 @@
 # Corresponding to:
 # https://launchpad.net/~learningequality/+archive/ubuntu/kolibri
 
-# Kolibri folder to store its data and configuration files.
-kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
-
 kolibri_url_without_slash: /kolibri
 kolibri_url: "{{ kolibri_url_without_slash }}/"    # /kolibri/
 
 kolibri_exec_path: /usr/bin/kolibri
-
-kolibri_user: kolibri    # Whereas a vanilla install of Kolibri auto-identifies
-# and saves a 'desktop' user like {iiab-admin, pi} to /etc/kolibri/username,
-# towards guaranteeing access to USB devices, per:
-# https://kolibri.readthedocs.io/en/latest/install.html#changing-the-owner-of-kolibri-system-service
 
 # To populate /library/kolibri with essential/minimum files and dirs.  This
 # provisions Kolibri with facility name, admin acnt / password, preset type,

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -14,6 +14,7 @@
     shell: /bin/false
     system: yes
     create_home: no
+    home: "{{ kolibri_home }}"
 
 - name: Create directory {{ kolibri_home }} for Kolibri content, configuration, sqlite3 databases ({{ kolibri_user }}:{{ apache_user }}, by default 0755)
   file:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -483,7 +483,9 @@ kalite_root: "{{ content_base }}/ka-lite"    # /library/ka-lite
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: False
 kolibri_enabled: False
-kolibri_language: en    # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
+kolibri_language: en     # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
+kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
+kolibri_user: kolibri    # WARNING: https://github.com/learningequality/kolibri-installer-debian/issues/115
 kolibri_http_port: 8009
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console


### PR DESCRIPTION
Small/general hygiene improvements for [roles/kolibri](https://github.com/iiab/iiab/tree/master/roles/kolibri) :

- moves vars `kolibri_home` and `kolibri_user` from /opt/iiab/iiab/roles/kolibri/defaults/main.yml to /opt/iiab/iiab/vars/default_vars.yml, allowing Ansible to access both as @tim-moody requested
- sets `/library/kolibri` instead of `/home/kolibri` as user kolibri's homedir in /etc/passwd

Tested on Ubuntu 23.04 pre-release.

Changes were earlier outlined within these tickets:

- #3504 
- PR #3505
- #3506