### PR TITLE
iiab-diagnostics: Pipe everything thru `cat -v` so ASCII control characters become visible

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -49,11 +49,11 @@ function cat_file_raw() {    # $1 = path/filename; $2 = # of lines, for tail
         elif [ $# -eq 1 ]; then
             echo >> $outfile
             # Redact (mask) most passwords from /etc/iiab/local_vars.yml, /etc/hostapd/hostapd.conf, /etc/wpa_supplicant/wpa_supplicant.conf, /etc/netplan/*, /etc/network/interfaces, /etc/network/interfaces.d/*, /etc/NetworkManager/system-connections/* ETC -- not much to worry about in /etc/iiab/iiab.ini (' = ')
-            cat "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' "$1" | iconv -t UTF-8//IGNORE | cat -v >> $outfile
         else    # e.g. last 100 lines, maximum
             echo "                        ...ITS LAST $2 LINES FOLLOW..." >> $outfile
             echo >> $outfile
-            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE >> $outfile
+            tail -$2 "$1" | sed 's/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\):\).*/\1 [REDACTED]/; s/^\(\s*[[:alnum:]#_-]*\(psk\|passphrase\|password\|wep-key[0-3]\)[= \t]\).*/\1[REDACTED]/' | iconv -t UTF-8//IGNORE | cat -v >> $outfile
         fi
         echo >> $outfile
     elif [ -h "$1" ]; then


### PR DESCRIPTION
Helps make hidden characters in log files and other diagnostics files more visible, partially solving situations like:

- iiab/calibre-web#105

Related:

- PR #3697
- PR #3698