### PR TITLE
Modernize Yarn install w/ signed apt/PPA key (prereq for Internet Archive)

### DIFF
--- a/roles/yarn/tasks/install.yml
+++ b/roles/yarn/tasks/install.yml
@@ -1,30 +1,41 @@
-- name: "Yarn | GPG"
-  apt_key:
-    url: https://dl.yarnpkg.com/debian/pubkey.gpg
-    state: present
+- name: Yarn | Download apt key to /usr/share/keyrings/yarn.gpg
+  shell: curl https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn.gpg
 
-- name: "Yarn | Ensure Debian sources list file exists"
-  file:
-    path: /etc/apt/sources.list.d/yarn.list
-    owner: root
-    mode: '0644'
-    state: touch
+- name: Yarn | Add signed Yarn PPA to /etc/apt/sources.list.d/dl_yarnpkg_com_debian.list
+  apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main"
+    #filename: yarn    # If legacy filename yarn.list is preferred
 
-- name: "Yarn | Ensure Debian package is in sources list"
-  lineinfile:
-    dest: /etc/apt/sources.list.d/yarn.list
-    regexp: 'deb https://dl.yarnpkg.com/debian/ stable main'
-    line: 'deb https://dl.yarnpkg.com/debian/ stable main'
-    state: present
+# 2023-04-01 above avoids DEPRECATED apt-key command & associated problems:
+# https://github.com/iiab/iiab/wiki/IIAB-Platforms#etcapttrustedgpg-legacy-keyring-warnings
 
-- name: "Yarn | Update APT cache"
+# - name: "Yarn | GPG"
+#   apt_key:
+#     url: https://dl.yarnpkg.com/debian/pubkey.gpg
+#     state: present
+
+# - name: "Yarn | Ensure Debian sources list file exists"
+#   file:
+#     path: /etc/apt/sources.list.d/yarn.list
+#     owner: root
+#     mode: '0644'
+#     state: touch
+
+# - name: "Yarn | Ensure Debian package is in sources list"
+#   lineinfile:
+#     dest: /etc/apt/sources.list.d/yarn.list
+#     regexp: 'deb https://dl.yarnpkg.com/debian/ stable main'
+#     line: 'deb https://dl.yarnpkg.com/debian/ stable main'
+#     state: present
+
+- name: Yarn | Update APT cache
   apt:
     update_cache: yes
 
-- name: "Yarn | Install"
+- name: Yarn | Install
   package:
     name: yarn
-    state: latest
+    #state: latest    # No need to mention it, with apt
 
 
 # RECORD Yarn AS INSTALLED


### PR DESCRIPTION
This avoids the ugly warnings whenever running `apt update` that had been blocking IIAB installs earlier:

- PR iiab/iiab-factory#236

Modernized apt/PPA key-signing inspired by:

- #3356
- [roles/mongodb/tasks/install.yml](https://github.com/iiab/iiab/blob/master/roles/mongodb/tasks/install.yml)

Tested on Ubuntu 22.04

cc: @mitra42 (hope this is OK!)