### PR TITLE
Recommend ansible-core 2.16.0, Deprecate EOL'd 2.13.x (both ETA 2023-11-06)

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -11,7 +11,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}    # Remove all '"'
 MIN_RPI_KERN=5.4.0         # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.13.13    # 2023-05-22: ansible-core 2.12 EOL per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+MIN_ANSIBLE_VER=2.14.11    # 2023-05-22: ansible-core 2.12 EOL per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
 
 REINSTALL=false
 DEBUG=false

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.15.5]
-GOOD_VER=2.15.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.16.0]
+GOOD_VER=2.16.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -34,6 +34,8 @@ GOOD_VER=2.15.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # https://www.ansible.com/blog/ansible-3.0.0-qa
 # https://github.com/ansible/ansible/tags
 # https://github.com/ansible/ansible/releases
+# https://github.com/ansible/ansible/commits/stable-2.16
+# https://github.com/ansible/ansible/blob/stable-2.16/changelogs/CHANGELOG-v2.16.rst
 # https://github.com/ansible/ansible/commits/stable-2.15
 # https://github.com/ansible/ansible/blob/stable-2.15/changelogs/CHANGELOG-v2.15.rst
 # https://github.com/ansible/ansible/commits/stable-2.14


### PR DESCRIPTION
Both are expected Monday (tomorrow) 2023-11-06:

- https://docs.ansible.com/ansible/devel//roadmap/ROADMAP_2_16.html
- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

As tested with ansible-core 2.16.0 RC1, 18 days ago:

- #3661