### PR TITLE
Force nginx_high_php_limits / 'memory_limit = 512M' if 'nextcloud_install: True'

### DIFF
--- a/roles/nginx/templates/server.conf.j2
+++ b/roles/nginx/templates/server.conf.j2
@@ -10,8 +10,8 @@ server {
     # NGINX's 1MB default is far too low for Calibre-Web and LMS-like apps.
     # So IIAB sets this to 500M, roughly aligning with similar settings...
     # 1. 'upload_max_filesize = 500M' and 'post_max_size = 500M' are SOMETIMES set in:
-    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L106-L107
-    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/main.yml#L120-L121
+    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml#L90-L91
+    #    https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml#L104-L105
     # 2. 'client_max_body_size 512M;' is set in:
     #    https://github.com/iiab/iiab/blob/master/roles/nextcloud/templates/nextcloud-nginx.conf.j2#L62
     client_max_body_size 500M;

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -61,7 +61,7 @@
 # WordPress) so './runrole <ROLE>' and similar are fully self-sufficient!
 - name: "Run php-settings.yml -- allows post-install toggling of nginx_high_php_limits in /etc/iiab/local_vars.yml -- if you run './runrole www_options'"
   include_tasks: php-settings.yml
-  when: matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
+  when: nginx_high_php_limits or matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -64,7 +64,7 @@
     - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
     - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-  when: not nginx_high_php_limits and not moodle_install
+  when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
 
 - name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/cli/php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
   lineinfile:
@@ -78,10 +78,10 @@
     - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
     - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-  when: not nginx_high_php_limits and not moodle_install
+  when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
 
 
-- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle or INTENSIVE use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
   lineinfile:
     path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
     regexp: "{{ item.regexp }}"
@@ -93,9 +93,9 @@
     - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
     - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-  when: nginx_high_php_limits or moodle_install
+  when: nginx_high_php_limits or moodle_install or nextcloud_install
 
-- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for Moodle or INTENSIVE use of Matomo/Nextcloud/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow photos/docs up to 500MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
   lineinfile:
     path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
     regexp: "{{ item.regexp }}"
@@ -107,7 +107,7 @@
     - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
     - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-  when: nginx_high_php_limits or moodle_install
+  when: nginx_high_php_limits or moodle_install or nextcloud_install
 
 
 # To tweak .ini files, Ansible's ini_file is normally better than lineinfile:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -340,11 +340,12 @@ nmb_service: nmbd    # Could move to roles/samba/defaults/main.yml
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
+# Set to True if intensively using Matomo/PBX/WordPress:
 nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# SIMILARLY: 'moodle_install: True' and 'nextcloud_install: True' effectively
+# force this, via roles/www_options & roles/moodle & roles/nextcloud
+# WARNING: This might cause excess use of RAM/disk or other resources!
+# WARNING: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -211,11 +211,12 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
+# Set to True if intensively using Matomo/PBX/WordPress:
 nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# SIMILARLY: 'moodle_install: True' and 'nextcloud_install: True' effectively
+# force this, via roles/www_options & roles/moodle & roles/nextcloud
+# WARNING: This might cause excess use of RAM/disk or other resources!
+# WARNING: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -211,11 +211,12 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
+# Set to True if intensively using Matomo/PBX/WordPress:
 nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# SIMILARLY: 'moodle_install: True' and 'nextcloud_install: True' effectively
+# force this, via roles/www_options & roles/moodle & roles/nextcloud
+# WARNING: This might cause excess use of RAM/disk or other resources!
+# WARNING: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -211,11 +211,12 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
+# Set to True if intensively using Matomo/PBX/WordPress:
 nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# SIMILARLY: 'moodle_install: True' and 'nextcloud_install: True' effectively
+# force this, via roles/www_options & roles/moodle & roles/nextcloud
+# WARNING: This might cause excess use of RAM/disk or other resources!
+# WARNING: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -211,11 +211,12 @@ samba_enabled: False
 
 # roles/www_options HANDLES THE 3 VARS BELOW:
 
-# For schools using Moodle, or intensively using Matomo/Nextcloud/PBX/WordPress:
+# Set to True if intensively using Matomo/PBX/WordPress:
 nginx_high_php_limits: False
-# WARNING: Enabling this might cause excess use of RAM/disk or other resources!
-# roles/www_options & roles/moodle FORCE high limits if 'moodle_install: True'
-# REGARDLESS: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
+# SIMILARLY: 'moodle_install: True' and 'nextcloud_install: True' effectively
+# force this, via roles/www_options & roles/moodle & roles/nextcloud
+# WARNING: This might cause excess use of RAM/disk or other resources!
+# WARNING: AFTER INSTALLING IIAB, PLEASE VERIFY THESE 6 SETTINGS...
 # https://github.com/iiab/iiab/blob/master/roles/www_options/tasks/php-settings.yml
 # ...ARE SUITABLE FOR YOUR HARDWARE, as saved in: /etc/php/<VERSION>/*/php.ini
 # ALSO: ADJUST "client_max_body_size 500M;" AS NEC, IN: /etc/nginx/server.conf


### PR DESCRIPTION
Enough years have gone by that it's time to mandate 512 MB (both 'memory_limit = 512M' PHP settings) among those installing Nextcloud on IIAB.

Tested on Linux Mint 21.1

Related:

- PR #3208
- PR #3559