### PR TITLE
Bypass KA Lite install during initial install of IIAB, on recent OS's like Ubuntu 24.04+

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: KALITE
   include_role:
     name: kalite
-  when: kalite_install
+  when: kalite_install and (is_ubuntu_2204 or is_ubuntu_2310 or is_debian_12)    # Also covers is_linuxmint_21 and is_raspbian_12
 
 - name: KOLIBRI
   include_role:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -49,6 +49,9 @@
     extra_args: "--no-cache-dir"
   when: is_ubuntu_2204 or is_ubuntu_2310 or is_debian_12    # Also covers is_linuxmint_21 and is_raspbian_12
 
+# 2024-04-30: Sadly no longer works with Ubuntu 24.04 LTS final release (#3731).
+# So roles/kalite is OS-restricted during initial install, SEE: roles/7-edu-apps/tasks/main.yml
+# CLARIF: If install_python2_kalite-venv_u2404.sh proves no longer useful, it will deprecated in coming months.
 - name: Run scripts/install_python2_kalite-venv_u2404.sh -- if Ubuntu 24.04+ or Mint 22
   command: bash "{{ iiab_dir }}/scripts/install_python2_kalite-venv_u2404.sh"
   when: is_ubuntu and not is_linuxmint and os_ver is version('ubuntu-2404', '>=') or is_linuxmint_22


### PR DESCRIPTION
This is the most pragmatic way to begin phasing out KA Lite for now.

Building on the conclusions uncovered in recent days here:

- #3731

As a result of the sad conclusion that Python 2 can no longer easily be installed on Ubuntu 24.04 — as had been working just a few weeks ago, thanks to:

- PR #3718

Earlier work:

- PR #3527
- PR #3535
- PR #3587