### PR TITLE
iiab-diagnostics: Try paste.centos.org instead of dpaste.com

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -275,7 +275,7 @@ echo -e "\e[1m"
 if ! [[ $ans =~ ^[nNqQ]$ ]]; then
     echo -ne "PUBLISHING TO URL... "    # Run 'pastebinit -l' to list other possible pastebin site URLs
     pastebinit -b paste.centos.org $outfile    # 2024-08-10: Basic line numbers & "4 weeks" good enough?
-    #nc termbin.com 9999 < $outfile            # 2024-08-10: No line numbers & limited to 7 days!
+    #nc termbin.com 9999 < $outfile            # 2024-08-10: No line numbers & limited to 7 days (rudimentary but reliable option if nec in future?!)
     #pastebinit -b dpaste.com $outfile         # 2024-08-10: Unfortunately limited to 30 days by default.  Claims 1,000,000 character maximum pastebin size (or usage quota within N days?)  But newly restricted to LESS THAN 500 LINES (e.g. after IP address blocks & email appeals kinda work, but take almost 24h each time!)
     #pastebinit -b sprunge.us $outfile         # Stopped working for many weeks (mid-2023, and again in mid-2024)
     #pastebinit -b paste2.org $outfile         # Spammy/dangerous pastebins

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -273,13 +273,15 @@ echo
 echo -e "\e[1m"
 #if [ "$ans" == "" ] || [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
 if ! [[ $ans =~ ^[nNqQ]$ ]]; then
-    echo -ne "PUBLISHING TO URL... "        # Run 'pastebinit -l' to list other possible pastebin site URLs
-    pastebinit -b dpaste.com $outfile     # Unfortunately limited to 30 days by default.  Claims 1,000,000 character maximum pastebin size, but that claim is not 100% accurate.
-    #pastebinit -b sprunge.us $outfile    # Stopped working for many weeks (mid-2023, and again in mid-2024)
-    #pastebinit -b paste2.org $outfile    # Spammy/dangerous pastebins
+    echo -ne "PUBLISHING TO URL... "    # Run 'pastebinit -l' to list other possible pastebin site URLs
+    pastebinit -b paste.centos.org $outfile    # 2024-08-10: Basic line numbers & "4 weeks" good enough?
+    #nc termbin.com 9999 < $outfile            # 2024-08-10: No line numbers & limited to 7 days!
+    #pastebinit -b dpaste.com $outfile         # 2024-08-10: Unfortunately limited to 30 days by default.  Claims 1,000,000 character maximum pastebin size (or usage quota within N days?)  But newly restricted to LESS THAN 500 LINES (e.g. after IP address blocks & email appeals kinda work, but take almost 24h each time!)
+    #pastebinit -b sprunge.us $outfile         # Stopped working for many weeks (mid-2023, and again in mid-2024)
+    #pastebinit -b paste2.org $outfile         # Spammy/dangerous pastebins
 else
     echo -e "If you later decide to publish it, run:"
     echo
-    echo -e "   pastebinit -b dpaste.com < $outfile"
+    echo -e "   pastebinit -b paste.centos.org $outfile"
 fi
 echo -e "\e[0m"


### PR DESCRIPTION
...as a result of https://dpaste.com blocking numerous IP addresses in recent weeks, and then even after unblocking (email appeal process) pastes appear to be restricted to much less than 500 lines! 😢

So moving forward, https://paste.centos.org looks like the best option at the moment.

(https://termbin.com is also documented, if worst case that very rudimentary option proves necessary!)

Tested on Raspberry Pi OS.