### PR TITLE
iiab-diagnostics: Change pastebin service (paste2.org -> dpaste.com)

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -264,12 +264,12 @@ echo -e "\e[1m"
 #if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
 if ! [[ $ans =~ ^[nNqQ]$ ]]; then
     echo -ne "PUBLISHING TO URL... "
-    #pastebinit -b dpaste.com < $outfile
-    #pastebinit -b sprunge.us < $outfile
-    pastebinit -b paste2.org < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
+    #pastebinit -b sprunge.us < $outfile    # Stopped working mid-2023
+    #pastebinit -b paste2.org < $outfile    # Spammy/dangerous pastebins
+    pastebinit -b dpaste.com < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
 else
     echo -e "If you later decide to publish it, run:"
     echo
-    echo -e "   pastebinit -b paste2.org < $outfile"
+    echo -e "   pastebinit -b dpaste.com < $outfile"
 fi
 echo -e "\e[0m"


### PR DESCRIPTION
[DPASTE.COM](https://dpaste.com/help) may be limited to 30 days by default, but appears substantially more solid/reliable than [PASTE2.ORG](https://paste2.org) whose pastebin URL's (dangerously?) redirect to phishing-like spam.

So this PR supersedes:

- PR #3618