### PR TITLE
Kolibri 0.17.0 (final release process underway) if Python >= 3.12

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -125,10 +125,10 @@
 #   when: is_debian or is_linuxmint_20
 
 
-- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to a Kolibri 0.17 (pre-release or final release) if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
+- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.17.x (pre-release or final release) if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
   set_fact:
     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
-  when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if it changes from Python 3.12 to 3.13).  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11892 learningequality/kolibri#11316
+  when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
   apt:

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -125,9 +125,9 @@
 #   when: is_debian or is_linuxmint_20
 
 
-- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to a Kolibri 0.17 pre-release, if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
+- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to a Kolibri 0.17 (pre-release or final release) if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
   set_fact:
-    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0-rc3/kolibri_0.17.0rc3-0ubuntu1_all.deb
+    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if it changes from Python 3.12 to 3.13).  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11892 learningequality/kolibri#11316
 
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)


### PR DESCRIPTION
ANNC:

https://github.com/learningequality/kolibri/releases/tag/v0.17.0

FYI Kolibri install approach(es) will evolve in coming days/weeks/months, as Kolibri refines its PPA strategy:

- learningequality/kolibri#11892

Building on:

- PR #3751
- PR #3782