### PR TITLE
Fix PR #3576, allowing regular Kiwix installs too!

### DIFF
--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -24,7 +24,17 @@
     url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-armhf-3.4.0.tar.gz
     dest: "{{ downloads_dir }}"
     timeout: "{{ download_timeout }}"
-  register: kiwix_dl
+  #register: kiwix_dl    # CLOBBERS kiwix_dl.dest WHEN THIS STANZA DOES NOT RUN :/
+  when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
+
+# Ansible does not allow changing individuals subfields in a dictionary, but
+# this crude hack works, overwriting the entire kiwix_dl dictionary var with
+# the single (needed) key/value pair.  (Or "register: tmp_dl" could be set
+# above, if its other [subfields, key/value pairs, etc] really mattered...)
+- name: "2023-05-15: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
+  set_fact:
+    kiwix_dl:
+      dest: /opt/iiab/downloads/kiwix-tools_linux-armhf-3.4.0.tar.gz
   when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
 
 - name: Does {{ kiwix_path }}/bin already exist? (as a directory, symlink or file)


### PR DESCRIPTION
Oops: once again bitten by Ansible overwriting a register even when a stanza's `when:` clause is not triggered.

Tested on 32-bit Raspberry Pi OS, and 64-bit Raspberry Pi OS testing is ongoing...

Patches:

- PR #3576

 Building on:

- #3574
- PR #3575