### PR TITLE
Revert to installing Kolibri (i.e. 0.17.0+) via PPA across the board, by default anyway, regardless whether or not Python >= 3.12

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -125,10 +125,13 @@
 #   when: is_debian or is_linuxmint_20
 
 
-- name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.17.x (pre-release or final release) if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
-  set_fact:
-    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
-  when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
+# 2024-08-07: Hack no longer needed!  As Kolibri 0.17.0 now installs via "kolibri" PPA (https://launchpad.net/~learningequality/+archive/ubuntu/kolibri).
+# Hopefully "kolibri-proposed" PPA will install 0.18 pre-releases soon, on Python 3.13 too!  https://github.com/learningequality/kolibri/issues/11892
+
+# - name: '2024-06-25 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.17.x (pre-release or final release) if Python >= 3.12 -- kolibri-proposed PPA should do this automatically in future!'
+#   set_fact:
+#     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
+#   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
   apt:


### PR DESCRIPTION
As brand new [Kolibri 0.17.0](https://github.com/learningequality/kolibri/releases/tag/v0.17.0) now installs via "kolibri" PPA (https://launchpad.net/~learningequality/+archive/ubuntu/kolibri) — as was smoke-tested on Ubuntu 22.04 and 24.04.

So this PR restores the PPA approach to installing Kolibri (i.e. 0.17.0 for now) across the board — regardless whether or not Python >= 3.12.

- Hopefully Kolibri 0.17.0 works well today on almost all OS's, CPU architectures, etc — but please shout if you discover any problems!

- And hopefully their other PPA ([kolibri-proposed](https://launchpad.net/~learningequality/+archive/ubuntu/kolibri-proposed)) will install Kolibri 0.18 pre-releases very soon, on Python 3.13 too in preparation for Debian 13!

Building on:

- PR #3783