### PR TITLE
Safer /usr/local/bin/yt-dlp symlink creation

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -74,7 +74,13 @@
         else
             pipx install xklb
             ln -sf /root/.local/bin/lb /usr/local/bin/lb
-            ln -sf /root/.local/share/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
+            if [ -f /root/.local/share/pipx/venvs/xklb/bin/yt-dlp ]; then
+                ln -sf /root/.local/share/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
+            elif [ -f /root/.local/pipx/venvs/xklb/bin/yt-dlp ]; then
+                ln -sf /root/.local/pipx/venvs/xklb/bin/yt-dlp /usr/local/bin/yt-dlp
+            else
+                echo "ERROR: yt-dlp NOT FOUND"
+            fi
         fi
         cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/
         chmod a+x /usr/local/bin/lb-wrapper


### PR DESCRIPTION
### Fixes bug:

yt-dlp is not runnable at the CLI on some OS's like Ubuntu 23.10, whereas it works on Ubuntu 24.04

As outlined here:

- https://github.com/iiab/calibre-web/issues/158#issuecomment-2087086538

### Description of changes proposed in this pull request:

bash code is reinforced to be much more resilient, handling both kinds of OS/environments, so that we tolerate both common paths used by pipx, thereby refining this PR from 2023-12-30:

- PR #3689

### Smoke-tested on which OS or OS's:

Debian 12.  Further testing will be useful after merging!  On OS's like:

- Ubuntu 24.04
- Ubuntu 22.04 and/or Mint 21
- Raspberry Pi OS 12

### Mention a team member @username e.g. to help with code review:

@EMG70 @deldesir