### PR TITLE
WIP: Try 'transmission_compile_latest: True' BitTorrent software (e.g. Transmission 4.1.0-dev, instead of 3.0 from May 2020)

### DIFF
--- a/roles/transmission/README.rst
+++ b/roles/transmission/README.rst
@@ -111,10 +111,13 @@ Docs
 As of June 2023, these docs appear to be the most up-to-date:
 
 - https://github.com/transmission/transmission/tree/main/docs
+   - https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md
    - https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md
+   - https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md
    - https://github.com/transmission/transmission/blob/main/docs/Headless-Usage.md
-- https://wiki.archlinux.org/title/transmission (updated regularly)
 - https://cli-ck.io/transmission-cli-user-guide/ (2016 but still useful)
+   - https://github.com/transmission/transmission#command-line-interface-notes ("``transmission-cli`` is deprecated and exists primarily to support older hardware dependent upon it. In almost all instances, ``transmission-remote`` should be used instead.")
+- https://wiki.archlinux.org/title/transmission (updated regularly)
 - https://trac.transmissionbt.com/wiki (2006-2019)
 
 Logging

--- a/roles/transmission/README.rst
+++ b/roles/transmission/README.rst
@@ -115,6 +115,8 @@ As of June 2023, these docs appear to be the most up-to-date:
    - https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md
    - https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md
    - https://github.com/transmission/transmission/blob/main/docs/Headless-Usage.md
+   - https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md
+      - https://transmission-rpc.readthedocs.io
 - https://cli-ck.io/transmission-cli-user-guide/ (2016 but still useful)
    - https://github.com/transmission/transmission#command-line-interface-notes ("``transmission-cli`` is deprecated and exists primarily to support older hardware dependent upon it. In almost all instances, ``transmission-remote`` should be used instead.")
 - https://wiki.archlinux.org/title/transmission (updated regularly)

--- a/roles/transmission/README.rst
+++ b/roles/transmission/README.rst
@@ -125,14 +125,14 @@ As of June 2023, these docs appear to be the most up-to-date:
 Logging
 -------
 
-To turn on logging and/or record the Process ID (PID), follow these instructions: https://pawelrychlicki.pl/Home/Details/59/transmission-daemon-doesnt-create-a-log-file-nor-a-pid-file-ubuntu-server-1804
+Increase logging by changing transmission-daemon's ``--log-level=error`` to ``--log-level=debug`` in ``/lib/systemd/system/transmission-daemon.service``
 
-This gives permissions to user ``debian-transmission`` — if you use these 3 lines in ``/lib/systemd/system/transmission-daemon.service`` :
+(Options are: ``critical``, ``error``, ``warn``, ``info``, ``debug`` or ``trace``)
 
-::
+Then run::
 
-  RuntimeDirectory=transmission-daemon
-  LogsDirectory=transmission-daemon
-  ExecStart=/usr/bin/transmission-daemon -f --log-error --log-debug --logfile /var/log/transmission-daemon/transmission.log --pid-file /run/transmission-daemon/transmission.pid
+  systemctl daemon-reload
+  systemctl restart transmission-daemon
+  journalctl -eu transmission-daemon
 
 Noting that one should not normally edit files in ``/lib`` or ``/usr/lib`` — systemd has a command for customizing unit files: ``systemctl edit --full transmission-daemon.service``

--- a/roles/transmission/defaults/main.yml
+++ b/roles/transmission/defaults/main.yml
@@ -1,6 +1,7 @@
 # Transmission is a BitTorrent downloader for large Content Packs etc
 # transmission_install: False
 # transmission_enabled: False
+# transmission_compile_latest: True
 # transmission_username: Admin
 # transmission_password: changeme
 

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -26,7 +26,7 @@
         - libssl-dev
       state: present
 
-  - name: Git clone latest to /opt/iiab/transmission
+  - name: Git clone https://github.com/transmission/transmission to /opt/iiab/transmission
     git:
       repo: https://github.com/transmission/transmission
       dest: /opt/iiab/transmission

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -26,7 +26,6 @@
         - libssl-dev
       state: present
 
