### PR TITLE
Auto-calculate IIAB + EduPack disk space needs, in advance [& design review]

### DIFF
--- a/scripts/iiab-item-size.py
+++ b/scripts/iiab-item-size.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python3
+# Creates json files for presets
+
+import os, sys, syslog
+from datetime import date
+import pwd, grp
+import shutil
+import argparse
+import sqlite3
+import iiab.iiab_lib as iiab
+import iiab.adm_lib as adm
+import requests
+import json
+
+all_menu_defs = adm.get_all_menu_defs()
+
+def main():
+    parser = argparse.ArgumentParser(description="Get size for item.")
+    parser.add_argument("name", help="Name item.")
+
+    # menu_dir
+    args =  parser.parse_args()
+
+    name = args.name
+
+    content= get_item_size(name)
+
+    #print('size: ',iiab.human_readable(content["size"]))
+    print(f'content ', content)
+
+    sys.exit()
+
+def get_zims_size_from_header(url):
+    #url = 'https://download.kiwix.org/zim/other/mdwiki_en_all_2023-03.zim'
+    response = requests.head(url, allow_redirects=True)
+    size = 0
+    if (response.status_code == 200):
+        size = int(response.headers.get('Content-Length', 0))
+    return size
+
+def get_zims_size_from_file(name):
+    data_output = {}
+    data_output['download_url']= ''
+    data_output['size'] = 0
+
+    with open('/etc/iiab/kiwix_catalog.json') as json_file:
+        data = json.load(json_file)['zims']
+        result = { data[element]['perma_ref']: data[element]  for element in  list(data.keys())}
+        if result.get(name) is not None:
+            data_output['download_url']= result[name]['download_url']
+            data_output['size']= (int(result[name].get('size',0)) * 1024) + 1023
+    return data_output
+
+def get_zims_size(name):
+    data = get_zims_size_from_file(name)
+    #if data['size'] <= 1023:
+    #    data['size'] = get_zims_size_from_header(data['download_url'])
+    return data
+
+def get_oer2go_size_from_file(name):
+    data_output = {}
+    data_output['download_url']= ''
+    data_output['size'] = 0
+
+    with open('/etc/iiab/oer2go_catalog.json') as json_file:
+        data = json.load(json_file)['modules']
+        if data.get(name) is not None:
+            data_output['download_url']= data[name]['rsync_url']
+            data_output['size']= (int(data[name].get('ksize',0)) * 1024) + 1023
+    return data_output
+
+def get_map_size_from_file(name):
+    data_output = {}
+    data_output['download_url']= ''
+    data_output['size'] = 0
+
+    with open('/etc/iiab/map-catalog.json') as json_file:
+        data = json.load(json_file)['base']
+        result = { data[element]['perma_ref']: data[element]  for element in  list(data.keys())}
+        if result.get(name) is not None:
+            data_output['download_url']= result[name]['archive_url']
+            data_output['size']= (int(result[name].get('size',0))) + 1023
+    return data_output
+
+
+def get_item_size(name_input):
+	return [get_size(element) for element in [name_input]]
+
+def get_items_size(name_input):	
+	return [get_size(element) for element in name_input]
+
+def element_unknown(name):
+	return {"size":0}
+
+def build_otput(name, type_element, function):
+    data = function(name)
+    if data['size']== 0:
+    	print(name, "element",type_element,"not found")
+
+    return {
+        "name": name
+        ,"type": type_element
+        ,"size": data['size']
+    }
+
+def get_size(name_input):
+    if name_input in all_menu_defs:
+        info = all_menu_defs[name_input]
+        intended_use = info["intended_use"]
+
+        if intended_use == "html":
+            name_element = info["moddir"]
+            return build_otput(name_element, "module", get_oer2go_size_from_file)
+
+        elif intended_use == "zim":
+            name_element = info["zim_name"]
+            return build_otput(name_element, "zim", get_zims_size)
+       
+        elif intended_use == "webroot":
+            name_element = info["name"]
+            return build_otput(name_element, "map", get_map_size_from_file)
+                    
+    return build_otput(name_input, "unknown", element_unknown)
+
+# Now start the application
+if __name__ == "__main__":
+    main()
+

--- a/scripts/iiab-item-size.py
+++ b/scripts/iiab-item-size.py
@@ -95,7 +95,7 @@ def element_unknown(name):
 def build_otput(name, type_element, function):
     data = function(name)
     if data['size']== 0:
