### PR TITLE
mongodb libssl1.1

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -22,8 +22,8 @@
 
 - name: Force install libssl1.1 for python2
   include_role:
-    name: libssl1.1
-  when: libssl1.1_installed is undefined
+    name: libssl1
+  when: libssl1_installed is undefined
 
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -28,7 +28,7 @@
 
 - name: Use scripts/install_python2.sh to install python2 and virtualenv for arm64 & amd64 on newer OS's
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
+  when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -24,11 +24,11 @@
 - name: Force install libssl1.1 for python2 on non x86_64 machines
   include_role:
     name: libssl1
-  when: not ansible_architecture == "x86_64" and libssl1_installed is undefined
+  when: is_raspbian_12 and ansible_architecture == "armhf" and libssl1_installed is undefined
 
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
+  when: (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -10,7 +10,7 @@
 #  ignore_errors: yes
 #  when: is_raspbian
 
-- name: 'Install packages: python2, python-setuptools, virtualenv (for Python 2)'
+- name: 'Install packages: python2, python-setuptools, virtualenv (for Python 2) on older OSs'
   package:
     name:
       - python2
@@ -21,12 +21,12 @@
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 # libpython2.7-stdlib from ubuntu-22.04 used in install_python2.sh amd64|arm64 is compiled against libssl3 and libffi8
-- name: Force install libssl1.1 for python2 on RasPiOS 'armhf'
+- name: Force install libssl1.1 for python2 on RasPiOS-12 'armhf'
   include_role:
     name: libssl1
   when: is_raspbian_12 and ansible_architecture == "armhf" and libssl1_installed is undefined
 
-- name: Use scripts/install_python2.sh to install python2 and virtualenv
+- name: Use scripts/install_python2.sh to install python2 and virtualenv for arm64 & amd64 on newer OS's
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
   when: (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
 

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -20,10 +20,11 @@
   when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
-- name: Force install libssl1.1 for python2
+# libpython2.7-stdlib from ubuntu-22.04 used in install_python2.sh amd64 is compiled against libssl3 and libffi8
+- name: Force install libssl1.1 for python2 on non x86_64 machines
   include_role:
     name: libssl1
-  when: libssl1_installed is undefined
+  when: not ansible_architecture == "x86_64" and libssl1_installed is undefined
 
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -20,6 +20,11 @@
   when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
+- name: Force install libssl1.1 for python2
+  include_role:
+    name: libssl1.1
+  when: libssl1.1_installed is undefined
+
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
   when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -20,8 +20,8 @@
   when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
-# libpython2.7-stdlib from ubuntu-22.04 used in install_python2.sh amd64 is compiled against libssl3 and libffi8
-- name: Force install libssl1.1 for python2 on non x86_64 machines
+# libpython2.7-stdlib from ubuntu-22.04 used in install_python2.sh amd64|arm64 is compiled against libssl3 and libffi8
+- name: Force install libssl1.1 for python2 on RasPiOS 'armhf'
   include_role:
     name: libssl1
   when: is_raspbian_12 and ansible_architecture == "armhf" and libssl1_installed is undefined

--- a/roles/libssl1.1/tasks/main.yml
+++ b/roles/libssl1.1/tasks/main.yml
@@ -39,6 +39,6 @@
   ansible.builtin.apt:
     update_cache: true
 
-- name: "Set 'libssl1_installed: True'"
+- name: "Set 'libssl1.1_installed: True'"
   set_fact:
-    libssl1_installed: True
+    libssl1.1_installed: True

--- a/roles/libssl1.1/tasks/main.yml
+++ b/roles/libssl1.1/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Create /etc/apt/sources.list.d/libssl1.1.list
+  file:
+    path: /etc/apt/sources.list.d/libssl1.1.list
+    state: touch
+
+- name: Ubuntu - install repo
+  lineinfile:
+    dest: /etc/apt/sources.list.d/libssl1.1.list
+    line: 'deb http://security.ubuntu.com/ubuntu focal-security main'
+    state: present
+  when: not is_debian
+
+- name: Debian - install repo
+  lineinfile:
+    dest: /etc/apt/sources.list.d/libssl1.1.list
+    line: 'deb http://security.debian.org/debian-security bullseye-security main'
+    state: present
+  when: not is_raspbian and is_debian
+
+- name: RasPiOS - install repo
+  lineinfile:
+    dest: /etc/apt/sources.list.d/libssl1.1.list
+    line: 'deb http://archive.raspberrypi.org/debian/ bullseye main'
+    state: present
+  when: is_raspbian
+
+- name: Install libssl1.1
+  ansible.builtin.apt:
+    name: libssl1.1
+    state: present
+    update_cache: true
+
+- name: Remove repo file /etc/apt/sources.list.d/libssl1.1.list
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/libssl1.1
+    state: absent
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: "Set 'libssl1_installed: True'"
+  set_fact:
+    libssl1_installed: True

--- a/roles/libssl1/tasks/main.yml
+++ b/roles/libssl1/tasks/main.yml
@@ -3,19 +3,19 @@
     path: /etc/apt/sources.list.d/libssl1.1.list
     state: touch
 
-- name: Ubuntu - install repo
+- name: Ubuntu - x86_64 install repo
   lineinfile:
     dest: /etc/apt/sources.list.d/libssl1.1.list
     line: 'deb http://security.ubuntu.com/ubuntu focal-security main'
     state: present
-  when: not is_debian
+  when: not is_debian and ansible_architecture == "x86_64"
 
-- name: Debian - install repo
+- name: Debian and Ubuntu aarch64 - install repo
   lineinfile:
     dest: /etc/apt/sources.list.d/libssl1.1.list
     line: 'deb http://security.debian.org/debian-security bullseye-security main'
     state: present
-  when: not is_raspbian and is_debian
+  when: (not is_raspbian and is_debian) or (is_ubuntu and ansible_architecture == "aarch64")
 
 - name: RasPiOS - install repo
   lineinfile:

--- a/roles/libssl1/tasks/main.yml
+++ b/roles/libssl1/tasks/main.yml
@@ -39,6 +39,6 @@
   ansible.builtin.apt:
     update_cache: true
 
-- name: "Set 'libssl1.1_installed: True'"
+- name: "Set 'libssl1_installed: True'"
   set_fact:
-    libssl1.1_installed: True
+    libssl1_installed: True

--- a/roles/libssl1/tasks/main.yml
+++ b/roles/libssl1/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Install libssl1.1
   ansible.builtin.apt:
     name: libssl1.1
-    state: present
+    state: latest
     update_cache: true
 
 - name: Remove repo file /etc/apt/sources.list.d/libssl1.1.list

--- a/roles/libssl1/tasks/main.yml
+++ b/roles/libssl1/tasks/main.yml
@@ -3,19 +3,19 @@
     path: /etc/apt/sources.list.d/libssl1.1.list
     state: touch
 
-- name: Ubuntu - x86_64 install repo
+- name: Ubuntu - install repo
   lineinfile:
     dest: /etc/apt/sources.list.d/libssl1.1.list
-    line: 'deb http://security.ubuntu.com/ubuntu focal-security main'
+    line: 'deb http://ports.ubuntu.com/ubuntu-ports focal-security main'
     state: present
-  when: not is_debian and ansible_architecture == "x86_64"
+  when: not is_debian
 
-- name: Debian and Ubuntu aarch64 - install repo
+- name: Debian - install repo
   lineinfile:
     dest: /etc/apt/sources.list.d/libssl1.1.list
     line: 'deb http://security.debian.org/debian-security bullseye-security main'
     state: present
-  when: (not is_raspbian and is_debian) or (is_ubuntu and ansible_architecture == "aarch64")
+  when: not is_raspbian and is_debian
 
 - name: RasPiOS - install repo
   lineinfile:
@@ -32,7 +32,7 @@
 
 - name: Remove repo file /etc/apt/sources.list.d/libssl1.1.list
   ansible.builtin.file:
-    path: /etc/apt/sources.list.d/libssl1.1
+    path: /etc/apt/sources.list.d/libssl1.1.list
     state: absent
 
 - name: Update apt cache

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -184,8 +184,8 @@
 
 - name: Force install libssl1.1 for version < 6.0 (aarch64/arm64)
   include_role:
-    name: libssl1.1
-  when: mongodb_version is version('6.0', '<') and libssl1.1_installed is undefined
+    name: libssl1
+  when: mongodb_version is version('6.0', '<') and libssl1_installed is undefined
 
 #  - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
 #    apt_repository:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -164,7 +164,7 @@
 - debug:
     msg: 5-STANZA BLOCK FOLLOWS, TO FORCE INSTALL libssl1.1 -- runs *IF* mandated mongodb_version ({{ mongodb_version }}) < 6.0 (i.e. for aarch64/arm64) on Ubuntu 22.04+ or Debian 12+ -- whereas Linux Mint should never need libssl1.1
 
-- block:
+#- block:
 
 #  - name: Install OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
 #    apt_repository:
@@ -182,15 +182,10 @@
 #      name: libssl1.1
 #      state: present
 
-  - name: Force install libssl1.1 on aarch64
-    ansible.builtin.apt:
-      deb: http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
-    when: ansible_architecture == "aarch64"
-
-  - name: Force install libssl1.1 on x86_64
-    ansible.builtin.apt:
-      deb: http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-    when: ansible_architecture == "x86_64"
+- name: Force install libssl1.1 on aarch64
+  ansible.builtin.apt:
+    deb: http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
+  when: mongodb_version is version('6.0', '<')
 
 #  - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
 #    apt_repository:
@@ -205,7 +200,8 @@
 #      state: absent
 #    when: is_ubuntu
 
-  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
+#  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
+
 
 - debug:
     msg: 5-STANZA BLOCK ABOVE, RAN *IF* FORCED INSTALL OF libssl1.1 WAS NEEDED
@@ -322,14 +318,14 @@
 
 - name: If hardware is Raspberry Pi and mongodb_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
   command: apt-mark hold mongodb-org mongodb-org-server
-  when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
+  when: mongodb_version is version('6.0', '<')
 
 - name: If hardware is Raspberry Pi and mongodb_version >= 5.0, unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
   unarchive:
     remote_src: yes
     src: "{{ iiab_download_url }}/raspbian_mongodb_5.0.5.gz"
     dest: /usr/bin
-  when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
+  when: mongodb_version is version('6.0', '<')
 
 #   # end block
 #   when: ansible_architecture == "aarch64" or ansible_architecture == "x86_64"

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -182,7 +182,7 @@
 #      name: libssl1.1
 #      state: present
 
-- name: Force install libssl1.1 on aarch64
+- name: Force install libssl1.1 for version < 6.0 (aarch64/arm64)
   ansible.builtin.apt:
     deb: http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
   when: mongodb_version is version('6.0', '<')
@@ -316,11 +316,11 @@
 # https://andyfelong.com/downloads/raspbian_mongodb_5.0.5.gz
 # https://andyfelong.com/2021/08/mongodb-4-4-under-raspberry-pi-os-64-bit-raspbian64/
 
-- name: If hardware is Raspberry Pi and mongodb_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
+- name: If mongodb_version < 6.0, (aarch64/arm64) run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
   command: apt-mark hold mongodb-org mongodb-org-server
   when: mongodb_version is version('6.0', '<')
 
-- name: If hardware is Raspberry Pi and mongodb_version >= 5.0, unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
+- name: If mongodb_version < 6.0, (aarch64/arm64) unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
   unarchive:
     remote_src: yes
     src: "{{ iiab_download_url }}/raspbian_mongodb_5.0.5.gz"

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -166,34 +166,44 @@
 
 - block:
 
-  - name: Install OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
-    apt_repository:
-      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
-    when: is_ubuntu
+#  - name: Install OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
+#    apt_repository:
+#      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
+#    when: is_ubuntu
 
-  - name: Install OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
-    apt_repository:
-      repo: deb http://security.debian.org/debian-security bullseye-security main
+#  - name: Install OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
+#    apt_repository:
+#      repo: deb http://security.debian.org/debian-security bullseye-security main
       #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
-    when: is_debian
+#    when: is_debian
 
-  - name: Force install libssl1.1
-    package:
-      name: libssl1.1
-      state: present
+#  - name: Force install libssl1.1
+#    package:
+#      name: libssl1.1
+#      state: present
 
-  - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
-    apt_repository:
-      repo: deb http://security.debian.org/debian-security bullseye-security main
-      #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
-      state: absent
-    when: is_debian
+  - name: Force install libssl1.1 on aarch64
+    ansible.builtin.apt:
+      deb: http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
+    when: ansible_architecture == "aarch64"
 
-  - name: Remove OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
-    apt_repository:
-      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
-      state: absent
-    when: is_ubuntu
+  - name: Force install libssl1.1 on x86_64
+    ansible.builtin.apt:
+      deb: http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+    when: ansible_architecture == "x86_64"
+
+#  - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
+#    apt_repository:
+#      repo: deb http://security.debian.org/debian-security bullseye-security main
+#      #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
+#      state: absent
+#    when: is_debian
+
+#  - name: Remove OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
+#    apt_repository:
+#      repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
+#      state: absent
+#    when: is_ubuntu
 
   when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
 

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -183,9 +183,9 @@
 #      state: present
 
 - name: Force install libssl1.1 for version < 6.0 (aarch64/arm64)
-  ansible.builtin.apt:
-    deb: http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
-  when: mongodb_version is version('6.0', '<')
+  include_role:
+    name: libssl1.1
+  when: mongodb_version is version('6.0', '<') and libssl1.1_installed is undefined
 
 #  - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
 #    apt_repository:

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -9,9 +9,6 @@ apt -y install mime-support #transitional package
 cd /tmp
 case $ARCH in
     "arm64")
-        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
-        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
-
         wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
         apt install ./libffi7_3.3-6_arm64.deb
 
@@ -29,9 +26,6 @@ case $ARCH in
         ;;
 
     "amd64")
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-        apt install ./libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-
         wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb
         apt install ./libffi7_3.3-5ubuntu1_amd64.deb
 