-  # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#building-transmission-from-git-first-time
   - name: Git clone latest to /opt/iiab/transmission
     git:
       repo: https://github.com/transmission/transmission
@@ -35,6 +34,7 @@
       depth: 1
       force: yes
 
+  # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#building-transmission-from-git-first-time
   - name: Compile & Install (CAN TAKE 10+ MINUTES, OR MUCH MORE ON A RASPBERRY PI!)
     shell: |
       cd /opt/iiab/transmission

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -10,6 +10,47 @@
       - transmission-cli
     state: present
 
+
+- block:
+
+  - name: "TRY TO COMPILE & INSTALL very latest Transmission, installing ~5 binaries in /usr/local/bin to take precedence over above binaries in /usr/bin (attempt surgery on systemd unit file from apt install above!)"
+    meta: noop
+
+  # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#on-unix
+  - name: apt install build-essential cmake libcurl4-openssl-dev libssl-dev    # git python3
+    package:
+      name:
+        - build-essential
+        - cmake
+        - libcurl4-openssl-dev
+        - libssl-dev
+      state: present
+
+  # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#building-transmission-from-git-first-time
+  - name: Git clone latest to /opt/iiab/transmission
+    git:
+      repo: https://github.com/transmission/transmission
+      dest: /opt/iiab/transmission
+      #version: 4.0.x    # Otherwise default branch 'main'
+      depth: 1
+      force: yes
+
+  - name: Compile & Install (CAN TAKE 10+ MINUTES, OR MUCH MORE ON A RASPBERRY PI!)
+    shell: |
+      cd /opt/iiab/transmission
+      git submodule update --init --recursive
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+      make
+      make install
+
+  - name: Attempt surgery on /lib/systemd/system/transmission-daemon.service changing /usr/bin/transmission* to /usr/local/bin/transmission*
+    command: sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
+
+  when: transmission_compile_latest
+
+
 - name: Create download dir {{ transmission_download_dir }}, owned by {{ transmission_user }}:{{ transmission_group }}
   file:
     state: directory
@@ -23,7 +64,10 @@
     state: stopped
   ignore_errors: yes
 
-- name: Back up prior /etc/transmission-daemon/settings.json (original file from apt, or new symlink contents) to /etc/transmission-daemon/settings.json.old*
+# 'transmission-daemon -d' (--dump-settings) CAN GENERATE A NEW settings.json
+# ...then customize ~8 var lines to create a new templates/settings.json.j2
+
+- name: Back up prior /etc/transmission-daemon/settings.json (file originally from apt, or new symlink contents) to /etc/transmission-daemon/settings.json.old*
   copy:
     src: /etc/transmission-daemon/settings.json
     dest: /etc/transmission-daemon/settings.json.old
@@ -52,7 +96,7 @@
 - name: "Reverse Transmission's fragile OOTB symlink -- instead we establish /etc/transmission-daemon/settings.json -> /var/lib/transmission-daemon/.config/transmission-daemon/settings.json -- REASON: /etc/transmission-daemon/settings.json was intermittently being IGNORED, as Transmission sometimes breaks its own symlink from /var/lib/transmission-daemon/.config/transmission-daemon/settings.json (by turning it into a file instead)"
   file:
     path: /etc/transmission-daemon/settings.json
-    src: /var/lib/transmission-daemon/.config/transmission-daemon/settings.json
+    src: /var/lib/transmission-daemon/.config/transmission-daemon/settings.json    # Symlink /var/lib/transmission-daemon/home/settings.json also points to this
     state: link
     force: yes
 

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -13,7 +13,7 @@
 
 - block:
 
-  - name: "TRY TO COMPILE & INSTALL very latest Transmission, installing ~5 binaries in /usr/local/bin to take precedence over above binaries in /usr/bin (attempt surgery on systemd unit file from apt install above!)"
+  - name: "TRY TO COMPILE & INSTALL very latest Transmission, installing ~5 binaries in /usr/local/bin to take precedence over above ~6 binaries in /usr/bin (attempt surgery on systemd unit file from apt install above!)"
     meta: noop
 
   # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#on-unix

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -47,7 +47,7 @@
 
   - name: Attempt surgery on /lib/systemd/system/transmission-daemon.service (1) changing --log-error to --log-level=error (2) changing /usr/bin/transmission* to /usr/local/bin/transmission*
     shell: |
