### PR TITLE
Begin transition to 'nodejs_version: 20.x' [& internetarchive upstream patch]

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -9,10 +9,10 @@
   include_role:
     name: nodejs
 
-- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 19.x
+- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 20.x
   assert:
-    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('19.x', '<=')
-    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 19.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('20.x', '<=')
+    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 20.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
     quiet: yes
 
 - name: "Set 'yarn_install: True' and 'yarn_enabled: True'"

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -8,15 +8,15 @@ Nodesource.com often supports Debian long before each Debian release, whereas fo
 For late-breaking details on Nodesource.com support for your particular Linux OS, keep an eye on:
 
 - https://github.com/nodesource/distributions#deb
-- https://deb.nodesource.com/node_18.x/dists/
-  - https://deb.nodesource.com/node_18.x/pool/main/n/nodejs/
-  - https://nodejs.org/dist/latest-v18.x/
+- https://deb.nodesource.com/node_20.x/dists/
+  - https://deb.nodesource.com/node_20.x/pool/main/n/nodejs/
+  - https://nodejs.org/dist/latest-v20.x/
 - https://deb.nodesource.com/node_19.x/dists/
   - https://deb.nodesource.com/node_19.x/pool/main/n/nodejs/
   - https://nodejs.org/dist/latest-v19.x/
 - _ETC!_
 
-If Nodesource.com does not yet support your Linux OS and IIAB's asked to install Node.js &mdash; IIAB will then [fall back](https://github.com/iiab/iiab/blob/15a689e30b4eea325e4bb8d35e19990dd8062fbc/roles/nodejs/tasks/install.yml#L103-L107) to: (running the equivalent of)
+If Nodesource.com does not yet support your Linux OS and IIAB's asked to install Node.js &mdash; IIAB will then [fall back](https://github.com/iiab/iiab/blob/91a5cd33f34d5d2a55e75bf0cdc85bcd9d7b4821/roles/nodejs/tasks/install.yml#L103-L107) to: (running the equivalent of)
 
 ```
 sudo apt install nodejs npm
@@ -41,7 +41,7 @@ On the original Raspberry Pi Zero W (ARMv6) however: Node.js applications like I
 
 If necessary, run `sudo apt purge nodejs npm` then `sudo rm /etc/apt/sources.list.d/nodesource.list` then  `sudo apt update` and then attempt to [install Node.js](https://github.com/iiab/iiab/blob/master/roles/nodejs/tasks/install.yml) _on the Raspberry Pi Zero W itself_ (`cd /opt/iiab/iiab` then `sudo ./runrole --reinstall nodejs`).
 
-Earlier, some preferred installing the tar file version mentioned at [#2082](https://github.com/iiab/iiab/issues/2082#issuecomment-569344617) &mdash; if that is your preference, consider a more recent version like: https://nodejs.org/dist/latest-v18.x/
+Earlier, some preferred installing the tar file version mentioned at [#2082](https://github.com/iiab/iiab/issues/2082#issuecomment-569344617) &mdash; if that is your preference, consider a more recent version like: https://nodejs.org/dist/latest-v20.x/
 
 Either way, you'll (likely) then also need to run: `sudo apt install npm`
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -443,7 +443,7 @@ mosquitto_port: 1883
 # JupyterHub, nodered (Node-RED), pbx (Asterix, FreePBX) &/or Sugarizer:
 nodejs_install: False
 nodejs_enabled: False
-nodejs_version: 18.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20
+nodejs_version: 20.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20, 18.x til 2023-05-20
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
Others have successfully transitioned from Node.js 18 to 20 in the past month, so likely no need to wait for October when it more officially becomes LTS: 

- #3566