### PR TITLE
New Gitea release 1.20

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -9,7 +9,7 @@
 
 # Info needed to install Gitea:
 
-gitea_version: 1.19    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.
+gitea_version: "1.20"    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.  Quotes nec if trailing zero.
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
New Gitea 1.20 release:
https://github.com/go-gitea/gitea/releases/tag/v1.20.0

ANNC:
https://blog.gitea.com/release-of-1.20.0/

Building on:
- PR #3499