### PR TITLE
iiab-update: Permit /opt/iiab/iiab untracked files like adm-run-roles-tmp.yml

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -32,7 +32,7 @@
     fi
 
     cd /opt/iiab/iiab
-    if [[ $(git branch --show-current) != "master" || $(git status --porcelain) != "" ]]; then
+    if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit detritus, e.g. untracked files like adm-run-roles-tmp.yml
         echo -e "\n\n\e[41;1mIn /opt/iiab/iiab, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
         exit 1
     fi


### PR DESCRIPTION
Thank you @nzola for catching this important case I missed!

(i.e. Admin Console's Ansible playbooks created on-the-fly)

```
root@lokole2:/opt/iiab/iiab# git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        adm-run-roles-tmp.yml

nothing added to commit but untracked files present (use "git add" to track)
```

Building on / Related tickets:

- iiab/calibre-web#31
- PR #3768
- PR #3769
- PR #3770
- PR #3771