### PR TITLE
dpaste.com pastebin disallows null char — so make iiab-summary & iiab-diagnostics output safer (and force odd chars to be visible)

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -132,7 +132,7 @@ echo "This is: $outfile" >> $outfile
 echo >> $outfile
 echo -e "\n\n\n0. HW + SW Quick Summary" >> $outfile
 echo >> $outfile
-/opt/iiab/iiab/scripts/iiab-summary >> $outfile
+/opt/iiab/iiab/scripts/iiab-summary | iconv -t UTF-8//IGNORE | cat -v >> $outfile    # Make odd chars visible, just in case (e.g. dpaste.com pastebin disallows null chars)
 if [ -f /etc/rpi-issue ]; then
     echo "stage2 = Raspberry Pi OS Lite" >> $outfile
     echo "stage4 = Raspberry Pi OS with desktop" >> $outfile

--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -67,7 +67,7 @@ echo "display-manager? $(systemctl is-active display-manager.service)   Arch1: $
 uname -nrvm
 echo "$(lscpu | grep '^Model name:' | sed 's/^Model name:\s*//')   $(lscpu | grep '^CPU(s):' | tr -s ' ')   "$(free -m | tail -2 | tr -s ' ' | cut -d' ' -f1-2)
 if [ -f /proc/device-tree/model ]; then
-    cat /proc/device-tree/model ; echo    # MORE RPi DETAIL: tail -4 /proc/cpuinfo
+    cat /proc/device-tree/model | tr -d '\000' ; echo    # dpaste.com pastebin doesn't allow null chars!  MORE RPi DETAIL: tail -4 /proc/cpuinfo
 fi
 if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
     echo "Temperature(s): "$(cat /sys/class/thermal/thermal_zone*/temp)    # Prettier if avail: vcgencmd measure_temp


### PR DESCRIPTION
This is a bug fix thanks to @nzola:

It's necessary on RPi due to the null char at the end of `/proc/device-tree/model` — so this PR:

- removes all null chars from that line, in iiab-summary output
- additionally, forces odd chars to be visible when iiab-diagnostics receives iiab-summary output (just in case, as OS's evolve!)

Building on:

- #3745
- PR #3748