### PR TITLE
Install MySQL/MariaDB on-demand--for MediaWiki, [Nextcloud,] WordPress, Matomo &/or Admin Console

### DIFF
--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -64,7 +64,7 @@
 # 2020-11-04: Fix validation of 5 [now 4] core dependencies, for ./runrole etc
 
 
-- name: Set vars_checklist for 44 + 44 + 40 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
+- name: Set vars_checklist for 45 + 45 + 40 vars ("XYZ_install" + "XYZ_enabled" + "XYZ_installed") to be checked
   set_fact:
     vars_checklist:
       - hostapd
@@ -76,7 +76,7 @@
       - admin_console
       #- nginx              # MANDATORY
       #- apache             # Unmaintained - former dependency
-      #- mysql              # MANDATORY
+      - mysql               # Dependency - excluded from _installed check below
       - squid
       - cups
       - samba
@@ -155,7 +155,7 @@
     that: "{{ item }}_install or {{ item }}_installed is undefined"
     fail_msg: "DISALLOWED: '{{ item }}_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN '{{ item }}_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
     quiet: yes
-  when: item != 'nodejs' and item != 'postgresql' and item != 'mongodb' and item != 'yarn'    # Exclude auto-installed dependencies
+  when: item != 'mysql' and item != 'postgresql' and item != 'mongodb' and item != 'nodejs' and item != 'yarn'    # Exclude auto-installed dependencies
   loop: "{{ vars_checklist }}"
 
 - name: 'DISALLOW "XYZ_install: True" if deprecated'

--- a/roles/0-init/tasks/validate_vars.yml
+++ b/roles/0-init/tasks/validate_vars.yml
@@ -76,7 +76,6 @@
       - admin_console
       #- nginx              # MANDATORY
       #- apache             # Unmaintained - former dependency
-      - mysql               # Dependency - excluded from _installed check below
       - squid
       - cups
       - samba
@@ -85,6 +84,7 @@
       - gitea
       - jupyterhub
       - lokole
+      - mysql               # Dependency - excluded from _installed check below
       - mediawiki
       - mosquitto
       - nodejs              # Dependency - excluded from _installed check below

--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -15,7 +15,7 @@
 
 This 3rd `stage <https://github.com/iiab/iiab/wiki/IIAB-Contributors-Guide#ansible>`_ installs base server infra that `Internet-in-a-Box (IIAB) <https://internet-in-a-box.org/>`_ requires, including:
 
-- |ss| `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps). |se|  (NEW of 2023-11-05, MySQL / MariaDB is instead installed on demand  as a dependency of Matomo, MediaWiki, WordPress &/or Admin Console.)  This IIAB role also installs apt package:
+- |ss| `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps). |se| |nbsp|  *As of 2023-11-05, MySQL / MariaDB is NO LONGER INSTALLED by 3-base-server — instead it's installed on-demand — as a dependency of Matomo, MediaWiki, WordPress &/or Admin Console.*  This IIAB role (roles/mysql) also installs apt package:
    - **php{{ php_version }}-mysql** — which forcibly installs **php{{ php_version }}-common**
 - `NGINX <https://github.com/iiab/iiab/blob/master/roles/nginx>`_ web server (with Apache in some lingering cases).  This IIAB role also installs apt package:
    - **php{{ php_version }}-fpm** — which forcibly installs **php{{ php_version }}-cli**, **php{{ php_version }}-common** and **libsodium23**

--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -1,10 +1,21 @@
+.. |ss| raw:: html
+
+   <strike>
+
+.. |se| raw:: html
+
+   </strike>
+
+.. |nbsp| unicode:: 0xA0
+   :trim:
+
 ====================
 3-base-server README
 ====================
 
 This 3rd `stage <https://github.com/iiab/iiab/wiki/IIAB-Contributors-Guide#ansible>`_ installs base server infra that `Internet-in-a-Box (IIAB) <https://internet-in-a-box.org/>`_ requires, including:
 
