### PR TITLE
WIP: Kiwix arch changes

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -29,8 +29,8 @@ kiwix_arch_dict:      # 'dpkg --print-architecture' key would be: (to mitigate #
   #i386:              # ?
   i686: i586          # ?
   x86_64: x86_64      # amd64
-  armv6l: armhf       # armhf
-  armv7l: armhf       # armhf  BEWARE: armhf version of kiwix-tools suddenly FAILS on 64-bit RasPiOS, since 3.5.0 released 2023-04-28 -- #3574, PR #3576
+  armv6l: armv6       # armhf
+  armv7l: armv8       # armhf  BEWARE: armhf version of kiwix-tools suddenly FAILS on 64-bit RasPiOS, since 3.5.0 released 2023-04-28 -- #3574, PR #3576
   aarch64: aarch64    # arm64  BEWARE: "32-bit" RasPiOS suddenly boots 64-bit kernel since March 2023 -- #3516, explained at https://github.com/iiab/iiab/pull/3422#issuecomment-1533441463
 
 # ansible_architecture might also work, if not quite as well:

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -42,6 +42,7 @@ kiwix_arch: "{{ kiwix_arch_dict[ansible_machine] | default('unsupported') }}"
 # Latest official kiwix-tools release, per Kiwix permalink redirects:
 # https://www.kiwix.org/en/downloads/kiwix-serve/
 # https://github.com/kiwix/container-images/issues/236
+# https://github.com/kiwix/kiwix-tools/issues/623
 kiwix_tar_gz: "kiwix-tools_linux-{{ kiwix_arch }}.tar.gz"
 #kiwix_tar_gz: "kiwix-tools_linux-{{ kiwix_arch }}-3.3.0-1.tar.gz"    # Version can be hard-coded if you prefer (as was done til 2022-10-04)
 

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -24,23 +24,23 @@
     timeout: "{{ download_timeout }}"
   register: kiwix_dl    # PATH /opt/iiab/downloads + ACTUAL filename put in kiwix_dl.dest, for unarchive ~28 lines below
 
-- name: "2023-05-14: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
-  get_url:
-    url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-armhf-3.4.0.tar.gz
-    dest: "{{ downloads_dir }}"
-    timeout: "{{ download_timeout }}"
-  #register: kiwix_dl    # CLOBBERS kiwix_dl.dest WHEN THIS STANZA DOES NOT RUN :/
-  when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
-
-# Ansible does not allow changing individuals subfields in a dictionary, but
-# this crude hack works, overwriting the entire kiwix_dl dictionary var with
-# the single (needed) key/value pair.  (Or "register: tmp_dl" could be set
-# above, if its other [subfields, key/value pairs, etc] really mattered...)
-- name: "2023-05-15: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
-  set_fact:
-    kiwix_dl:
-      dest: /opt/iiab/downloads/kiwix-tools_linux-armhf-3.4.0.tar.gz
-  when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
+# - name: "2023-05-14: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
+#   get_url:
+#     url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-armhf-3.4.0.tar.gz
+#     dest: "{{ downloads_dir }}"
+#     timeout: "{{ download_timeout }}"
+#   #register: kiwix_dl    # CLOBBERS kiwix_dl.dest WHEN THIS STANZA DOES NOT RUN :/
+#   when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
+#
+# # Ansible does not allow changing individuals subfields in a dictionary, but
+# # this crude hack works, overwriting the entire kiwix_dl dictionary var with
+# # the single (needed) key/value pair.  (Or "register: tmp_dl" could be set
+# # above, if its other [subfields, key/value pairs, etc] really mattered...)
+# - name: "2023-05-15: TEMPORARY PATCH REVERTING TO KIWIX-TOOLS 3.4.0 IF BUGGY 32-BIT (armhf) VERSION 3.5.0 IS DETECTED -- #3574"
+#   set_fact:
+#     kiwix_dl:
+#       dest: /opt/iiab/downloads/kiwix-tools_linux-armhf-3.4.0.tar.gz
+#   when: kiwix_dl.dest == "/opt/iiab/downloads/kiwix-tools_linux-armhf-3.5.0.tar.gz"
 
 - name: Does {{ kiwix_path }}/bin already exist? (as a directory, symlink or file)
   stat:


### PR DESCRIPTION
In keeping with upstream changes as they evolve here:

- kiwix/kiwix-tools#623

For the moment, both above redirects [are] live.

If however Kiwix chooses to drop armv8 (which is presumably 32-bit, possibly @mgautierfr can confirm?) that can be dropped (i.e. if indeed those are 32-bit builds, the armv6 builds would then be used in their place).

Many thanks to @mgautierfr for all his hard work making all this possible ✅

- PR #3391 
- PR #3576