### PR TITLE
Restore apt install of Kolibri 0.16.1+, thx to upstream changes

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -26,7 +26,7 @@
 # https://github.com/iiab/iiab/issues/1675
 # https://github.com/learningequality/kolibri/issues/5664
 
-# 2024-04-08: Kolibri 0.16.1 restores install via apt
+# 2024-04-08: Kolibri 0.16.1+ restores install via apt
 # https://github.com/learningequality/kolibri/issues/11892#issuecomment-2043073998
 # 2022-07-30: UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -26,9 +26,9 @@
 # https://github.com/iiab/iiab/issues/1675
 # https://github.com/learningequality/kolibri/issues/5664
 
-# 2024-03-17: Temporary stub to force February's Kolibri 0.16.0 for now, awaiting upstream redirects etc, e.g. #11892 below...
-kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.16.0/kolibri_0.16.0-0ubuntu1_all.deb
-# 2022-07-30: OR UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
+# 2024-04-08: Kolibri 0.16.1 restores install via apt
+# https://github.com/learningequality/kolibri/issues/11892#issuecomment-2043073998
+# 2022-07-30: UNCOMMENT ONE OF THE FOLLOWING LINES TO TEST A PARTICULAR .deb INSTALL
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-latest
 # 2024-02-17: https://github.com/learningequality/kolibri/issues/11892
 # kolibri_deb_url: https://learningequality.org/r/kolibri-deb-next


### PR DESCRIPTION
While Kolibri 0.17.x pre-releases are not quite yet available (for OS with Python 3.12 like Ubuntu 24.04), the ability to install recent release of Kolibri via apt should be restored very shortly, hopefully in coming hours, as explained at:

- https://github.com/learningequality/kolibri/issues/11892#issuecomment-2043073998

Related:

- PR #3343
- PR #3709
- PR #3722