### PR TITLE
sysd-netd-debian.yml: Install apt package 'systemd-resolved' if OS offers it (RasPiOS Bookworm issue)

### DIFF
--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -31,7 +31,6 @@
       - libnss-mdns            #   27kB download: RasPiOS (and package avahi-daemon, above) install this regardless -- client-side library -- provides name resolution via mDNS (Multicast DNS) using Zeroconf/Bonjour e.g. Avahi
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
-      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
       - wireless-tools         #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -75,13 +75,13 @@
   - name: NetworkManager in use
     include_tasks: NM-debian.yml
     when: network_manager_active
-    #when: is_debuntu and network_manager_active
 
   - name: systemd-networkd in use
     include_tasks: sysd-netd-debian.yml
     when: systemd_networkd_active
-    #when: is_debuntu and systemd_networkd_active
+    #when: systemd_networkd_active and not network_manager_active    # 2023-10-11: NOT the right way to solve #3657 (systemd-resolved issue on RasPiOS 12+) as this would damage Ubuntu/Mint.
 
+  # 2023-10-11: Should rpi_debian.yml go away in future, now that RasPiOS Bookworm uses NetworkManager?
   - name: Raspbian can use dhcpcd only with no N-M or SYS-NETD active
     include_tasks: rpi_debian.yml
     when: is_raspbian and not network_manager_active

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -4,10 +4,10 @@
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
-- name: 'Install networkd-resolved
+- name: 'Install systemd-resolved for RasPiOS
   package:
     name:
-      - networkd-resolved
+      - systemd-resolved
   when:  is_raspbian and os_ver is version('raspbian-12', '>=')   
 
 - name: Copy the bridge script - Creates br0

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -4,6 +4,12 @@
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
+- name: 'Install networkd-resolved
+  package:
+    name:
+      - networkd-resolved
+  when:  is_raspbian and os_ver is version('raspbian-12', '>=')   
+
 - name: Copy the bridge script - Creates br0
   template:
     dest: /etc/systemd/network/IIAB-Bridge.netdev

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,5 +1,5 @@
 # sysd-netd-debian.yml
-- name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
+- name: 'Install networkd-dispatcher
   package:
     name:
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,14 +1,19 @@
 # sysd-netd-debian.yml
-- name: 'Install networkd-dispatcher
+- name: Install networkd-dispatcher
   package:
-    name:
-      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
+    name: networkd-dispatcher                       #  15kB download: Dispatcher service for systemd-networkd connection status changes
 
-- name: 'Install systemd-resolved for RasPiOS
+# 2023-10-14 #3657, #3658, #3659: New RasPiOS 12/Bookworm issue.
+# FWIW Ubuntu >= 22.10 offers 'systemd-resolved' as a distinct apt package.
+# Whereas Ubuntu <= 22.04 bundled the functionality within apt package 'systemd'
+# Debian 12/Bookworm (like Ubuntu >= 22.10) offers it as a distinct package:
+# https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#systemd-resolved
+- name: Install systemd-resolved (or intentionally show red error then continue, if apt package not available)
   package:
-    name:
-      - systemd-resolved
-  when:  is_raspbian and os_ver is version('raspbian-12', '>=')   
+    name: systemd-resolved    # 278kB download: For RasPiOS 12/Bookworm
+  ignore_errors: yes
+  #shell: apt -y install systemd-resolved || true
+  #when: is_raspbian and os_ver is version('raspbian-12', '>=')
 
 - name: Copy the bridge script - Creates br0
   template:

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,4 +1,11 @@
 # sysd-netd-debian.yml
+- name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
+  package:
+    name:
+      - systemd-networkd
+      - systemd-resolved
+      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
+
 - name: Copy the bridge script - Creates br0
   template:
     dest: /etc/systemd/network/IIAB-Bridge.netdev

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -2,8 +2,6 @@
 - name: 'Install systemd-networkd, systemd-resolved, networkd-dispatcher
   package:
     name:
-      - systemd-networkd
-      - systemd-resolved
       - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes
 
 - name: Copy the bridge script - Creates br0

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,7 +1,7 @@
 # sysd-netd-debian.yml
 - name: Install networkd-dispatcher
   package:
-    name: networkd-dispatcher                       #  15kB download: Dispatcher service for systemd-networkd connection status changes
+    name: networkd-dispatcher    #  15kB download: Dispatcher service for systemd-networkd connection status changes
 
 # 2023-10-14 #3657, #3658, #3659: New RasPiOS 12/Bookworm issue.
 # FWIW Ubuntu >= 22.10 offers 'systemd-resolved' as a distinct apt package.
@@ -10,7 +10,7 @@
 # https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#systemd-resolved
 - name: Install systemd-resolved (or intentionally show red error then continue, if apt package not available)
   package:
-    name: systemd-resolved    # 278kB download: For RasPiOS 12/Bookworm
+    name: systemd-resolved       # 278kB download: For RasPiOS 12/Bookworm
   ignore_errors: yes
   #shell: apt -y install systemd-resolved || true
   #when: is_raspbian and os_ver is version('raspbian-12', '>=')


### PR DESCRIPTION
Thanks to @jvonau and @tim-moody progress working towards solving:

- #3657

This PR seeks to expand testing across more OS's/versions, by building on:

- PR #3659

Related:

- #3526