### PR TITLE
Allow multiple (timestamped) backups of WiFi firmware originals (as your OS evolves!)

### DIFF
--- a/roles/firmware/tasks/download.yml
+++ b/roles/firmware/tasks/download.yml
@@ -17,7 +17,7 @@
   #   src: /lib/firmware/cypress/{{ item }}
   #   dest: /lib/firmware/cypress/{{ item }}.orig
   #   #local_follow: False    # FAILS TO PRESERVE LINKS (ansible/ansible#74777) e.g. /lib/firmware/cypress/cyfmac43455-sdio.bin -> /etc/alternatives/cyfmac43455-sdio.bin -> ...
-  command: cp -a /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig    # "cp -P" == "cp --no-dereference" sufficient to replicate these symlinks and files ("cp -d" & "cp -a" are incrementally stronger, and so probably can't hurt)
+  shell: mv /lib/firmware/cypress/{{ item }}.orig /lib/firmware/cypress/{{ item }}.orig.$(date +%F-%T) || true && cp -a /lib/firmware/cypress/{{ item }} /lib/firmware/cypress/{{ item }}.orig    # "cp -P" == "cp --no-dereference" sufficient to replicate these symlinks and files ("cp -d" & "cp -a" are incrementally stronger, and so probably can't hurt)
   with_items:
     - cyfmac43430-sdio.bin
     - cyfmac43430-sdio.clm_blob


### PR DESCRIPTION
CAVEAT: Anybody that really wants to re-run `roles/firmware/tasks/download.yml` would first need to delete these 2 lines from `/etc/iiab/iiab_state.yml` :

```
firmware_downloaded: True
firmware_installed: True
```

And then run the following:

```
cd /opt/iiab/iiab
./runrole firmware
```

Tested on 64-bit RasPiOS Lite.

Building on:

- PR #3482