-- `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps).  This IIAB role also installs apt package:
+- |ss| `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps). |se|  (NEW of 2023-11-05, MySQL / MariaDB is instead installed on demand  as a dependency of Matomo, MediaWiki, WordPress &/or Admin Console.)  This IIAB role also installs apt package:
    - **php{{ php_version }}-mysql** — which forcibly installs **php{{ php_version }}-common**
 - `NGINX <https://github.com/iiab/iiab/blob/master/roles/nginx>`_ web server (with Apache in some lingering cases).  This IIAB role also installs apt package:
    - **php{{ php_version }}-fpm** — which forcibly installs **php{{ php_version }}-cli**, **php{{ php_version }}-common** and **libsodium23**

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -3,10 +3,13 @@
 - name: ...IS BEGINNING =====================================
   meta: noop
 
-- name: MYSQL + CORE PHP
-  include_role:
-    name: mysql
-  #when: mysql_install
+# 2023-11-05: MySQL (actually MariaDB) had been mandatory, installed on every
+# IIAB by 3-base-server.  Now installed on demand -- as a dependency of Matomo,
+# MediaWiki, WordPress &/or Admin Console.
+# - name: MYSQL + CORE PHP
+#   include_role:
+#     name: mysql
+#   #when: mysql_install
 
 # 2021-05-21: Apache role 'httpd' is installed as nec by any of these 6 roles:
 #

--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -23,11 +23,6 @@
     name: monit
   when: monit_install
 
-- name: MUNIN
-  include_role:
-    name: munin
-  when: munin_install
-
 - name: PHPMYADMIN
   include_role:
     name: phpmyadmin

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -55,6 +55,24 @@
     name: pbx
   when: pbx_install
 
+
+- name: '2023-11-05 / TEMPORARY UNTIL ADMIN CONSOLE DECLARES ITS DEPENDENCY: Install MySQL (MariaDB) if admin_console_install (for setup-feedback and record_feedback.php)'
+  set_fact:
+    mysql_install: True
+    mysql_enabled: True
+  when: admin_console_install
+
+- name: '2023-11-05 / TEMPORARY UNTIL ADMIN CONSOLE DECLARES ITS DEPENDENCY: Install MySQL (MariaDB) if admin_console_install (for setup-feedback and record_feedback.php)'
+  include_role:
+    name: mysql
+  when: admin_console_install
+
+- name: '2023-11-05 / TEMPORARY UNTIL ADMIN CONSOLE DECLARES ITS DEPENDENCY: Install MySQL (MariaDB) if admin_console_install (for setup-feedback and record_feedback.php)'
+  fail:
+    msg: "Admin Console install cannot proceed, as MySQL / MariaDB is not installed."
+  when: admin_console_install and mysql_installed is undefined
+
+
 - name: Read 'disk_used_a_priori' from /etc/iiab/iiab.ini
   set_fact:
     df1: "{{ lookup('ansible.builtin.ini', 'disk_used_a_priori', section='summary', file=iiab_ini_file) }}"

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -73,6 +73,13 @@
   when: admin_console_install and mysql_installed is undefined
 
 
+# 2023-11-05: Moved from Stage 8, as it acts on mysql_installed (that might be set just above!)
+- name: MUNIN
+  include_role:
+    name: munin
+  when: munin_install
+
+
 - name: Read 'disk_used_a_priori' from /etc/iiab/iiab.ini
   set_fact:
     df1: "{{ lookup('ansible.builtin.ini', 'disk_used_a_priori', section='summary', file=iiab_ini_file) }}"

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -12,6 +12,21 @@
 # fatal: [127.0.0.1]: FAILED! => {"cache_control": "private, no-cache, no-store", "changed": false, "connection": "close", "content_type": "text/html; charset=utf-8", "date": "Wed, 15 Jun 2022 05:07:41 GMT", "elapsed": 0, "expires": "Thu, 19 Nov 1981 08:52:00 GMT", "msg": "Status code was 500 and not [200]: HTTP Error 500: Internal Server Error", "pragma": "no-cache", "redirected": false, "server": "nginx/1.18.0 (Ubuntu)", "set_cookie": "MATOMO_SESSID=psak3aem27vrdrt8t2f016600f; path=/; HttpOnly; SameSite=Lax", "status": 500, "transfer_encoding": "chunked", "url": "http://box.lan/matomo/index.php?action=welcome", "x_matomo_request_id": "fbfd2"}
 
 
