### PR TITLE
Patch 8

### DIFF
--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -31,7 +31,6 @@
       - libnss-mdns            #   27kB download: RasPiOS (and package avahi-daemon, above) install this regardless -- client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
-      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
       - wireless-tools         #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -4,10 +4,10 @@
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
-- name: 'Install networkd-resolved
+- name: 'Install systemd-resolved for RasPiOS
   package:
     name:
-      - networkd-resolved
+      - systemd-resolved
   when:  is_raspbian and os_ver is version('raspbian-12', '>=')   
 
 - name: Copy the bridge script - Creates br0

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -4,6 +4,12 @@
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
+- name: 'Install networkd-resolved
+  package:
+    name:
+      - networkd-resolved
+  when:  is_raspbian and os_ver is version('raspbian-12', '>=')   
+
 - name: Copy the bridge script - Creates br0
   template:
     dest: /etc/systemd/network/IIAB-Bridge.netdev

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,5 +1,5 @@
 # sysd-netd-debian.yml
-- name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
+- name: 'Install networkd-dispatcher
   package:
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,4 +1,11 @@
 # sysd-netd-debian.yml
+- name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
+  package:
+    name:
+      - systemd-networkd
+      - systemd-resolved
+      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
+
 - name: Copy the bridge script - Creates br0
   template:
     dest: /etc/systemd/network/IIAB-Bridge.netdev

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -2,8 +2,6 @@
 - name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
   package:
     name:
-      - systemd-networkd
-      - systemd-resolved
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
 - name: Copy the bridge script - Creates br0


### PR DESCRIPTION
### Fixes bug:
RasPiOS
### Description of changes proposed in this pull request:
Ubuntu's Netplan has both NM and sysd preinstalled, account for what RasPiOS might be missing
### Smoke-tested on which OS or OS's:
not yet
### Mention a team member @username e.g. to help with code review:
