### PR TITLE
Strengthen pin of python3-virtualenv 20.13 in install_python2.sh for KA Lite: 'apt-mark hold python3-virtualenv'

### DIFF
--- a/scripts/install_python2.sh
+++ b/scripts/install_python2.sh
@@ -90,7 +90,7 @@ if grep -qi ubuntu /etc/os-release; then    # Ubuntu 23.10+ (and Mint 22+ ?) nee
     apt -y install python3-platformdirs=2.5.1-1
     apt-mark hold python3-platformdirs
     apt -y install python3-virtualenv=20.13.0+ds-2
-    apt-mark hold virtualenv
+    apt-mark hold python3-virtualenv    # 2023-09-26: 'apt-mark hold virtualenv' was definitely insufficient on Ubuntu 23.10
     # 2023-05-21 PR #3587: Above 4 lines should really install a more recent
     # version of virtualenv, probably from 'lunar' (Ubuntu 23.04) ?
 else


### PR DESCRIPTION
Only time will tell if this is quite enough?

But this PR is definitely stronger than the prior code — which was definitely insufficient to hold apt to `python3-virtualenv=20.13.0+ds-2` — e.g. on Ubuntu 23.10 `apt update && apt -y dist-upgrade` currently ignores the hold on `virtualenv`, upgrading to `python3-virtualenv=20.24.1+ds-1`

(While KA Lite on Python 2 lasts, likely another year or two maximum! :-)

Building on:

- #3573 
- PR #3582 
- PR #3587