### PR TITLE
Change default to `transmission_compile_latest: False`

### DIFF
--- a/roles/transmission/README.rst
+++ b/roles/transmission/README.rst
@@ -19,14 +19,14 @@ Transmission is intended to download content like KA Lite to Internet-in-a-Box (
 
 For example, once KA Lite videos and thumbnails are confirmed downloaded, copy them (carefully!) from ``/library/transmission`` into ``/library/ka-lite/content`` as outlined by "KA Lite Administration: What tips & tricks exist?" at http://FAQ.IIAB.IO
 
-2023 Caution
-------------
+Transmission 4.x Preview (Optional)
+-----------------------------------
 
-In order to make the latest features available to you as of Q4 2023, Internet-in-a-Box compiles the very latest `Transmission 4.0.5+ <https://github.com/transmission/transmission/commits/main>`_ as you install it, which unfortunately can take most of an hour.
+2023-12-31: To make the `latest Transmission features <https://github.com/transmission/transmission/commits/main>`_ available to you, Internet-in-a-Box can compile the very latest (above and beyond `Transmission 4.x+ official releases <https://github.com/transmission/transmission/releases>`_).   Just note this can take most of an hour, and is not without risk!
 
-Thankfully `Transmission 4.1+ <https://github.com/transmission/transmission/milestones>`_ should once again install quickly, starting sometime soon in early 2024 (`#5585 <https://github.com/transmission/transmission/discussions/5585>`_, `PR #5866 <https://github.com/transmission/transmission/pull/5866>`_).
+If you decide you want this, set ``transmission_compile_latest: True`` in `/etc/iiab/local_vars.yml <https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ prior to installing Transmission, as explained below.
 
-Finally, if instead you want to quickly install an older version of Transmission (e.g. version 3.0 from May 2020) then set ``transmission_compile_latest: False`` in `/etc/iiab/local_vars.yml <https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ prior to installing.
+NOTE: Later in 2024, fast auto-installation of `Transmission 4.1+ <https://github.com/transmission/transmission/milestones>`_ should once again hopefully become mainline (`#5585 <https://github.com/transmission/transmission/discussions/5585>`_, `PR #5866 <https://github.com/transmission/transmission/pull/5866>`_) just as in recent years with Transmission 3.0 (originally from May, 2020).
 
 .. Transmission can consume significant Internet data and system resources.  Caveat emptor!  (That's Latin for "Buyer Beware")
 

--- a/roles/transmission/defaults/main.yml
+++ b/roles/transmission/defaults/main.yml
@@ -1,7 +1,7 @@
 # Transmission is a BitTorrent downloader for large Content Packs etc
 # transmission_install: False
 # transmission_enabled: False
-# transmission_compile_latest: True
+# transmission_compile_latest: False
 # transmission_username: Admin
 # transmission_password: changeme
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -544,7 +544,7 @@ sugarizer_port: 8089
 # Transmission is a BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
-transmission_compile_latest: True
+transmission_compile_latest: False
 transmission_username: Admin
 transmission_password: changeme
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -321,7 +321,7 @@ sugarizer_enabled: True
 # BitTorrent downloader for large Content Packs etc
 transmission_install: True
 transmission_enabled: True
-transmission_compile_latest: True
+transmission_compile_latest: False
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -321,7 +321,7 @@ sugarizer_enabled: True
 # BitTorrent downloader for large Content Packs etc
 transmission_install: True
 transmission_enabled: True
-transmission_compile_latest: True
+transmission_compile_latest: False
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -321,7 +321,7 @@ sugarizer_enabled: False
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
-transmission_compile_latest: True
+transmission_compile_latest: False
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -321,7 +321,7 @@ sugarizer_enabled: False
 # BitTorrent downloader for large Content Packs etc
 transmission_install: False
 transmission_enabled: False
-transmission_compile_latest: True
+transmission_compile_latest: False
 # A. UNCOMMENT LANGUAGE(S) TO DOWNLOAD KA Lite VIDEOS TO /library/transmission
 #    using https://pantry.learningequality.org/downloads/ka-lite/0.17/content/
 transmission_kalite_languages:


### PR DESCRIPTION
While Transmission's compile almost always completes (within an hour, or much less on a modern CPU) the downside is that Transmission 4.0.5+ 's systemd service often fails to start after that (in recent weeks especially).

So let's revert IIAB's default to OS's age-old Transmission 3.0 from 2020-05-22 for now.

A fringe benefit of reverting above-and-beyond [1] much more reliable and [2] much faster Transmission installs (e.g. as part of MEDIUM-sized and LARGE-sized IIAB) is that the [3] age-old Transmission 3.0 executables (from apt, i.e. from the OS) are also far more compact. 

Background:

- #3190
- PR #3599