@@ -49,9 +43,6 @@ case $ARCH in
         ;;
 
     "armhf")
-        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
-        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
-
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
         apt install ./libffi7_3.3-6_armhf.deb
 

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -4,10 +4,28 @@ ARCH=$(dpkg --print-architecture)
 
 apt -y install virtualenv
 apt -y install mime-support #transitional package
-#apt -y install libffi8
 
+# libpython2.7-stdlib from ubuntu-22.04 used in amd64 is compiled against libssl3 and libffi8
+# `apt info libpython2.7-stdlib`
 cd /tmp
 case $ARCH in
+    "amd64")
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi8_3.4.2-4_amd64.deb
+        apt install ./libffi8_3.4.2-4_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+        apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
+        apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
+        ;;
+
     "arm64")
         wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
         apt install ./libffi7_3.3-6_arm64.deb
@@ -23,23 +41,6 @@ case $ARCH in
 
         wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
         apt install ./python2.7_2.7.18-8_arm64.deb
-        ;;
-
-    "amd64")
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb
-        apt install ./libffi7_3.3-5ubuntu1_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
         ;;
 
     "armhf")

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -49,27 +49,33 @@ case $ARCH in
 deb [trusted=yes] http://ports.ubuntu.com/ jammy main universe
 deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe
 EOF
