### PR TITLE
32-bit fixes (Calibre-Web, JuperterHub, Moodle) + defer iiab-install of Internet Archive if 32-bit

### DIFF
--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -14,10 +14,23 @@
     name: captiveportal
   when: captiveportal_install
 
+# WARNING: Since March 2023, 32-bit RasPiOS can act as 64-bit on RPi 4 and
+# RPi 400 (unlike RPi 3!)  SEE: https://github.com/iiab/iiab/pull/3516
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NO LONGER enough!)
+  command: dpkg --print-architecture
+  register: dpkg_arch
+  when: internetarchive_install
+
+- name: Explain bypassing of Internet Archive install if 32-bit OS
+  fail:    # FORCE IT RED THIS ONCE!
+    msg: "BYPASSING INTERNET ARCHIVE PER https://github.com/iiab/iiab/issues/3641 -- 'dpkg --print-architecture' output for your OS: {{ dpkg_arch.stdout }}"
+  when: internetarchive_install and not dpkg_arch.stdout is search("64")
+  ignore_errors: True
+
 - name: INTERNETARCHIVE
   include_role:
     name: internetarchive
-  when: internetarchive_install
+  when: internetarchive_install and dpkg_arch.stdout is search("64")
 
 - name: MINETEST
   include_role:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -63,8 +63,9 @@
   pip:
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
-    virtualenv_site_packages: no
+    #virtualenv_site_packages: no
     virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
+    extra_args: --prefer-binary    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 # VIRTUALENV EXAMPLE COMMANDS:
 # cd /usr/local/calibre-web-py3

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -53,7 +53,7 @@
     virtualenv_site_packages: no
     virtualenv_command: python3 -m venv --system-site-packages "{{ jupyterhub_venv }}"    # 2021-07-29: This works on RasPiOS 10, Debian 11, Ubuntu 20.04 and Mint 20 -- however if you absolutely must use the older Debian 10 -- you can work around errors "can't find Rust compiler" and "This package requires Rust >=1.41.0" if you (1) revert this line to 'virtualenv_command: virtualenv' AND (2) uncomment the line just below
     #virtualenv_python: python3    # 2021-07-29: Was needed when above line was 'virtualenv_command: virtualenv' (generally for Python 2)
-    extra_args: "--no-cache-dir"    # 2021-11-30, 2022-07-07: The "--pre" flag had earlier been needed, for beta-like pre-releases of JupyterHub 2.0.0
+    extra_args: "--no-cache-dir --prefer-binary"    # 2021-11-30, 2022-07-07: The "--pre" flag had earlier been needed, for beta-like pre-releases of JupyterHub 2.0.0
 
 # 2022-07-07: Attempting to "pip install" all 7 together (3 above + 4 below)
 # fails on OS's like 64-bit RasPiOS (but interestingly works on Ubuntu 22.04!)
@@ -69,7 +69,7 @@
     virtualenv: "{{ jupyterhub_venv }}"
     virtualenv_site_packages: no
     virtualenv_command: python3 -m venv --system-site-packages "{{ jupyterhub_venv }}"
-    extra_args: "--no-cache-dir"
+    extra_args: "--no-cache-dir --prefer-binary"    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 - name: "Install from template: {{ jupyterhub_venv }}/etc/jupyterhub/jupyterhub_config.py"
   template:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -71,10 +71,16 @@
   when: opt_iiab_moodle.stat.exists
 
 
-- name: "2023-04-30: MOODLE 4.2+ REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER MOODLE 4.1 LTS ON OS's WITH PHP 7.x -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
+# WARNING: Since March 2023, 32-bit RasPiOS can act as 64-bit on RPi 4 and
+# RPi 400 (unlike RPi 3!)  SEE: https://github.com/iiab/iiab/pull/3516
+- name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NO LONGER enough!)
+  command: dpkg --print-architecture
+  register: dpkg_arch
+
+- name: "2023-04-30: MOODLE 4.2+ REQUIRES PHP 8 AND *FULL* 64-BIT OPERATION -- SO WE REVERT TO INSTALLING THE OLDER MOODLE 4.1 LTS WHEN NECESSARY -- NOTE PHP 7.x END-OF-LIFE WAS NOVEMBER 2022"
   set_fact:
     moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
-  when: php_version is version('8.0', '<')
+  when: php_version is version('8.0', '<') or not dpkg_arch.stdout is search("64")
 
 - name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.3
   git:


### PR DESCRIPTION
### Fixes 4 bugs:

- #3639 
- #3640 
- #3641 
- #3642

### Description of changes proposed in this pull request:

- pip with Ansible's `extra_args: --prefer-binary` resolves Calibre-Web (3642) and JupyterHub (3639) installs on 32-bit ✅
- Moodle version is reverted to 4.1 (LTS) in more cases for 3640 — i.e. not only in cases where PHP < 8.0 _BUT ALSO_ in cases where `dpkg --print-architecture` detects 32-bit _(further validation will be helpful here, e.g. to reconfirm on 32-bit RasPiOS running with 64-bit kernel!)_
- Installation of the Internet Archive app/service is deferred during iiab-install if `dpkg --print-architecture` detects 32-bit, for 3641 — intentionally allowing later install attempts-or-refinements using `./runrole internetarchive` or Admin Console ⚠️

### Smoke-tested on which OS or OS's:

Fully 32-bit Raspberry OS Bullseye, i.e. booted with `arm_64bit=0` in `/boot/config.txt` per March 2023 OS behavior change (#3516).

### Mention a team member @username e.g. to help with code review:

@EMG70 will further test for corner cases later this week on 2023-10-06, e.g. using Raspberry Pi OS Bookworm (#3526) just prior to its release in [mid-October](https://raspberrypi.com/5), _Thank You Ed!_

This PR builds on:

- PR #3422
- #3503
- #3547
- PR #3567
- #3650
  - PR #3652