### PR TITLE
scripts/ansible: Evaluate 'apt install ansible-core' on "32-bit" RasPiOS 12 Bookworm

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -201,9 +201,11 @@ $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
 # 2023-09-08: 'apt install ansible-core' is overweight, but @EMG70 is trying it
-# on "32-bit" RasPiOS 12 too (regardless if it boot 32-bit or 64-bit kernel).
-# Ugly hack sufficient across the board, on all OS's purporting to be 32-bit?
-# (If so, similar to 32-bit Debian 12 on Intel/AMD a month ago...)
+# on "32-bit" RasPiOS 12 too (regardless if it boots 32-bit or 64-bit kernel,
+# i.e. whether or not booting a 32-bit kernel thanks to 'arm_64bit=0' in
+# /boot/config.txt per #3516).
+# IN SHORT: Ugly hack sufficient across the board, on all OS's purporting to be
+# 32-bit ?  (If so, similar to 32-bit Debian 12 on Intel/AMD a month ago...)
 if ! dpkg --print-architecture | grep -q 64; then
 #if [[ $(dpkg --print-architecture) == i386 ]]; then
     # 2023-08-10: Quick+Dirty (BRUTE FORCE) on legacy 32-bit i386 avoids #3547

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -200,13 +200,12 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-# 2023-09-08: 'apt install ansible-core' is overweight, but @EMG70 is trying it
-# on "32-bit" RasPiOS 12 too (regardless if it boots 32-bit or 64-bit kernel,
-# i.e. whether or not booting a 32-bit kernel thanks to 'arm_64bit=0' in
-# /boot/config.txt per #3516).
-# IN SHORT: Ugly hack sufficient across the board, on all OS's purporting to be
-# 32-bit ?  (If so, similar to 32-bit Debian 12 on Intel/AMD a month ago...)
-if ! dpkg --print-architecture | grep -q 64; then
+# 2023-09-08 PR #3634: 'apt install ansible-core' is overweight, but works on
+# "32-bit" RasPiOS 12 (@EMG70 set 'arm_64bit=0' in /boot/config.txt per #3516
+# to force boot its 32-bit kernel; its 64-bit kernel should work too!)
+# IN SHORT: This ugly hack appears sufficient for all "32-bit" Bookworm+ OS's
+# (similar to 32-bit Debian 12 on AMD/Intel a month ago, i.e. PR #3617).
+if ! dpkg --print-architecture | grep -q 64 && ! grep -q 11 /etc/debian_version; then
 #if [[ $(dpkg --print-architecture) == i386 ]]; then
     # 2023-08-10: Quick+Dirty (BRUTE FORCE) on legacy 32-bit i386 avoids #3547
     # rust/wheels/cryptography compiling mess!  DEBIAN 12+ OR SIMILAR REQUIRED!

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -200,7 +200,12 @@ echo -e "\napt update; apt install python3-venv"
 $APT_PATH/apt update
 $APT_PATH/apt -y install python3-venv
 
-if [[ $(dpkg --print-architecture) == i386 ]]; then
+# 2023-09-08: 'apt install ansible-core' is overweight, but @EMG70 is trying it
+# on "32-bit" RasPiOS 12 too (regardless if it boot 32-bit or 64-bit kernel).
+# Ugly hack sufficient across the board, on all OS's purporting to be 32-bit?
+# (If so, similar to 32-bit Debian 12 on Intel/AMD a month ago...)
+if ! dpkg --print-architecture | grep -q 64; then
+#if [[ $(dpkg --print-architecture) == i386 ]]; then
     # 2023-08-10: Quick+Dirty (BRUTE FORCE) on legacy 32-bit i386 avoids #3547
     # rust/wheels/cryptography compiling mess!  DEBIAN 12+ OR SIMILAR REQUIRED!
     $APT_PATH/apt -y install ansible-core    # Bookworm ~= ansible-core 2.14.3


### PR DESCRIPTION
Possible replacement for PR #3632 if @EMG70 has time to try this approach?

(NOT elegant... basically forcing the install of _old & overweight ansible-core 2.14.3..._ but might be easier than fighting "endless dependency hell" !)

Related:

- #3501
- #3516
- #3526
- PR #3617
- PR #3632