### PR TITLE
no-pipx [possible alternative approach to installing yt-dlp for Calibre-Web]

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -68,13 +68,16 @@
 - name: If Calibre-Web is being enhanced with audio/video "books" too, install/upgrade additional prereqs -- SEE https://github.com/iiab/calibre-web/wiki
   shell: |
     if [ -f {{ calibreweb_venv_path }}/scripts/lb-wrapper ]; then
-        apt install ffmpeg pipx -y
+        apt install -y ffmpeg
         if lb --version; then
-            pipx upgrade --include-injected xklb
+            cd /usr/local/xklb
+            bin/pip install --upgrade
         else
-            pipx install xklb
-            ln -sf /root/.local/bin/lb /usr/local/bin/lb
-            ln -sf /root/.local/share/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
+            python3 -m venv /usr/local/xklb
+            cd /usr/local/xklb
+            bin/pip install xklb
+            ln -sf /usr/local/xklb/bin/lb /usr/local/bin/lb
+            ln -sf /usr/local/xklb/share/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
         fi
         cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/
         chmod a+x /usr/local/bin/lb-wrapper


### PR DESCRIPTION
Would be nice to see the provided share/doc/yt_dlp/README.txt file without being root.