-    	print(name, "element",type_element,"not found")
+        print(name, ": the size of this",type_element,"element is unknown")
 
     return {
         "name": name
@@ -103,22 +103,77 @@ def build_otput(name, type_element, function):
         ,"size": data['size']
     }
 
+
+intended_use_dict = {
+    "azuracast":{
+        "name":"name"
+        ,"type":"azuracast"
+        ,"function":element_unknown
+    }
+    ,"calibre":{
+        "name":"name"
+        ,"type":"calibre"
+        ,"function":element_unknown
+    }
+    ,"external":{
+        "name":"name"
+        ,"type":"external"
+        ,"function":element_unknown
+    }
+    ,"html":{
+        "name":"moddir"
+        ,"type":"module"
+        ,"function":get_oer2go_size_from_file
+    }
+    ,"info":{
+        "name":"name"
+        ,"type":"info"
+        ,"function":element_unknown
+    }
+    ,"internetarchive":{
+        "name":"name"
+        ,"type":"internetarchive"
+        ,"function":element_unknown
+    }
+    ,"kalite":{
+        "name":"name"
+        ,"type":"kalite"
+        ,"function":element_unknown
+    }
+    ,"kolibri":{
+        "name":"name"
+        ,"type":"kolibri"
+        ,"function":element_unknown
+    }
+    ,"map":{
+        "name":"name"
+        ,"type":"map"
+        ,"function":get_map_size_from_file
+    }
+    ,"webroot":{
+        "name":"name"
+        ,"type":"webroot"
+        ,"function":element_unknown
+    }
+    ,"zim":{
+        "name":"zim_name"
+        ,"type":"zim"
+        ,"function":get_zims_size
+    }
+}
+
+
 def get_size(name_input):
     if name_input in all_menu_defs:
         info = all_menu_defs[name_input]
         intended_use = info["intended_use"]
 
-        if intended_use == "html":
-            name_element = info["moddir"]
-            return build_otput(name_element, "module", get_oer2go_size_from_file)
-
-        elif intended_use == "zim":
-            name_element = info["zim_name"]
-            return build_otput(name_element, "zim", get_zims_size)
-       
-        elif intended_use == "webroot":
-            name_element = info["name"]
-            return build_otput(name_element, "map", get_map_size_from_file)
+        try:
+            data_intend = intended_use_dict[intended_use]
+            name_element = info[data_intend["name"]]
+            return build_otput(name_element, data_intend["type"], data_intend["function"])
+        except:
+            pass
                     
     return build_otput(name_input, "unknown", element_unknown)
 

--- a/scripts/iiab-size.py
+++ b/scripts/iiab-size.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+# Creates json files for presets
+
+import os, sys, syslog
+from datetime import date
+import pwd, grp
+import shutil
+import argparse
+import sqlite3
+import iiab.iiab_lib as iiab
+import iiab.adm_lib as adm
+import requests
+import json
+import importlib
+from functools import reduce
+iiab_item_size = importlib.import_module("iiab-item-size")
+
+def main():
+    parser = argparse.ArgumentParser(description="Read menu file for get size.")
+    parser.add_argument("menuFile", help="Is the menu file.")
+    # menu_dir
+    args =  parser.parse_args()
+
+    menu_file = args.menuFile
+    if not os.path.exists(menu_file):
+        print('Menu file ' + menu_file + ' not found.')
+        exit(1)
+
+    total_size= content_from_menu(menu_file)
+
+    print('total: ',iiab.human_readable(total_size))
+    print(f'total (bytes): ', total_size)
+
+    sys.exit()
+
+def content_from_menu(menu_file):
+    menu = adm.read_json(menu_file)
+    items = iiab_item_size.get_items_size(menu["menu_items_1"])
+    total_size = reduce(lambda accumulator,item: accumulator+int(item['size']), items, 0)    
+    return total_size
+
+# Now start the application
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description of changes proposed in this pull request:
The iiab-item-size.py and iiab-size.py files are added, whose intention is to determine the size of a module name and of the elements that make up a menu.json

These are the test results of the files:

```
$ python3 iiab-item-size.py en-mdwiki_en_all
content  [{'name': 'mdwiki_en_all', 'type': 'zim', 'size': 9125730303}]

$ python3 iiab-size.py /opt/iiab/iiab-admin-console/roles/cmdsrv/files/presets/en-medical/menu.json
en-kalite_health element unknown not found
en-credits element map not found
total:  53.0G
total (bytes):  56879432689
```
