### PR TITLE
Support Ubuntu 24.04 pre-releases

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -775,6 +775,7 @@ pbx_http_port: 83
 is_debuntu: False    # Covers all 4: Ubuntu, Linux Mint, Debian, Raspberry Pi OS (Raspbian)
 
 is_ubuntu: False    # Covers: Ubuntu, Linux Mint
+is_ubuntu_2404: False
 is_ubuntu_2310: False
 is_ubuntu_2304: False
 is_ubuntu_2210: False

--- a/vars/ubuntu-2404.yml
+++ b/vars/ubuntu-2404.yml
@@ -1,0 +1,5 @@
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
+is_ubuntu_2404: True


### PR DESCRIPTION
Building on:

- PR #3622 
- #3662

IIAB preliminary support for Ubuntu 24.04 is outlined here:

- https://github.com/iiab/iiab/wiki/IIAB-Platforms#ubuntu-2404