+- name: "Set 'mysql_install: True' and 'mysql_enabled: True'"
+  set_fact:
+    mysql_install: True
+    mysql_enabled: True
+
+- name: MYSQL - run 'mysql' role (attempt to install & enable MySQL / MariaDB)
+  include_role:
+    name: mysql
+
+- name: FAIL (STOP THE INSTALL) IF 'mysql_installed is undefined'
+  fail:
+    msg: "Matomo install cannot proceed, as MySQL / MariaDB is not installed."
+  when: mysql_installed is undefined
+
+
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,3 +1,18 @@
+- name: "Set 'mysql_install: True' and 'mysql_enabled: True'"
+  set_fact:
+    mysql_install: True
+    mysql_enabled: True
+
+- name: MYSQL - run 'mysql' role (attempt to install & enable MySQL / MariaDB)
+  include_role:
+    name: mysql
+
+- name: FAIL (STOP THE INSTALL) IF 'mysql_installed is undefined'
+  fail:
+    msg: "MediaWiki install cannot proceed, as MySQL / MariaDB is not installed."
+  when: mysql_installed is undefined
+
+
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -32,7 +32,7 @@
     name: "{{ munin_username}}"         # Admin
     password: "{{ munin_password }}"    # changeme
 
-- name: If MySQL is enabled, let Munin monitor it
+- name: If MySQL is installed, let Munin monitor it
   copy:
     src: "{{ item }}"
     dest: /etc/munin/plugins/
@@ -44,7 +44,8 @@
     - /usr/share/munin/plugins/mysql_queries
     - /usr/share/munin/plugins/mysql_slowqueries
     - /usr/share/munin/plugins/mysql_threads
-  when: mysql_enabled
+  when: mysql_installed
+  #when: mysql_enabled
 
 
 # RECORD Munin AS INSTALLED

--- a/roles/mysql/tasks/enable-or-disable.yml
+++ b/roles/mysql/tasks/enable-or-disable.yml
@@ -1,0 +1,15 @@
+- name: Enable & Start MySQL ({{ mysql_service }}) systemd service, if mysql_enabled
+  systemd:
+    name: "{{ mysql_service }}"
+    daemon_reload: yes
+    state: started
+    enabled: yes
+  when: mysql_enabled
+
+# We had to start MySQL in order to configure it, now turn if off if not enabled
+- name: Disable & Stop MySQL ({{ mysql_service }}) systemd service, if not mysql_enabled
+  systemd:
+    name: "{{ mysql_service }}"
+    enabled: no
+    state: stopped
+  when: not mysql_enabled

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -26,40 +26,33 @@
     var: mysql_installed
 
 
-- name: Install MySQL if 'mysql_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
-  include_tasks: install.yml
-  when: mysql_installed is undefined
+- block:
 
+  - name: Install MySQL if 'mysql_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
+    include_tasks: install.yml
+    when: mysql_installed is undefined
 
-- name: Enable & Start MySQL ({{ mysql_service }}) systemd service, if mysql_enabled
-  systemd:
-    name: "{{ mysql_service }}"
-    daemon_reload: yes
-    state: started
-    enabled: yes
-  when: mysql_enabled
+  - include_tasks: enable-or-disable.yml
 
-# We had to start MySQL in order to configure it, now turn if off if not enabled
-- name: Disable & Stop MySQL ({{ mysql_service }}) systemd service, if not mysql_enabled
-  systemd:
-    name: "{{ mysql_service }}"
-    enabled: no
-    state: stopped
-  when: not mysql_enabled
+  - name: Add 'mysql' variable values to {{ iiab_ini_file }}
+    ini_file:
+      path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+      section: mysql
+      option: "{{ item.option }}"
+      value: "{{ item.value | string }}"
+    with_items:
+      - option: name
+        value: MySQL
+      - option: description
+        value: '"MySQL is a widely used free and open source (GPLv2) database, offered by most web hosting services, on a diversity of platforms."'
+      - option: mysql_install
+        value: "{{ mysql_install }}"
+      - option: mysql_enabled
+        value: "{{ mysql_enabled }}"
 
