### PR TITLE
Python2 fix [for KA Lite on Debian 12 or Ubuntu 23.04 / 23.10]

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -17,12 +17,12 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  when: not (is_debian_12 or is_ubuntu_2304)
+  when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: is_debian_12 or is_ubuntu_2304
+  when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -17,8 +17,12 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
+  when: not (is_debian_12 or is_ubuntu_2304)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
+
+- name: Use scripts/install_python2.sh to install python2 and virtualenv
+  command: "{{ iiab_dir }}/scripts/install_python2.sh"
+  when: is_debian_12 or is_ubuntu_2304
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19
   pip:

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+# https://packages.debian.org/bullseye/libpython2.7-stdlib
 ARCH=$(dpkg --print-architecture)
+
+apt -y install virtualenv
+apt -y install mime-support #transitional package
+#apt -y install libffi8
+
 cd /tmp
 case $ARCH in
     "arm64")
@@ -11,12 +17,23 @@ case $ARCH in
         apt install ./python2.7-minimal_2.7.18-8_arm64.deb
         ;;
     "amd64")
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_amd64.deb
-        apt install ./libpython2.7-minimal_2.7.18-8_amd64.deb
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_amd64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-8_amd64.deb
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_amd64.deb
-        apt install ./python2.7-minimal_2.7.18-8_amd64.deb
+        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+        apt install ./libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb
+        apt install ./libffi7_3.3-5ubuntu1_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+        apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
+        apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
         ;;
     "armhf")
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
@@ -28,4 +45,3 @@ case $ARCH in
         ;;
 esac
 rm *.deb
-apt -y install virtualenv

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -9,12 +9,23 @@ apt -y install mime-support #transitional package
 cd /tmp
 case $ARCH in
     "arm64")
+        wget http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4_arm64.deb
+        apt install ./libssl1.1_1.1.1n-0+deb11u4_arm64.deb
+
+        wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
+        apt install ./libffi7_3.3-6_arm64.deb
+
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
         apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
         apt install ./python2.7-stdlib_2.7.18-8_arm64.deb
+
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
         apt install ./python2.7-minimal_2.7.18-8_arm64.deb
+
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
+        apt install ./python2.7_2.7.18-8_arm64.deb
         ;;
     "amd64")
         wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -19,7 +19,7 @@ case $ARCH in
         apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
 
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
-        apt install ./python2.7-stdlib_2.7.18-8_arm64.deb
+        apt install ./libpython2.7-stdlib_2.7.18-8_arm64.deb
 
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
         apt install ./python2.7-minimal_2.7.18-8_arm64.deb
@@ -27,6 +27,7 @@ case $ARCH in
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
         apt install ./python2.7_2.7.18-8_arm64.deb
         ;;
+
     "amd64")
         wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
         apt install ./libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
@@ -46,13 +47,13 @@ case $ARCH in
         wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
         apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
         ;;
+
     "armhf")
         wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
         apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
 
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
         apt install ./libffi7_3.3-6_armhf.deb
-
 
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
         apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -5,20 +5,26 @@ case $ARCH in
     "arm64")
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
         apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
+        apt install ./python2.7-stdlib_2.7.18-8_arm64.deb
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
         apt install ./python2.7-minimal_2.7.18-8_arm64.deb
         ;;
     "amd64")
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_amd64.deb
         apt install ./libpython2.7-minimal_2.7.18-8_amd64.deb
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_amd64.deb
+        apt install ./libpython2.7-stdlib_2.7.18-8_amd64.deb
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_amd64.deb
         apt install ./python2.7-minimal_2.7.18-8_amd64.deb
         ;;
     "armhf")
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
         apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+        apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
-        apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
         ;;
 esac
 rm *.deb

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -47,12 +47,24 @@ case $ARCH in
         apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
         ;;
     "armhf")
+        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
+        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
+
+        wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
+        apt install ./libffi7_3.3-6_armhf.deb
+
+
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
         apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
         apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
         apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
