### PR TITLE
scripts/ansible: 'pip install --prefer-binary ansible-core' is simpler/faster & more future-proof

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -250,18 +250,24 @@ EOF
     # 2023-09-07: Commenting out cryptography 40.0.1 below, as @EMG70 evaluates
     #             new upstream piwheels fix (e.g. cryptography 41.0.3 for now)
     #             on pre-release 32-bit RasPiOS 12... (#3526)
-    if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
-        $APT_PATH/apt -y install libffi-dev python3-dev    # 2023-09-30: cryptography 40.0.1 and 41.0.4 both fail for now, see #3650
-        /usr/local/ansible/bin/python3 -m pip install cryptography==41.0.3
-        # else
-        # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
-        # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
-        # `dpkg --print-architecture` was i386 and `uname -m` was i686:
-        #     $APT_PATH/apt -y install python3-cryptography
-    fi
+    # if [[ $(dpkg --print-architecture) == armhf ]]; then    # 32-bit ARM
+    #     # 2023-09-30: cryptography 40.0.1 and 41.0.4 both fail for now, see #3650
+    #     $APT_PATH/apt -y install libffi-dev python3-dev
+    #     /usr/local/ansible/bin/python3 -m pip install cryptography==41.0.3
+    #     # else
+    #     # 2023-08-10: 'apt install rustc pkg-config libssl-dev' was not enough!
+    #     # So we use apt to install cryptography 38.0.4 for Debian 12.1 -- where
+    #     # `dpkg --print-architecture` was i386 and `uname -m` was i686:
+    #     #     $APT_PATH/apt -y install python3-cryptography
+    # fi
 
     # 2023-05-22: 2.14.6 was better than 2.15.0 for FreePBX (#3588, ansible/ansible#80863)
-    /usr/local/ansible/bin/python3 -m pip install --upgrade ansible-core
+    # 2023-10-01 #3650: --prefer-binary or --only-binary ensure you get wheels,
+    # even if they're not the very latest release -- thereby avoiding compiling
+    # messes -- and obviating the need for these 2: (above, both commented out)
+    # - 'install libffi-dev python3-dev'
+    # - painstaking pinning of cryptography or cffi (etc) to older version numbers
+    /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core
     echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
     cd /usr/local/ansible/bin
     for bin in ansible*; do

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -265,8 +265,8 @@ EOF
     # 2023-10-01 #3650: --prefer-binary or --only-binary ensure you get wheels,
     # even if they're not the very latest release -- thereby avoiding compiling
     # messes -- and obviating the need for these 2: (above, both commented out)
-    # - 'install libffi-dev python3-dev'
-    # - painstaking pinning of cryptography or cffi (etc) to older version numbers
+    # - 'apt -y install libffi-dev python3-dev'
+    # - painstaking pinning of cryptography or cffi (etc) to older version #s
     /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core
     echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
     cd /usr/local/ansible/bin


### PR DESCRIPTION
More future-proof solution than even:

- PR #3651 

Huge thanks to those who provided essential, breakthrough tips here:

- #3650

Tangentially related:

- #3547
- PR #3615 
- PR #3617
- PR #3632