+  rescue:
 
-- name: Add 'mysql' variable values to {{ iiab_ini_file }}
-  ini_file:
-    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
-    section: mysql
-    option: "{{ item.option }}"
-    value: "{{ item.value | string }}"
-  with_items:
-    - option: name
-      value: MySQL
-    - option: description
-      value: '"MySQL is a widely used free and open source (GPLv2) database, offered by most web hosting services, on a diversity of platforms."'
-    - option: mysql_install
-      value: "{{ mysql_install }}"
-    - option: mysql_enabled
-      value: "{{ mysql_enabled }}"
+  - name: 'SEE ERROR ABOVE (skip_role_on_error: {{ skip_role_on_error }})'
+    fail:
+      msg: ""
+    when: not skip_role_on_error

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -12,6 +12,21 @@
 # can arise without warning when WordPress is online, since WordPress ~4.8
 
 
+- name: "Set 'mysql_install: True' and 'mysql_enabled: True'"
+  set_fact:
+    mysql_install: True
+    mysql_enabled: True
+
+- name: MYSQL - run 'mysql' role (attempt to install & enable MySQL / MariaDB)
+  include_role:
+    name: mysql
+
+- name: FAIL (STOP THE INSTALL) IF 'mysql_installed is undefined'
+  fail:
+    msg: "WordPress install cannot proceed, as MySQL / MariaDB is not installed."
+  when: mysql_installed is undefined
+
+
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -265,12 +265,11 @@ pi_swap_file_size: 1024
 
 # 3-BASE-SERVER
 
-# 2020-09-24: MySQL / MariaDB is MANDATORY but still evolving - please see:
-# https://github.com/iiab/iiab/blob/master/roles/mysql/tasks/install.yml
-# https://github.com/iiab/iiab/blob/master/roles/3-base-server/tasks/main.yml
-# THESE 2 LEGACY VARS ARE PRESERVED BUT HAVE NO EFFECT:
-mysql_install: True
-mysql_enabled: True
+# 2023-11-05: MySQL (actually MariaDB) had been mandatory, installed on every
+# IIAB by 3-base-server.  Now installed on demand -- as a dependency of Matomo,
+# MediaWiki, WordPress &/or Admin Console.  BOTH VALUES BELOW INITIALLY IGNORED:
+mysql_install: False
+mysql_enabled: False
 mysql_service: mariadb
 
 # 2020-09-24: NGINX is MANDATORY but still evolving - please see:


### PR DESCRIPTION
Goal is being able to offer *Lightweight IIAB* installs, in situations where MySQL (MariaDB) is not wanted:

Examples include more rapid unit-testing of diverse aspects of IIAB, as well as other dev and field scenarios where {MediaWiki, WordPress, Matomo, Admin Console} are not desired.

An interim stub is included in roles/9-local-addons/tasks/main.yml to install MySQL (MariaDB) when `admin_console_install: True` — however it's possible that Admin Console doesn't much use [setup-feedback](https://github.com/iiab/iiab-admin-console/blob/master/setup-feedback) and [record_feedback.php](https://github.com/iiab/iiab-admin-console/blob/master/roles/js-menu/files/menu-files/services/record_feedback.php) (invoked by [Line 970 of js-menu.js](https://github.com/iiab/iiab-admin-console/blob/4a3b004fc56970daae9987606ec6a4b7dc1ddf4a/roles/js-menu/files/menu-files/js/js-menu.js#L970)) anymore so this can be further refined in whatever direction is appropriate.  Hopefully @tim-moody can offer suggestions, if this PR's stub in 9-local-addons needs further improvement.

This PR is functionality-tested in a few different ways on Ubuntu Server 24.04's latest pre-release daily build.  (Further testing on different OS's and in more novel scenarios definitely can't hurt, before and after merging, to uncover important/overlooked corner cases!)  If changes are required, please LMK! 🎯