### PR TITLE
TEMPORARILY revert ansible-core 2.15.0 to 2.14.6 til the dust settles — e.g. for FreePBX #3588

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -216,7 +216,7 @@ if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
     /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
 fi
 
-/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
+/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core==2.14.6    # 2023-05-22: TEMPORARILY REVERT FROM 2.15.0 UNTIL ansible/ansible#80863 FIXED (e.g. for FreePBX, #3588)
 echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
 cd /usr/local/ansible/bin
 for bin in ansible*; do


### PR DESCRIPTION
Hopefully Ansible will resolve this with ansible-core 2.15.1+ in/around June?

- ansible/ansible#80863

A few more details:

- #3588
- #3589

Related:

- PR #3550 
- #3552 
- PR #3577