### PR TITLE
Bypass initial install of Transmission on 24.04 & 24.10 & Linux Mint 22 [allowing smooth MEDIUM-sized & LARGE-sized IIAB installs]

### DIFF
--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: TRANSMISSION
   include_role:
     name: transmission
-  when: transmission_install
+  when: transmission_install and not (is_ubuntu_2404 or is_ubuntu_2410)    # Also excludes is_linuxmint_22, for #3756 (whereas Debian 13 works great!)
 
 - name: AWSTATS
   include_role:


### PR DESCRIPTION
### Fixes bug:

Streamlines IIAB installation on several recent OS's, by bypassing Ubuntu's broken Transmission (apt package) as documented in places like:

- https://github.com/iiab/iiab/issues/3756#issuecomment-2262892912

### Description of changes proposed in this pull request:

If Ubuntu 24.04 or 24.10 or Mint 22 are detected, bypass initial install of Transmission thanks to [roles/8-mgmt-tools/tasks/main.yml](https://github.com/iiab/iiab/blob/master/roles/8-mgmt-tools/tasks/main.yml)

### Smoke-tested on which OS or OS's:

Ubuntu 24.10

### Mention a team member @username e.g. to help with code review:

@EMG70

Related:

- #3736