### PR TITLE
Very basic iiab-update command, that also upgrades IIAB Calibre-Web

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -34,14 +34,22 @@
 
 # Copies the latest/known version of iiab-diagnostics into /usr/bin (so it can
 # be run even if local source tree /opt/iiab/iiab is deleted to conserve disk).
-- name: Copy iiab-summary & iiab-diagnostics from /opt/iiab/iiab/scripts/ to /usr/bin/
+- name: Copy iiab-update & iiab-summary & iiab-diagnostics from /opt/iiab/iiab/scripts/ to /usr/bin/
   copy:
     src: "{{ iiab_dir }}/scripts/{{ item }}"
     dest: /usr/bin/
     mode: '0755'
   with_items:
+    - iiab-update
     - iiab-summary
     - iiab-diagnostics
+
+- name: Symlink /usr/bin/iiab-upgrade -> /usr/bin/iiab-update
+  file:
+    src: /usr/bin/iiab-update
+    path: /usr/bin/iiab-upgrade
+    state: link
+    force: yes
 
 - name: Create globally-writable directory /etc/iiab/diag (0777) so non-root users can run 'iiab-diagnostics'
   file:

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -49,7 +49,7 @@
     src: /usr/bin/iiab-update
     path: /usr/bin/iiab-upgrade
     state: link
-    force: yes
+    #force: yes
 
 - name: Create globally-writable directory /etc/iiab/diag (0777) so non-root users can run 'iiab-diagnostics'
   file:

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -99,8 +99,8 @@ echo -e "    'apt purge ansible'       and/or  'pip3 uninstall ansible'"
 #echo -e "(3) Remove all lines containing 'ansible' from..."
 #echo -e "    /etc/apt/sources.list and /etc/apt/sources.list.d/*\n"
 
-echo -e "IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)"
-echo -e "https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n"
+#echo -e "IIAB INSTALL INSTRUCTIONS: (OLDER, MANUAL APPROACH)"
+#echo -e "https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch\n"
 
 if [ "$(command -v ansible)" ]; then    # "command -v" is POSIX compliant; also catches built-in commands like "cd"
     CURR_VER=$(ansible --version | head -1 | cut -f 2- -d " ")
@@ -308,5 +308,5 @@ echo -e "\n\nSUCCESS!  PLEASE VERIFY ANSIBLE WITH COMMANDS LIKE:\n"
 echo -e "    ansible --version"
 echo -e "    /usr/local/ansible/bin/pip3 show ansible-core"
 echo -e '    apt -a list "ansible*"'
