### PR TITLE
PR to help with Asterisk 20 testing

### DIFF
--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -22,7 +22,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 asterisk_url: https://downloads.asterisk.org/pub/telephony/asterisk
-asterisk_src_file: asterisk-19-current.tar.gz
+asterisk_src_file: asterisk-20-current.tar.gz
 asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
 # freepbx_url: https://mirror.freepbx.org/modules/packages/freepbx/7.4


### PR DESCRIPTION
Thank you @EMG70 if you get the chance to run this on Debian 11:

```curl iiab.io/install.txt | bash -s 3508```

As outlined within:

- #3502

ASIDE: The May 2022 fix to assure the latest FreePBX is here:

- PR #3229