### PR TITLE
iiab-update: minor refinements for safety + usability

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -e
+# "-e" tries to exit right away on error.
 
 # Upgrade IIAB core software (apt updates, Ansible, Admin Console, etc).
 
@@ -40,7 +41,7 @@
     if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise ./runrole does it below! (as Ansible runs roles/0-init)
         cd scripts
         echo -e "\n\e[4mNow running: cp iiab-update iiab-summary iiab-diagnostics /usr/bin\e[0m\n"
-        cp iiab-update iiab-summary iiab-diagnostics /usr/bin
+        cp -u iiab-update iiab-summary iiab-diagnostics /usr/bin
     fi
 
     if [[ $1 == "-f" || $1 == "--fast" ]]; then

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -40,7 +40,7 @@
     git pull https://github.com/iiab/iiab --no-rebase --no-edit
     if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise ./runrole does it below! (as Ansible runs roles/0-init)
         cd scripts
-        echo -e "\n\e[4mNow running: cp iiab-update iiab-summary iiab-diagnostics /usr/bin\e[0m\n"
+        echo -e "\n\e[4mNow running: cp -u iiab-update iiab-summary iiab-diagnostics /usr/bin\e[0m\n"
         cp -u iiab-update iiab-summary iiab-diagnostics /usr/bin
     fi
 


### PR DESCRIPTION
1) Running the bash script with `bash -e` seems prudent during initial testing/validation especially.
2) When run in fast mode (`iiab-update -f` or `iiab-update --fast`), copying with `cp -u` (--update, i.e. files are replaced if they're older than the corresponding source file) is more appropriate — when overwriting /usr/bin/iiab-update, /usr/bin/iiab-summary and /usr/bin/iiab-diagnostics.

Related:

- iiab/calibre-web#31
- PR #3768
- PR #3769
- PR #3770