### PR TITLE
ka-lite libssl1.1 use raspi repo

### DIFF
--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -9,8 +9,8 @@ apt -y install mime-support #transitional package
 cd /tmp
 case $ARCH in
     "arm64")
-        wget http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4_arm64.deb
-        apt install ./libssl1.1_1.1.1n-0+deb11u4_arm64.deb
+        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
+        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
 
         wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
         apt install ./libffi7_3.3-6_arm64.deb


### PR DESCRIPTION
### Fixes bug:
On the off chance **deb11u4+rpt1_arm64** is already installed **deb11u4_arm64** would refuse to install as apt sees the '+rpt1' as a later version. The only situation I can think where this might come in to play of is in an upgrade of RasPiOS-11 to 12 #3526 but at least cover that possibility.

### Description of changes proposed in this pull request:
Change to use archive.raspberrypi.org repo for arm64
### Smoke-tested on which OS or OS's:
3526
### Mention a team member @username e.g. to help with code review:
