### PR TITLE
kolibri/tasks/install.yml spring cleaning (tighten up code, flow, in-line docs)

### DIFF
--- a/roles/4-server-options/README.rst
+++ b/roles/4-server-options/README.rst
@@ -2,7 +2,7 @@
 4-server-options README
 =======================
 
-Whereas 3-base-server installs critical packages needed by all, this 4th `stage <https://github.com/iiab/iiab/wiki/IIAB-Contributors-Guide#ansible>`_ installs a broad array of *options* ⁠— depending on which server apps will be installed in later stages ⁠— as specified in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_
+Whereas 3-base-server installs critical packages needed by all, this 4th `stage <https://github.com/iiab/iiab/wiki/IIAB-Contributors-Guide#ansible>`_ installs a broad array of *options* ⁠— depending on which server apps will be installed in later stages ⁠— as specified in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_
 
 This includes more networking fundamentals, that may further be configured later on.
 
@@ -11,7 +11,7 @@ Specifically, these might be installed:
 - Python libraries
 - SSH daemon
 - Bluetooth for Raspberry Pi
-- Instant-sharing of `USB stick content <https://wiki.iiab.io/go/FAQ#Can_teachers_display_their_own_content.3F>`_
+- Instant-sharing of `USB stick content <https://wiki.iiab.io/go/FAQ#Can_teachers_display_their_own_content%3F>`_
 - CUPS Printing
 - Samba for Windows filesystems
 - `www_options <https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml>`_

--- a/roles/cups/README.md
+++ b/roles/cups/README.md
@@ -8,7 +8,7 @@ This can be useful if a printer is attached to your IIAB &mdash; so student/teac
 
 ## Using it
 
