### PR TITLE
Improved upgrading of Calibre-Web via BOTH approaches: (1) `iiab-update -f` fast way, via bash (2) `iiab-update` slow/forcible/thorough way, via Ansible

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -72,7 +72,7 @@
 # https://github.com/janeczku/calibre-web/pull/1459
 
 #- name: "Clone i.e. download Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~120 MB initially, ~203+ MB later) -- if {{ calibreweb_venv_path }} created just above"
-- name: "Clone (or 'git pull' to update, forcibly!) Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~122 MB initially, ~191+ MB later)"
+- name: "Clone (or 'git pull' to update, forcibly!) Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~122 MB initially, ~191+ or ~203+ MB later)"
   git:
     repo: "{{ calibreweb_repo_url }}"    # e.g. https://github.com/iiab/calibre-web or https://github.com/janeczku/calibre-web
     dest: "{{ calibreweb_venv_path }}"

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -1,12 +1,22 @@
-# To upgrade IIAB Calibre-Web:
+# Or try 'iiab-update -f' for a more rapid upgrade of IIAB Calibre-Web:
+#
+# https://wiki.iiab.io/go/FAQ#Can_I_upgrade_IIAB_software%3F
 # https://github.com/iiab/calibre-web/wiki#upgrading
 # https://github.com/iiab/iiab/blob/master/scripts/iiab-update
+# https://github.com/iiab/iiab/tree/master/roles/calibre-web#upgrading
 
 
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1
 
+
+- name: Stop 'calibre-web' systemd service for safety (RED ERROR CAN BE IGNORED!)
+  systemd:
+    name: calibre-web
+    state: stopped
+  ignore_errors: True    # Shows red errors, and continue...
+  #failed_when: False    # Hides red errors, and continue...
 
 - name: "Install packages: imagemagick, python3-netifaces"
   package:
@@ -38,10 +48,10 @@
     state: absent
   when: calibreweb_venv_wipe
 
-- name: Does {{ calibreweb_venv_path }} exist?
-  stat:
-    path: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
-  register: calibreweb_venv
+# - name: Does {{ calibreweb_venv_path }} exist?
+#   stat:
+#     path: "{{ calibreweb_venv_path }}"
+#   register: calibreweb_venv
 
 - name: "Create 3 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_venv_path }}, {{ calibreweb_config }} (all set to {{ calibreweb_user }}:{{ apache_user }}) (default to 0755)"
   file:
@@ -52,7 +62,7 @@
   with_items:
     - "{{ calibreweb_home }}"         # /library/calibre-web
     - "{{ calibreweb_config }}"       # /library/calibre-web/config
-    - "{{ calibreweb_venv_path }}"
+    - "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
 
 # FYI since May 2021, Calibre-Web (major releases) can be installed with pip:
 # https://pypi.org/project/calibreweb/
@@ -61,14 +71,15 @@
 # https://github.com/janeczku/calibre-web/pull/927
 # https://github.com/janeczku/calibre-web/pull/1459
 
-- name: "Clone i.e. download Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~120 MB initially, ~203+ MB later) -- if {{ calibreweb_venv_path }} created just above"
+#- name: "Clone i.e. download Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~120 MB initially, ~203+ MB later) -- if {{ calibreweb_venv_path }} created just above"
+- name: "Clone (or 'git pull' to update, forcibly!) Calibre-Web ({{ calibreweb_version }}) from {{ calibreweb_repo_url }} to {{ calibreweb_venv_path }} (~122 MB initially, ~191+ MB later)"
   git:
     repo: "{{ calibreweb_repo_url }}"    # e.g. https://github.com/iiab/calibre-web or https://github.com/janeczku/calibre-web
     dest: "{{ calibreweb_venv_path }}"
-    force: yes
-    #depth: 1    # 2023-11-04: Full clone for now, to help @deldesir & wider community testing
-    version: "{{ calibreweb_version }}"    # e.g. master, 0.6.21
-  when: not calibreweb_venv.stat.exists
+    force: yes    # "any modified files in the working repository will be discarded"
+    #depth: 1     # 2023-11-04: Full clone for now, to help @deldesir & wider community testing
+    version: "{{ calibreweb_version }}"    # e.g. master, 0.6.22
+  #when: not calibreweb_venv.stat.exists
 
 - name: If Calibre-Web is being enhanced with audio/video "books" too, install/upgrade additional prereqs -- SEE https://github.com/iiab/calibre-web/wiki
   shell: |

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -81,6 +81,11 @@
     version: "{{ calibreweb_version }}"    # e.g. master, 0.6.22
   #when: not calibreweb_venv.stat.exists
 
+- debug:
+    msg:
+      - "NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  RUN THE NEXT LINE -- for the latest yt-dlp 'nightly' release:"
+      - sudo pipx inject --pip-args='--upgrade --pre' -f xklb yt-dlp[default]
+
 - name: If Calibre-Web is being enhanced with audio/video "books" too, install/upgrade additional prereqs -- SEE https://github.com/iiab/calibre-web/wiki
   shell: |
     if [ -f {{ calibreweb_venv_path }}/scripts/lb-wrapper ]; then
@@ -98,7 +103,7 @@
                 echo "ERROR: yt-dlp NOT FOUND"
             fi
         fi
