### PR TITLE
Kolibri 0.17 RC2 if Python >= 3.12

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -127,7 +127,7 @@
 
 - name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to a Kolibri 0.17 pre-release, if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
   set_fact:
-    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0-rc0/kolibri_0.17.0rc0-0ubuntu1_all.deb
+    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0-rc2/kolibri_0.17.0rc2-0ubuntu1_all.deb
   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, and pre-releases of 24.10, and soon Debian 13 (which still uses Python 3.11 for now, but will likely start using Python 3.13 in coming months).  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11892 learningequality/kolibri#11316
 
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)


### PR DESCRIPTION
ANNC:

https://github.com/learningequality/kolibri/releases/tag/v0.17.0-rc2

Building on:
- PR #3778