### PR TITLE
ansible-core 2.14.5 & beefed up for latest 32-bit ARM (armhf) cryptography / piwheels / rust problems

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -204,6 +204,12 @@ $APT_PATH/apt -y install python3-venv
 # https://peps.python.org/pep-0668
 echo -e "\nCreate virtual environment for Ansible"
 python3 -m venv /usr/local/ansible
+
+# Same detection as local_facts.fact https://github.com/iiab/iiab/issues/3547
+if [ -f /etc/rpi-issue ] && [ "$(dpkg --print-architecture)" = armhfp ]; then
+    /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
+fi
+
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
 for bin in /usr/local/ansible/bin/ansible*; do

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -96,7 +96,7 @@ echo -e "    /etc/apt/sources.list and /etc/apt/sources.list.d/*\n"
 echo -e "IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)"
 echo -e "https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n"
 
-if [ $(command -v ansible) ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
+if [ "$(command -v ansible)" ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
     CURR_VER=$(ansible --version | head -1 | cut -f 2- -d " ")
     # Above works with 'ansible [core 2.11.0rc2]' -- these old ways do not:
     #CURR_VER=$(ansible --version | head -1 | awk '{print $2}')
@@ -201,14 +201,13 @@ $APT_PATH/apt -y install python3-venv
 
 # 2023-03-22: OS's like Ubuntu 23.04 and Debian 12 (e.g. with Python 3.11+) ask
 # that virtual environments (venv) be used to safely isolate pip installs:
-# https://peps.python.org/pep-0668 
+# https://peps.python.org/pep-0668
 echo -e "\nCreate virtual environment for Ansible"
 python3 -m venv /usr/local/ansible
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
-cd /usr/local/ansible/bin
-for bin in $(ls ansible*); do
-    ln -sf /usr/local/ansible/bin/$bin /usr/local/bin/$bin
+for bin in /usr/local/ansible/bin/ansible*; do
+    ln -sf /usr/local/ansible/bin/"$bin" /usr/local/bin/"$bin"
 done
 
 # (Re)running collection installs appears safe, with --force-with-deps to force

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.14.4]
-GOOD_VER=2.14.4       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.14.5]
+GOOD_VER=2.14.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -205,14 +205,21 @@ $APT_PATH/apt -y install python3-venv
 echo -e "\nCreate virtual environment for Ansible"
 python3 -m venv /usr/local/ansible
 
-# Same detection as local_facts.fact https://github.com/iiab/iiab/issues/3547
-if [ -f /etc/rpi-issue ] && [ "$(dpkg --print-architecture)" = armhfp ]; then
+# "if not ubuntu" (covers RasPiOC & Debian) would also work, but is overbroad:
+# if ! grep -qi ubuntu /etc/os-release; then
+#
+# if [ -f /etc/rpi-issue ] && [[ $(dpkg --print-architecture) == armhf ]]; then
+#
+# 2023-03-24 #3547 similar to #3459 re: cryptography, piwheels, rust.
+# Release problems chart: https://www.piwheels.org/project/cryptography/
+if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
     /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
 fi
 
 /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
-for bin in /usr/local/ansible/bin/ansible*; do
+cd /usr/local/ansible/bin
+for bin in ansible*; do
     ln -sf /usr/local/ansible/bin/"$bin" /usr/local/bin/"$bin"
 done
 


### PR DESCRIPTION
Tested on Ubuntu 23.04, 64-RasPiOS and `dpkg --print-architecture` output verified on 32-bit ARM (armhf).

Building on:

- PR #3459
- PR #3496
- PR #3513
- #3547
- PR #3548
- PR piwheels/piwheels#328
- piwheels/packages#348