-        # NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  UNCOMMENT THE NEXT LINE -- for the latest yt-dlp "nightly" release::
+        # NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  UNCOMMENT THE NEXT LINE -- for the latest yt-dlp "nightly" release:
         # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
         #
         # https://github.com/yt-dlp/yt-dlp-nightly-builds/releases

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -98,8 +98,11 @@
                 echo "ERROR: yt-dlp NOT FOUND"
             fi
         fi
-        # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
+        # NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  UNCOMMENT THE NEXT LINE -- for the latest yt-dlp "nightly" release::
         # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
+        #
+        # https://github.com/yt-dlp/yt-dlp-nightly-builds/releases
+        # https://pypi.org/project/yt-dlp/#history
         cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/
         chmod a+x /usr/local/bin/lb-wrapper
     fi

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -59,13 +59,16 @@
             pipx install xklb
             echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
             yt-dlp --version
-	    echo -e '\n\e[4mNeed better YouTube scraping? Run this for the latest yt-dlp "nightly" release:\e[0m\n\n\e[1mpipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]\e[0m\n'
-            # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
+            echo -e '\n\e[4mNeed better YouTube scraping? Run this for the latest yt-dlp "nightly" release:\e[0m\n\n\e[1mpipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]\e[0m\n'
+            # NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  UNCOMMENT THE NEXT LINE:
             # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
+            #
+            # https://github.com/yt-dlp/yt-dlp-nightly-builds/releases
+            # https://pypi.org/project/yt-dlp/#history
             cd /usr/local/calibre-web-py3
             if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit venv detritus, e.g. untracked files like these 5: bin/ include/ lib/ lib64 pyvenv.cfg
-		echo -e "\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
-		exit 1
+                echo -e "\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
+                exit 1
             fi
             echo -e "\e[4mNow running: systemctl stop calibre-web\e[0m\n"
             systemctl stop calibre-web

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -52,24 +52,25 @@
     fi
 
     if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
-        echo -e "\e[4mNow running: pipx uninstall xklb    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
-        pipx uninstall xklb
-        echo -e "\n\e[4mNow running: pipx install xklb      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
-        pipx install xklb
-        # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
-        # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
-        echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
-        yt-dlp --version
-        cd /usr/local/calibre-web-py3
-        if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit venv detritus, e.g. untracked files like these 5: bin/ include/ lib/ lib64 pyvenv.cfg
-            echo -e "\n\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
-            exit 1
-        fi
-        echo -e "\n\e[4mNow running: systemctl stop calibre-web\e[0m\n"
-        systemctl stop calibre-web
-        echo -e "\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
-        git pull https://github.com/iiab/calibre-web --no-rebase --no-edit
         if [[ $1 == "-f" || $1 == "--fast" ]]; then
+            echo -e "\e[4mNow running: pipx uninstall xklb    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
+            pipx uninstall xklb
+            echo -e "\n\e[4mNow running: pipx install xklb      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
+            pipx install xklb
+            echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"
+            yt-dlp --version
+	    echo -e '\n\e[4mNeed better YouTube scraping? Run this for the latest yt-dlp "nightly" release:\e[0m\n\n\e[1mpipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]\e[0m\n'
+            # IF YOU WANT THE "nightly" RELEASE OF yt-dlp, UNCOMMENT THE NEXT LINE:
+            # pipx inject --pip-args="--upgrade --pre" -f xklb yt-dlp[default]
+            cd /usr/local/calibre-web-py3
+            if [[ $(git branch --show-current) != "master" || $(git status --porcelain --untracked-files=no) != "" ]]; then    # Permit venv detritus, e.g. untracked files like these 5: bin/ include/ lib/ lib64 pyvenv.cfg
+		echo -e "\n\e[41;1mIn /usr/local/calibre-web-py3, (1) 'git branch' MUST show current branch 'master' and (2) 'git status' must show NO MODIFIED FILES.\e[0m\n\n"
+		exit 1
+            fi
+            echo -e "\e[4mNow running: systemctl stop calibre-web\e[0m\n"
+            systemctl stop calibre-web
+            echo -e "\e[4mNow running: git pull https://github.com/iiab/calibre-web --no-rebase --no-edit\e[0m\n"
+            git pull https://github.com/iiab/calibre-web --no-rebase --no-edit
             echo -e "\n\e[4mNow running: bin/pip install -r requirements.txt --prefer-binary\e[0m\n"
             bin/pip install -r requirements.txt --prefer-binary > /dev/null
             echo -e "\e[4mNow running: systemctl restart calibre-web\e[0m\n"


### PR DESCRIPTION
The bash version of Calibre-Web's upgrader (within `/usr/bin/iiab-update`) is increasingly now very solid, very explanatory — and in fact more resilient + more useful than the Ansible version in almost every way. 😄

So the [Ansible version](https://github.com/iiab/iiab/blob/master/roles/calibre-web/tasks/install.yml) will need to be tightened up very soon.

Hopefully as part of this PR in coming days, or coming hours.

This PR (WIP) was tested on Ubuntu 24.10.  It builds on:

- iiab/calibre-web#31
- PR #3768
- PR #3769 
- PR #3770 
- PR #3771
- PR #3772 
- PR #3773 
- PR #3774