### PR TITLE
BUG: no path [formerly Apache's roles/httpd/tasks/homepage.yml]

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -13,9 +13,9 @@
     mode: '0755'
 
 # Used to be run by httpd/tasks/install.yml
-- name: "IN CASE NGINX IS DISABLED: Enable IIAB pages via Apache (e.g. on port 80) if apache_install"
-  include_tasks: roles/httpd/tasks/homepage.yml
-  when: apache_installed is defined
+#- name: "IN CASE NGINX IS DISABLED: Enable IIAB pages via Apache (e.g. on port 80) if apache_install"
+#  include_tasks: roles/httpd/tasks/homepage.yml
+#  when: apache_installed is defined
 
 # Used to be run by nginx/tasks/install.yml
 - name: Enable IIAB pages via NGINX (e.g. on port 80) if nginx_install


### PR DESCRIPTION
### Fixes bug:
```
ASK [WWW_OPTIONS (WWW_BASE should have been installed earlier)] ************************************************************************

TASK [www_options : Create dir /library/www/html/home just in case variable iiab_home_url was customized.  (Standard path /library/www/html/home was created earlier.)] ***
ok: [127.0.0.1]

TASK [www_options : IN CASE NGINX IS DISABLED: Enable IIAB pages via Apache (e.g. on port 80) if apache_install] ************************
fatal: [127.0.0.1]: FAILED! => {"reason": "Could not find or access '/opt/iiab/iiab/roles/httpd/tasks/homepage.yml' on the Ansible Controller."}

PLAY RECAP ******************************************************************************************************************************
127.0.0.1                  : ok=49   changed=5    unreachable=0    failed=1    skipped=17   rescued=0    ignored=0   
```
### Description of changes proposed in this pull request:
remove conditional pointing to dead code path '/opt/iiab/iiab/roles/httpd/tasks/homepage.yml'
### Smoke-tested on which OS or OS's:
Ran across this post asterisk install with apache enabled and running iiab-configure after asterisk install
### Mention a team member @username e.g. to help with code review:
