### PR TITLE
iiab-clone-wifi needs template from hostapd - record wifi_up_down [& doc re: Ansible facts like ansible_ap0, ansible_eth0, ansible_wlan0] [& 5GHz versus 2.4GHz test]

### DIFF
--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -100,6 +100,18 @@
     line: 'HOSTAPD_ENABLED={{ hostapd_enabled }}'
     state: present
 
+- name: Create /etc/hostapd/hostapd.conf and backup .iiab from template if needed
+  template:
+    owner: root
+    group: root
+    mode: 0644
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf' }
+    - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf.iiab' }
+  when: can_be_ap
+
 - name: Record host_country_code_applied and host_channel in network of {{ iiab_ini_file }}
   ini_file:
     dest: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
@@ -113,6 +125,8 @@
       value: "{{ host_ssid }}"
     - option: host_wifi_mode
       value: "{{ host_wifi_mode }}"
+    - option: wifi_up_down
+      value: "{{ wifi_up_down }}"
     - option: host_country_code_applied
       value: "{{ host_country_code }}"
     - option: host_channel

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -14,18 +14,6 @@
     - wpa_supplicant
   when: wifi_up_down and hostapd_enabled
 
-- name: Create /etc/hostapd/hostapd.conf and backup .iiab from template if needed
-  template:
-    owner: root
-    group: root
-    mode: 0644
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-  with_items:
-    - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf' }
-    - { src: 'hostapd/hostapd.conf.j2', dest: '/etc/hostapd/hostapd.conf.iiab' }
-  when: can_be_ap
-
 - name: Enable & Restart networkd-dispatcher.service
   systemd:
     name: networkd-dispatcher
@@ -33,6 +21,12 @@
     enabled: yes
     masked: no
   when: systemd_networkd_active
+
+- name: Clone wifi if needed
+  systemd:
+    name: iiab-clone-wifi
+    state: restarted
+  when: wifi_up_down and can_be_ap and ansible_ap0 is undefined
 
 - name: Restart hostapd when WiFi is present but not when using WiFi as gateway with wifi_up_down False
   systemd:

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -78,12 +78,6 @@
   systemd:
     daemon_reload: yes
 
-- name: Clone wifi if needed
-  systemd:
-    name: iiab-clone-wifi
-    state: restarted
-  when: wifi_up_down and can_be_ap and ansible_ap0 is undefined
-
 - name: Restart the networking service if appropriate
   systemd:
     name: networking

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -87,12 +87,6 @@
   systemd:
     daemon_reload: yes
 
-- name: Clone wifi if needed
-  systemd:
-    name: iiab-clone-wifi
-    state: restarted
-  when: wifi_up_down and can_be_ap and ansible_ap0 is undefined
-
 - name: Enable & Restart systemd-networkd.service
   systemd:
     name: systemd-networkd
@@ -106,4 +100,3 @@
     state: restarted
     enabled: yes
     masked: no
-


### PR DESCRIPTION
### Fixes bug:
This issue should show up on a clean install with wifi_up_down: True, slight hole in testing
### Description of changes proposed in this pull request:
iiab-clone-wifi needs template from hostapd.yml that moved so reposition the restart to be after hostapd.yml
### Smoke-tested on which OS or OS's:
Not as of yet, but if installs start failing at the noted restarting of iiab-clone-wifi, the service file is not installed yet.
### Mention a team member @username e.g. to help with code review:
