### PR TITLE
Gitea 1.21 released

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -9,7 +9,7 @@
 
 # Info needed to install Gitea:
 
-gitea_version: "1.20"    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.  Quotes nec if trailing zero.
+gitea_version: "1.21"    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.  Quotes nec if trailing zero.
 iset_suffixes:
   i386: 386
   x86_64: amd64

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -51,7 +51,7 @@
 - name: Download Gitea binary {{ gitea_download_url }} to {{ gitea_install_path }} (0775, ~126 MB, SLOW DOWNLOAD CAN TAKE ~15 MIN)
   get_url:
     url: "{{ gitea_download_url }}"
-    dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.20
+    dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.21
     mode: 0775
     timeout: "{{ download_timeout }}"
 


### PR DESCRIPTION
ANNC:
https://blog.gitea.com/release-of-1.21.0/

CHANGELOG:
https://github.com/go-gitea/gitea/releases/tag/v1.21.0

Testing of this PR is ongoing...

Related:

- PR #3608
- PR #3609