### PR TITLE
'pip install virtualenv==20.21.1' for Python 2 required by KA Lite on Ubuntu 23.10

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -17,7 +17,7 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  when: is_debian_11 or is_ubuntu_2204    # Covers is_linuxmint_12, and is more future-proof than...
+  when: is_debian_11 or is_ubuntu_2204    # Covers is_linuxmint_21, and is more future-proof than...
   #when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
@@ -32,7 +32,7 @@
 # use key retrieval from mongodb
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_linuxmint_12, and is more future-proof than...
+  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_linuxmint_21, and is more future-proof than...
   #when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -17,7 +17,7 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  when: is_debian_11 or is_ubuntu_2204    # Covers is_linuxmint_21, and is more future-proof than...
+  when: is_debian_11 or is_ubuntu_2204    # Covers is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
   #when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
@@ -32,7 +32,7 @@
 # use key retrieval from mongodb
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_linuxmint_21, and is more future-proof than...
+  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
   #when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -17,7 +17,8 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
+  when: is_debian_11 or is_ubuntu_2204    # Covers is_linuxmint_12, and is more future-proof than...
+  #when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
 #- name: Install Ubuntu keyrings on Debian
@@ -31,7 +32,8 @@
 # use key retrieval from mongodb
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
+  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_linuxmint_12, and is more future-proof than...
+  #when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19
   pip:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -38,7 +38,7 @@
     name: setuptools==44
     virtualenv: "{{ kalite_venv }}"    # /usr/local/kalite/venv
     virtualenv_site_packages: no
-    virtualenv_command: /usr/bin/virtualenv
+    virtualenv_command: virtualenv    # Traditionally /usr/bin/virtual/env -- but install_python2.sh (for Ubuntu 23.10+) sets up /usr/local/bin/virtualenv
     virtualenv_python: python2.7
     extra_args: "--no-use-pep517 --no-cache-dir --no-python-version-warning"
   #when: not (is_debian_9 or is_debian_10 or is_ubuntu_16 or is_ubuntu_17 or is_ubuntu_18 or is_ubuntu_19)
@@ -50,7 +50,7 @@
     version: "{{ kalite_version }}"
     virtualenv: "{{ kalite_venv }}"
     virtualenv_site_packages: no
-    virtualenv_command: /usr/bin/virtualenv
+    virtualenv_command: virtualenv
     virtualenv_python: python2.7
     extra_args: "--no-cache-dir"
 

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -15,12 +15,11 @@
 
 export DEBIAN_FRONTEND=noninteractive
 ARCH=$(dpkg --print-architecture)
-
 # 2023-05-19: #3573 -> PR #3582: Ubuntu 23.10's virtualenv 20.23 no longer
-# supports Python 2.  Older version from Ubuntu 23.04 seemed plausible...
+# supports Python 2.  Older versions from Ubuntu 22.04 (#3583) & 23.04 like...
 # http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb
-# ...but drags in newer 20.23+ version of python3-virtualenv, leaving us
-# with /usr/bin/virtualenv 20.23 once again, i.e. preventing Python 2.
+# ...unfortunately drag in newer 20.23+ version of python3-virtualenv, leaving
+# us with /usr/bin/virtualenv 20.23 once again, i.e. preventing Python 2.
 # Whereas pip (which installs /usr/local/bin/virtualvenv) at least works:
 apt -y install python3-pip
 pip install virtualenv==20.21.1 --break-system-packages

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -15,6 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 ARCH=$(dpkg --print-architecture)
+
 # 2023-05-19: #3573 -> PR #3582: Ubuntu 23.10's virtualenv 20.23 no longer
 # supports Python 2.  Older versions from Ubuntu 22.04 (#3583) & 23.04 like...
 # http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -16,9 +16,12 @@
 export DEBIAN_FRONTEND=noninteractive
 ARCH=$(dpkg --print-architecture)
 
-# Older version http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb
-# unfortunately drags in newer 20.23+ version of python3-virtualenv, preventing Python 2.
-# So let's try pip: (which installs to /usr/local/bin)
+# 2023-05-19: #3573 -> PR #3582: Ubuntu 23.10's virtualenv 20.23 no longer
+# supports Python 2.  Older version from Ubuntu 23.04 seemed plausible...
+# http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb
+# ...but drags in newer 20.23+ version of python3-virtualenv, leaving us
+# with /usr/bin/virtualenv 20.23 once again, i.e. preventing Python 2.
+# Whereas pip (which installs /usr/local/bin/virtualvenv) at least works:
 apt -y install python3-pip
 pip install virtualenv==20.21.1 --break-system-packages
 #apt -y install virtualenv

--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -16,7 +16,12 @@
 export DEBIAN_FRONTEND=noninteractive
 ARCH=$(dpkg --print-architecture)
 
-apt -y install virtualenv
+# Older version http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb
+# unfortunately drags in newer 20.23+ version of python3-virtualenv, preventing Python 2.
+# So let's try pip: (which installs to /usr/local/bin)
+apt -y install python3-pip
+pip install virtualenv==20.21.1 --break-system-packages
+#apt -y install virtualenv
 # https://github.com/iiab/iiab/pull/3535#issuecomment-1503626474
 #apt -y install media-types libffi8 libssl3
 


### PR DESCRIPTION
### Fixes bug:

- #3573

### Description of changes proposed in this pull request:

apt install of http://launchpadlibrarian.net/651276954/virtualenv_20.19.0+ds-1_all.deb does not work, as it drags in 20.23+ version of python3-virtualenv, as explained in the PR.  So pip (with all its risks) is used instead.

### Smoke-tested on which OS or OS's:

Ubuntu 23.10

@EMG70 may be able to test on Debian 12 and Ubuntu 23.04 next week.

### Mention a team member @username e.g. to help with code review:

@neomatrixcode figured this out.

@jvonau @tim-moody should take a look if they have time.

Related:

- #3535
- PR #3583