-      sed -i 's/--log-error/--log-level=error/' /lib/systemd/system/transmission-daemon.service    # --log-error deprecated since 2020
+      sed -i 's/--log-error/--log-level=error/' /lib/systemd/system/transmission-daemon.service    # --log-error deprecated since ~2020
       sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
 
   when: transmission_compile_latest

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -37,7 +37,7 @@
       force: yes
 
   # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#building-transmission-from-git-first-time
-  - name: Compile & Install (CAN TAKE 10+ MINUTES, OR MUCH MORE ON A RASPBERRY PI!)
+  - name: Compile, install & remove detritus (CAN TAKE 50 MINUTES OR MORE ON A RASPBERRY PI 4!)
     shell: |
       cd /opt/iiab/transmission
       git submodule update --init --recursive
@@ -46,6 +46,8 @@
       cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
       make
       make install
+      cd
+      rm -rf /opt/iiab/transmission    # 2023-06-12: Frees up 1.1 GB on 32-bit RasPiOS.  Frees up 1.6 GB on 64-bit RasPiOS.
 
   - name: Attempt surgery on /lib/systemd/system/transmission-daemon.service (1) changing --log-error to --log-level=error (2) changing /usr/bin/transmission* to /usr/local/bin/transmission*
     shell: |

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -45,8 +45,10 @@
       make
       make install
 
-  - name: Attempt surgery on /lib/systemd/system/transmission-daemon.service changing /usr/bin/transmission* to /usr/local/bin/transmission*
-    command: sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
+  - name: Attempt surgery on /lib/systemd/system/transmission-daemon.service (1) changing --log-error to --log-level=error (2) changing /usr/bin/transmission* to /usr/local/bin/transmission*
+    shell: |
+      sed -i 's/--log-error/--log-level=error/' /lib/systemd/system/transmission-daemon.service    # --log-error deprecated since 2020
+      sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
 
   when: transmission_compile_latest
 

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -17,13 +17,15 @@
     meta: noop
 
   # https://github.com/transmission/transmission/blob/main/docs/Building-Transmission.md#on-unix
-  - name: apt install build-essential cmake libcurl4-openssl-dev libssl-dev    # git python3
+  # https://github.com/transmission/transmission/issues/5362 tips thanks to @tearfur
+  - name: apt install build-essential cmake libcurl4-openssl-dev libssl-dev libsystemd-dev    # git python3
     package:
       name:
         - build-essential
         - cmake
         - libcurl4-openssl-dev
         - libssl-dev
+        - libsystemd-dev
       state: present
 
   - name: Git clone https://github.com/transmission/transmission to /opt/iiab/transmission

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -543,6 +543,7 @@ sugarizer_port: 8089
 # Transmission is a BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
+transmission_compile_latest: True
 transmission_username: Admin
 transmission_password: changeme
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -320,6 +320,7 @@ sugarizer_enabled: True
 # BitTorrent downloader for large Content Packs etc
 transmission_install: True
 transmission_enabled: True
+transmission_compile_latest: True
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -320,6 +320,7 @@ sugarizer_enabled: True
 # BitTorrent downloader for large Content Packs etc
 transmission_install: True
 transmission_enabled: True
+transmission_compile_latest: True
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -320,6 +320,7 @@ sugarizer_enabled: False
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
+transmission_compile_latest: True
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -320,6 +320,7 @@ sugarizer_enabled: False
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
+transmission_compile_latest: True
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:


### PR DESCRIPTION
@neomatrixcode this is just a proof-of-concept for now.

But if this-or-similar proves reliable/promising we can optimize later... for both reliability and faster install (compile time is about 10 min on a recent PC, but likely to be painful on all Raspberry Pi's, possibly an hour or even worse!?)

Related:

- #1078
- PR #2572
- #3473