### PR TITLE
iiab-diagnostics: Change pastebinit service from dpaste.com back to sprunge.us

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -265,13 +265,13 @@ echo
 echo -e "\e[1m"
 #if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
 if ! [[ $ans =~ ^[nNqQ]$ ]]; then
-    echo -ne "PUBLISHING TO URL... "
-    #pastebinit -b sprunge.us < $outfile    # Stopped working mid-2023
+    echo -ne "PUBLISHING TO URL... "        # Run 'pastebinit -l' to list other possible pastebin site URLs
+    pastebinit -b sprunge.us < $outfile     # Stopped working for many weeks (mid-2023)
     #pastebinit -b paste2.org < $outfile    # Spammy/dangerous pastebins
-    pastebinit -b dpaste.com < $outfile    # Run 'pastebinit -l' to list other possible pastebin site URLs
+    #pastebinit -b dpaste.com < $outfile    # Claims 1,000,000 character maximum pastebin size, but not reliable
 else
     echo -e "If you later decide to publish it, run:"
     echo
-    echo -e "   pastebinit -b dpaste.com < $outfile"
+    echo -e "   pastebinit -b sprunge.us < $outfile"
 fi
 echo -e "\e[0m"

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -55,7 +55,7 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
    Or, you can later/manually upload it using the ``pastebinit`` command:
 
    ```
-   pastebinit -b dpaste.com < /etc/iiab/diag/NEW-FILE-NAME
+   pastebinit -b sprunge.us < /etc/iiab/diag/NEW-FILE-NAME
    ```
 
    Either way, this will generate an actual web link (URL).


### PR DESCRIPTION
As a result of dpaste.com having become unreliable with larger pastebins, in recent weeks, for reasons unknown.

Building on:

- PR #3618
- PR #3619