### PR TITLE
scripts/ansible: Install cryptography 40.0.1 on ALL 32-bit arch's

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -212,7 +212,8 @@ python3 -m venv /usr/local/ansible
 #
 # 2023-03-24 #3547 similar to #3459 re: cryptography, piwheels, rust.
 # Release problems chart: https://www.piwheels.org/project/cryptography/
-if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
+#if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
+if ! dpkg --print-architecture | grep -q 64; then        # 32-bit in general!
     /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
 fi
 


### PR DESCRIPTION
Might help some legacy installs on older 32-bit AMD / Intel machines!

Building on:

- #3547 
- PR #3550
- PR #3610