### PR TITLE
Allow rescue/continue if CUPS or Samba installs fail [if skip_role_on_error: True]

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -1,6 +1,6 @@
 # 2022-03-16: 'apt show <pkg> | grep Size' revealed download sizes, on 64-bit RasPiOS with desktop.
 
-- name: "Install 17 common packages: acpid, bzip2, cron, curl, gawk, htop, i2c-tools, logrotate, plocate, pandoc, pastebinit, rsync, sqlite3, tar, unzip, usbutils, wget"
+- name: "Install 17 common packages: acpid, bzip2, cron, curl, gawk, htop, i2c-tools, logrotate, pandoc, pastebinit, plocate, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:
     name:
       - acpid              #   55kB download: Daemon for ACPI (power mgmt) events
@@ -16,12 +16,12 @@
       - logrotate          #   67kB download: RasPiOS installs this regardless
       #- lynx              #  505kB download: Installed by 1-prep's roles/iiab-admin/tasks/main.yml
       #- make              #  376kB download: 2021-07-27: Currently used by roles/pbx and no other roles
-      #- mlocate           #   92kB download
-      - plocate            #   97kB download: Faster & smaller than locate & mlocate
       #- ntfs-3g           #  379kB download: RasPiOS installs this regardless -- 2021-07-31: But this should no longer be nec with 5.4+ kernels, similar to exfat packages above -- however, see also this symlink warning: https://superuser.com/questions/1050544/mount-with-kernel-ntfs-and-not-ntfs-3g -- and upcoming kernel 5.15 improvements: https://www.phoronix.com/scan.php?page=news_item&px=New-NTFS-Likely-For-Linux-5.15
       #- openssh-server    #  318kB download: RasPiOS installs this regardless -- this is also installed by 1-prep's roles/sshd/tasks/main.yml to cover all OS's
       - pandoc             #   19kB download: For /usr/bin/iiab-refresh-wiki-docs
       - pastebinit         #   47kB download: For /usr/bin/iiab-diagnostics
+      #- mlocate           #   92kB download
+      - plocate            #   97kB download: Faster & smaller than locate & mlocate
       #- python3-pip       #  337kB download: 2023-03-22: Used to be installed by /opt/iiab/iiab/scripts/ansible -- which would auto-install 'python3-setuptools' and 'python3' etc
       #- python3-venv      # 1188kB download: 2023-03-22: Already installed by /opt/iiab/iiab/scripts/ansible -- used by roles like {calibre-web, jupyterhub, lokole} -- whereas roles/kalite uses (virtual) package 'virtualenv' for Python 2 -- all these 3+1 IIAB roles install 'python3-venv' for themselves.  FYI: Debian 11 no longer auto-installs 'python3-venv' when you install 'python3'
       - rsync              #  351kB download: RasPiOS installs this regardless

--- a/roles/cups/tasks/main.yml
+++ b/roles/cups/tasks/main.yml
@@ -23,26 +23,33 @@
     quiet: yes
 
 
-- name: Install CUPS if 'cups_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: cups_installed is undefined
+- block:
 
+  - name: Install CUPS if 'cups_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: cups_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'cups' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: cups
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: CUPS
+      - option: description
+        value: '"CUPS (Common UNIX Printing System) is a modular printing system that allows a computer to act as a print server.  A computer running CUPS is a host that can accept print jobs from client computers, process them, and send them to the appropriate printer."'
+      - option: cups_install
+        value: "{{ cups_install }}"
+      - option: cups_enabled
+        value: "{{ cups_enabled }}"
 
-- name: Add 'cups' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: cups
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: CUPS
-    - option: description
-      value: '"CUPS (Common UNIX Printing System) is a modular printing system that allows a computer to act as a print server.  A computer running CUPS is a host that can accept print jobs from client computers, process them, and send them to the appropriate printer."'
-    - option: cups_install
-      value: "{{ cups_install }}"
-    - option: cups_enabled
-      value: "{{ cups_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -19,26 +19,33 @@
     quiet: yes
 
 
-- name: Install Samba if 'samba_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: samba_installed is undefined
+- block:
 
+  - name: Install Samba if 'samba_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: samba_installed is undefined
 
-- include_tasks: enable-or-disable.yml
+  - include_tasks: enable-or-disable.yml
 
+  - name: Add 'samba' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: samba
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: Samba
+      - option: description
+        value: '"Samba is a Microsoft-compatible network file system that re-implements SMB/CIFS (Common Internet File System)."'
+      - option: samba_install
+        value: "{{ samba_install }}"
+      - option: samba_enabled
+        value: "{{ samba_enabled }}"
 
-- name: Add 'samba' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: samba
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: Samba
-    - option: description
-      value: '"Samba is a Microsoft-compatible network file system that re-implements SMB/CIFS (Common Internet File System)."'
-    - option: samba_install
-      value: "{{ samba_install }}"
-    - option: samba_enabled
-      value: "{{ samba_enabled }}"
+  rescue:
+
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error


### PR DESCRIPTION
Allows "rescue" from these 2 Ansible roles, if continuing with Ansible is desire,  As mentioned here:

- https://github.com/iiab/iiab/issues/3487#issuecomment-1495021508

i.e. IIAB implementers can now use `skip_role_on_error: True` to install even larger sets IIAB Apps without interruption.

Tested on Ubuntu 23.04 pre-release.

Building on:

- PR #3262