### PR TITLE
Set rpi_model from /proc/cpuinfo for QEMU

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -113,8 +113,9 @@ tmp=$(git rev-parse --verify HEAD) &&
     IIAB_COMMIT=$tmp
 
 
-grep -iq raspberry /proc/device-tree/model &&
-    RPI_MODEL=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0')
+grep -iq raspberry /proc/cpuinfo &&
+    RPI_MODEL=$(grep -i raspberry /proc/cpuinfo | sed 's/.*: //')
+    #RPI_MODEL=$(grep -ai raspberry /proc/device-tree/model | tr -d '\0')
 
 # /proc/device-tree/model e.g. 'Parallels ARM Virtual Machine' identical to...
 # /sys/firmware/devicetree/base/model (also true on RPi hardware!)


### PR DESCRIPTION
In support of @neomatrixcode's

- PR #3569

Tested on Raspberry Pi 3.