### PR TITLE
Doc updates for Asterisk 20 & remaining PHP 7.4 OS's (as FreePBX 16 requires)

### DIFF
--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -4,7 +4,7 @@
 
 https://internet-in-a-box.org[Internet-in-a-Box (IIAB)] can install https://asterisk.org/[Asterisk] and https://freepbx.org/[FreePBX] for Voice over IP (VoIP) calls using regular Android and iPhone softphone (SIP) apps — e.g. for low-cost and rural telephony.
 
-As of May 2022, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+19+Documentation[Asterisk 19] and https://www.freepbx.org/freepbx-16-is-now-released-for-general-availability/[FreePBX 16].
+As of March 2023, IIAB installs https://wiki.asterisk.org/wiki/display/AST/Asterisk+20+Documentation[Asterisk 20] and https://www.freepbx.org/freepbx-16-is-now-released-for-general-availability/[FreePBX 16].
 
 *PHP 7.4 is REQUIRED (https://github.com/iiab/iiab/pull/2899[PR #2899]) and PHP 8.x does not yet work (https://github.com/iiab/iiab/pull/3019#issuecomment-962469346[PR #3109]) &mdash; this remains true in 2023, and will likely remain true until https://github.com/FreePBX/framework/tree/release/17.0[FreePBX 17] is eventually released &mdash; so please consider installing on https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems[Debian 11 "Bullseye", or 64-bit Raspberry Pi OS versions based on "Bullseye"] (https://github.com/iiab/iiab/wiki/IIAB-8.1-Release-Notes#known-issues[WARNING]).*
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -682,7 +682,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
+# REQUIRES PHP 7.4 e.g. Debian 11 Bullseye.  64-bit RaspiOS MIGHT work: #3489
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -415,7 +415,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
+# REQUIRES PHP 7.4 e.g. Debian 11 Bullseye.  64-bit RaspiOS MIGHT work: #3489
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -415,7 +415,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
+# REQUIRES PHP 7.4 e.g. Debian 11 Bullseye.  64-bit RaspiOS MIGHT work: #3489
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -415,7 +415,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
+# REQUIRES PHP 7.4 e.g. Debian 11 Bullseye.  64-bit RaspiOS MIGHT work: #3489
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -415,7 +415,7 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
-# REQUIRES PHP 7.4 e.g. Ubuntu 20.04, Debian 11 -- RaspiOS 11 might also work.
+# REQUIRES PHP 7.4 e.g. Debian 11 Bullseye.  64-bit RaspiOS MIGHT work: #3489
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme
 # If using PBX intensively, investigate nginx_high_php_limits further above.
 pbx_install: False


### PR DESCRIPTION
ASIDE: FreePBX 17 is still as long ways off it appears, so PHP 8.x OS's from 2022 and 2023 have no practical FreePBX options as of yet.

This PR builds on:

- PR #3508