### PR TITLE
Patch NGINX conf file for Nextcloud 27.1.2+ — and deprecate support for EOL Nextcloud 25 on older OS's — whose PHP 7 was (also!) EOL'd a year ago

### DIFF
--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -118,10 +118,12 @@
     state: directory
     path: "{{ nextcloud_root_dir }}"    # /library/www/nextcloud
 
-- name: "2023-03-24: NEXTCLOUD 26 REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER NEXTCLOUD 25 ON OS's WITH PHP 7.x -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
-  set_fact:
-    nextcloud_dl_url: https://download.nextcloud.com/server/releases/latest-25.tar.bz2
-  when: php_version is version('8.0', '<')
+# Nextcloud 25 EOL was 2023-10-01: https://endoflife.date/nextcloud
+# https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule#eol-versions
+#- name: "2023-03-24: NEXTCLOUD 26 REQUIRES PHP 8 -- SO THIS TEMPORARY PATCH INSTALLS THE OLDER NEXTCLOUD 25 ON OS's WITH PHP 7.x -- WHOSE END-OF-LIFE WAS NOVEMBER 2022"
+#  set_fact:
+#    nextcloud_dl_url: https://download.nextcloud.com/server/releases/latest-25.tar.bz2
+#  when: php_version is version('8.0', '<')
 
 - name: Unarchive {{ nextcloud_dl_url }} (~172 MB) to {{ nextcloud_root_dir }} (~607 MB initially, sometimes ~643 MB later, {{ apache_user }}:{{ apache_user }})
   unarchive:

--- a/roles/nextcloud/templates/nextcloud-nginx.conf.j2
+++ b/roles/nextcloud/templates/nextcloud-nginx.conf.j2
@@ -85,7 +85,7 @@ location ^~ {{ nextcloud_url }} {
         deny all;
     }
 
-    location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
+    location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+)\.php(?:$|\/) {
         fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
         set $path_info $fastcgi_path_info;
         try_files $fastcgi_script_name =404;
@@ -102,7 +102,7 @@ location ^~ {{ nextcloud_url }} {
         fastcgi_request_buffering off;
     }
 
-    location ~ ^\/nextcloud\/(?:updater|oc[ms]-provider)(?:$|\/) {
+    location ~ ^\/nextcloud\/(?:updater|ocs-provider)(?:$|\/) {
         try_files $uri/ =404;
         index index.php;
     }


### PR DESCRIPTION
### Fixes bug:

- #3669

### Description of changes proposed in this pull request:

Changes enacted as described within above #3669 bug ticket.

### Smoke-tested on which OS or OS's:

Ubuntu Server 24.04 (latest pre-release).

Tangentially related:

- PR #3208
- PR #3559
- PR #3624
- PR #3668