### PR TITLE
KA Lite is dying: Time for Kolibri to become mainline

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -476,14 +476,14 @@ wordpress_enabled: False
 # 7-EDU-APPS
 
 # KA Lite - SEE THE "Transmission" BITTORRENT DOWNLOADER FURTHER BELOW, TO INSTALL THOUSANDS OF VIDEOS
-kalite_install: True
-kalite_enabled: True
+kalite_install: False
+kalite_enabled: False
 kalite_server_port: 8008
 kalite_root: "{{ content_base }}/ka-lite"    # /library/ka-lite
 
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
-kolibri_install: False
-kolibri_enabled: False
+kolibri_install: True
+kolibri_enabled: True
 kolibri_language: en     # See KOLIBRI_SUPPORTED_LANGUAGES at the bottom of https://github.com/learningequality/kolibri/blob/develop/kolibri/utils/i18n.py
 kolibri_home: "{{ content_base }}/kolibri"    # /library/kolibri
 kolibri_user: kolibri    # WARNING: https://github.com/learningequality/kolibri-installer-debian/issues/115

--- a/vars/local_vars_medical.yml
+++ b/vars/local_vars_medical.yml
@@ -1,7 +1,7 @@
 # Default overrides
 kiwix_incl_apk: True
-kalite_install: False
-kalite_enabled: False
+kolibri_install: False
+kolibri_enabled: False
 captiveportal_install: True
 captiveportal_enabled: True
 mediawiki_install: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -284,8 +284,8 @@ wordpress_enabled: True
 # 7-EDU-APPS
 
 # KA Lite - SEE THE "Transmission" BITTORRENT DOWNLOADER FURTHER BELOW, TO INSTALL THOUSANDS OF VIDEOS
-kalite_install: True
-kalite_enabled: True
+kalite_install: False
+kalite_enabled: False
 
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
 kolibri_install: True

--- a/vars/local_vars_none.yml
+++ b/vars/local_vars_none.yml
@@ -1,8 +1,8 @@
 # turn off defaults
 remoteit_install: False
 openvpn_install: False
-kalite_install: False
-kalite_enabled: False
+kolibri_install: False
+kolibri_enabled: False
 kiwix_install: False
 kiwix_enabled: False
 osm_vector_maps_install: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -284,12 +284,12 @@ wordpress_enabled: False
 # 7-EDU-APPS
 
 # KA Lite - SEE THE "Transmission" BITTORRENT DOWNLOADER FURTHER BELOW, TO INSTALL THOUSANDS OF VIDEOS
-kalite_install: True
-kalite_enabled: True
+kalite_install: False
+kalite_enabled: False
 
 # Successor to KA Lite, for offline-first teaching and learning - from learningequality.org
-kolibri_install: False
-kolibri_enabled: False
+kolibri_install: True
+kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console


### PR DESCRIPTION
KA Lite (based on Python 2.7) is officially dying, almost 5 years after many sincere efforts to rescue it!

So it's time to face reality and begin mainlining Kolibri instead, as a recommendation for many-if-not-most IIAB installations, and especially with Kolibri 0.17's release being imminent in coming weeks.

(It's been a very long and important road with KA Lite, no question — with just some of those more recent efforts hereunder ;)

- #2680
- PR #3534
- PR #3587
- PR #3648
- #3731
- PR #3733