### PR TITLE
MongoDB block on RasPiOS-32bit

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -43,3 +43,5 @@
       value: "{{ rpi_model }}"
     - option: devicetree_model
       value: "{{ devicetree_model }}"
+    - option: dpkg_arch
+      value: "{{ dpkg_arch }}"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -15,6 +15,7 @@
     os_ver: "{{ ansible_local.local_facts.os_ver }}"
     python_version: "{{ ansible_local.local_facts.python_version }}"
     php_version: "{{ ansible_local.local_facts.php_version }}"
+    dpkg_arch: "{{ ansible_local.local_facts.dpkg_arch }}"
 
 # Initialize /etc/iiab/iiab.ini writing the 'location' and 'version' sections
 # once and only once, to preserve the install date and git hash.

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -34,19 +34,19 @@
     var: is_debian
 - debug:
     var: is_raspbian
-
-# # might be able to lift this once we know using bionic would work
-# - name: EXIT 'mongodb' ROLE & CONTINUE, IF 'is_debian_10 and aarch64 and not is_raspbian' i.e. TRUE DEBIAN with arch64
-#   fail:    # FORCE IT RED THIS ONCE!
-#     msg: ATTEMPTED MongoDB INSTALLATION WITH (TRUE) DEBIAN aarch64, which is not supported upstream.  Nevertheless IIAB will continue (consider this a warning!)
-#   when: (ansible_architecture == "aarch64") and is_debian_10 and not is_raspbian
-#   ignore_errors: yes
-
-# ELSE...
-
+- debug:
+    var: dpkg_arch
+- debug:
+    var: mongodb_version
 
 - block:
 
+  - name: EXIT 'mongodb' ROLE & CONTINUE, when 32bit RasPiOS is in use or 'unsupported'
+    fail:    # FORCE IT RED THIS ONCE!
+      msg: ATTEMPTED MongoDB INSTALLATION WITH 32bit RasPiOS, which is not supported upstream.  Nevertheless IIAB will continue (consider this a warning!)
+    when: (mongodb_version == "unsupported") or (dpkg_arch == "armhf")
+
+# ELSE...
   - name: Install MongoDB if 'mongodb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
     include_tasks: install.yml
     when: mongodb_installed is undefined

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -19,6 +19,7 @@ IIAB_RECENT_TAG="none"
 IIAB_COMMIT="none"
 RPI_MODEL="none"
 DEVICETREE_MODEL="none"
+DPKG_ARCH="none"
 ANSIBLE_VERSION="none"
 PYTHON_VERSION="none"
 PHP_VERSION="none"
@@ -142,6 +143,7 @@ tmp=$(apt list php) &&
 # Safer than: echo $tmp | grep php | head -1 | sed 's/.*://; s/[^0-9.].*//')
 # https://stackoverflow.com/questions/16675179/how-to-use-sed-to-extract-substring/16675391#16675391
 
+DPKG_ARCH=$(dpkg --print-architecture)
 
 # THE LAST 3 BELOW ARE DIFFERENT as "systemctl is-enabled" unhelpfully returns
 # the same error code (i.e. 1) REGARDLESS whether the service is (A) disabled
@@ -175,6 +177,7 @@ cat <<EOF
 "iiab_commit"             : "$IIAB_COMMIT",
 "rpi_model"               : "$RPI_MODEL",
 "devicetree_model"        : "$DEVICETREE_MODEL",
+"dpkg_arch"               : "$DPKG_ARCH",
 "ansible_version"         : "$ANSIBLE_VERSION",
 "python_version"          : "$PYTHON_VERSION",
 "php_version"             : "$PHP_VERSION",


### PR DESCRIPTION
### Fixes bug:
https://github.com/iiab/iiab/issues/3516#issuecomment-1490656423 will effect medium installs going forward
https://github.com/iiab/iiab/pull/3478#issuecomment-1444395170 won't fix
Ref: https://github.com/iiab/iiab/issues/2873#issuecomment-884362675  #2880 
### Description of changes proposed in this pull request:
adds dpkg_arch that could be used in other roles
Don't install MongoDB on 32bit userspace
### Smoke-tested on which OS or OS's:
RasPiOS 32bit with all updates running latest 64bit kernel tested with runrole
http://sprunge.us/nyhaCL?en
