### PR TITLE
Temporarily Enable sysctl's IPv6 during Munin install/enable, so munin-node.service starts

### DIFF
--- a/roles/munin/tasks/enable-or-disable.yml
+++ b/roles/munin/tasks/enable-or-disable.yml
@@ -1,3 +1,9 @@
+# SEE ALSO roles/network/tasks/install.yml
+- name: TEMPORARILY REVERT net.ipv6.conf.all.disable_ipv6 to 0 in /etc/sysctl.conf for #3434
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 0
+
 - name: Enable & Start 'munin-node' systemd service
   systemd:
     name: munin-node
@@ -5,6 +11,12 @@
     enabled: yes
     state: started
   when: munin_enabled
+
+# SEE ALSO roles/network/tasks/install.yml
+- name: RESTORE net.ipv6.conf.all.disable_ipv6 to 1 in /etc/sysctl.conf for #3434
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 1
 
 - name: Disable & Stop 'munin-node' systemd service
   systemd:

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -1,3 +1,9 @@
+# SEE ALSO roles/network/tasks/install.yml
+- name: TEMPORARILY REVERT net.ipv6.conf.all.disable_ipv6 to 0 in /etc/sysctl.conf for #3434
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 0
+
 - name: "Install 5 packages: libcgi-fast-perl, munin, munin-node, munin-plugins-extra, python3-passlib"
   package:
     name:
@@ -8,6 +14,12 @@
       - munin-plugins-extra
       - python3-passlib    # For Ansible module 'htpasswd' in Ansible collection community.general -- used just below
     state: present
+
+# SEE ALSO roles/network/tasks/install.yml
+- name: RESTORE net.ipv6.conf.all.disable_ipv6 to 1 in /etc/sysctl.conf for #3434
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 1
 
 - name: Establish username/password Admin/changeme in /etc/munin/munin-htpasswd
   htpasswd:

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -59,7 +59,7 @@
     - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }              # Default: 2.  Enable Spoof protection (reverse-path filter)
     - { name: 'net.ipv4.conf.default.accept_source_route', value: '0' }    # Default: 1.  Do not accept IP source route packets (we are not a router)
     #- { name: 'net.ipv4.tcp_syncookies', value: '1' }               # Very standard in 2020
-    - { name: 'net.ipv6.conf.all.disable_ipv6', value: '1' }               # Default: 0.  Disable IPv6
+    - { name: 'net.ipv6.conf.all.disable_ipv6', value: '1' }               # Default: 0.  Disable IPv6.  SEE ALSO: roles/munin/tasks/install.yml & enable-and-disable.yml
     #- { name: 'net.ipv6.conf.default.disable_ipv6', value: '1' }    # AUTO-SET
     #- { name: 'net.ipv6.conf.lo.disable_ipv6', value: '1' }         # BY ABOVE
 


### PR DESCRIPTION
Resolves:

- #3434

Tested on Ubuntu Server 23.04