### PR TITLE
'./start_asterisk start' works at CLI—but ansible 2.15.0 freezes trying to wrap up running the same command—unless it's already been run manually! [Ugly Hack Works: run it as an async background task & wait 30 sec] [WAS: Break apart FreePBX install into 2 distinct Ansible steps] [WAS: Experimentally eliminate freepbx.yml blocking on presence of /var/www/html/freepbx]

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -232,12 +232,17 @@
     dest: /etc/asterisk/cdr_mysql.conf
 
 
-- name: FreePBX - Run './start_asterisk start' (works regardless if it's already started)
+# 2023-05-21: Asterisk is normally OFF at this point (but that doesn't matter, either way!)
+- name: "FreePBX - Spawn './start_asterisk start' in {{ freepbx_src_dir }} -- giving this background task 600s maximum, as the next ~5 steps likely need it (SEE #3588)"
   command: ./start_asterisk start
   args:
     chdir: "{{ freepbx_src_dir }}"
-  async: 30
-  ignore_errors: yes
+  async: 600
+  poll: 0
+
+- name: "Pause 30s, allowing Asterisk to launch (above) even on very old machines -- trying to emulate './start_asterisk start' at CLI which has no such problems -- FYI none of this was nec prior to April/May 2023 (SEE #3588)"
+  pause:
+    seconds: 30
 
 - name: FreePBX - Install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
   command: ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -233,14 +233,14 @@
 
 
 # 2023-05-21: Asterisk is normally OFF at this point (but that doesn't matter, either way!)
-- name: "FreePBX - Spawn './start_asterisk start' in {{ freepbx_src_dir }} -- giving this background task 600s maximum, as the next ~5 steps likely need it (SEE #3588)"
+- name: "FreePBX - Spawn './start_asterisk start' in {{ freepbx_src_dir }} -- giving this background task 600s maximum, as the next ~5 steps likely need it (SEE PR #3588)"
   command: ./start_asterisk start
   args:
     chdir: "{{ freepbx_src_dir }}"
   async: 600
   poll: 0
 
-- name: "Pause 30s, allowing Asterisk to launch (above) even on very old machines -- trying to emulate './start_asterisk start' at CLI which has no such problems -- FYI none of this was nec prior to April/May 2023 (SEE #3588)"
+- name: "Pause 30s, allowing Asterisk to launch (above) even on very old machines -- trying to emulate './start_asterisk start' at CLI which has no such problems -- FYI none of this was nec prior to April/May 2023 (SEE PR #3588)"
   pause:
     seconds: 30
 

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -236,7 +236,7 @@
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"
-    creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
+    #creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
   with_items:
     - ./start_asterisk start
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -232,15 +232,26 @@
     dest: /etc/asterisk/cdr_mysql.conf
 
 
-- name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
-  command: "{{ item }}"
+- name: FreePBX - Run './start_asterisk start' (works regardless if it's already started)
+  command: ./start_asterisk start
+  args:
+    chdir: "{{ freepbx_src_dir }}"
+
+- name: FreePBX - Install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
+  command: ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
   args:
     chdir: "{{ freepbx_src_dir }}"
     #creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
-  with_items:
-    - ./start_asterisk start
-    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
-    # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+
+# - name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
+#   command: "{{ item }}"
+#   args:
+#     chdir: "{{ freepbx_src_dir }}"
+#     #creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
+#   with_items:
+#     - ./start_asterisk start
+#     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
+#     # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 
 
 # 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -236,6 +236,8 @@
   command: ./start_asterisk start
   args:
     chdir: "{{ freepbx_src_dir }}"
+  async: 30
+  ignore_errors: yes
 
 - name: FreePBX - Install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
   command: ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}


### PR DESCRIPTION
Ongoing experiment with @EMG70 to try to eliminate freezing during install of FreePBX, that suddently appeared in recent days.

Possibly due to ansible-core 2.15.0 [??] or upstream change(s) in Asterisk or FreePBX [MAYBE ALSO?]