### PR TITLE
Remote.it CLI can no longer coexist with remoteit Device Package

### DIFF
--- a/roles/remoteit/README.md
+++ b/roles/remoteit/README.md
@@ -2,7 +2,7 @@
 
 Remote.it can be a [great way](https://docs.remote.it/introduction/get-started/readme) to remotely support an Internet-in-a-Box (IIAB).
 
-As of [June 2023](https://remote.it/pricing/), 5 IIAB devices can be managed for free (their personal / non-commercial plan) and larger numbers for $10+/month.
+As of [July 2023](https://remote.it/pricing/), 5 IIAB devices can be managed for free (their personal / non-commercial plan) and larger numbers for $10+/month.
 
 For other approaches, please see [FAQ.IIAB.IO](https://wiki.iiab.io/go/FAQ) -> "How can I remotely manage my Internet-in-a-Box?"
 
@@ -14,13 +14,13 @@ For other approaches, please see [FAQ.IIAB.IO](https://wiki.iiab.io/go/FAQ) -> "
 
 2. Consider downloading and installing the remote.it [desktop application](https://remote.it/download/) (e.g. for Windows, macOS or Linux) on your own laptop/computer.  Their https://remote.it Web Portal and [mobile apps](https://docs.remote.it/introduction/get-started/readme#installation-packages) are also sometimes sufficient, but less functional.
 
-   COMPARISON: "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
+   2023-07-26 WARNING: IIAB no longer installs the `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli), as it can [no longer coexist](https://github.com/iiab/iiab/blob/remoteit-remove-cli/roles/remoteit/tasks/install.yml#L116-L132) with the core `remoteit` Device Package.  Whereas in the past the remote.it CLI had offered [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device): "The Desktop and [CLI](https://docs.remote.it/software/cli) can [each] support both peer to peer connections and proxy connections [whereas] the Web Portal and API can only support proxy connections" according to https://docs.remote.it/software/device-package/usage
 
 <!-- ### Install remote.it onto an IIAB + register it + authorize services/ports -->
 ### OPTION #1: Generate a remote.it claim code for your IIAB + register it + authorize services/ports
 <!-- ### OPTION #1: Run `sudo iiab-remoteit` to enable remote.it -->
 
-Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  This means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is already installed on your IIAB, most important.  It also means the _strictly optional_ `/usr/bin/remoteit` [command-line interface (CLI)](https://docs.remote.it/software/cli) is installed, offering [a few more features](https://support.remote.it/hc/en-us/articles/4412786750861-Install-the-remoteit-agent-on-your-device) than the Device Package.
+Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_state.yml` (this is the default!)  This means that the remote.it [Device Package](https://docs.remote.it/software/device-package) is already installed on your IIAB, most important.
 
 1. Run `sudo iiab-remoteit` to enable remote.it on your IIAB:
 
@@ -158,7 +158,7 @@ Prerequisite: Find any IIAB with `remoteit_installed: True` in `/etc/iiab/iiab_s
 <!-- "auto-registration" of remote.it, and other more advanced configuration options, see: -->
 
 - https://docs.remote.it
-  - https://docs.remote.it/developer-tools/cli-usage
+  - ~https://docs.remote.it/developer-tools/cli-usage~
   - https://docs.remote.it/oem-and-bulk-provisioning/registration-into-a-users-account
 - https://support.remote.it
   - https://support.remote.it/hc/en-us/categories/360003417511-Getting-Started

--- a/roles/remoteit/defaults/main.yml
+++ b/roles/remoteit/defaults/main.yml
@@ -41,16 +41,19 @@
 # SEE https://www.remote.it/download-list
 #     https://www.remote.it/download-list?products=cli to refine arch/URL below
 # BUT https://docs.remote.it/software/cli/overview can be useful OR stale :/
-remoteit_arch_dict:
-  armv6: arm-v6
-  armv6l: arm-v6
-  armv7: arm-v7
-  armv7l: arm-v7
-  armv8: aarch64
-  aarch64: aarch64
-  x86_64: x86_64
-remoteit_arch: "{{ remoteit_arch_dict[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
-remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit.{{ remoteit_arch }}-linux
+#
+# 2023-07-26: Remote.It CLI can no longer coexist with their "Device Package"
+# SEE remoteit/tasks/install.yml Line ~121.
+# remoteit_arch_dict:
+#   armv6: arm-v6
+#   armv6l: arm-v6
+#   armv7: arm-v7
+#   armv7l: arm-v7
+#   armv8: aarch64
+#   aarch64: aarch64
+#   x86_64: x86_64
+# remoteit_arch: "{{ remoteit_arch_dict[ansible_machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
+# remoteit_cli_url: https://downloads.remote.it/cli/latest/remoteit.{{ remoteit_arch }}-linux
 
 
 # OPTION #1: Run 'sudo iiab-remoteit' after IIAB is installed.

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -113,15 +113,15 @@
     mode: 0755
 
 
-- name: Fail if architecture remoteit_arch == "unknown"
-  fail:
-    msg: "Could not find a remote.it CLI binary for CPU architecture \"{{ ansible_architecture }}\""
-  when: remoteit_arch == "unknown"
-
 # 2023-07-26: Remote.It CLI used to coexist fine with their "Device Package"
 # e.g. it worked with remoteit apt package 4.17.12 in Q2 2023.
 # But no longer--with remoteit apt package 4.18.4 (in Q3 2023) which fails to
 # install with error: "Device Package cannot coexist with Remote.It CLI"
+#
+# - name: Fail if architecture remoteit_arch == "unknown"
+#   fail:
+#     msg: "Could not find a remote.it CLI binary for CPU architecture \"{{ ansible_architecture }}\""
+#   when: remoteit_arch == "unknown"
 #
 # - name: Download OPTIONAL {{ remoteit_cli_url }} (CLI) to /usr/bin/remoteit (755)
 #   get_url:

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -118,13 +118,18 @@
     msg: "Could not find a remote.it CLI binary for CPU architecture \"{{ ansible_architecture }}\""
   when: remoteit_arch == "unknown"
 
-- name: Download OPTIONAL {{ remoteit_cli_url }} (CLI) to /usr/bin/remoteit (755)
-  get_url:
-    url: "{{ remoteit_cli_url }}"
-    dest: /usr/bin/remoteit
-    mode: 0755
-    force: yes
-    timeout: "{{ download_timeout }}"
+# 2023-07-26: Remote.It CLI used to coexist fine with their "Device Package"
+# e.g. it worked with remoteit apt package 4.17.12 in Q2 2023.
+# But no longer--with remoteit apt package 4.18.4 (in Q3 2023) which fails to
+# install with error: "Device Package cannot coexist with Remote.It CLI"
+#
+# - name: Download OPTIONAL {{ remoteit_cli_url }} (CLI) to /usr/bin/remoteit (755)
+#   get_url:
+#     url: "{{ remoteit_cli_url }}"    # e.g. https://downloads.remote.it/cli/latest/remoteit.{{ remoteit_arch }}-linux
+#     dest: /usr/bin/remoteit
+#     mode: 0755
+#     force: yes
+#     timeout: "{{ download_timeout }}"
 
 
 # RECORD remote.it AS INSTALLED


### PR DESCRIPTION
As a result of their sudden upstream change in recent weeks :/

Background:

- PR #3161
- PR #3395
- PR #3601