### PR TITLE
iiab-diagnostics: 300 last lines of /var/log/xklb.log for now

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -232,7 +232,7 @@ cat_cmd 'cd /usr/local/calibre-web-py3; git log --graph --oneline --decorate | h
 cat_cmd 'systemctl status calibre-web' 'Is Calibre-Web running?'
 cat_cmd 'journalctl -u calibre-web | tail -100' 'Calibre-Web systemd log'
 cat_tail /var/log/calibre-web.log 100
-cat_tail /var/log/xklb.log 100
+cat_tail /var/log/xklb.log 300
 cat_cmd 'journalctl -t IIAB-CMDSRV' 'Admin Console CMDSRV log'
 #cat_cmd 'ansible localhost -m setup 2>/dev/null' 'All Ansible facts'    # For cleaner scraping of Ansible vars, consider "./runrole all-vars /tmp/all-ansible-vars" 27-31 lines above?
 


### PR DESCRIPTION
100 last lines have proved to be somewhat spammy and incomplete so far.

So just for now let's collect the 300 last lines, until we understand better... _what's truly needed from:_ [/var/log/xklb.log](https://github.com/iiab/calibre-web/wiki#how-do-i-check-logs)

Related:

- PR #3697
- iiab/calibre-web#68
- iiab/calibre-web#70
- https://github.com/iiab/calibre-web/pull/95#issuecomment-1891207475

