### PR TITLE
Moodle dev branch renamed from 'master' to 'main'

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -8,11 +8,11 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# 2023-04-25: Currently testing Moodle's master branch is mandatory if your
+# April 2024: Currently testing Moodle's main branch is mandatory if your
 # OS PHP >= 8.3, see moodle/tasks/install.yml for detail!  OR, *IF* your
 # OS PHP < 8.3, then {{ moodle_version }} will be attempted:
 moodle_version: MOODLE_404_STABLE    # Moodle 4.4
-#moodle_version: master              # e.g. to try Moodle's "weekly" 4.5dev pre-release *EVEN IF* OS PHP < 8.4
+#moodle_version: main                # e.g. to try Moodle's "weekly" 4.5dev pre-release *EVEN IF* OS PHP < 8.4
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -104,12 +104,12 @@
     version: "{{ moodle_version }}"    # e.g. MOODLE_404_STABLE (Moodle 4.4)
   when: php_version is version('8.3', '<')
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'master' to {{ moodle_base }} (~458 MB initially, ~485 MB later) if OS PHP {{ php_version }} >= 8.3"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'main' to {{ moodle_base }} (~458 MB initially, ~485 MB later) if OS PHP {{ php_version }} >= 8.3"
   git:
     repo: "{{ moodle_repo_url }}"
     dest: "{{ moodle_base }}"
     depth: 1
-    version: master    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023, 4.4dev in Oct 2023, 4.5dev in Apr 2024)
+    version: main    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023, 4.4dev in Oct 2023, 4.5dev in Apr 2024)
   when: php_version is version('8.3', '>=')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)


### PR DESCRIPTION
Thanks to @EMG70 who surfaced this bug a few weeks ago and I finally now understand it!

This PR fixes the problem by cloning (and documenting!) [Moodle branch main](https://github.com/moodle/moodle) instead of branch `master` — a change that occurred in the Moodle dev community only very recently.

Tested by installing Moodle 4.5dev LTS on Ubuntu 24.10, with PHP 8.3 ✅ 

Tangentially related:

- PR #3656
- PR #3730