### PR TITLE
local_vars_large.yml: Set Lokole to False/False due to lack of mkwvconf wheel

### DIFF
--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -245,8 +245,8 @@ jupyterhub_install: True
 jupyterhub_enabled: True
 
 # Lokole (email for rural communities) from https://ascoderu.ca
-lokole_install: True    # 2022-03-13: Python 3.9+ work
-lokole_enabled: True    # https://github.com/iiab/iiab/issues/3132
+lokole_install: False    # 2023-09-06: wheel for mkwvconf still
+lokole_enabled: False    # missing from Ubuntu 23.10 (#3572)
 
 # Wikipedia's community editing platform - from MediaWiki.org
 mediawiki_install: True


### PR DESCRIPTION
Eliminate Lokole from LARGE-sized IIAB installs for now.

As too many people are running into this problem:

- #3572 
  - #3629
- PR #3591 