### PR TITLE
"32-bit" OS's more resilient: Verify that apt package 'ansible-core' is in fact available (equivalent to testing for Debian 12+ but safer!)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -206,7 +206,10 @@ $APT_PATH/apt -y install python3-venv
 # to force boot its 32-bit kernel; its 64-bit kernel should work too!)
 # IN SHORT: This ugly hack appears sufficient for all "32-bit" Bookworm+ OS's
 # (similar to 32-bit Debian 12 on AMD/Intel a month ago, i.e. PR #3617).
-if ! dpkg --print-architecture | grep -q 64 && ! grep -q 11 /etc/debian_version; then
+# 2023-09-10: Even safer test than querying for Debian 12+ -- verify that apt
+# package ansible-core is truly available:
+if ! dpkg --print-architecture | grep -q 64 && apt-cache show ansible-core > /dev/null; then
+#if ! dpkg --print-architecture | grep -q 64 && ! grep -q ^11 /etc/debian_version; then
 #if [[ $(dpkg --print-architecture) == i386 ]]; then
     # 2023-08-10: Quick+Dirty (BRUTE FORCE) on legacy 32-bit i386 avoids #3547
     # rust/wheels/cryptography compiling mess!  DEBIAN 12+ OR SIMILAR REQUIRED!


### PR DESCRIPTION
Building on:

- PR #3634

Related:

- #3501
- #3516
- #3526
- PR #3617
- PR #3632