### PR TITLE
Recommend ansible-core 2.15.1 [and interim workaround to start Asterisk, so FreePBX can install]

### DIFF
--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -232,7 +232,8 @@
     dest: /etc/asterisk/cdr_mysql.conf
 
 
-- name: FreePBX - 2-step install - won't run if {{ freepbx_install_dir }} already exists - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
+# 2023-05-21: Asterisk is normally OFF at this point (but that doesn't matter, either way!)
+- name: FreePBX - 2-step install - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
   command: "{{ item }}"
   args:
     chdir: "{{ freepbx_src_dir }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -240,18 +240,18 @@
 
 # 2023-06-21: Interim use of 'nohup' didn't quite solve ansible 2.15.x
 # regression ansible/ansible#80863, which led to PR's #3588 and #3604.
-- name: FreePBX - INTERIM USE OF 'systemctl start asterisk' TIL ANSIBLE FIXES 2.15.x REGRESSION ansible/ansible#80863 -- 'nohup ./start_asterisk start' ALSO DOESN'T WORK WITH 2.15.0 AND 2.15.1
+- name: FreePBX - INTERIM USE OF 'systemctl start asterisk' TIL ANSIBLE FIXES 2.15.x REGRESSION ansible/ansible#80863 -- AS EVEN 'nohup ./start_asterisk start' DOESN'T WORK WITH 2.15.0 AND 2.15.1
   systemd:
     name: asterisk
     state: started
     #enabled: yes
 
-# 2023-06-21: Commands to try to see if Asterisk has started & stabilized?
+# 2023-06-21: Commands to try, to see if Asterisk has started & stabilized?
 # pidof asterisk
 # /usr/sbin/asterisk -rx 'core show version'
 # journalctl -eu asterisk
 
-- name: FreePBX - WAIT 5 SECONDS TO SIMULATE './start_asterisk start' (REQUIRED DUE TO ABOVE ANSIBLE BUG) THEN install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
+- name: FreePBX - WAIT 5 SECONDS TO SIMULATE './start_asterisk start' (REQUIRED DUE TO ABOVE ANSIBLE BUG) THEN... install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
   shell: sleep 5 && ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
   args:
     chdir: "{{ freepbx_src_dir }}"

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -232,16 +232,30 @@
     dest: /etc/asterisk/cdr_mysql.conf
 
 
-# 2023-05-21: Asterisk is normally OFF at this point (but that doesn't matter, either way!)
-- name: FreePBX - 2-step install - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
-  command: "{{ item }}"
+# 2023-05-21: Asterisk is in fact normally OFF at this point (shouldn't matter!)
+# - name: FreePBX - Spawn 'nohup ./start_asterisk start' in {{ freepbx_src_dir }}
+#   command: nohup ./start_asterisk start
+#   args:
+#     chdir: "{{ freepbx_src_dir }}"
+
+# 2023-06-21: Interim use of 'nohup' didn't quite solve ansible 2.15.x
+# regression ansible/ansible#80863, which led to PR's #3588 and #3604.
+- name: FreePBX - INTERIM USE OF 'systemctl start asterisk' TIL ANSIBLE FIXES 2.15.x REGRESSION ansible/ansible#80863 -- 'nohup ./start_asterisk start' ALSO DOESN'T WORK WITH 2.15.0 AND 2.15.1
+  systemd:
+    name: asterisk
+    state: started
+    #enabled: yes
+
+# 2023-06-21: Commands to try to see if Asterisk has started & stabilized?
+# pidof asterisk
+# /usr/sbin/asterisk -rx 'core show version'
+# journalctl -eu asterisk
+
+- name: FreePBX - WAIT 5 SECONDS TO SIMULATE './start_asterisk start' (REQUIRED DUE TO ABOVE ANSIBLE BUG) THEN install FreePBX to {{ freepbx_install_dir }} - FAST W/ GITHUB (OR freepbx-16.0-latest.tgz CAN TAKE 3-12 MIN OR LONGER!)
+  shell: sleep 5 && ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
   args:
     chdir: "{{ freepbx_src_dir }}"
-    creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
-  with_items:
-    - nohup ./start_asterisk start    # 2023-06-20: Interim use of 'nohup' until ansible 2.15.x solves regression ansible/ansible#80863
-    - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
-    # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
+    #creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
 
 
 # 2022-05-25 BACKGROUND: https://github.com/iiab/iiab/pull/3229#issuecomment-1138061460

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -238,7 +238,7 @@
     chdir: "{{ freepbx_src_dir }}"
     creates: "{{ freepbx_install_dir }}"    # /var/www/html/freepbx
   with_items:
-    - ./start_asterisk start
+    - nohup ./start_asterisk start    # 2023-06-20: Interim use of 'nohup' until ansible 2.15.x solves regression ansible/ansible#80863
     - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }}
     # - ./install -n --webroot {{ freepbx_install_dir }} --dbuser {{ asterisk_db_user }} --dbpass {{ asterisk_db_password }} --dbname {{ asterisk_db_dbname }} --cdrdbname {{ asterisk_db_cdrdbname }}
 

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.14.6]
-GOOD_VER=2.14.6       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.15.1]
+GOOD_VER=2.15.1       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -216,7 +216,8 @@ if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
     /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
 fi
 
-/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core==2.14.6    # 2023-05-22: TEMPORARILY REVERT FROM 2.15.0 UNTIL ansible/ansible#80863 FIXED (e.g. for FreePBX, #3588)
+# 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)
+/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
 echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
 cd /usr/local/ansible/bin
 for bin in ansible*; do


### PR DESCRIPTION
ANNC:

https://groups.google.com/g/ansible-announce/c/Ga3ULTgnEqM

Changelog:

https://github.com/ansible/ansible/blob/v2.15.1/changelogs/CHANGELOG-v2.15.rst#v2-15-1

Likely good enough — even if installing FreePBX (in the face of Ansible's command/shell failures) isn't quite yet fully solved upstream?

- PR #3588

Related:

- PR #3229
- PR #3523
- PR #3550
- PR #3577
- PR #3590