### PR TITLE
local_facts.fact: Deprecate support for EOL'd Ubuntu 22.10 (Kinetic Kudu)

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -70,6 +70,7 @@ OS_VER="$OS-$VERSION_ID"
     #"ubuntu-2004"  | \
     #"ubuntu-2104"  | \
     #"ubuntu-2110"  | \
+    #"ubuntu-2210"  | \
     #"linuxmint-20" | \
     #"raspbian-8"   | \
     #"raspbian-9"   | \
@@ -83,7 +84,6 @@ case $OS_VER in
     "debian-12"    | \
     "debian-13"    | \
     "ubuntu-2204"  | \
-    "ubuntu-2210"  | \
     "ubuntu-2304"  | \
     "ubuntu-2310"  | \
     "linuxmint-21" | \


### PR DESCRIPTION
Ubuntu 22.10 "Kinetic Kudu" reached end-of-life on July 20th.

Other distribution versions (likely to include both Debian 11 and Raspberry Pi OS 11) will be desupported before end of 2023 so software quality focuses on the future not the past — as explained in:

- PR #3034
  - PR #3045
- PR #3087
- PR #3306
- PR #3415 
- #3416 
- PR #3598