### PR TITLE
Strengthen Calibre-Web's yt-dlp upgrading + document yt-dlp "nightly" version + mention NEW (WIP) iiab-update command

### DIFF
--- a/roles/calibre-web/README.rst
+++ b/roles/calibre-web/README.rst
@@ -157,26 +157,31 @@ as it contains your Calibre-Web content **and** configuration settings!
 Upgrading
 ---------
 
-"Reinstalling" Calibre-Web automatically installs the latest version — if your
-Internet-in-a-Box (IIAB) is online.
+Please see our `new/automated upgrade technique (iiab-update) <https://github.com/iiab/calibre-web/wiki#upgrading>`_
+introduced in July 2024.
 
-But first: back up your content **and** configuration settings, as explained above.
+But first: back up your content **and** configuration settings, as outlined
+above!
 
-**Also move your /library/calibre-web/config/app.db AND/OR
-/library/calibre-web/metadata.db out of the way — if you're sure you want to
-fully reset your Calibre-Web settings (to install defaults) AND/OR remove all
-e-book metadata!  Then run, as root**::
+**Conversely if you're sure you want to fully reset your Calibre-Web settings,
+and remove all existing e-book/video/media metadata — then move your
+/library/calibre-web/config/app.db, /library/calibre-web/metadata.db and
+/library/calibre-web/xklb-metadata.db out of the way.**
+
+RECAP: In general, "reinstalling" Calibre-Web automatically installs the latest
+version — if your Internet-in-a-Box (IIAB) is online.  Strongly consider the
+new ``iiab-update`` technique described above.  But if you must use the
+older/manual technique, you would need to run, as root::
 
   cd /opt/iiab/iiab
   ./runrole --reinstall calibre-web
 
-Or, if you just want to upgrade Calibre-Web code alone, prior to proceeding
-manually::
+Or, if you want to try upgrading Calibre-Web code alone::
 
   cd /usr/local/calibre-web-py3
   git pull
 
-This older way is *no longer recommended*::
+Finally, this much older way is *no longer recommended*::
 
   cd /opt/iiab/iiab
   ./iiab-install --reinstall    # OR: ./iiab-configure

--- a/roles/calibre-web/README.rst
+++ b/roles/calibre-web/README.rst
@@ -168,15 +168,15 @@ and remove all existing e-book/video/media metadata — then move your
 /library/calibre-web/config/app.db, /library/calibre-web/metadata.db and
 /library/calibre-web/xklb-metadata.db out of the way.**
 
-RECAP: In general, "reinstalling" Calibre-Web automatically installs the latest
-version — if your Internet-in-a-Box (IIAB) is online.  Strongly consider the
-new ``iiab-update`` technique described above.  But if you must use the
-older/manual technique, you would need to run, as root::
+RECAP: Either way, "reinstalling" Calibre-Web automatically installs the latest
+version — so long as your Internet-in-a-Box (IIAB) is online.  Most people
+should stick with the new ``iiab-update`` technique above.  However if you must
+use the older/manual approach, you would need to run, as root::
 
   cd /opt/iiab/iiab
   ./runrole --reinstall calibre-web
 
-Or, if you want to try upgrading Calibre-Web code alone::
+Or, if there's a need to try updating Calibre-Web's code alone::
 
   cd /usr/local/calibre-web-py3
   git pull

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -70,7 +70,7 @@
     if [ -f {{ calibreweb_venv_path }}/scripts/lb-wrapper ]; then
         apt install ffmpeg pipx -y
         if lb --version; then
-            pipx upgrade --include-injected xklb
+            pipx reinstall xklb
         else
             pipx install xklb
             ln -sf /root/.local/bin/lb /usr/local/bin/lb
@@ -82,6 +82,8 @@
                 echo "ERROR: yt-dlp NOT FOUND"
             fi
         fi
+        # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
+        # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
         cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/
         chmod a+x /usr/local/bin/lb-wrapper
     fi

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -1,3 +1,8 @@
+# To upgrade IIAB Calibre-Web:
+# https://github.com/iiab/calibre-web/wiki#upgrading
+# https://github.com/iiab/iiab/blob/master/scripts/iiab-update
+
+
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1


### PR DESCRIPTION
Very important to use a recent version of [yt-dlp](https://github.com/yt-dlp/yt-dlp), now that YouTube would appear to be adding many new restrictions.

A few more details:

- https://github.com/iiab/calibre-web/wiki#xklb-and-yt-dlp-back-end-integration
- https://github.com/iiab/calibre-web/wiki#upgrading

This PR builds on:

- PR #3678