### PR TITLE
If 32-bit OS, bypass Sugarizer & Explain during iiab-install

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -40,10 +40,23 @@
     name: pathagar
   when: pathagar_install is defined and pathagar_install
 
+# WARNING: Since March 2023, 32-bit RasPiOS can act as 64-bit on RPi 4 and
+# RPi 400 (unlike RPi 3!)  SEE: https://github.com/iiab/iiab/pull/3422 and #3516
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NO LONGER enough!)
+  command: dpkg --print-architecture
+  register: dpkg_arch
+  when: sugarizer_install
+
+- name: Explain bypassing of Sugarizer install if 32-bit OS
+  fail:    # FORCE IT RED THIS ONCE!
+    msg: "BYPASSING SUGARIZER INSTALL ATTEMPT, as Sugarizer Server 1.5.0 requires MongoDB 3.2+ which is NO LONGER SUPPORTED on 32-bit Raspberry Pi OS.  'dpkg --print-architecture' output for your OS: {{ dpkg_arch.stdout }}"
+  when: sugarizer_install and not dpkg_arch.stdout is search("64")
+  ignore_errors: True
+
 - name: SUGARIZER
   include_role:
     name: sugarizer
-  when: sugarizer_install
+  when: sugarizer_install and dpkg_arch.stdout is search("64")
 
 - name: Recording STAGE 7 HAS COMPLETED ========================
   lineinfile:

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -37,7 +37,9 @@
 - debug:
     var: mongodb_version
 
-- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NOT enough!)
+# WARNING: Since March 2023, 32-bit RasPiOS can act as 64-bit on RPi 4 and
+# RPi 400 (unlike RPi 3!)  SEE: https://github.com/iiab/iiab/pull/3422 and #3516
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NO LONGER enough!)
   command: dpkg --print-architecture
   register: dpkg_arch
 - debug:
@@ -45,10 +47,11 @@
 
 - block:
 
-  - name: EXIT 'mongodb' ROLE, if 'dpkg --print-architecture' shows "armhf" or mongodb_version == "unsupported" or ansible_machine not found
+  - name: EXIT 'mongodb' ROLE, if 'dpkg --print-architecture' appears to be 32-bit (i.e. does not contain "64") or mongodb_version == "unsupported" or ansible_machine not found
     fail:    # FORCE IT RED THIS ONCE!
       msg: MongoDB 3.2+ (as needed by Sugarizer Server 1.5.0) is NO LONGER SUPPORTED on 32-bit Raspberry Pi OS.
-    when: dpkg_arch.stdout == "armhf" or mongodb_version == "unsupported" or mongodb_version == "unknown"
+    when: not dpkg_arch.stdout is search("64") or mongodb_version == "unsupported" or mongodb_version == "unknown"
+    #when: dpkg_arch.stdout == "armhf" or mongodb_version == "unsupported" or mongodb_version == "unknown"
 
   - name: Install MongoDB if 'mongodb_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
     include_tasks: install.yml


### PR DESCRIPTION
Requested by @EMG70.

Essentially this is a refinement of...

- PR #3519

...so as to allow MEDIUM-sized and LARGE-sized IIAB installs to proceed in a more uninterrupted AND informative manner.

An even louder/longer RED warning is displayed on purpose, to make very clear why the install of Sugarizer is being bypassed when invoked from iiab-install.  A shorter RED warning is displayed if the install of Sugarizer or MongoDB are attempted using things like...

```
cd /opt/iiab/iiab
sudo ./runrole mongodb
```

Or...

```
cd /opt/iiab/iiab
sudo ./runrole mongodb
```

Tested on 32-bit RasPiOS Lite on RPi 3.

Building on:

- PR #3422
- #3516