### PR TITLE
Record arch

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -4,6 +4,10 @@
     path: "{{ iiab_ini_file }}"
     state: touch
 
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_archicture ~= ansible_machine is NOT enough!)
+  command: dpkg --print-architecture
+  register: dpkg_arch
+
 - name: Add 'location' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
@@ -44,4 +48,4 @@
     - option: devicetree_model
       value: "{{ devicetree_model }}"
     - option: dpkg_arch
-      value: "{{ dpkg_arch }}"
+      value: "{{ dpkg_arch.stdout }}"

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -4,14 +4,18 @@
     path: "{{ iiab_ini_file }}"
     state: touch
 
-- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_archicture ~= ansible_machine is NOT enough!)
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NOT enough!)
   command: dpkg --print-architecture
   register: dpkg_arch
+
+- name: Run command 'dpkg --print-foreign-architectures' (secondary OS arch, if available)
+  command: dpkg --print-foreign-architectures
+  register: dpkg_foreign_arch
 
 - name: Add 'location' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
-    section: location
+    section: initial-location
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
@@ -23,7 +27,7 @@
 - name: Add 'version' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
-    section: version
+    section: initial-version
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
@@ -31,6 +35,10 @@
       value: "{{ ansible_distribution }}"
     - option: arch
       value: "{{ ansible_architecture }}"
+    - option: dpkg_arch
+      value: "{{ dpkg_arch.stdout }}"
+    - option: dpkg_foreign_arch
+      value: "{{ dpkg_foreign_arch.stdout }}"
     - option: iiab_base_ver
       value: "{{ iiab_base_ver }}"
     - option: iiab_remote_url
@@ -47,5 +55,3 @@
       value: "{{ rpi_model }}"
     - option: devicetree_model
       value: "{{ devicetree_model }}"
-    - option: dpkg_arch
-      value: "{{ dpkg_arch.stdout }}"

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -31,8 +31,10 @@
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
+    - option: os_ver
+      value: "{{ os_ver }}"
     - option: distribution
-      value: "{{ ansible_distribution }}"
+      value: "{{ ansible_facts['distribution'] }}"
     - option: arch
       value: "{{ ansible_architecture }}"
     - option: dpkg_arch

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -43,3 +43,5 @@
       value: "{{ rpi_model }}"
     - option: devicetree_model
       value: "{{ devicetree_model }}"
+    - option: dpkg_arch
+      value: "{{ dpkg_arch }}"

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -41,6 +41,10 @@
       value: "{{ dpkg_arch.stdout }}"
     - option: dpkg_foreign_arch
       value: "{{ dpkg_foreign_arch.stdout }}"
+    - option: rpi_model
+      value: "{{ rpi_model }}"
+    - option: devicetree_model
+      value: "{{ devicetree_model }}"
     - option: iiab_base_ver
       value: "{{ iiab_base_ver }}"
     - option: iiab_remote_url
@@ -53,7 +57,3 @@
       value: "{{ ansible_local.local_facts.iiab_recent_tag }}"
     - option: install_date
       value: "{{ ansible_date_time.iso8601 }}"
-    - option: rpi_model
-      value: "{{ rpi_model }}"
-    - option: devicetree_model
-      value: "{{ devicetree_model }}"

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -15,6 +15,7 @@
     os_ver: "{{ ansible_local.local_facts.os_ver }}"
     python_version: "{{ ansible_local.local_facts.python_version }}"
     php_version: "{{ ansible_local.local_facts.php_version }}"
+    dpkg_arch: "{{ ansible_local.local_facts.dpkg_arch }}"
 
 # Initialize /etc/iiab/iiab.ini writing the 'location' and 'version' sections
 # once and only once, to preserve the install date and git hash.

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -15,7 +15,6 @@
     os_ver: "{{ ansible_local.local_facts.os_ver }}"
     python_version: "{{ ansible_local.local_facts.python_version }}"
     php_version: "{{ ansible_local.local_facts.php_version }}"
-    dpkg_arch: "{{ ansible_local.local_facts.dpkg_arch }}"
 
 # Initialize /etc/iiab/iiab.ini writing the 'location' and 'version' sections
 # once and only once, to preserve the install date and git hash.

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -37,7 +37,7 @@
 - debug:
     var: mongodb_version
 
-- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_archicture ~= ansible_machine is NOT enough!)
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NOT enough!)
   command: dpkg --print-architecture
   register: dpkg_arch
 - debug:


### PR DESCRIPTION
>Avoid expanding [scripts/local_facts.fact](https://github.com/iiab/iiab/blob/master/scripts/local_facts.fact) which should shrink in coming years, rather than expanding — to reduce the number of global variables (in favor of modular-not-monolithic code, whenever possible).

Should meet the above requirement, just record the value so it can be easily displayed in the admin-console