### PR TITLE
TEMPORARY PATCH: Installs older Nextcloud 25 on PHP 7.4 OS's

### DIFF
--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -98,6 +98,11 @@
     state: directory
     path: "{{ nextcloud_root_dir }}"    # /library/www/nextcloud
 
+- name: "2023-03-24: NEXTCLOUD 26 REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER NEXTCLOUD 25 ON OS's WITH PHP <= 7.4 -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
+  set_fact:
+    nextcloud_dl_url: https://download.nextcloud.com/server/releases/latest-25.tar.bz2
+  when: php_version is version('7.4', '<=')
+
 - name: Unarchive {{ nextcloud_dl_url }} (~140 MB) to {{ nextcloud_root_dir }} (~519 MB initially, sometimes ~543 MB later, {{ apache_user }}:{{ apache_user }})
   unarchive:
     remote_src: yes    # Overwrite even if "already exists on the target"


### PR DESCRIPTION
Thank you to @EMG70 who reported the problem.

PHP 7.4 reached end-of-life in November 2022 so we should not be supporting it much longer.

But for now the PR does the deed — installing Nextcloud 25 instead of 26 when an older such OS with PHP <= 7.4 is detected:

- #3509 

Tested on Debian 11.