-        apt update
-        apt -y install python2
-        rm /etc/apt/sources.list.d/python2.list
-        apt update
         ;;
 
+# assume armhf is from raspbian
     "armhf")
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
-        apt install ./libffi7_3.3-6_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
+        #apt install ./libffi7_3.3-6_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
-        apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        #apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
-        apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
-        apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
+        #apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
-        apt install ./python2.7_2.7.18-13.2_armhf.deb
-        rm *.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
+        #apt install ./python2.7_2.7.18-13.2_armhf.deb
+        #rm *.deb
+        cat << EOF >> /etc/apt/sources.list.d/python2.list
+deb http://raspbian.raspberrypi.org/raspbian/ bullseye main
+deb http://archive.raspberrypi.org/debian/ bullseye main
+EOF
         ;;
 esac
+
+apt update
+apt -y install python2
+rm /etc/apt/sources.list.d/python2.list
+apt update

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -44,6 +44,7 @@ case $ARCH in
         #;;
 
     "arm64"|"amd64")
+        apt -y install libffi8
         cat << EOF >> /etc/apt/sources.list.d/python2.list
 deb [trusted=yes] http://ports.ubuntu.com/ jammy main universe
 deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -9,38 +9,49 @@ apt -y install mime-support #transitional package
 # `apt info libpython2.7-stdlib`
 cd /tmp
 case $ARCH in