+
+        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
+        apt install ./python2.7_2.7.18-13.2_armhf.deb
         ;;
 esac
 rm *.deb

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+ARCH=$(dpkg --print-architecture)
+cd /tmp
+case $ARCH in
+    "arm64")
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
+        apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
+        apt install ./python2.7-minimal_2.7.18-8_arm64.deb
+        ;;
+    "amd64")
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_amd64.deb
+        apt install ./libpython2.7-minimal_2.7.18-8_amd64.deb
+        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_amd64.deb
+        apt install ./python2.7-minimal_2.7.18-8_amd64.deb
+        ;;
+    "armhf")
+        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
+        apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        ;;
+esac
+rm *.deb
+apt -y install virtualenv

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -84,6 +84,7 @@ case $OS_VER in
     "ubuntu-2204"  | \
     "ubuntu-2210"  | \
     "ubuntu-2304"  | \
+    "ubuntu-2310"  | \
     "linuxmint-21" | \
     "raspbian-11"  | \
     "raspbian-12")

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -773,6 +773,7 @@ pbx_http_port: 83
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)
 
 is_ubuntu: False    # Covers: Ubuntu, Linux Mint
+is_ubuntu_2310: False
 is_ubuntu_2304: False
 is_ubuntu_2210: False
 is_ubuntu_2204: False

--- a/vars/ubuntu-2310.yml
+++ b/vars/ubuntu-2310.yml
@@ -1,0 +1,21 @@
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
+is_ubuntu_2310: True
+
+# proxy: squid
+# proxy_user: proxy
+# apache_service: apache2
+# apache_user: www-data
+# smb_service: smbd
+# nmb_service: nmbd
+# systemctl_program: /bin/systemctl
+# mysql_service: mariadb
+# sshd_package: openssh-server
+# sshd_service: ssh
+# systemd_location: /lib/systemd/system
+# php_version: "8.1"
+# postgresql_version: 14
+# python_version: "3.10"
+


