### PR TITLE
 gitea/defaults/main.yml: gitea_version: "1.22"

### DIFF
--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -9,7 +9,7 @@
 
 # Info needed to install Gitea:
 
-gitea_version: "1.21"    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.  Quotes nec if trailing zero.
+gitea_version: "1.22"    # 2022-01-30: Grabs latest from this MAJOR/MINOR release branch.  Rather than exhaustively hard-coding point releases (e.g. 1.14.5) every few weeks.  Quotes nec if trailing zero.
 iset_suffixes:
   i386: 386
   x86_64: amd64


### PR DESCRIPTION
New version / branch for Gitea now available:

- https://github.com/go-gitea/gitea/releases/tag/v1.22.0
- https://blog.gitea.com (announcement coming soon!)

Ref:

- PR #3671