### PR TITLE
scripts/ansible: Install cryptography==41.0.3 if dpkg 32-bit arch armhf (interim patch til https://piwheels.org/simple offers better 'cp39' coverage?)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -251,7 +251,8 @@ EOF
     #             new upstream piwheels fix (e.g. cryptography 41.0.3 for now)
     #             on pre-release 32-bit RasPiOS 12... (#3526)
     if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
-        /usr/local/ansible/bin/python3 -m pip install cryptography==41.0.3    # 2023-09-30: 41.0.4 fails for now, see #3650
+        $APT_PATH/apt -y install libffi-dev python3-dev    # 2023-09-30: cryptography 40.0.1 and 41.0.4 both fail for now, see #3650
+        /usr/local/ansible/bin/python3 -m pip install cryptography==41.0.3
         # else
         # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
         # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -250,14 +250,14 @@ EOF
     # 2023-09-07: Commenting out cryptography 40.0.1 below, as @EMG70 evaluates
     #             new upstream piwheels fix (e.g. cryptography 41.0.3 for now)
     #             on pre-release 32-bit RasPiOS 12... (#3526)
-    # if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
-    #     /usr/local/ansible/bin/python3 -m pip install cryptography==40.0.1
-    #     # else
-    #     # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
-    #     # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
-    #     # `dpkg --print-architecture` was i386 and `uname -m` was i686:
-    #     #     $APT_PATH/apt -y install python3-cryptography
-    # fi
+    if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
+        /usr/local/ansible/bin/python3 -m pip install cryptography==41.0.3    # 2023-09-30: 41.0.4 fails for now, see #3650
+        # else
+        # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
+        # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
+        # `dpkg --print-architecture` was i386 and `uname -m` was i686:
+        #     $APT_PATH/apt -y install python3-cryptography
+    fi
 
     # 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)
     /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core


### PR DESCRIPTION
### Fixes bug:

- #3650

### Description of changes proposed in this pull request:

Workaround:
`apt install libffi-dev python3-dev` then pip install `cryptography==41.0.3` into venv `/usr/local/ansible` — when `dpkg --print-architecture` detects 32-bit arch `armhf`.

As cryptography 41.0.4 is not yet installable on fully 32-bit RPi's.

FYI this patch might no longer be needed later in 2023, after `cp39` wheels (for Python 3.9 / Bullseye) begin to appear in places like:

https://www.piwheels.org/simple/cryptography/ e.g. for 41.0.4
https://www.piwheels.org/simple/cffi/ e.g. for 1.16.0

### Smoke-tested on which OS or OS's:

Fully 32-bit Raspberry Pi OS on RPi 4.

More testing can't hurt, given cryptography 40.0.1 which used to work also failed, and several new insights came to light at #3650.

Related:

- PR #3632
- PR #3638