### PR TITLE
asterisk_installed

### DIFF
--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -186,3 +186,13 @@
     path: /etc/asterisk/asterisk.conf
     regexp: 'rungroup ='
     line: 'rungroup = asterisk'
+
+- name: "Set 'asterisk_installed: True'"
+  set_fact:
+    asterisk_installed: True
+
+- name: "Add 'asterisk_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^asterisk_installed'
+    line: 'asterisk_installed: True'

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -36,6 +36,7 @@
 
 - name: Install Asterisk
   include_tasks: asterisk.yml
+  when: asterisk_installed is undefined
 
 - name: Install FreePBX
   include_tasks: freepbx.yml


### PR DESCRIPTION
### Fixes bug:
Enhancement for development.
### Description of changes proposed in this pull request:
'installed' marker for asterisk. Quick note of what is installed just like the apache marker.
### Smoke-tested on which OS or OS's:
RasPiOS 
### Mention a team member @username e.g. to help with code review:

The current pbx role is not having a problem installing asterisk on any platform #3502, the issue is with FreePBX's php7.4 requirement with version 16. This PR's addition allows for more rapid testing and evaluation of other FreePBX versions via 'freepbx_git_branch: release/17.0' without attempting to alter the underling asterisk install. Also a very nice speed improvement when doing evaluations of newer branches from the git repo of FreePBX

Version 17 is not quite there yet.
```
TASK [pbx : FreePBX - Revert the above just-installed FreePBX 'framework' module by a few weeks-or-so from GitHub's bleeding edge, to a more official version (which can help to install the ~15 modules below!)] ***
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": ["fwconsole", "ma", "downloadinstall", "framework"], "delta": "0:00:00.202558", "end": "2023-04-04 08:03:48.214742", "msg": "non-zero return code", "rc": 255, "start": "2023-04-04 08:03:48.012184", "stderr": "PHP Fatal error:  During inheritance of ArrayAccess: Uncaught ArgumentCountError: Too few arguments to function freepbx_error_handler(), 4 passed in /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php on line 20 and exactly 5 expected in /var/www/html/freepbx/admin/libraries/utility.functions.php:306\nStack trace:\n#0 /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php(20): freepbx_error_handler()\n#1 /var/www/html/freepbx/admin/libraries/Composer/vendor/composer/ClassLoader.php(444): include('/var/www/html/f...')\n#2 /var/www/html/freepbx/admin/libraries/Composer/vendor/composer/ClassLoader.php(322): Composer\\Autoload\\includeFile()\n#3 [internal function]: Composer\\Autoload\\ClassLoader->loadClass()\n#4 /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Run.php(117): class_exists()\n#5 /var/www/html/freepbx/admin/bootstrap.php(135): Whoops\\Run->register()\n#6 /etc/freepbx.conf(10): require_once('/var/www/html/f...')\n#7 /var/lib/asterisk/bin/fwconsole(12): include_once('/etc/freepbx.co...')\n#8 {main} in /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php on line 20", "stderr_lines": ["PHP Fatal error:  During inheritance of ArrayAccess: Uncaught ArgumentCountError: Too few arguments to function freepbx_error_handler(), 4 passed in /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php on line 20 and exactly 5 expected in /var/www/html/freepbx/admin/libraries/utility.functions.php:306", "Stack trace:", "#0 /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php(20): freepbx_error_handler()", "#1 /var/www/html/freepbx/admin/libraries/Composer/vendor/composer/ClassLoader.php(444): include('/var/www/html/f...')", "#2 /var/www/html/freepbx/admin/libraries/Composer/vendor/composer/ClassLoader.php(322): Composer\\Autoload\\includeFile()", "#3 [internal function]: Composer\\Autoload\\ClassLoader->loadClass()", "#4 /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Run.php(117): class_exists()", "#5 /var/www/html/freepbx/admin/bootstrap.php(135): Whoops\\Run->register()", "#6 /etc/freepbx.conf(10): require_once('/var/www/html/f...')", "#7 /var/lib/asterisk/bin/fwconsole(12): include_once('/etc/freepbx.co...')", "#8 {main} in /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php on line 20"], "stdout": "", "stdout_lines": []}

TASK [pbx : SEE ERROR ABOVE (skip_role_on_error: False)] ******************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": ""}
```
> "PHP Fatal error:  During inheritance of ArrayAccess: Uncaught ArgumentCountError: Too few arguments to function freepbx_error_handler(), 4 passed in /var/www/html/freepbx/admin/libraries/Composer/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php on line 20 and exactly 5 expected in /var/www/html/freepbx/admin/libraries/utility.functions.php:306

EDIT: The above is on an upgrade of FreePBX from 16 -> 17 where the databases were already created on RasPiOS64bit