### PR DESCRIPTION
### Fixes bug:
#3450 #3399 #3289 
### Description of changes proposed in this pull request:
see new file
### Smoke-tested on which OS or OS's:
http://sprunge.us/rtK5U5 My home-brew RasPiOS-12arm64 test box #3526 Should work on Ubuntu-23.04 and Debian-12 also
>1478  108343 ?        00:00:01   kalite
```
1994 2023-04-05 20:53:33,009 p=106685 u=root n=ansible | TASK [0-init : STAGE 0 HAS COMPLETED ======================================] ******************************************************
1995 2023-04-05 20:53:33,096 p=106685 u=root n=ansible | TASK [kalite : Assert that "kalite_install is sameas true" (boolean not string etc)] **********************************************
1996 2023-04-05 20:53:33,184 p=106685 u=root n=ansible | ok: [127.0.0.1]
1997 2023-04-05 20:53:33,237 p=106685 u=root n=ansible | TASK [kalite : Assert that "kalite_enabled | type_debug == 'bool'" (boolean not string etc)] **************************************
1998 2023-04-05 20:53:33,303 p=106685 u=root n=ansible | ok: [127.0.0.1]
1999 2023-04-05 20:53:33,355 p=106685 u=root n=ansible | TASK [kalite : Install KA Lite if 'kalite_installed' not defined, e.g. in /etc/iiab/iiab_state.yml] *******************************
2000 2023-04-05 20:53:33,510 p=106685 u=root n=ansible | included: /opt/iiab/iiab/roles/kalite/tasks/install.yml for 127.0.0.1
2001 2023-04-05 20:53:33,585 p=106685 u=root n=ansible | TASK [kalite : Download https://raw.githubusercontent.com/learningequality/ka-lite/master/requirements.txt to /opt/iiab/pip-packages/kalite.txt] ***
2002 2023-04-05 20:53:35,535 p=106685 u=root n=ansible | ok: [127.0.0.1]
2003 2023-04-05 20:53:35,586 p=106685 u=root n=ansible | TASK [kalite : Install packages: python2, python-setuptools, virtualenv (for Python 2)] *******************************************
2004 2023-04-05 20:53:35,641 p=106685 u=root n=ansible | skipping: [127.0.0.1]
2005 2023-04-05 20:53:35,691 p=106685 u=root n=ansible | TASK [kalite : Use scripts/install_python2.sh to install python2 and virtualenv] **************************************************
2006 2023-04-05 20:54:05,571 p=106685 u=root n=ansible | changed: [127.0.0.1]
2007 2023-04-05 20:54:05,622 p=106685 u=root n=ansible | TASK [kalite : Use pip to pin setuptools to 44 in /usr/local/kalite/venv] *********************************************************
2008 2023-04-05 20:54:29,789 p=106685 u=root n=ansible | changed: [127.0.0.1]
2009 2023-04-05 20:54:29,841 p=106685 u=root n=ansible | TASK [kalite : Use pip to install ka-lite-static to /usr/local/kalite/venv] *******************************************************
2010 2023-04-05 20:55:09,021 p=106685 u=root n=ansible | changed: [127.0.0.1]
2011 2023-04-05 20:55:09,068 p=106685 u=root n=ansible | TASK [kalite : Install from templates: venv wrapper /usr/bin/kalite, unit file /etc/systemd/system/kalite-serve.service] **********
2012 2023-04-05 20:55:10,812 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'src': 'kalite.sh.j2', 'dest': '/usr/bin/kalite', 'mode': '0755'})
2013 2023-04-05 20:55:12,040 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'src': 'kalite-serve.service.j2', 'dest': '/etc/systemd/system/kalite-serve.service', 'mode': '0644'})
2014 2023-04-05 20:55:12,098 p=106685 u=root n=ansible | TASK [kalite : Fix KA Lite bug in regex parsing ifconfig output (ifcfg/parser.py) for @m-anish's network names that contain dashes] ***
2015 2023-04-05 20:55:13,189 p=106685 u=root n=ansible | changed: [127.0.0.1]
2016 2023-04-05 20:55:13,242 p=106685 u=root n=ansible | TASK [kalite : Create dir /library/ka-lite] ***************************************************************************************
2017 2023-04-05 20:55:13,945 p=106685 u=root n=ansible | changed: [127.0.0.1]
2018 2023-04-05 20:55:13,997 p=106685 u=root n=ansible | TASK [kalite : Run '/usr/local/kalite/venv/bin/kalite manage setup ...'] **********************************************************
2019 2023-04-05 20:55:37,665 p=106685 u=root n=ansible | changed: [127.0.0.1]
2020 2023-04-05 20:55:37,714 p=106685 u=root n=ansible | TASK [kalite : Set 'kalite_installed: True'] **************************************************************************************
2021 2023-04-05 20:55:37,772 p=106685 u=root n=ansible | ok: [127.0.0.1]
2022 2023-04-05 20:55:37,826 p=106685 u=root n=ansible | TASK [kalite : Add 'kalite_installed: True' to /etc/iiab/iiab_state.yml] **********************************************************
2023 2023-04-05 20:55:38,507 p=106685 u=root n=ansible | changed: [127.0.0.1]
2024 2023-04-05 20:55:38,559 p=106685 u=root n=ansible | TASK [kalite : include_tasks] *****************************************************************************************************
2025 2023-04-05 20:55:38,732 p=106685 u=root n=ansible | included: /opt/iiab/iiab/roles/kalite/tasks/enable-or-disable.yml for 127.0.0.1
2026 2023-04-05 20:55:38,813 p=106685 u=root n=ansible | TASK [kalite : Enable & (Re)Start 'kalite-serve' service, if kalite_enabled] ******************************************************
2027 2023-04-05 20:55:45,509 p=106685 u=root n=ansible | changed: [127.0.0.1]
2028 2023-04-05 20:55:45,568 p=106685 u=root n=ansible | TASK [kalite : Disable & Stop 'kalite-serve' service, if not kalite_enabled] ******************************************************
2029 2023-04-05 20:55:45,630 p=106685 u=root n=ansible | skipping: [127.0.0.1]
2030 2023-04-05 20:55:45,691 p=106685 u=root n=ansible | TASK [kalite : Add 'kalite' variable values to /etc/iiab/iiab.ini] ****************************************************************
2031 2023-04-05 20:55:46,454 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'name', 'value': 'KA Lite'})
2032 2023-04-05 20:55:47,115 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'description', 'value': '"KA Lite downloads Khan Academy videos for offline use, with exercises and accounts if students want to track their own progress."'})
2033 2023-04-05 20:55:47,782 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'kalite_install', 'value': True})
2034 2023-04-05 20:55:48,444 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'kalite_enabled', 'value': True})
2035 2023-04-05 20:55:49,107 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'path', 'value': '/library/ka-lite'})
2036 2023-04-05 20:55:49,805 p=106685 u=root n=ansible | changed: [127.0.0.1] => (item={'option': 'port', 'value': 8008})
2037 2023-04-05 20:55:50,041 p=106685 u=root n=ansible | PLAY RECAP ************************************************************************************************************************
2038 2023-04-05 20:55:50,041 p=106685 u=root n=ansible | 127.0.0.1                  : ok=36   changed=12   unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
2039 
```