### PR TITLE
New Sugarizer 1.7.0

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -9,8 +9,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-sugarizer_dir_version: sugarizer-1.6.0    # WAS: sugarizer-1.0, sugarizer-master, sugarizer-1.1.0, sugarizer-1.2.0, sugarizer-1.3.0, sugarizer-1.4.0, sugarizer-1.5.0
-sugarizer_git_version: v1.6.0             # WAS: v1.0.1, master, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0
+sugarizer_dir_version: sugarizer-1.7.0    # WAS: sugarizer-1.0, sugarizer-master, sugarizer-1.1.0, sugarizer-1.2.0, sugarizer-1.3.0, sugarizer-1.4.0, sugarizer-1.5.0, sugarizer-1.6.0
+sugarizer_git_version: v1.7.0             # WAS: v1.0.1, master, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
 sugarizer_server_dir_version: sugarizer-server-1.5.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0, sugarizer-server-1.1.1, sugarizer-server-1.2.0, sugarizer-server-1.3.0, sugarizer-server-1.4.0


### PR DESCRIPTION
Tested on Ubuntu 22.04:

- https://github.com/llaske/sugarizer/releases/tag/v1.7.0
- https://github.com/llaske/sugarizer/blob/master/CHANGELOG.md#170---2023-03-28

Building on:

- PR #3478
- PR #3481 
- PR #3483
- PR #3485