-    "amd64")
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi8_3.4.2-4_amd64.deb
-        apt install ./libffi8_3.4.2-4_amd64.deb
+    #"amd64")
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi8_3.4.2-4_amd64.deb
+        #apt install ./libffi8_3.4.2-4_amd64.deb
 
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
-        ;;
+        #wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
+        #;;
 
-    "arm64")
-        wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
-        apt install ./libffi7_3.3-6_arm64.deb
+    #"arm64")
+        #wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
+        #apt install ./libffi7_3.3-6_arm64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
-        apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
+        #apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-8_arm64.deb
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-8_arm64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
-        apt install ./python2.7-minimal_2.7.18-8_arm64.deb
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
+        #apt install ./python2.7-minimal_2.7.18-8_arm64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
-        apt install ./python2.7_2.7.18-8_arm64.deb
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
+        #apt install ./python2.7_2.7.18-8_arm64.deb
+        #;;
+
+    "arm64"|"amd64")
+        cat << EOF >> /etc/apt/sources.list.d/python2.list
+deb [trusted=yes] http://ports.ubuntu.com/ jammy main universe
+deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe
+EOF
+        apt update
+        apt -y install python2
+        rm /etc/apt/sources.list.d/python2.list
+        apt update
         ;;
 
     "armhf")
@@ -58,6 +69,6 @@ case $ARCH in
 
         wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
         apt install ./python2.7_2.7.18-13.2_armhf.deb
+        rm *.deb
         ;;
 esac
-rm *.deb


### PR DESCRIPTION
### Fixes bug:
On the off chance **deb11u4+rpt1_arm64** is already installed **deb11u4_arm64** would refuse to install as apt sees the '+rpt1' as a later version. The only situation I can think where this might come in to play of is in an upgrade of RasPiOS-11 to 12 https://github.com/iiab/iiab/issues/3526 but at least cover that possibility.
### Description of changes proposed in this pull request:
Drop use of 'apt_repository' and use 'apt' directly similar to scripts/install_python2.sh
### Smoke-tested on which OS or OS's:
3526 
### Mention a team member @username e.g. to help with code review: