### PR TITLE
Install /usr/local/bin/lb-wrapper.greedy for Calibre-Web OOM (out of memory) testing

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -76,8 +76,8 @@
             ln -sf /root/.local/bin/lb /usr/local/bin/lb
             ln -sf /root/.local/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
         fi
-        cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/lb-wrapper
-        chmod a+x /usr/local/bin/lb-wrapper
+        cp {{ calibreweb_venv_path }}/scripts/lb-wrapper {{ calibreweb_venv_path }}/scripts/lb-wrapper.greedy /usr/local/bin/
+        chmod a+x /usr/local/bin/lb-wrapper /usr/local/bin/lb-wrapper.greedy
     fi
 
 - name: Download Calibre-Web dependencies from 'requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }}


### PR DESCRIPTION
To streamline testing of Calibre-Web OOM (out of memory) problems like:

- iiab/calibre-web#37
- iiab/calibre-web#53

And associated design challenges:

- PR iiab/calibre-web#51
- PR iiab/calibre-web#57

By building on:

- PR iiab/calibre-web#64
- PR #3676
  - PR #3677