-echo -e "    ansible-galaxy collection list\n"
-echo -e "WARNING: Start a new Linux shell, if it changed from /usr/bin to /usr/local/bin\n\n"
+echo -e "    ansible-galaxy collection list\n\n"
+#echo -e "WARNING: Start a new Linux shell, if it changed from /usr/bin to /usr/local/bin\n\n"

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Basic updating/upgrading of IIAB's core software (2 main repos) from GitHub.
+
+# With a focus on upgrading IIAB Calibre-Web, if that's installed:
+# https://github.com/iiab/calibre-web/wiki
+
+if [[ $(id -un) != "root" ]]; then
+    echo -e "\nPlease run: sudo iiab-update\n"
+    exit 1
+fi
+
+if [[ $1 == "-f" || $1 == "--fast" ]]; then
+    echo -e "\n\n\e[44;1mAttempting a FAST upgrade of IIAB Calibre-Web...\e[0m\n"
+    echo -e "\n\e[33m'iiab-update -f' DOES NOT apply apt updates.\e[0m"
+else
+    echo -e "\n\n\e[44;1mBasic upgrade of IIAB core software (2 main repos) & Calibre-Web:\e[0m\n"
+    echo -e "\n\e[44;1mOr try 'iiab-update -f' for a FAST upgrade of IIAB Calibre-Web!\e[0m\n\n"
+    echo -e "\e[4mNow running: apt update\e[0m\n"
+    apt update
+    echo -e "\n\e[4mNow running: apt dist-upgrade -y\e[0m\n"
+    apt dist-upgrade -y
+    echo -e "\n\e[4mNow running: apt autoremove -y\e[0m\n"
+    apt autoremove -y
+fi
+
+cd /opt/iiab/iiab
+if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "" ]]; then
+    echo -e "\n\n\e[41;1mIn /opt/iiab/iiab, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
+    exit 1
+fi
+echo -e "\n\n\e[4mNow running: git pull https://github.com/iiab/iiab --no-rebase --no-edit\e[0m\n"
+git pull https://github.com/iiab/iiab --no-rebase --no-edit
+if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise Ansible (roles/0-init) does it below!
+    cd scripts
+    echo -e "\n\e[4mNow running: cp iiab-update iiab-summary iiab-diagnostics /usr/bin\e[0m\n"
+    cp iiab-update iiab-summary iiab-diagnostics /usr/bin
+fi
+
+if [[ $1 == "-f" || $1 == "--fast" ]]; then
+    echo -e "\n\e[33m'iiab-update -f' DOES NOT upgrade Ansible.\e[0m\n"
+else
+    echo -e "\n\n\e[4mNow running: scripts/ansible\e[0m"
+    scripts/ansible
+fi
+
+if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
+    if [[ $1 == "-f" || $1 == "--fast" ]]; then
+        echo -e "\n\e[1mIf you want a COMPLETE reinstall of Calibre-Web, then also run:\n\n\e[0m\e[7mcd /opt/iiab/iiab ; ./runrole --reinstall calibre-web\e[0m\n"
+    fi
+    echo -e "\e[4mNow running: pipx uninstall xklb    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
+    pipx uninstall xklb
+    echo -e "\n\e[4mNow running: pipx install xklb      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
+    pipx install xklb
+    echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
+    yt-dlp --version
+    echo
+    cd /usr/local/calibre-web-py3
+    if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "" ]]; then
+	echo -e "\n\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
+	exit 1
+    fi
+    echo -e "\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
+    git pull https://github.com/iiab/calibre-web --no-rebase --no-edit
+    cd /opt/iiab/iiab
+    if [[ $1 == "-f" || $1 == "--fast" ]]; then
+	echo -e "\n\e[4mNow running: systemctl restart calibre-web\e[0m\n"
+        systemctl restart calibre-web
+    else
+	echo -e "\n\e[4mNow running: ./runrole --reinstall calibre-web\e[0m\n"
+        ./runrole --reinstall calibre-web
+    fi
+fi
+
+# 2024-07-17: Run Admin Console stanza last for safety -- it failed ~50% of the
+# time over 20 tests for me -- leading to 3+ different kinds of errors right
+# after "(Restarting CMDSRV" e.g. "syntax error near unexpected token" was the
+# most common error -- once the error was "command not found" -- and another
+# time Admin Console's ./install VERY MYSTERIOUSLY RAN TWICE!
+#
+# Any chance this get_oer2go_catalog error ~15 lines up...might be related ?
+#
+# ...
+# Finished writing to /etc/iiab/kiwix_catalog.json
+# SUCCESS/opt/admin/cmdsrv/scripts/get_oer2go_catalog:52: SyntaxWarning: invalid escape sequence '\<'
+#   php_parser = re.compile('\<\?php echo .+? \?>')
+# Skipping module not needed by Internet in a Box 12 en-PhET
+# ...
+# [ ~15 lines ]
+# ...
+# (Restarting CMDSRV
+# ...
+# [ VARIOUS ERRORS SOMETIMES HAPPEN HERE ]
+
+if [ -d /opt/admin ]; then
+    if [[ $1 == "-f" || $1 == "--fast" ]]; then
+	echo -e "\n\e[33m'iiab-update -f' DOES NOT upgrade Admin Console.\e[0m"
+    else
+	cd /opt/iiab/iiab-admin-console
+	if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "" ]]; then
+	    echo -e "\n\n\e[41;1mIn /opt/iiab/iiab-admin-console, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
+	    exit 1
+	fi
+	echo -e "\n\e[4mNow running: git pull https://github.com/iiab/iiab-admin-console --no-rebase --no-edit\e[0m\n"
+	git pull https://github.com/iiab/iiab-admin-console --no-rebase --no-edit
+	echo -e "\n\e[4mNow running: ./install\e[0m\n"
+	./install
+    fi
+fi
+
+echo -e "\n\n\e[44;1miiab-update COMPLETE!\e[0m\n\n"

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -52,6 +52,8 @@ if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
     pipx uninstall xklb
     echo -e "\n\e[4mNow running: pipx install xklb      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
     pipx install xklb
+    # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
+    # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
     echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
     yt-dlp --version
     cd /usr/local/calibre-web-py3

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -54,13 +54,12 @@ if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
     pipx install xklb
     echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
     yt-dlp --version
-    echo
     cd /usr/local/calibre-web-py3
     if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit venv detritus, e.g. untracked files like these 5: bin/ include/ lib/ lib64 pyvenv.cfg
 	echo -e "\n\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
 	exit 1
     fi
-    echo -e "\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
+    echo -e "\n\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
     git pull https://github.com/iiab/calibre-web --no-rebase --no-edit
     cd /opt/iiab/iiab
     if [[ $1 == "-f" || $1 == "--fast" ]]; then

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -56,7 +56,7 @@ if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
     yt-dlp --version
     echo
     cd /usr/local/calibre-web-py3
-    if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "" ]]; then
+    if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit venv detritus, e.g. untracked files like these 5: bin/ include/ lib/ lib64 pyvenv.cfg
 	echo -e "\n\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
 	exit 1
     fi

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -31,7 +31,7 @@ if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "
 fi
 echo -e "\n\n\e[4mNow running: git pull https://github.com/iiab/iiab --no-rebase --no-edit\e[0m\n"
 git pull https://github.com/iiab/iiab --no-rebase --no-edit
-if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise Ansible (roles/0-init) does it below!
+if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise ./runrole and ./install do it below! (as Ansible runs roles/0-init)
     cd scripts
     echo -e "\n\e[4mNow running: cp iiab-update iiab-summary iiab-diagnostics /usr/bin\e[0m\n"
     cp iiab-update iiab-summary iiab-diagnostics /usr/bin


### PR DESCRIPTION
- This PR is introduces an extremely simple command-line tool (iiab-update) to "git pull" from IIAB's 2 main repos, while offering a few basic extras, e.g. to validate that these very basic upgrades of IIAB and Admin Console appear sane.
- Also assists with "git pull" upgrading of IIAB Calibre-Web (i.e. sync'ing from GitHub to local repo `/usr/local/calibre-web-py3`, and using pipx to upgrade xklb and yt-dlp).
- Safeguards are built in, in all 3 cases — e.g. to avoid damage if local repo is being customized (e.g. if any of the 3 local repos have files modified or have staged changes; or if any of these 3 local repos {iiab, iiab-admin-console, calibre-web} are not currently set to the "master" branch).

Related:

- iiab/calibre-web#31