### PR TITLE
Revert to Moodle 4.1 LTS / Nextcloud 25 if PHP 7 + toughen Moodle/Nextcloud

### DIFF
--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -49,13 +49,27 @@
   when: php_settings_done is undefined
 
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.3"
-  git:
-    repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
-    dest: "{{ moodle_base }}"        # /opt/iiab/moodle
-    depth: 1
-    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022)
-  when: php_version is version('8.3', '>=')
+- name: Does /opt/iiab/moodle exist?
+  stat:
+    path: /opt/iiab/moodle
+  register: opt_iiab_moodle
+
+# 2023-04-30: Allows re-running (e.g. 'sudo iiab') if git clone was already
+# begun, avoiding this error: (arises from 'www-data' ownership)
+#   "Failed to set a new url https://github.com/moodle/moodle for origin:
+#   fatal: detected dubious ownership in repository at '/opt/iiab/moodle'
+#   To add an exception for this directory, call:
+#   git config --global --add safe.directory /opt/iiab/moodle"
+
+- name: If /opt/iiab/moodle exists, move it to /tmp/opt-iiab-moodle.old (TO BE DELETED ON NEXT BOOT) -- allows re-running if git clone (below) was already begun
+  shell: rm -rf /tmp/opt-iiab-moodle.old && mv /opt/iiab/moodle /tmp/opt-iiab-moodle.old
+  when: opt_iiab_moodle.stat.exists
+
+
+- name: "2023-04-30: MOODLE 4.2+ REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER MOODLE 4.1 LTS ON OS's WITH PHP 7.x -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
+  set_fact:
+    moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
+  when: php_version is version('8.0', '<')
 
 - name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.3
   git:
@@ -64,6 +78,14 @@
     depth: 1
     version: "{{ moodle_version }}"    # e.g. MOODLE_402_STABLE (Moodle 4.2)
   when: php_version is version('8.3', '<')
+
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.3"
+  git:
+    repo: "{{ moodle_repo_url }}"
+    dest: "{{ moodle_base }}"
+    depth: 1
+    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023)
+  when: php_version is version('8.3', '>=')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -98,10 +98,10 @@
     state: directory
     path: "{{ nextcloud_root_dir }}"    # /library/www/nextcloud
 
-- name: "2023-03-24: NEXTCLOUD 26 REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER NEXTCLOUD 25 ON OS's WITH PHP <= 7.4 -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
+- name: "2023-03-24: NEXTCLOUD 26 REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER NEXTCLOUD 25 ON OS's WITH PHP 7.x -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
   set_fact:
     nextcloud_dl_url: https://download.nextcloud.com/server/releases/latest-25.tar.bz2
-  when: php_version is version('7.4', '<=')
+  when: php_version is version('8.0', '<')
 
 - name: Unarchive {{ nextcloud_dl_url }} (~140 MB) to {{ nextcloud_root_dir }} (~519 MB initially, sometimes ~543 MB later, {{ apache_user }}:{{ apache_user }})
   unarchive:


### PR DESCRIPTION
Tested on 64-bit RasPiOS Lite.

This allows IIAB to tolerate PHP 7 for a couple more months.  As explained here:

- #3558

Building on:

- PR #3208
- PR #3511
- PR #3551