### PR TITLE
FIX: 'apt install gpg' required on Debian 12+ for apt installs of gitea, kolibri, mongodb (for sugarizer), yarn (for internetarchive)

### DIFF
--- a/roles/2-common/tasks/packages.yml
+++ b/roles/2-common/tasks/packages.yml
@@ -1,6 +1,6 @@
 # 2022-03-16: 'apt show <pkg> | grep Size' revealed download sizes, on 64-bit RasPiOS with desktop.
 
-- name: "Install 17 common packages: acpid, bzip2, cron, curl, gawk, htop, i2c-tools, logrotate, pandoc, pastebinit, plocate, rsync, sqlite3, tar, unzip, usbutils, wget"
+- name: "Install 18 common packages: acpid, bzip2, cron, curl, gawk, gpg, htop, i2c-tools, logrotate, pandoc, pastebinit, plocate, rsync, sqlite3, tar, unzip, usbutils, wget"
   package:
     name:
       - acpid              #   55kB download: Daemon for ACPI (power mgmt) events
@@ -11,6 +11,7 @@
       #- exfat-fuse        #   28kB download: 2021-07-27: Should no longer be nec with 5.4+ kernels, so let's try commenting it out
       #- exfat-utils       #   41kB download: Ditto!  See also 'ntfs-3g' below
       - gawk               #  533kB download
+      - gpg                #  884kB download: Debian 12+ (especially!) require this for apt installs of gitea, kolibri, mongodb, yarn
       - htop               #  109kB download: RasPiOS installs this regardless
       - i2c-tools          #   78kB download: Low-level bus/chip/register/EEPROM tools e.g. for RTC
       - logrotate          #   67kB download: RasPiOS installs this regardless


### PR DESCRIPTION
Tested on Debian 12.

Related:

- #3399