### PR TITLE
Install Kolibri 0.17 pre-release, when OS Python >= 3.12

### DIFF
--- a/roles/7-edu-apps/tasks/main.yml
+++ b/roles/7-edu-apps/tasks/main.yml
@@ -11,7 +11,8 @@
 - name: KOLIBRI
   include_role:
     name: kolibri
-  when: kolibri_install and python_version is version('3.12', '<')    # Debian 13 still uses Python 3.11 (for now!) so really this just avoids Ubuntu 24.04 and 24.10 pre-releases during initial iiab-install.  CLARIF: This is all TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases (expected very soon).
+  when: kolibri_install
+  #when: kolibri_install and python_version is version('3.12', '<')    # Debian 13 still uses Python 3.11 (for now!) so really this just avoids Ubuntu 24.04 and 24.10 pre-releases during initial iiab-install.  CLARIF: This is all TEMPORARY until learningequality/kolibri#11316 brings Python 3.12 support to Kolibri 0.17 pre-releases (expected very soon).
 
 - name: KIWIX
   include_role:

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -121,6 +121,12 @@
 #     codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
 #   when: is_debian or is_linuxmint_20
 
+
+- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to a Kolibri 0.17 pre-release, if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
+  set_fact:
+    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0-alpha0/kolibri_0.17.0a0-0ubuntu1_all.deb
+  when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, and pre-releases of 24.10, and Debian 13 (which still uses Python 3.11 for now!?)  PLEASE SEE: learningequality/kolibri#11316
+
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
   apt:
     name: kolibri


### PR DESCRIPTION
When Kolibri 0.16.x or 0.17 pre-releases allow for this, hopefully very soon in coming weeks, thanks to upstream work ongoing here:

- learningequality/kolibri#11316

In short, this PR will revert...

- PR #3741

Related:

- https://github.com/iiab/iiab/issues/3709#issuecomment-1962517952
- #3733