### PR TITLE
Revert to kiwix-tools 3.4.0 if armhf 3.5.0 downloads [for 32-bit Raspberry Pi Zero W]

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -25,12 +25,12 @@ kiwix_base_url: https://download.kiwix.org/release/kiwix-tools/
 #kiwix_base_url: https://download.kiwix.org/nightly/2022-10-04/
 #kiwix_base_url: "{{ iiab_download_url }}/"    # e.g. https://download.iiab.io/packages/
 
-kiwix_arch_dict:      # 'dpkg --print-architecture' key would be:
+kiwix_arch_dict:      # 'dpkg --print-architecture' key would be: (to mitigate #3516 in future, if truly nec?)
   #i386:              # ?
   i686: i586          # ?
   x86_64: x86_64      # amd64
-  armv6l: armhf       # arm6l
-  armv7l: armhf       # arm7l  BEWARE: armhf version of kiwix-tools suddenly FAILS on 64-bit RasPiOS, since 3.5.0 released 2023-04-28 -- #3574
+  armv6l: armhf       # armhf
+  armv7l: armhf       # armhf  BEWARE: armhf version of kiwix-tools suddenly FAILS on 64-bit RasPiOS, since 3.5.0 released 2023-04-28 -- #3574, PR #3576
   aarch64: aarch64    # arm64  BEWARE: "32-bit" RasPiOS suddenly boots 64-bit kernel since March 2023 -- #3516, explained at https://github.com/iiab/iiab/pull/3422#issuecomment-1533441463
 
 # ansible_architecture might also work, if not quite as well:

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -19,6 +19,14 @@
     timeout: "{{ download_timeout }}"
   register: kiwix_dl    # PATH /opt/iiab/downloads + ACTUAL filename put in kiwix_dl.dest, for unarchive ~28 lines below
 
+- name: "2023-05-14: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
+  get_url:
+    url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-armhf-3.4.0.tar.gz
+    dest: "{{ downloads_dir }}"
+    timeout: "{{ download_timeout }}"
+  register: kiwix_dl
+  when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
+
 - name: Does {{ kiwix_path }}/bin already exist? (as a directory, symlink or file)
   stat:
     path: "{{ kiwix_path }}/bin"    # /opt/iiab/kiwix
@@ -58,6 +66,8 @@
     src: "{{ kiwix_dl.dest }}"    # See ~28 lines above, e.g. /opt/iiab/downloads/kiwix-tools_linux-x86_64-3.3.0-1.tar.gz
     dest: "{{ kiwix_path }}/bin"
     extra_opts: --strip-components=1
+    owner: root    # 2023-05-14: When unpacking let's avoid bogus owner/group,
+    group: root    # arising from UID/GID on Kiwix's build machine.
 
 
 # 3. ENABLE MODS FOR APACHE PROXY IF DEBUNTU


### PR DESCRIPTION
### [Works around] bug:

- #3574

### Description of changes proposed in this pull request:

If the 32-bit `armhf` version of kiwix-tools 3.5.0 is downloaded[1][2] this PR arranges to revert to 3.4.0, e.g. for 32-bit hardware like the Raspberry Pi Zero W.

[1] Which for now happens when 32-bit Raspberry Pi OS is booted with a true 32-bit kernel.  _If you want to force its 32-bit kernel to run on RPi 4 or 400 since March 2023, put `arm_64bit=0` in `/boot/config.txt` then reboot._ #3516 https://github.com/iiab/iiab/pull/3422#issuecomment-1533441463

[2] In keeping with our CI/CD community philosophy that everyone should partake in testing the successor to 3.5.0 in coming weeks (or so) when that arrives,  Regardless whether that's named 3.5.0-1 or 3.5.1 or 3.6.0 any other version number!

Finally, this PR also cleans up file ownership (both owner and group) under `/opt/iiab/kiwix/bin` — which had been a real mess, arising from very bogus UID/GID's (that are effectively random numbers, when kiwix-tools' .tar.gz is unpacked on a very different OS).

### Smoke-tested on which OS or OS's:

32-bit Raspberry Pi OS on RPi 3.

### Mention a team member @username e.g. to help with code review:

@deldesir @tim-moody

Related:

- #3391