### PR TITLE
Support experimental IIAB installs on Raspberry Pi OS 13 "Trixie"

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -91,7 +91,8 @@ case $OS_VER in
     "ubuntu-2410"  | \
     "linuxmint-21" | \
     "linuxmint-22" | \
-    "raspbian-12")
+    "raspbian-12"  | \
+    "raspbian-13")
         ;;
     *) echo -e "\n\e[41;1mOS '$OS_VER' IS NOT SUPPORTED. Please read:\e[0m\n\n\e[1mhttps://github.com/iiab/iiab/wiki/IIAB-Platforms\e[0m\n" ; exit 1    # Used by /opt/iiab/iiab/iiab-install
         ;;

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -802,6 +802,7 @@ is_debian_12: False
 #is_debian_8: False
 
 is_raspbian: False    # Covers both: RPi HW + non-RPi HW versions of Raspberry Pi OS (Raspbian)
+is_raspbian_13: False
 is_raspbian_12: False
 #is_raspbian_11: False
 #is_raspbian_10: False

--- a/vars/raspbian-13.yml
+++ b/vars/raspbian-13.yml
@@ -1,0 +1,7 @@
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_debian: True    # Opposite of is_ubuntu for now
+is_debian_13: True
+is_raspbian: True
+is_raspbian_13: True


### PR DESCRIPTION
Debian 13 "Trixie" and Raspberry Pi OS 13 "Trixie" are both about a year away, but experimental IIAB installs onto both pre-release OS's greatly help to prepare, as well as toughening up overall code safety.

Related:

- PR #3598
- #3736