### PR TITLE
Defer initial install of Kolibri on Ubuntu 24.04+ (for now!) awaiting Python 3.12 compatibility

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install
+  when: kolibri_install and not (is_ubuntu_2404 or is_ubuntu_2410)    # Also covers is_linuxmint_22.  This is TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases.
 
 - name: KIWIX
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install and python_version is version('3.12', '<')    # Debian 13 still uses Python 3.11 (for now!) so really this just avoids Ubuntu 24.04 and 24.10 pre-releases at the moment.  CLARIF: This is all TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases (expected very soon).
+  when: kolibri_install and python_version is version('3.12', '<')    # Debian 13 still uses Python 3.11 (for now!) so really this just avoids Ubuntu 24.04 and 24.10 pre-releases during initial iiab-install.  CLARIF: This is all TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases (expected very soon).
 
 - name: KIWIX
   include_role:

--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install and not (is_ubuntu_2404 or is_ubuntu_2410)    # Also covers is_linuxmint_22.  This is TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases.
+  when: kolibri_install and python_version is version('3.12', '<')    # Debian 13 still uses Python 3.11 (for now!) so really this just avoids Ubuntu 24.04 and 24.10 pre-releases at the moment.  CLARIF: This is all TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases (expected very soon).
 
 - name: KIWIX
   include_role:

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -305,7 +305,6 @@ ansible-galaxy collection install --force-with-deps \
 echo -e "\n\nSUCCESS!  PLEASE VERIFY ANSIBLE WITH COMMANDS LIKE:\n"
 echo -e "    ansible --version"
 echo -e "    /usr/local/ansible/bin/pip3 show ansible-core"
-echo -e "    pip3 show ansible-core"
 echo -e '    apt -a list "ansible*"'
 echo -e "    ansible-galaxy collection list\n"
 echo -e "WARNING: Start a new Linux shell, if it changed from /usr/bin to /usr/local/bin\n\n"

--- a/test.yml
+++ b/test.yml
@@ -19,11 +19,16 @@
   #- include_role:
   #    name: 0-init
 
-  - debug:
-      msg: "{{ 'changeme' | password_hash('sha512') }}"
+  # 2024-05-16: ansible-core 2.17 RC2 still hasn't fixed this, as they migrate from Python's crypt library to passlib:
+  # https://github.com/iiab/iiab/blob/485a619bfa082716ec848b5b34893dd3046175a8/roles/cups/tasks/install.yml#L70-L78
+  #- debug:
+  #    msg: "{{ 'changeme' | password_hash('sha512') }}"
       # msg: "{{ 'changeme' | password_hash('yescrypt') }}"    # crypt.crypt STILL doesn't support 'yescrypt' algorithm ?
 
   #- pause:
+
+  - debug:
+      var: "'3.12.3' is version('3.12', '<')"
 
   - name: DOUBLE UP to escape single quotes... '"''"' e.g. iiab.ini descriptions for azuracast, captiveportal, mosquitto, munin, nodejs, osm-vector-maps, sshd
     debug:


### PR DESCRIPTION
Until upstream (Kolibri) catches up with Python 3.12+ support for Ubuntu 24.04 and 24.10 etc:

- https://github.com/learningequality/kolibri/issues/11316#issuecomment-2048394487