### PR TITLE
Set `asterisk_rpi_patch: False` & mandate MySQL / MariaDB [as we wait for FreePBX 17 pre-releases to support Asterisk 21, which was released 2023-10-18]

### DIFF
--- a/roles/3-base-server/README.rst
+++ b/roles/3-base-server/README.rst
@@ -15,7 +15,7 @@
 
 This 3rd `stage <https://github.com/iiab/iiab/wiki/IIAB-Contributors-Guide#ansible>`_ installs base server infra that `Internet-in-a-Box (IIAB) <https://internet-in-a-box.org/>`_ requires, including:
 
-- |ss| `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps). |se| |nbsp|  *As of 2023-11-05, MySQL / MariaDB is NO LONGER INSTALLED by 3-base-server — instead it's installed on-demand — as a dependency of Matomo, MediaWiki, Nextcloud, WordPress &/or Admin Console.*  This IIAB role (roles/mysql) also installs apt package:
+- |ss| `MySQL <https://github.com/iiab/iiab/blob/master/roles/mysql>`_ (database underlying many/most user-facing apps). |se| |nbsp|  *As of 2023-11-05, MySQL / MariaDB is NO LONGER INSTALLED by 3-base-server — instead it's installed on-demand — as a dependency of Matomo, MediaWiki, Nextcloud, PBX (for FreePBX), WordPress &/or Admin Console.*  This IIAB role (roles/mysql) also installs apt package:
    - **php{{ php_version }}-mysql** — which forcibly installs **php{{ php_version }}-common**
 - `NGINX <https://github.com/iiab/iiab/blob/master/roles/nginx>`_ web server (with Apache in some lingering cases).  This IIAB role also installs apt package:
    - **php{{ php_version }}-fpm** — which forcibly installs **php{{ php_version }}-cli**, **php{{ php_version }}-common** and **libsodium23**

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -5,7 +5,7 @@
 
 # 2023-11-05: MySQL (actually MariaDB) had been mandatory, installed on every
 # IIAB by 3-base-server.  Now installed on demand -- as a dependency of Matomo,
-# MediaWiki, Nextcloud, WordPress &/or Admin Console.
+# MediaWiki, Nextcloud, PBX (for FreePBX), WordPress &/or Admin Console.
 # - name: MYSQL + CORE PHP
 #   include_role:
 #     name: mysql

