### PR TITLE
Install/enable Calibre-Web by default, e.g. with SMALL-sized IIAB installs too

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -654,8 +654,8 @@ minetest_game_dir: "{{ minetest_working_dir }}/games/{{ minetest_default_game }}
 minetest_flat_world: False
 
 # Calibre-Web E-Book Library -- Alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
+calibreweb_install: True
+calibreweb_enabled: True
 calibreweb_port: 8083       # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url1: /books     # For SHORT URL http://box/books  (English)

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -393,8 +393,8 @@ minetest_install: False
 minetest_enabled: False
 
 # Calibre-Web E-Book Library -- Alternative to Calibre, offers a clean/modern UX
-calibreweb_install: False
-calibreweb_enabled: False
+calibreweb_install: True
+calibreweb_enabled: True
 calibreweb_port: 8083       # PORT VARIABLE HAS NO EFFECT (as of January 2019)
 # http://box/books works.  Add {box/libros, box/livres, box/livros, box/liv} etc?
 calibreweb_url1: /books     # For SHORT URL http://box/books  (English)


### PR DESCRIPTION
Building on...

- PR #3694

...as Calibre-Web is extremely lightweight and increasingly useful to many more kinds of grassroots communities.

And needing broader community testing to become truly reliable month-by-month!