### PR TITLE
Stub support for upcoming Debian 13 "Trixie" pre-releases

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -81,6 +81,7 @@ OS_VER="$OS-$VERSION_ID"
 case $OS_VER in
     "debian-11"    | \
     "debian-12"    | \
+    "debian-13"    | \
     "ubuntu-2204"  | \
     "ubuntu-2210"  | \
     "ubuntu-2304"  | \

--- a/vars/debian-13.yml
+++ b/vars/debian-13.yml
@@ -1,5 +1,5 @@
 # Every is_<OS_VER> var is initially set to 'False' at the bottom of
 # /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
 is_debuntu: True
-is_ubuntu: True    # Opposite of is_debian for now
-is_ubuntu_2310: True
+is_debian: True    # Opposite of is_ubuntu for now
+is_debian_13: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -790,6 +790,7 @@ is_linuxmint_21: False
 is_linuxmint_20: False
 
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
+is_debian_13: False
 is_debian_12: False
 is_debian_11: False
 #is_debian_10: False


### PR DESCRIPTION
Now that Debian 12 "Bookworm" is released ([micronews](https://micronews.debian.org/)) and the [Debian 13](https://www.phoronix.com/linux/Debian) landscape is beginning to take shape, please avoid installing IIAB on Debian 11 "Bullseye" (or Ubuntu 22.10 "Kinetic Kudu" !) going forward:

- #3399

Advance Notice this will increasingly be enforced in coming months — helping schools/clinics/families/community keep urgent QE (quality engineering) focus on present and future needs — rather than expending our energy on vintage/retro quirks:

- #3415
- #3416