-Make sure your IIAB was installed with these 2 lines in [/etc/iiab/local_vars.yml](http://faq.iiab.io/#What_is_local_vars.yml_and_how_do_I_customize_it.3F) :
+Make sure your IIAB was installed with these 2 lines in [/etc/iiab/local_vars.yml](http://faq.iiab.io/#What_is_local_vars.yml_and_how_do_I_customize_it%3F) :
 
 ```
 cups_install: True

--- a/roles/kolibri/README.rst
+++ b/roles/kolibri/README.rst
@@ -24,7 +24,7 @@ Please look in `/opt/iiab/iiab/roles/kolibri/defaults/main.yml <defaults/main.ym
 Automatic Device Provisioning
 -----------------------------
 
-When kolibri_provision is enabled (e.g. in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_) the installation will set up the following defaults::
+When kolibri_provision is enabled (e.g. in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_) the installation will set up the following defaults::
 
   kolibri_facility: Kolibri-in-a-Box   
   kolibri_language: en      # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -26,9 +26,8 @@
 - name: Create Linux user {{ kolibri_user }} and add it to groups {{ apache_user }}, disk
   user:
     name: "{{ kolibri_user }}"
-    groups:
-      - "{{ apache_user }}"
-      - disk    # 2023-03-27: IS THIS REALLY NECESSARY? Unclear. "Mostly equivalent to root access" according to https://wiki.debian.org/SystemGroups
+    groups: "{{ apache_user }}"    # 2023-03-29: Not really necessary (Kolibri is demonstrated to work without group 'www-data').  But it likely doesn't hurt.
+      #- disk    # 2023-03-29: Tested to be unnec with USB sticks (with 64-bit RasPiOS).  FWIW group 'disk' is "Mostly equivalent to root access" according to https://wiki.debian.org/SystemGroups
     state: present
     shell: /bin/false
     system: yes

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -28,7 +28,7 @@
     name: "{{ kolibri_user }}"
     groups:
       - "{{ apache_user }}"
-      - disk    # 2023-03-27: IS THIS REALLY NECESSARY?
+      - disk    # 2023-03-27: IS THIS REALLY NECESSARY? Unclear. "Mostly equivalent to root access" according to https://wiki.debian.org/SystemGroups
     state: present
     shell: /bin/false
     system: yes

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -4,12 +4,31 @@
 # https://github.com/learningequality/pi-gen/blob/master/stage2/04-hostapd/offline.yml
 # https://github.com/learningequality/pi-gen/blob/master/stage2/04-hostapd/online.yml
 
+# Install Kolibri » Debian/Ubuntu
+# https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html
+
+# Advanced management
+# https://kolibri.readthedocs.io/en/latest/manage/advanced.html
+
+# Working with Kolibri from the command line
+# https://kolibri.readthedocs.io/en/latest/manage/command_line.html
+
+# Customize Kolibri settings with the [ /library/kolibri/options.ini ] file
+# https://kolibri.readthedocs.io/en/latest/manage/options_ini.html
+
+# Test Kolibri server performance
+# https://kolibri.readthedocs.io/en/latest/manage/performance.html
+
+# Provisioning many servers
+# https://kolibri.readthedocs.io/en/latest/install/provision.html
+
+
 - name: Create Linux user {{ kolibri_user }} and add it to groups {{ apache_user }}, disk
   user:
     name: "{{ kolibri_user }}"
     groups:
       - "{{ apache_user }}"
-      - disk
+      - disk    # 2023-03-27: IS THIS REALLY NECESSARY?
     state: present
     shell: /bin/false
     system: yes
@@ -39,83 +58,86 @@
     dest: /etc/kolibri/daemon.conf
 
 
-- name: apt install latest Kolibri .deb from {{ kolibri_deb_url }} (populates {{ kolibri_home }}, migrates database)    # i.e. /library/kolibri
+# https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html claims:
+# "When you use the PPA installation method, upgrades to newer versions
+# will be automatic, provided there is internet access available."
+#
+# IN REALITY: apt upgrading Kolibri is messy, as up-to-5 debconf screens prompt
+# PPL WHO DON'T KNOW with the wrong default username, instead of 'kolibri' :/
+# https://github.com/learningequality/kolibri-installer-debian/pull/117
+
+# 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
+- name: Download Kolibri's apt key to /usr/share/keyrings/learningequality-kolibri.gpg
+  shell: |
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --yes --output /usr/share/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+
+- name: Add signed Kolibri PPA 'jammy' (if Ubuntu 22.04+ or Mint 21 or Debian 12)
+  apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
+  when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
+  #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
+
+- name: Add signed Kolibri PPA 'focal' (if other/older OS's)
+  apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu focal main"
+  when: not (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12)
+  #when: not (is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12)
+
+# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu and not is_linuxmint)
+#   apt_repository:
+#     repo: ppa:learningequality/kolibri
+#   when: is_ubuntu and not is_linuxmint
+
+# 2022-08-19: 'add-apt-repository ppa:learningequality/kolibri' works at CLI on
+# Mint 21 (creating /etc/apt/sources.list.d/learningequality-kolibri-jammy.list)
+# BUT equivalent Ansible command (STANZA ABOVE) failed with error...
+# "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/learningequality/kolibri/ubuntu vanessa Release' does not have a Release file."
+# ...so for now we special case Mint, similar to Debian (BOTH STANZAS BELOW!)
+
+# 2022-08-19: https://github.com/learningequality/kolibri/issues/9647 also asks
+# about the warning below, arising no matter if codename is 'focal' or 'jammy'
+# with Kolibri 0.15.6 on Mint 21 -- if you run '/usr/bin/kolibri --version':
+#
+# /usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
+# warnings.warn(
+
+# 2022-08-19: 'apt-key list' & 'apt-key del 3194 DD81' are useful if you also
+# want to clear out Kolibri's key from the DEPRECATED /etc/apt/trusted.gpg
+
+# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'jammy' (if is_linuxmint_21)
+#   apt_repository:
+#     repo: ppa:learningequality/kolibri
+#     codename: jammy    # CONSOLIDATE THIS SPECIAL CASE STANZA WITH UBUNTU ABOVE IN FUTURE?
+#   when: is_linuxmint_21
+
+# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian or is_linuxmint_20)
+#   apt_repository:
+#     repo: ppa:learningequality/kolibri
+#     codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
+#   when: is_debian or is_linuxmint_20
+
+- name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
+  apt:
+    name: kolibri
+  when: kolibri_deb_url is undefined
+  # environment:
+  #   KOLIBRI_HOME: "{{ kolibri_home }}"    # 2023-03-27: These don't do a thing
+  #   KOLIBRI_USER: "{{ kolibri_user }}"    # for now.
+
+- name: apt install {{ kolibri_deb_url }} (if kolibri_deb_url IS defined)
   apt:
     deb: "{{ kolibri_deb_url }}"    # e.g. https://learningequality.org/r/kolibri-deb-latest
-  environment:
-    KOLIBRI_HOME: "{{ kolibri_home }}"    # These don't do a thing for now but
-    KOLIBRI_USER: "{{ kolibri_user }}"    # both can't hurt & Might Help Later
   when: kolibri_deb_url is defined
+  # environment:
+  #   KOLIBRI_HOME: "{{ kolibri_home }}"    # 2023-03-27: These don't do a thing
+  #   KOLIBRI_USER: "{{ kolibri_user }}"    # for now.
 
-- block:    # ELSE...
 
-  # https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html says:
-  # "When you use the PPA installation method, upgrades to newer versions
-  # will be automatic, provided there is internet access available."
-  #
-  # IN REALITY: apt upgrading Kolibri is risky, as 3 pink/blue screens prompt
-  # PPL WHO DON'T KNOW TO TYPE IN things like Linux username 'kolibri' :/ #3356
-
-  # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-  - name: Download Kolibri's apt key to /usr/share/keyrings/learningequality-kolibri.gpg
-    shell: |
-      gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-      gpg --yes --output /usr/share/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-
-  - name: Add signed Kolibri PPA 'jammy' (if Ubuntu 22.04+ or Mint 21 or Debian 12)
-    apt_repository:
-      repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
-    when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
-    #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
-
-  - name: Add signed Kolibri PPA 'focal' (if other/older OS's)
-    apt_repository:
-      repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu focal main"
-    when: not (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12)
-    #when: not (is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12)
-
-  # - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu and not is_linuxmint)
-  #   apt_repository:
-  #     repo: ppa:learningequality/kolibri
-  #   when: is_ubuntu and not is_linuxmint
-
-  # 2022-08-19: 'add-apt-repository ppa:learningequality/kolibri' works at CLI on
-  # Mint 21 (creating /etc/apt/sources.list.d/learningequality-kolibri-jammy.list)
-  # BUT equivalent Ansible command (STANZA ABOVE) failed with error...
-  # "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/learningequality/kolibri/ubuntu vanessa Release' does not have a Release file."
-  # ...so for now we special case Mint, similar to Debian (BOTH STANZAS BELOW!)
-
-  # 2022-08-19: https://github.com/learningequality/kolibri/issues/9647 also asks
-  # about the warning below, arising no matter if codename is 'focal' or 'jammy'
-  # with Kolibri 0.15.6 on Mint 21 -- if you run '/usr/bin/kolibri --version':
-  #
-  # /usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
-  # warnings.warn(
-
-  # 2022-08-19: 'apt-key list' & 'apt-key del 3194 DD81' are useful if you also
-  # want to clear out Kolibri's key from the DEPRECATED /etc/apt/trusted.gpg
-
-  # - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'jammy' (if is_linuxmint_21)
-  #   apt_repository:
-  #     repo: ppa:learningequality/kolibri
-  #     codename: jammy    # CONSOLIDATE THIS SPECIAL CASE STANZA WITH UBUNTU ABOVE IN FUTURE?
-  #   when: is_linuxmint_21
-
-  # - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian or is_linuxmint_20)
-  #   apt_repository:
-  #     repo: ppa:learningequality/kolibri
-  #     codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
-  #   when: is_debian or is_linuxmint_20
-
-  - name: apt install kolibri (populates {{ kolibri_home }}, migrates database)    # i.e. /library/kolibri
-    apt:
-      name: kolibri
-    environment:
-      KOLIBRI_HOME: "{{ kolibri_home }}"    # These don't do a thing for now but
-      KOLIBRI_USER: "{{ kolibri_user }}"    # both can't hurt & Might Help Later
-
-  when: kolibri_deb_url is undefined
-
+- name: Run 'rm -rf /root/.kolibri' to remove "unavoidable" pollution created above
+  file:
+    state: absent
+    path: /root/.kolibri
 
 - name: 'Install from template: /etc/systemd/system/kolibri.service'
   template:
@@ -124,8 +146,8 @@
 
 - name: Stop 'kolibri' systemd service, for Kolibri provisioning (after daemon_reload)
   systemd:
-    name: kolibri
     daemon_reload: yes
+    name: kolibri
     state: stopped
 
 
@@ -146,9 +168,13 @@
 #   become_user: "{{ kolibri_user }}"
 #   when: kolibri_provision
 
+# Run "kolibri manage help provisiondevice" to see CLI options, e.g.:
+#   --facility_settings FACILITY_SETTINGS
+#                         JSON file containing facility settings
+#   --device_settings DEVICE_SETTINGS
+#                         JSON file containing device settings
 - name: 'Provision Kolibri, while setting: facility name, admin acnt / password, preset type, and language'
   shell: >
-    export KOLIBRI_HOME="{{ kolibri_home }}" &&
     "{{ kolibri_exec_path }}" manage provisiondevice --facility "{{ kolibri_facility }}"
     --superusername "{{ kolibri_admin_user }}" --superuserpassword "{{ kolibri_admin_password }}"
     --preset "{{ kolibri_preset }}" --language_id "{{ kolibri_language }}"
@@ -157,18 +183,22 @@
   become: yes
   become_user: "{{ kolibri_user }}"
   when: kolibri_provision
+  environment:
+    KOLIBRI_HOME: "{{ kolibri_home }}"     # 2023-03-27: Required!
+    #KOLIBRI_USER: "{{ kolibri_user }}"    # 2023-03-27: Not nec due to /etc/kolibri/username ?
+
 
 # 2023-03-25: Likely overkill (let's strongly consider removing this stanza?)
 # Certainly, setting owner (recursively) is advised when moving /library/kolibri :
 # https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html#changing-the-owner-of-kolibri-system-service
-- name: chown -R {{ kolibri_user }}:{{ apache_user }} {{ kolibri_home }} for good measure?
-  file:
-    path: "{{ kolibri_home }}"     # /library/kolibri
-    owner: "{{ kolibri_user }}"    # kolibri
-    group: "{{ apache_user }}"     # www-data (on Debian/Ubuntu/Raspbian)
-    recurse: yes
-  when: kolibri_provision
-
+# 2023-03-27: Commented out on a provisional basis (Spring Cleaning)
+# - name: chown -R {{ kolibri_user }}:{{ apache_user }} {{ kolibri_home }} for good measure?
+#   file:
+#     path: "{{ kolibri_home }}"     # /library/kolibri
+#     owner: "{{ kolibri_user }}"    # kolibri
+#     group: "{{ apache_user }}"     # www-data (on Debian/Ubuntu/Raspbian)
+#     recurse: yes
+#   when: kolibri_provision
 
 # 2019-10-07: Moved to roles/httpd/tasks/main.yml
 # 2019-09-29: roles/kiwix/tasks/kiwix_install.yml installs 4 Apache modules

--- a/roles/matomo/README.adoc
+++ b/roles/matomo/README.adoc
@@ -4,7 +4,7 @@ https://matomo.org/[Matomo] is a web analytics alternative to Google Analytics, 
 
 == Install it
 
-Prior to installing Matomo with IIAB, the default URL (http://box.lan/matomo) can be customized in https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F[/etc/iiab/local_vars.yml]
+Prior to installing Matomo with IIAB, the default URL (http://box.lan/matomo) can be customized in https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F[/etc/iiab/local_vars.yml]
 
 One way to do that is by changing these 2 lines:
 

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -14,7 +14,7 @@ The Nextcloud suite is divided into three main categories:
 
 ## Install It
 
-(1) Set these 2 variable in [/etc/iiab/local_vars.yml](http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F) prior to installing Internet-in-a-Box:
+(1) Set these 2 variable in [/etc/iiab/local_vars.yml](http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it%3F) prior to installing Internet-in-a-Box:
 
     nextcloud_install: True
     nextcloud_enabled: True

--- a/roles/nodered/README.rst
+++ b/roles/nodered/README.rst
@@ -9,7 +9,7 @@ Node-RED is a flow-based development tool for visual programming developed origi
 Using It
 --------
 
-Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ contains::
+Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ contains::
 
   nodered_install: True
   nodered_enabled: True

--- a/roles/osm-vector-maps/README.md
+++ b/roles/osm-vector-maps/README.md
@@ -18,8 +18,8 @@
    3. Multiple Hi-Res Satellite Photo Regions can be downloaded/installed (one "square" region at a time, thankfully duplicate disk space is avoided when such "squares" overlap!)
 
 4. Some variables have newer meanings:
-   1. `osm_vector_maps_install` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) means install the map program and 7 basic levels of zoom (48MB for OSM + 25 MB for satellite photos).
-   2. `osm_vector_maps_enabled` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) is once again standardized, solving #2484 install delays.
+   1. `osm_vector_maps_install` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F) means install the map program and 7 basic levels of zoom (48MB for OSM + 25 MB for satellite photos).
+   2. `osm_vector_maps_enabled` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F) is once again standardized, solving #2484 install delays.
    3. `osm_vector_maps_installed` in `/etc/iiab/iiab_state.yml` means a functioning world map with 7 levels of zoom (z0-z6) has been installed — i.e. a preview of IIAB's mapping system that helps you select Maps Pack(s) and Hi-Res Satellite Photo Region(s) to download and install on your IIAB.  (SEE 1. ABOVE)
 
 5. **Drag-and-Drop Map Overlays** — try this by dragging and dropping any relevant GeoJSON file onto the IIAB Maps (http://box/maps) in your browser!  For example try this GeoJSON file, to explore the shape of gerrymandered US Congressional districts: https://eric.clst.org/assets/wiki/uploads/Stuff/gz_2010_us_500_11_20m.json

--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -34,7 +34,7 @@ https://en.wikipedia.org/wiki/FreePBX[FreePBX] is a web-based open source GUI (g
 Edit /etc/iiab/local_vars.yml to customize your Internet-in-a-Box? [Y/n]
 ----
 +
-Accept the challenge!  Make sure your IIAB configuration file (https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F[/etc/iiab/local_vars.yml]) contains:
+Accept the challenge!  Make sure your IIAB configuration file (https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F[/etc/iiab/local_vars.yml]) contains:
 +
 ----
 pbx_install: True
@@ -43,7 +43,7 @@ pbx_enabled: True
 +
 FreePBX can be used with either or both web servers, NGINX on port 80 (as is new) and/or Apache on port 83 (as is traditional).
 +
-If you don't want Apache installed on your IIAB, and you prefer NGINX's shorter URL (http://box/freepbx), optionally set this line in your https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F[/etc/iiab/local_vars.yml] prior to installing IIAB:
+If you don't want Apache installed on your IIAB, and you prefer NGINX's shorter URL (http://box/freepbx), optionally set this line in your https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F[/etc/iiab/local_vars.yml] prior to installing IIAB:
 +
 ----
 pbx_use_apache: False
@@ -307,9 +307,9 @@ Node.js applications like Asterisk/FreePBX, Node-RED and Sugarizer won't work on
 ////
 == Raspberry Pi Known Issues
 
-As of 2019-02-14, "systemctl restart freepbx" failed more than 50% of the time when run on a https://wiki.iiab.io/go/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation.3F[LARGE-sized] install of IIAB 6.7 on RPi 3 or RPi 3 B+.
+As of 2019-02-14, "systemctl restart freepbx" failed more than 50% of the time when run on a https://wiki.iiab.io/go/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation%3F[LARGE-sized] install of IIAB 6.7 on RPi 3 or RPi 3 B+.
 
-It is possible that FreePBX restarts much more reliably when run on a SMALL-sized install of IIAB?  Please https://wiki.iiab.io/go/FAQ#What_are_the_best_places_for_community_support.3F[contact us] if you can assist here in any way: https://github.com/iiab/iiab/issues/1493[#1493]
+It is possible that FreePBX restarts much more reliably when run on a SMALL-sized install of IIAB?  Please https://wiki.iiab.io/go/FAQ#What_are_the_best_places_for_community_support%3F[contact us] if you can assist here in any way: https://github.com/iiab/iiab/issues/1493[#1493]
 ////
 
 

--- a/roles/pbx/README.rst.unused
+++ b/roles/pbx/README.rst.unused
@@ -33,7 +33,7 @@ FreePBX is a web-based open source GUI (graphical user interface) that controls 
 Using It
 --------
 
-Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ contains::
+Prior to installing IIAB, make sure your `/etc/iiab/local_vars.yml <http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ contains::
 
   pbx_install: True
   pbx_enabled: True
@@ -159,9 +159,9 @@ Some useful asterisk commands and information
 Raspberry Pi Known Issues
 -------------------------
 
-|ss| As of 2019-02-14, "systemctl restart freepbx" failed more than 50% of the time when run on a `BIG-sized <http://wiki.laptop.org/go/IIAB/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation.3F>`_ install of IIAB 6.7 on RPi 3 or RPi 3 B+.
+|ss| As of 2019-02-14, "systemctl restart freepbx" failed more than 50% of the time when run on a `BIG-sized <http://wiki.laptop.org/go/IIAB/FAQ#What_services_.28IIAB_apps.29_are_suggested_during_installation%3F>`_ install of IIAB 6.7 on RPi 3 or RPi 3 B+.
 
-It is possible that FreePBX restarts much more reliably when run on a MIN-sized install of IIAB?  Please `contact us <http://wiki.laptop.org/go/IIAB/FAQ#What_are_the_best_places_for_community_support.3F>`_ if you can assist here in any way: `#1493 <https://github.com/iiab/iiab/issues/1493>`_ |se|
+It is possible that FreePBX restarts much more reliably when run on a MIN-sized install of IIAB?  Please `contact us <http://wiki.laptop.org/go/IIAB/FAQ#What_are_the_best_places_for_community_support%3F>`_ if you can assist here in any way: `#1493 <https://github.com/iiab/iiab/issues/1493>`_ |se|
 
 Raspberry Pi Zero W Warning
 ---------------------------

--- a/roles/phpmyadmin/README.md
+++ b/roles/phpmyadmin/README.md
@@ -8,7 +8,7 @@
 2. phpMyAdmin, because it is a browser-based HTML PHP application, is limited in what it can do, and what it can access — until the "root" user creates users and access privileges, as mentioned above. (HTML servers always run with very low privileges)
 
 #### Installing phpMyAdmin
-1. First, a user will need to set `phpmyadmin_install: True` and `phpmyadmin_enabled: True` in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)
+1. First, a user will need to set `phpmyadmin_install: True` and `phpmyadmin_enabled: True` in [/etc/iiab/local_vars.yml](http://wiki.laptop.org/go/IIAB/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F)
 2. Then install IIAB.  Or if IIAB is already installed, run:
    ```
    cd /opt/iiab/iiab

--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -43,7 +43,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 2. If your IIAB software is already installed, run `sudo iiab-remoteit` then skip to Step 5. below.
 
-3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F)
+3. If your IIAB software isn't yet installed, set `remoteit_install` and `remoteit_enabled` to `True` in its [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F)
 
    Install [IIAB software](https://download.iiab.io/) e.g. by running `sudo iiab` then follow any on-screen instructions &mdash; until "INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE" eventually appears on screen.
 -->
@@ -98,7 +98,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 
 1. Copy your remote.it account _license key_ from their Desktop Application (https://remote.it/download/) or from their Web Portal (https://remote.it) &mdash; as shown in this [screenshot](https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account#3.-user-receives-the-device-and-registers-his-account).
 
-   Paste it into your IIAB's [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F) as in this example:
+   Paste it into your IIAB's [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F) as in this example:
 
    ```
    remoteit_license_key: 592AA9BB-XXXX-YYYY-ZZZZ-6E27654C3DF6

--- a/roles/samba/README.rst
+++ b/roles/samba/README.rst
@@ -3,7 +3,7 @@ Samba README
 
 Do you want your Internet-in-a-Box (IIAB) to act as a file server for your classroom or school?
 
-If `Samba <https://www.samba.org/samba/docs/>`_ is installed and enabled as part of your IIAB's `/etc/iiab/local_vars.yml <https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_, your IIAB server can advertise a shared "public" folder, available to Windows PC's and laptops on your network.
+If `Samba <https://www.samba.org/samba/docs/>`_ is installed and enabled as part of your IIAB's `/etc/iiab/local_vars.yml <https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_, your IIAB server can advertise a shared "public" folder, available to Windows PC's and laptops on your network.
 
 Default Permissions
 -------------------

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 76 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L76>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it.3F>`_ (preferably do this prior to installing IIAB).
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
 
 Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/releases>`_ documentation:
 


### PR DESCRIPTION
This "spring cleaning" PR is mostly about in-line docs, while also cleaning up Ansible / Kolibri hygiene, and a few small code/flow adjustments, e.g.:

- Deleting /root/.kolibri pollution left over by the apt install of Kolibri
- Kolibri's apt source (PPA) is now set across the board (even when an implementer sets Ansible var `kolibri_deb_url` to install a custom Kolibri .deb file, thereby allowing easier later upgrades).

Tested on Ubuntu 22.04

Recent related work:

- #3504 
  - PR #3505
- #3506 
  - PR #3507 
  - PR iiab/iiab-admin-console#531
- PR #3356 
  - #3357
  - learningequality/kolibri-installer-debian#115
  - PR learningequality/kolibri-installer-debian#117