### PR TITLE
kalite/tasks/install.yml: Toughen aging vars is_debian_11, is_ubuntu_2204

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -22,7 +22,7 @@
       - python-setuptools    # Provides setuptools-44 on recent OS's (last version compatible with python2)
       - virtualenv           # Drags in 'python3-virtualenv' which in turn drags in 'python3-pip' -- for Ansible module 'pip' when used with 'virtualenv_command: /usr/bin/virtualenv' and 'virtualenv_python: python2.7' -- compare package 'python3-venv' used by roles {calibre-web, jupyterhub, lokole}
     state: present
-  when: is_debian_11 or is_ubuntu_2204    # Covers is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
+  when: (is_debian_11 is defined and is_debian_11) or (is_ubuntu_2204 is defined and is_ubuntu_2204)    # Covers is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
   #when: not (is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310)
   # 2020-03-31: Testing for {is_raspbian_9, is_raspbian_10} is not currently nec, as testing for {is_debian_9, is_debian_10} covers that already.
 
@@ -37,7 +37,7 @@
 # use key retrieval from mongodb
 - name: Use scripts/install_python2.sh to install python2 and virtualenv
   command: "{{ iiab_dir }}/scripts/install_python2.sh"
-  when: not (is_debian_11 or is_ubuntu_2204)    # Also avoids is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
+  when: not ((is_debian_11 is defined and is_debian_11) or (is_ubuntu_2204 is defined and is_ubuntu_2204))    # Also avoids is_raspbian_11 and is_linuxmint_21, and is more future-proof than...
   #when: is_debian_12 or is_ubuntu_2304 or is_ubuntu_2310
 
 - name: Use pip to pin setuptools to 44 in {{ kalite_venv }}    # WAS: if Raspbian/Debian > 10 or Ubuntu > 19


### PR DESCRIPTION
This PR was tested on Ubuntu 22.04

It patches an oversight within...

- PR #3691

...allowing roles/kalite to continue running for another year or more possibly?

(Pending functional validation of course, as Python 2 code ages severely ;)