### PR TITLE
`iiab-update -f` installs Calibre-Web's latest requirements.txt + mentions alternative `iiab-update` w/o flags

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -21,7 +21,7 @@
         echo -e "\n\n\e[44;1mAttempting a FAST upgrade of IIAB Calibre-Web...\e[0m\n"
         echo -e "\n\e[33m'iiab-update -f' DOES NOT apply apt updates.\e[0m"
     else
-        echo -e "\n\n\e[44;1mUpgrade IIAB core software: (apt updates, Ansible, Admin Console, etc)\e[0m\n"
+        echo -e "\n\n\e[44;1mUpgrading IIAB core software: (apt updates, Ansible, Admin Console, etc)\e[0m\n"
         echo -e "\n\e[44;1mOr try 'iiab-update -f' for a FAST upgrade of IIAB Calibre-Web!\e[0m\n\n"
         echo -e "\e[4mNow running: apt update\e[0m\n"
         apt update
@@ -45,16 +45,13 @@
     fi
 
     if [[ $1 == "-f" || $1 == "--fast" ]]; then
-        echo -e "\n\e[33m'iiab-update -f' DOES NOT upgrade Ansible.\e[0m\n"
+        echo -e "\n\e[33m'iiab-update -f' DOES NOT upgrade Ansible.\e[0m\n\n"
     else
         echo -e "\n\n\e[4mNow running: scripts/ansible\e[0m"
         scripts/ansible
     fi
 
     if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
-        if [[ $1 == "-f" || $1 == "--fast" ]]; then
-            echo -e "\n\e[1mIf you want a COMPLETE reinstall of Calibre-Web, then also run:\n\n\e[0m\e[7mcd /opt/iiab/iiab ; ./runrole --reinstall calibre-web\e[0m\n"
-        fi
         echo -e "\e[4mNow running: pipx uninstall xklb    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
         pipx uninstall xklb
         echo -e "\n\e[4mNow running: pipx install xklb      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
@@ -72,11 +69,13 @@
         systemctl stop calibre-web
         echo -e "\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
         git pull https://github.com/iiab/calibre-web --no-rebase --no-edit
-        cd /opt/iiab/iiab
         if [[ $1 == "-f" || $1 == "--fast" ]]; then
-            echo -e "\n\e[4mNow running: systemctl restart calibre-web\e[0m\n"
+            echo -e "\n\e[4mNow running: bin/pip install -r requirements.txt --prefer-binary\e[0m\n"
+            bin/pip install -r requirements.txt --prefer-binary > /dev/null
+            echo -e "\e[4mNow running: systemctl restart calibre-web\e[0m\n"
             systemctl restart calibre-web
         else
+            cd /opt/iiab/iiab
             echo -e "\n\e[4mNow running: ./runrole --reinstall calibre-web\e[0m\n"
             ./runrole --reinstall calibre-web
         fi
@@ -124,7 +123,12 @@
         fi
     fi
 
-    echo -e "\n\n\e[44;1miiab-update COMPLETE!\e[0m\n\n"
+    if [[ $1 == "-f" || $1 == "--fast" ]]; then
+        echo -e "\n\n\e[44;1m'iiab-update -f' COMPLETE!\e[0m\n"
+        echo -e "\e[44;1mIf Calibre-Web fails, please try 'iiab-update' WITHOUT '-f'\e[0m\n\n"    # \e[7m == reverse video (e.g. black on white)
+    else
+        echo -e "\n\n\e[44;1miiab-update COMPLETE!\e[0m\n\n"
+    fi
 
     exit    # https://stackoverflow.com/questions/2285403/how-to-make-shell-scripts-robust-to-source-being-changed-as-they-run
 }


### PR DESCRIPTION
Thanks @avni for having tested, surfacing the problem arising from upstream changes to requirements.txt like `flask-httpAuth` suddenly appearing in https://github.com/janeczku/calibre-web/commit/2d470e0ce134339782108b4590113147e288b7f8#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552

So...

- `iiab-update -f` should now be substantially more resilient (e.g. when upstream changes in https://github.com/janeczku/calibre-web/commits/master/requirements.txt are merged into IIAB Calibre-Web).  All in all, it's now extremely similar to [IIAB's Ansible role](https://github.com/iiab/iiab/blob/master/roles/calibre-web/tasks/install.yml) (but much faster!)
- `iiab-update -f` should now be easier to understand, with this prominent blue warning displayed at the bottom as it finishes, reminding folks to try the alternative:

![image](https://github.com/user-attachments/assets/d3b43abf-6f72-4378-b42f-9afbb0a16f60)

Tested on Ubuntu 24.10

Related:

- iiab/calibre-web#31
- PR #3768
- PR #3769
- PR #3770
- PR #3771
- PR #3772
- PR #3773