### PR TITLE
Push Moodle 4.3 (released 2023-10-09) for wider testing, and Moodle 4.4dev if PHP >= 8.3 (e.g. new OS's)

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -11,7 +11,7 @@
 # 2023-04-25: Currently testing Moodle's master branch is mandatory if your
 # OS PHP >= 8.3, see moodle/tasks/install.yml for detail!  OR, *IF* your
 # OS PHP < 8.3, then {{ moodle_version }} will be attempted:
-moodle_version: MOODLE_402_STABLE    # Moodle 4.2
+moodle_version: MOODLE_403_STABLE    # Moodle 4.3
 #moodle_version: master              # e.g. to try Moodle's "weekly" 4.2dev pre-release *EVEN IF* OS PHP < 8.2
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -87,7 +87,7 @@
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
-    version: "{{ moodle_version }}"    # e.g. MOODLE_402_STABLE (Moodle 4.2)
+    version: "{{ moodle_version }}"    # e.g. MOODLE_403_STABLE (Moodle 4.3)
   when: php_version is version('8.3', '<')
 
 - name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.3"
@@ -95,7 +95,7 @@
     repo: "{{ moodle_repo_url }}"
     dest: "{{ moodle_base }}"
     depth: 1
-    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023)
+    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023, 4.4dev in Oct 2023)
   when: php_version is version('8.3', '>=')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -82,7 +82,7 @@
     moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
   when: php_version is version('8.0', '<') or not dpkg_arch.stdout is search("64")
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} < 8.3
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~403 MB initially, ~431 MB later) if OS PHP {{ php_version }} < 8.3
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
@@ -90,7 +90,7 @@
     version: "{{ moodle_version }}"    # e.g. MOODLE_403_STABLE (Moodle 4.3)
   when: php_version is version('8.3', '<')
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~389 MB initially, ~416 MB later) if OS PHP {{ php_version }} >= 8.3"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~403 MB initially, ~431 MB later) if OS PHP {{ php_version }} >= 8.3"
   git:
     repo: "{{ moodle_repo_url }}"
     dest: "{{ moodle_base }}"


### PR DESCRIPTION
Building on:

- PR #3470
- PR #3551 
- PR #3558 
- PR #3559
- PR #3653

Testing is underway on Ubuntu 23.10