### PR TITLE
Interim stub to force Kolibri 0.16.0 for now, awaiting upstream #11892

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -26,7 +26,9 @@
 # https://github.com/iiab/iiab/issues/1675
 # https://github.com/learningequality/kolibri/issues/5664
 
-# 2022-07-30: UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
+# 2024-03-17: Temporary stub to force February's Kolibri 0.16.0 for now, awaiting #11892 below...
+kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.16.0/kolibri_0.16.0-0ubuntu1_all.deb
+# 2022-07-30: OR UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest
 # 2024-02-17: https://github.com/learningequality/kolibri/issues/11892
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-next

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -26,7 +26,7 @@
 # https://github.com/iiab/iiab/issues/1675
 # https://github.com/learningequality/kolibri/issues/5664
 
-# 2024-03-17: Temporary stub to force February's Kolibri 0.16.0 for now, awaiting #11892 below...
+# 2024-03-17: Temporary stub to force February's Kolibri 0.16.0 for now, awaiting upstream redirects etc, e.g. #11892 below...
 kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.16.0/kolibri_0.16.0-0ubuntu1_all.deb
 # 2022-07-30: OR UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest


### PR DESCRIPTION
I thought Kolibri 0.16 would be fully be released by now.  But about a month after it first GitHub release, I was wrong.

So until the redirects below are enabled, let's make lives far easier for newcomers who keep struggling with Kolibri 0.15.x (e.g. 0.15.12) problems:

- learningequality/kolibri#11892

Tangentially related:

- PR #3514