### PR TITLE
local_vars_medium.yml: Avoid Lokole for now due to #3572

### DIFF
--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -244,8 +244,8 @@ jupyterhub_install: False
 jupyterhub_enabled: False
 
 # Lokole (email for rural communities) from https://ascoderu.ca
-lokole_install: True    # 2022-03-13: Python 3.9+ work
-lokole_enabled: True    # https://github.com/iiab/iiab/issues/3132
+lokole_install: False    # 2022-03-13: Python 3.9+ work
+lokole_enabled: False    # https://github.com/iiab/iiab/issues/3132
 
 # Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: False


### PR DESCRIPTION
Lokole is impeding testing on Ubuntu 23.10, so it's being removed from MEDIUM-sized /etc/iiab/local_vars.yml for now.

Related:

- #3132
- #3572