### PR TITLE
install_python2.sh: ports.ubuntu.com apt sources for "32-bit" RasPiOS 12 — regardless whether booting 32-bit or 64-bit "armhf" kernels

### DIFF
--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -38,7 +38,8 @@ ARCH=$(dpkg --print-architecture)
 
 # libpython2.7-stdlib from ubuntu-22.04 used in amd64|arm64|armhf is compiled against libssl3 and libffi8
 # `apt info libpython2.7-stdlib`
-cd /tmp
+#cd /tmp
+
 case $ARCH in
     "amd64")
         # works on U23.04 x86_64 VM
@@ -58,12 +59,16 @@ EOF
 
     "armhf")
         # armhf compile flags differ between RasPiOS and Ubuntu
-        if ! [ -f /etc/rpi-issue ]; then
-            # these might change
+        if [ -f /etc/rpi-issue ] && ! grep -q 11 /etc/issue; then    # RasPiOS 12+ / Bookworm+
             cat << EOF > /etc/apt/sources.list.d/python2.list
-deb http://ports.ubuntu.com/ jammy main universe
-deb http://ports.ubuntu.com/ jammy-updates main universe
+deb [trusted=yes] http://ports.ubuntu.com/ jammy main universe
+deb [trusted=yes] http://ports.ubuntu.com/ jammy-updates main universe
 EOF
+#         elif ! [ -f /etc/rpi-issue ]; then    # Ubuntu/Debian on armhf not supported
+#             cat << EOF > /etc/apt/sources.list.d/python2.list
+# deb http://ports.ubuntu.com/ jammy main universe
+# deb http://ports.ubuntu.com/ jammy-updates main universe
+# EOF
         fi
         ;;
 


### PR DESCRIPTION
### Fixes bug:

- #3635

### Description of changes proposed in this pull request:

1) Tweak apt sources for "32-bit" RasPiOS 12.

2) Make clear that 32-bit Ubuntu/Debian are not supported on Raspberry Pi.

### Smoke-tested on which OS or OS's:

scripts/install_python2.sh verified to install apt package `python2` on both:

1) "32-bit" RasPiOS 12 on RPi 4 — running a 64-bit kernel i.e. `uname -a` showed `aarch64`

2) "32-bit" RasPiOS 12 on RPi 4 — running a 32-bit kernel i.e. `uname -a` showed `armv7l` — due to `arm_64bit=0` in `/boot/config.txt` (per #3516)

### Mention a team member @username e.g. to help with code review:

@EMG70