### PR TITLE
remote.it workaround for incoming ICMP firewalls e.g. GitHub Actions [at least allowing IIAB installs to proceed, when service schannel does not exist]

### DIFF
--- a/roles/remoteit/tasks/enable-or-disable.yml
+++ b/roles/remoteit/tasks/enable-or-disable.yml
@@ -33,7 +33,7 @@
 # service, that they removed from 4.15.2 device packages on 2022-09-07.
 # (Either way, the job below never deletes /etc/remoteit/registration)
 
-- name: 'Run /usr/share/remoteit/refresh.sh to put a claim code in /etc/remoteit/config.json (if you don''t already have a license key in /etc/remoteit/registration) -- FYI this spawns 2 "child" services/daemons: schannel & e.g. remoteit@80:00:01:7F:7E:00:56:36.service'
+- name: 'Run /usr/share/remoteit/refresh.sh to put a claim code in /etc/remoteit/config.json (if you don''t already have a license key in /etc/remoteit/registration) -- FYI this should spawn 2 "child" services/daemons: schannel & e.g. remoteit@80:00:01:7F:7E:00:56:36.service'
   command: /usr/share/remoteit/refresh.sh
   when: remoteit_enabled
 
@@ -59,6 +59,7 @@
     name: schannel
     enabled: no
     state: stopped
+  ignore_errors: yes    # 2023-06-12: Let's make these rare-but-unavoidable errors RED very intentionally, as below.  Thanks to @neomatrixcode for surfacing this GitHub Actions problem, likely arising from inbound ICMP being blocked during remote.it install and/or above refresh.sh setup: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-used-by-github-hosted-runners
   when: not remoteit_enabled
 
 - name: Stop & Disable "Remote tcp connection services" remoteit@* found in /etc/systemd/system/multi-user.target.wants/ e.g. remoteit@80:00:01:7F:7E:00:56:36.service


### PR DESCRIPTION
Thanks to @neomatrixcode for surfacing this problem!

Bulding on:

- #3394
  - PR #3395