--- a/roles/pbx/README.adoc
+++ b/roles/pbx/README.adoc
@@ -61,12 +61,14 @@ If using PBX intensively, please adjust `/etc/php/X.Y/apache2/php.ini`, `/etc/ph
 nginx_high_php_limits: True
 ----
 +
+////
 As of April 2023 (https://github.com/iiab/iiab/pull/3523[PR #3523]) IIAB will patch Asterisk automatically (https://github.com/asterisk/asterisk/pull/32[PR asterisk/asterisk#32]) so it can be run experimentally on Raspberry Pi, so long as you keep this default settings:
 +
 ----
 asterisk_rpi_patch: True
 ----
 +
+////
 Optionally, you may want to enable https://github.com/wdoekes/asterisk-chan-dongle[chan_dongle], which is a channel driver for Huawei UMTS cards (e.g. 3G USB dongles) allowing regular voice calls over GSM mobile networks.  You will need to configure a dongle post-install, for it to be recognized properly:
 +
 ----

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -26,13 +26,13 @@
 
 
 asterisk_url: https://downloads.asterisk.org/pub/telephony/asterisk
-asterisk_src_file: asterisk-20-current.tar.gz
+asterisk_src_file: asterisk-21-current.tar.gz
 asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
 # freepbx_url: https://mirror.freepbx.org/modules/packages/freepbx/7.4
 # freepbx_src_file: freepbx-16.0-latest.tgz    # 2022-05-25 #3228: Filename has become bogus (as it's not really the latest!)  Manually unpacking the latest .tar.gz for FreePBX 16.x from https://github.com/FreePBX/framework/tags to /opt/iiab/freepbx can work if absolutely nec.
 freepbx_git_url: https://github.com/FreePBX/framework
-freepbx_git_branch: release/16.0    # EMERGING OPTION AS OF MAY 2022: https://github.com/FreePBX/framework/tree/release/17.0
+freepbx_git_branch: release/17.0    # EMERGING OPTION AS OF MAY 2022: https://github.com/FreePBX/framework/tree/release/17.0
 freepbx_src_dir: "{{ iiab_base }}/freepbx"
 freepbx_install_dir: /var/www/html/freepbx
 

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -32,7 +32,7 @@ asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 # freepbx_url: https://mirror.freepbx.org/modules/packages/freepbx/7.4
 # freepbx_src_file: freepbx-16.0-latest.tgz    # 2022-05-25 #3228: Filename has become bogus (as it's not really the latest!)  Manually unpacking the latest .tar.gz for FreePBX 16.x from https://github.com/FreePBX/framework/tags to /opt/iiab/freepbx can work if absolutely nec.
 freepbx_git_url: https://github.com/FreePBX/framework
-freepbx_git_branch: release/17.0    # EMERGING OPTION AS OF MAY 2022: https://github.com/FreePBX/framework/tree/release/17.0
+freepbx_git_branch: release/16.0    # EMERGING OPTION AS OF MAY 2022: https://github.com/FreePBX/framework/tree/release/17.0
 freepbx_src_dir: "{{ iiab_base }}/freepbx"
 freepbx_install_dir: /var/www/html/freepbx
 

--- a/roles/pbx/defaults/main.yml
+++ b/roles/pbx/defaults/main.yml
@@ -26,7 +26,7 @@
 
 
 asterisk_url: https://downloads.asterisk.org/pub/telephony/asterisk
-asterisk_src_file: asterisk-21-current.tar.gz
+asterisk_src_file: asterisk-20-current.tar.gz
 asterisk_src_dir: "{{ iiab_base }}/asterisk"    # /opt/iiab
 
 # freepbx_url: https://mirror.freepbx.org/modules/packages/freepbx/7.4

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -83,8 +83,8 @@
     creates: menuselect.makeopts
 
 - name: Asterisk - Do a bit of menuselect configuration
-  command: menuselect/menuselect --enable app_macro --enable format_mp3 menuselect.makeopts
-  # 2021-08-06: Let's standardize (ABOVE) if 6 others (BELOW) aren't needed?
+  command: menuselect/menuselect --enable format_mp3 menuselect.makeopts
+  # 2021-08-06 & 2023-11-19: Let's standardize (ABOVE) if 6 others (BELOW) aren't needed?
   # command: >
   #   menuselect/menuselect --enable app_macro --enable format_mp3
   #   --enable CORE-SOUNDS-EN-WAV --enable CORE-SOUNDS-EN-G722

--- a/roles/pbx/tasks/asterisk.yml
+++ b/roles/pbx/tasks/asterisk.yml
@@ -84,7 +84,7 @@
 
 - name: Asterisk - Do a bit of menuselect configuration
   command: menuselect/menuselect --enable format_mp3 menuselect.makeopts
-  # 2021-08-06 & 2023-11-19: Let's standardize (ABOVE) if 6 others (BELOW) aren't needed?
+  # 2021-08-06 & 2023-11-19: Let's standardize (ABOVE) if 7 others (BELOW) aren't needed?
   # command: >
   #   menuselect/menuselect --enable app_macro --enable format_mp3
   #   --enable CORE-SOUNDS-EN-WAV --enable CORE-SOUNDS-EN-G722

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -22,6 +22,21 @@
 #   when: nodejs_version != "12.x"
 
 
+- name: "Set 'mysql_install: True' and 'mysql_enabled: True'"
+  set_fact:
+    mysql_install: True
+    mysql_enabled: True
+
+- name: MYSQL - run 'mysql' role (attempt to install & enable MySQL / MariaDB)
+  include_role:
+    name: mysql
+
+- name: FAIL (STOP THE INSTALL) IF 'mysql_installed is undefined'
+  fail:
+    msg: "PBX install cannot proceed, as MySQL / MariaDB is not installed."
+  when: mysql_installed is undefined
+
+
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -692,7 +692,7 @@ pbx_enabled: False
 pbx_use_apache: False   # 2023-04-03: Set to 'True' if nec -- please also
 pbx_use_nginx: True     # read github.com/iiab/iiab/issues/2914 & #2916, THX!
 # 2023-04-03: For EXPERIMENTAL testing on Raspberry Pi... (#3489, PR #3523)
-asterisk_rpi_patch: True
+asterisk_rpi_patch: False
 asterisk_chan_dongle: False
 pbx_signaling_ports_chan_sip: 5160:5161
 pbx_signaling_ports_chan_pjsip: 5060

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -267,8 +267,8 @@ pi_swap_file_size: 1024
 
 # 2023-11-05: MySQL (actually MariaDB) had been mandatory, installed on every
 # IIAB by 3-base-server.  Now installed on demand -- as a dependency of Matomo,
-# MediaWiki, Nextcloud, WordPress &/or Admin Console.  SO BOTH VALUES BELOW ARE
-# INITIALLY IGNORED:
+# MediaWiki, Nextcloud, PBX (for FreePBX), WordPress &/or Admin Console.
+# SO BOTH VALUES BELOW ARE INITIALLY IGNORED:
 mysql_install: False
 mysql_enabled: False
 mysql_service: mariadb

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -425,5 +425,5 @@ pbx_enabled: False
 pbx_use_apache: False   # 2023-04-03: Set to 'True' if nec -- please also
 pbx_use_nginx: True     # read github.com/iiab/iiab/issues/2914 & #2916, THX!
 # 2023-04-03: For EXPERIMENTAL testing on Raspberry Pi... (#3489, PR #3523)
-asterisk_rpi_patch: True
+asterisk_rpi_patch: False
 asterisk_chan_dongle: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -425,5 +425,5 @@ pbx_enabled: False
 pbx_use_apache: False   # 2023-04-03: Set to 'True' if nec -- please also
 pbx_use_nginx: True     # read github.com/iiab/iiab/issues/2914 & #2916, THX!
 # 2023-04-03: For EXPERIMENTAL testing on Raspberry Pi... (#3489, PR #3523)
-asterisk_rpi_patch: True
+asterisk_rpi_patch: False
 asterisk_chan_dongle: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -425,5 +425,5 @@ pbx_enabled: False
 pbx_use_apache: False   # 2023-04-03: Set to 'True' if nec -- please also
 pbx_use_nginx: True     # read github.com/iiab/iiab/issues/2914 & #2916, THX!
 # 2023-04-03: For EXPERIMENTAL testing on Raspberry Pi... (#3489, PR #3523)
-asterisk_rpi_patch: True
+asterisk_rpi_patch: False
 asterisk_chan_dongle: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -425,5 +425,5 @@ pbx_enabled: False
 pbx_use_apache: False   # 2023-04-03: Set to 'True' if nec -- please also
 pbx_use_nginx: True     # read github.com/iiab/iiab/issues/2914 & #2916, THX!
 # 2023-04-03: For EXPERIMENTAL testing on Raspberry Pi... (#3489, PR #3523)
-asterisk_rpi_patch: True
+asterisk_rpi_patch: False
 asterisk_chan_dongle: False


### PR DESCRIPTION
@EMG70 consider testing this on Debian 12 and recent versions of Ubuntu?

(Asterisk 21 was released Oct 18, but FreePBX 17 is still evolving so this might need additional changes over coming months?)

P.S. This PR also contains the workaround for #3673 FWIW.

Related:

- #3489
- PR #3523
- #3556
- PR #3665
- PR #3668