### PR TITLE
Try aarch64 version of kiwix-tools 3.5.0+ [WARNING: such microSD cards will no longer be insertable in 32-bit Raspberry Pi Zero W]

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -8,11 +8,11 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# INSTRUCTIONS TO REINSTALL Kiwix:
-# (1) VERIFY THESE VARS IN /etc/iiab/local_vars.yml
+# ONLINE UPGRADE INSTRUCTIONS:
+# (1) VERIFY VARS IN /etc/iiab/local_vars.yml
 #     kiwix_install: True
 #     kiwix_enabled: True
-# (2) RUN: cd /opt/iiab/iiab; ./runrole --reinstall kiwix
+# (2) RUN: cd /opt/iiab/iiab; sudo ./runrole --reinstall kiwix
 
 
 # FYI /library/zims contains 3 important things:
@@ -25,13 +25,13 @@ kiwix_base_url: https://download.kiwix.org/release/kiwix-tools/
 #kiwix_base_url: https://download.kiwix.org/nightly/2022-10-04/
 #kiwix_base_url: "{{ iiab_download_url }}/"    # e.g. https://download.iiab.io/packages/
 
-kiwix_arch_dict:
-  #i386:
-  i686: i586
-  x86_64: x86_64
-  armv6l: armhf
-  armv7l: armhf
-  aarch64: aarch64
+kiwix_arch_dict:      # 'dpkg --print-architecture' key would be:
+  #i386:              # ?
+  i686: i586          # ?
+  x86_64: x86_64      # amd64
+  armv6l: armhf       # arm6l
+  armv7l: armhf       # arm7l  BEWARE: armhf version of kiwix-tools suddenly FAILS on 64-bit RasPiOS, since 3.5.0 released 2023-04-28 -- #3574
+  aarch64: aarch64    # arm64  BEWARE: "32-bit" RasPiOS suddenly boots 64-bit kernel since March 2023 -- #3516, explained at https://github.com/iiab/iiab/pull/3422#issuecomment-1533441463
 
 # ansible_architecture might also work, if not quite as well:
 # https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -31,7 +31,7 @@ kiwix_arch_dict:
   x86_64: x86_64
   armv6l: armhf
   armv7l: armhf
-  aarch64: armhf
+  aarch64: aarch64
 
 # ansible_architecture might also work, if not quite as well:
 # https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837


### PR DESCRIPTION
The downside (even if this does work well on 64-bit Raspberry Pis!) is that microSD cards will no longer be insertable into older 32-bit Raspberry Pi "Zero W" machines 😢

Tangentially related:

- #3516
  - Explained at: https://github.com/iiab/iiab/pull/3422#issuecomment-1533441463
- #3574