### PR TITLE
scripts/install_python2.sh: Bullseye apt sources for i386 Debian

### DIFF
--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -66,6 +66,16 @@ deb http://ports.ubuntu.com/ jammy-updates main universe
 EOF
         fi
         ;;
+
+    "i386")
+        # Building on scripts/ansible fix PR #3615
+        if grep -q '^ID=debian$' /etc/os-release; then
+            cat << EOF > /etc/apt/sources.list.d/python2.list
+deb http://deb.debian.org/debian bullseye main contrib non-free
+deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+EOF
+        fi
+        ;;
 esac
 
 apt update


### PR DESCRIPTION
Tested with roles/kalite on Debian 12.1 on 32-bit i386 (i686 really).

Alongside:

- PR #3613 
- PR #3615

Building on:

- PR #3535
- PR #3582
- PR #3587