### PR TITLE
Python2 fix [for KA Lite on Debian 12 or Ubuntu 23.04 / 23.10]

### DIFF
--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -43,6 +43,7 @@ case $ARCH in
         #apt install ./python2.7_2.7.18-8_arm64.deb
         #;;
 
+# trusted is used for Debian and RasPiOS as the keys would be missing for Ubuntu
     "arm64"|"amd64")
         apt -y install libffi8
         cat << EOF >> /etc/apt/sources.list.d/python2.list
@@ -51,7 +52,6 @@ deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe
 EOF
         ;;
 
-# assume armhf is from raspbian
     "armhf")
         #wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
         #apt install ./libffi7_3.3-6_armhf.deb
@@ -68,10 +68,18 @@ EOF
         #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
         #apt install ./python2.7_2.7.18-13.2_armhf.deb
         #rm *.deb
-        cat << EOF >> /etc/apt/sources.list.d/python2.list
+
+        if [ -f /etc/rpi-issue ]; then
+            cat << EOF >> /etc/apt/sources.list.d/python2.list
 deb http://raspbian.raspberrypi.org/raspbian/ bullseye main
 deb http://archive.raspberrypi.org/debian/ bullseye main
 EOF
+        else
+            cat << EOF >> /etc/apt/sources.list.d/python2.list
+deb http://ports.ubuntu.com/ jammy main universe
+deb http://ports.ubuntu.com/ jammy-updates main universe
+EOF
+        fi
         ;;
 esac
 

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -4,68 +4,78 @@ ARCH=$(dpkg --print-architecture)
 
 apt -y install virtualenv
 apt -y install mime-support #transitional package
-#apt -y install libffi8
 
+# libpython2.7-stdlib from ubuntu-22.04 used in amd64 is compiled against libssl3 and libffi8
+# `apt info libpython2.7-stdlib`
 cd /tmp
 case $ARCH in
-    "arm64")
-        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
-        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_arm64.deb
+    #"amd64")
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi8_3.4.2-4_amd64.deb
+        #apt install ./libffi8_3.4.2-4_amd64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
-        apt install ./libffi7_3.3-6_arm64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
-        apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-8_arm64.deb
+        #wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
-        apt install ./python2.7-minimal_2.7.18-8_arm64.deb
+        #wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
+        #apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
+        #;;
 
-        wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
-        apt install ./python2.7_2.7.18-8_arm64.deb
+    #"arm64")
+        #wget http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb
+        #apt install ./libffi7_3.3-6_arm64.deb
+
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8_arm64.deb
+        #apt install ./libpython2.7-minimal_2.7.18-8_arm64.deb
+
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8_arm64.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-8_arm64.deb
+
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8_arm64.deb
+        #apt install ./python2.7-minimal_2.7.18-8_arm64.deb
+
+        #wget http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8_arm64.deb
+        #apt install ./python2.7_2.7.18-8_arm64.deb
+        #;;
+
+    "arm64"|"amd64")
+        apt -y install libffi8
+        cat << EOF >> /etc/apt/sources.list.d/python2.list
+deb [trusted=yes] http://ports.ubuntu.com/ jammy main universe
+deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe
+EOF
         ;;
 
-    "amd64")
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-        apt install ./libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb
-        apt install ./libffi7_3.3-5ubuntu1_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
-        apt install ./libpython2.7-stdlib_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7-minimal_2.7.18-13ubuntu2_amd64.deb
-
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/p/python2.7/python2.7_2.7.18-13ubuntu2_amd64.deb
-        apt install ./python2.7_2.7.18-13ubuntu2_amd64.deb
-        ;;
-
+# assume armhf is from raspbian
     "armhf")
-        wget http://archive.raspberrypi.org/debian/pool/main/o/openssl/libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
-        apt install ./libssl1.1_1.1.1n-0+deb11u4+rpt1_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
+        #apt install ./libffi7_3.3-6_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/libf/libffi/libffi7_3.3-6_armhf.deb
-        apt install ./libffi7_3.3-6_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        #apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-13.2_armhf.deb
-        apt install ./libpython2.7-minimal_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+        #apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-13.2_armhf.deb
-        apt install ./libpython2.7-stdlib_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
+        #apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
 
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7-minimal_2.7.18-13.2_armhf.deb
-        apt install ./python2.7-minimal_2.7.18-13.2_armhf.deb
-
-        wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
-        apt install ./python2.7_2.7.18-13.2_armhf.deb
+        #wget http://raspbian.raspberrypi.org/raspbian/pool/main/p/python2.7/python2.7_2.7.18-13.2_armhf.deb
+        #apt install ./python2.7_2.7.18-13.2_armhf.deb
+        #rm *.deb
+        cat << EOF >> /etc/apt/sources.list.d/python2.list
+deb http://raspbian.raspberrypi.org/raspbian/ bullseye main
+deb http://archive.raspberrypi.org/debian/ bullseye main
+EOF
         ;;
 esac
-rm *.deb
+
+apt update
+apt -y install python2
+rm /etc/apt/sources.list.d/python2.list
+apt update


### PR DESCRIPTION
### Fixes bug:
Replacement for #3530 https://github.com/iiab/iiab/pull/3530#issuecomment-1501603024
### Description of changes proposed in this pull request:
drops the need to install libssl1.1 for python2
### Smoke-tested on which OS or OS's:
U23.04beta and RasPiOS-12 #3526 in PR3530
### Mention a team member @username e.g. to help with code review:
