### PR TITLE
Brute Force 'apt install ansible-core' (e.g. 2.14.3 on Debian Bookworm) on 32-bit legacy i386, to avoid rust/wheels/cryptography compiling mess

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -200,37 +200,42 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-# 2023-03-22: OS's like Ubuntu 23.04 and Debian 12 (e.g. with Python 3.11+) ask
-# that virtual environments (venv) be used to safely isolate pip installs:
-# https://peps.python.org/pep-0668
-echo -e "\nCreate virtual environment for Ansible"
-python3 -m venv /usr/local/ansible
+if [[ $(dpkg --print-architecture) == i386 ]]; then
+    # 2023-08-10: Quick+Dirty (BRUTE FORCE) on legacy 32-bit i386 avoids #3547
+    # rust/wheels/cryptography compiling mess!  DEBIAN 12+ OR SIMILAR REQUIRED!
+    $APT_PATH/apt -y install ansible-core    # Bookworm ~= ansible-core 2.14.3
+else
+    # 2023-03-22: OS's like Ubuntu 23.04 and Debian 12 (e.g. with Python 3.11+) ask
+    # that virtual environments (venv) be used to safely isolate pip installs:
+    # https://peps.python.org/pep-0668
+    echo -e "\nCreate virtual environment for Ansible"
+    python3 -m venv /usr/local/ansible
 
-# "if not ubuntu" (covers RasPiOS & Debian) would also work, but is overbroad:
-# if ! grep -qi ubuntu /etc/os-release; then
-#
-# if [ -f /etc/rpi-issue ] && [[ $(dpkg --print-architecture) == armhf ]]; then
-#
-# 2023-03-24 #3547 similar to #3459 re: cryptography, piwheels, rust.
-# Release problems chart: https://www.piwheels.org/project/cryptography/
-if ! dpkg --print-architecture | grep -q 64; then    # 32-bit in general!
+    # "if not ubuntu" (covers RasPiOS & Debian) would also work, but is overbroad:
+    # if ! grep -qi ubuntu /etc/os-release; then
+    #
+    # if [ -f /etc/rpi-issue ] && [[ $(dpkg --print-architecture) == armhf ]]; then
+    #
+    # 2023-03-24 #3547 similar to #3459 re: cryptography, piwheels, rust.
+    # Release problems chart: https://www.piwheels.org/project/cryptography/
+    # if ! dpkg --print-architecture | grep -q 64; then     # 32-bit in general!
     if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
 	/usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
-    else
-	# 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
-	# So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
-	# `dpkg --print-architecture` was i386 and `uname -m` was i686:
-	$APT_PATH/apt -y install python3-cryptography
+	# else
+	#     # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
+	#     # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
+	#     # `dpkg --print-architecture` was i386 and `uname -m` was i686:
+	#     $APT_PATH/apt -y install python3-cryptography
     fi
-fi
 
-# 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)
-/usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
-echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
-cd /usr/local/ansible/bin
-for bin in ansible*; do
-    ln -sf /usr/local/ansible/bin/"$bin" /usr/local/bin/"$bin"
-done
+    # 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)
+    /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
+    echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
+    cd /usr/local/ansible/bin
+    for bin in ansible*; do
+	ln -sf /usr/local/ansible/bin/"$bin" /usr/local/bin/"$bin"
+    done
+fi
 
 # (Re)running collection installs appears safe, with --force-with-deps to force
 # upgrade of collection and dependencies it pulls in.  Note Ansible may support


### PR DESCRIPTION
Not an elegant solution but this is a workaround for some corner cases arising with:

- PR #3613 
- PR #3615 

Background:

- #3547
- PR #3604
- PR #3610