### PR TITLE
iiab-summary output was incomplete: (1) use 'uname -n' to show hostname (2) use 'uname -m' to show kernel arch for RasPiOS

### DIFF
--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -64,7 +64,7 @@ else
     echo "$(cat /etc/issue.net)   $(cat /etc/debian_version)"
 fi
 echo "display-manager? $(systemctl is-active display-manager.service)   Arch1: $(dpkg --print-architecture)   Arch2: $(dpkg --print-foreign-architectures)"
-uname -rvp
+uname -nrvm
 echo "$(lscpu | grep '^Model name:' | sed 's/^Model name:\s*//')   $(lscpu | grep '^CPU(s):' | tr -s ' ')   "$(free -m | tail -2 | tr -s ' ' | cut -d' ' -f1-2)
 if [ -f /proc/device-tree/model ]; then
     cat /proc/device-tree/model ; echo    # MORE RPi DETAIL: tail -4 /proc/cpuinfo


### PR DESCRIPTION
Actual running kernel's architecture (e.g. armv7l or aarch64, etc) has been missing from iiab-summary and iiab-diagnostics output on RasPiOS.

(Without getting overly verbose, this should help clarify iiab-summary output...)

Related:

- #3516 
- PR #3520
- #3526
- PR #3634