### PR TITLE
Roughly Estimate iiab_software_disk_usage in /etc/iiab/iiab.ini 'summary' section

### DIFF
--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -1,7 +1,11 @@
-# workaround for fact that auto create does not work on iiab_ini_file (/etc/iiab/iiab.ini)
+- name: Record disk_space_a_priori (permanently, into {{ iiab_ini_file }}) to later estimate iiab_software_disk_usage
+  shell: df -PB1 $(findmnt / -o SOURCE -n) | awk 'NR==2 {print $4}'
+  register: df1
+
+# workaround for fact that auto create does not work on iiab_ini_file
 - name: Create {{ iiab_ini_file }}
   file:
-    path: "{{ iiab_ini_file }}"
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     state: touch
 
 - name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NOT enough!)
@@ -12,10 +16,11 @@
   command: dpkg --print-foreign-architectures
   register: dpkg_foreign_arch
 
-- name: Add 'location' variable values to {{ iiab_ini_file }}
+
+- name: Add 'summary' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
-    section: initial-location
+    section: summary
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:
@@ -23,11 +28,13 @@
       value: "{{ iiab_base }}"
     - option: iiab_dir
       value: "{{ iiab_dir }}"
+    - option: disk_space_a_priori
+      value: "{{ df1.stdout }}"
 
-- name: Add 'version' variable values to {{ iiab_ini_file }}
+- name: Add 'initial-versions' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
-    section: initial-version
+    section: initial-versions
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -31,10 +31,10 @@
     - option: disk_space_a_priori
       value: "{{ df1.stdout }}"
 
-- name: Add 'initial-versions' variable values to {{ iiab_ini_file }}
+- name: Add 'initial' variable values to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"
-    section: initial-versions
+    section: initial
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
   with_items:

--- a/roles/0-init/tasks/create_iiab_ini.yml
+++ b/roles/0-init/tasks/create_iiab_ini.yml
@@ -1,4 +1,4 @@
-- name: Record disk_space_a_priori (permanently, into {{ iiab_ini_file }}) to later estimate iiab_software_disk_usage
+- name: Record disk_space_a_priori (permanently, into {{ iiab_ini_file }} below) to later estimate iiab_software_disk_usage
   shell: df -PB1 $(findmnt / -o SOURCE -n) | awk 'NR==2 {print $4}'
   register: df1
 

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -42,6 +42,21 @@
     name: pbx
   when: pbx_install
 
+- name: Read 'disk_space_a_priori' from /etc/iiab/iiab.ini
+  set_fact:
+    df1: "{{ lookup('ansible.builtin.ini', 'disk_space_a_priori', section='summary', file=iiab_ini_file) }}"
+
+- name: Record currently available disk space, to compare with original 'disk_space_a_priori'
+  shell: df -PB1 $(findmnt / -o SOURCE -n) | awk 'NR==2 {print $4}'
+  register: df2
+
+- name: Add ESTIMATED 'iiab_software_disk_usage = {{ df1|int - df2.stdout|int }}' to {{ iiab_ini_file }}
+  ini_file:
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+    section: summary
+    option: iiab_software_disk_usage
+    value: "{{ df1|int - df2.stdout|int }}"
+
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:
     path: "{{ iiab_env_file }}"


### PR DESCRIPTION
This is NOT a perfect estimate, but it's a start:

Its accuracy is not perfect and as discussed on PR #3592 it misses disk usage arising from other repos like [iiab/iiab-admin-console](https://github.com/iiab/iiab-admin-console) and [iiab/iiab-factory](https://github.com/iiab/iiab-factory)

Still, recording `iiab_software_disk_usage` (integer, in bytes) in `/etc/iiab/iiab.ini` can be a great 1st order estimate — obtained by comparing (A) available disk space originally recorded near the beginning of Stage 0 ...with (B) available disk space as later recorded near the end of Stage 9.

FYI this works even if IIAB's installation is interrupted with reboots (etc) — thanks to `disk_space_a_priori` being recorded to `/etc/iiab/iiab.ini` early on — for later retrieval from disk.

Related:

- https://github.com/iiab/iiab/pull/3592#issuecomment-1565284916