### PR TITLE
iiab-update: Skip Admin Console `./install` if it appears already up-to-date

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -111,10 +111,16 @@
                 echo -e "\n\n\e[41;1mIn /opt/iiab/iiab-admin-console, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
                 exit 1
             fi
+            GITHASH1=$(git rev-parse HEAD)
             echo -e "\n\e[4mNow running: git pull https://github.com/iiab/iiab-admin-console --no-rebase --no-edit\e[0m\n"
             git pull https://github.com/iiab/iiab-admin-console --no-rebase --no-edit
-            echo -e "\n\e[4mNow running: ./install\e[0m\n"
-            ./install
+            GITHASH2=$(git rev-parse HEAD)
+            if [[ $GITHASH1 != $GITHASH2 ]]; then
+                echo -e "\n\e[4mNow running: ./install\e[0m\n"
+                ./install
+            else
+                echo -e "\n\e[33mSkipping Admin Console './install' — as it appears up-to-date!\e[0m"
+            fi
         fi
     fi
 


### PR DESCRIPTION
Just a hack / optimization that can sometimes help `iiab-update` run 2X to 5X faster.

Related:

- iiab/calibre-web#31
- PR #3768
- PR #3769
- PR #3770
- PR #3771
- PR #3772

Tested on Ubuntu 24.04