### PR TITLE
Gitea 1.20 patches, e.g.  app.ini.j2

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -19,7 +19,7 @@ iset_suffixes:
 
 gitea_iset_suffix: "{{ iset_suffixes[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
 
-gitea_download_url: "https://dl.gitea.io/gitea/{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_iset_suffix }}"
+gitea_download_url: "https://dl.gitea.com/gitea/{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_iset_suffix }}"
 gitea_integrity_url: "{{ gitea_download_url }}.asc"
 
 gitea_root_directory: "{{ content_base }}/gitea"    # /library/gitea

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -48,10 +48,10 @@
     msg: "Could not find a binary for the CPU architecture \"{{ ansible_architecture }}\""
   when: gitea_iset_suffix == "unknown"
 
-- name: Download Gitea binary {{ gitea_download_url }} to {{ gitea_install_path }} (0775, ~108 MB, SLOW DOWNLOAD CAN TAKE ~15 MIN)
+- name: Download Gitea binary {{ gitea_download_url }} to {{ gitea_install_path }} (0775, ~126 MB, SLOW DOWNLOAD CAN TAKE ~15 MIN)
   get_url:
     url: "{{ gitea_download_url }}"
-    dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.16
+    dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.20
     mode: 0775
     timeout: "{{ download_timeout }}"
 
@@ -63,7 +63,7 @@
 
 - name: Verify Gitea binary with GPG signature
   shell: |
-    gpg --keyserver pgp.mit.edu --recv {{ gitea_gpg_key }}
+    gpg --keyserver keys.openpgp.org --recv {{ gitea_gpg_key }}
     gpg --verify {{ gitea_checksum_path }} {{ gitea_install_path }}
   ignore_errors: yes
 

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -61,7 +61,7 @@
     dest: "{{ gitea_checksum_path }}"
     timeout: "{{ download_timeout }}"
 
-- name: Verify Gitea binary with GPG signature
+- name: Verify Gitea binary with GPG signature ("BAD signature" FALSE ALARMS continue as of 2023-07-16, despite their claims at https://docs.gitea.com/installation/install-from-binary#verify-gpg-signature)
   shell: |
     gpg --keyserver keys.openpgp.org --recv {{ gitea_gpg_key }}
     gpg --verify {{ gitea_checksum_path }} {{ gitea_install_path }}

--- a/roles/gitea/templates/app.ini.j2
+++ b/roles/gitea/templates/app.ini.j2
@@ -2,7 +2,8 @@
 ; Copy required sections to your own app.ini (default is custom/conf/app.ini)
 ; and modify as needed.
 
-; see https://docs.gitea.io/en-us/config-cheat-sheet/ for additional documentation.
+; see https://docs.gitea.com/administration/config-cheat-sheet for additional documentation.
+;     https://docs.gitea.com/next/administration/config-cheat-sheet
 
 ; App name that shows in every page title
 APP_NAME = {{ gitea_display_name }}
@@ -23,9 +24,11 @@ DEFAULT_PRIVATE = last
 ; Global limit of repositories per user, applied at creation time. -1 means no limit
 MAX_CREATION_LIMIT = -1
 ; Mirror sync queue length, increase if mirror syncing starts hanging
-MIRROR_QUEUE_LENGTH = 1000
+; 2023-07-16 ERROR: MIRROR_QUEUE_LENGTH = 1000
+;     `[repository].MIRROR_QUEUE_LENGTH`. Use new options in `[queue.mirror]`
 ; Patch test queue length, increase if pull request patch testing starts hanging
-PULL_REQUEST_QUEUE_LENGTH = 1000
+; 2023-07-16 ERROR: PULL_REQUEST_QUEUE_LENGTH = 1000
+;     `[repository].PULL_REQUEST_QUEUE_LENGTH`. Use new options in `[queue.pr_patch_checker]`
 ; Preferred Licenses to place at the top of the List
 ; The name here must match the filename in conf/license or custom/conf/license
 PREFERRED_LICENSES = Apache License 2.0,MIT License
@@ -201,12 +204,21 @@ PPROF_DATA_PATH = data/tmp/pprof
 LANDING_PAGE = home
 ; Enables git-lfs support. true or false, default is false.
 LFS_START_SERVER = false
-; Where your lfs files reside, default is data/lfs.
-LFS_CONTENT_PATH = {{ gitea_lfs_root }}
 ; LFS authentication secret, change this yourself
 LFS_JWT_SECRET =
 ; LFS authentication validity period (in time.Duration), pushes taking longer than this may fail.
 LFS_HTTP_AUTH_EXPIRY = 20m
+
+; lfs [Large File Storage] storage will override storage
+;
+[lfs]
+;STORAGE_TYPE = local
+;
+; Where your lfs files reside, default is data/lfs.
+PATH = {{ gitea_lfs_root }}
+;
+; override the minio base path if storage type is minio
+;MINIO_BASE_PATH = lfs/
 
 ; Define allowed algorithms and their minimum key length (use -1 to disable a type)
 [ssh.minimum_key_sizes]
@@ -240,7 +252,8 @@ ISSUE_INDEXER_PATH = indexers/issues.bleve
 ; repo indexer by default disabled, since it uses a lot of disk space
 REPO_INDEXER_ENABLED = false
 REPO_INDEXER_PATH = indexers/repos.bleve
-UPDATE_BUFFER_LEN = 20
+; 2023-07-16 ERROR: UPDATE_BUFFER_LEN = 20
+;        `[indexer].UPDATE_BUFFER_LEN`. Use new options in `[queue.issue_indexer]`
 MAX_FILE_SIZE = 1048576
 
 [admin]
@@ -360,7 +373,8 @@ PAGING_NUM = 10
 [mailer]
 ENABLED = false
 ; Buffer length of channel, keep it as it is if you don't know what it is.
-SEND_BUFFER_LEN = 100
+; 2023-07-16 ERROR: SEND_BUFFER_LEN = 100
+;         `[mailer].SEND_BUFFER_LEN`. Use new options in `[queue.mailer]`
 ; Name displayed in mail title
 SUBJECT = %(APP_NAME)s
 ; Mail server


### PR DESCRIPTION
At least resolves the many `/etc/gitea/app.ini` problems and updates URL's etc for more recent versions of Gitea:

- PR #3608

Gitea's PGP signature checking of their downloaded binaries is still a grand mess years later (https://docs.gitea.com/installation/install-from-binary#verify-gpg-signature doesn't actually work with 1.20) but this is their fault.  Hopefully they'll finally fix that soon.