### PR TITLE
PR For Discussion: "Just install systemd-resolved at the same place as systemd-networkd is installed"

### DIFF
--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -32,6 +32,7 @@
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
+      - systemd-resolved       #  278kB download: For RasPiOS Bookworm (#3657)
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
       - wireless-tools         #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -40,7 +40,7 @@
 - name: Install systemd-resolved if RasPiOS 12+ (package does not exist on Ubuntu! and is seemingly unneeded on pure Debian 12?)
   package:
     name: systemd-resolved     #  278kB download: For RasPiOS Bookworm (#3657)
-  when: is_raspios and os_ver is version('raspios-12', '>=')
+  when: is_raspbian and os_ver is version('raspbian-12', '>=')
 
 # 2021-08-17: Debian ignores this, according to 2013 post:
 # https://serverfault.com/questions/511099/debian-ignores-etc-network-if-pre-up-d-iptables

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -32,11 +32,15 @@
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
-      - systemd-resolved       #  278kB download: For RasPiOS Bookworm (#3657)
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
       - wireless-tools         #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
+
+- name: Install systemd-resolved if RasPiOS 12+ (package does not exist on Ubuntu! and is seemingly unneeded on pure Debian 12?)
+  package:
+    name: systemd-resolved     #  278kB download: For RasPiOS Bookworm (#3657)
+  when: is_raspios and os_ver is version('raspios-12', '>=')
 
 # 2021-08-17: Debian ignores this, according to 2013 post:
 # https://serverfault.com/questions/511099/debian-ignores-etc-network-if-pre-up-d-iptables

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -37,6 +37,8 @@
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
 
+# 2023-10-11: Trying to install 'systemd-resolved' alongside 'systemd-networkd'
+# but that's not an apt package: it seems to be part of core package 'systemd'
 - name: Install systemd-resolved if RasPiOS 12+ (package does not exist on Ubuntu! and is seemingly unneeded on pure Debian 12?)
   package:
     name: systemd-resolved     #  278kB download: For RasPiOS Bookworm (#3657)

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -75,13 +75,12 @@
   - name: NetworkManager in use
     include_tasks: NM-debian.yml
     when: network_manager_active
-    #when: is_debuntu and network_manager_active
 
   - name: systemd-networkd in use
     include_tasks: sysd-netd-debian.yml
-    when: systemd_networkd_active
-    #when: is_debuntu and systemd_networkd_active
+    when: systemd_networkd_active and not network_manager_active
 
+  # 2023-10-11: Should rpi_debian.yml go away in future, now that RasPiOS Bookworm uses NetworkManager?
   - name: Raspbian can use dhcpcd only with no N-M or SYS-NETD active
     include_tasks: rpi_debian.yml
     when: is_raspbian and not network_manager_active

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -78,7 +78,8 @@
 
   - name: systemd-networkd in use
     include_tasks: sysd-netd-debian.yml
-    when: systemd_networkd_active and not network_manager_active
+    when: systemd_networkd_active
+    #when: systemd_networkd_active and not network_manager_active   # 2023-10-11: Not the right way to solve #3657 (systemd-resolved issue on RasPiOS 12+) as this would damage Ubuntu/Mint.
 
   # 2023-10-11: Should rpi_debian.yml go away in future, now that RasPiOS Bookworm uses NetworkManager?
   - name: Raspbian can use dhcpcd only with no N-M or SYS-NETD active


### PR DESCRIPTION
[Former ticket title: Don't run sysd-netd-debian.yml if NetworkManager active?]

@jvonau would know much better (good chance he has a much better approach).

So this PR is just a stub towards getting things right for the new RasPiOS Bookworm, towards better understand and then resolving this issue:

- #3657

Related:

- #3399