### PR TITLE
scripts/ansible: python3-cryptography for 32-bit i386 e.g. i686

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -217,8 +217,9 @@ if ! dpkg --print-architecture | grep -q 64; then    # 32-bit in general!
     if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
 	/usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
     else
-	# 2023-08-10: Installs cryptography 38.0.4 on Debian 12.1 when
-	# `dpkg --print-architecture` is i386 e.g. `uname -m` is i686
+	# 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
+	# So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
+	# `dpkg --print-architecture` was i386 and `uname -m` was i686:
 	$APT_PATH/apt -y install python3-cryptography
     fi
 fi

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -213,9 +213,14 @@ python3 -m venv /usr/local/ansible
 #
 # 2023-03-24 #3547 similar to #3459 re: cryptography, piwheels, rust.
 # Release problems chart: https://www.piwheels.org/project/cryptography/
-#if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
-if ! dpkg --print-architecture | grep -q 64; then        # 32-bit in general!
-    /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
+if ! dpkg --print-architecture | grep -q 64; then    # 32-bit in general!
+    if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
+	/usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
+    else
+	# 2023-08-10: Installs cryptography 38.0.4 on Debian 12.1 when
+	# `dpkg --print-architecture` is i386 e.g. `uname -m` is i686
+	$APT_PATH/apt -y install python3-cryptography
+    fi
 fi
 
 # 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)


### PR DESCRIPTION
[Not quite...] Fixes:

- PR #3613

Smoke-tested on 32-bit Debian 12 VM where `uname -m` shows i686, and `dpkg --print-architecture` shows i386.

Background:

- #3547