### PR TITLE
Refine iiab-vpn status table of Tailscale IPs/usernames/etc

### DIFF
--- a/roles/tailscale/templates/iiab-vpn
+++ b/roles/tailscale/templates/iiab-vpn
@@ -58,6 +58,11 @@ echo -e "\e[4mTo permanently log out of VPN:\e[0m\n"
 echo -e "    tailscale logout\n"
 
 # More useful table of IPs/usernames/etc than 'tailscale status'
-echo -e "\e[44;1mVPN peers: (rightmost column = online/offline)\e[0m\n"
-tailscale status --json | jq -r '.Self,.Peer[] | .Tags[] + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + .OS + " " + .Relay + " " + (.Online|tostring)' | sort -V | column -t
+#echo -e "\e[44;1mVPN peers: (rightmost column = online/offline)\e[0m\n"
+#tailscale status --json | jq -r '.Self,.Peer[] | .Tags[] + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + .OS + " " + .Relay + " " + (.Online|tostring)' | sort -V | column -t
+echo -e '\e[44;1mVPN peers: ("true" in 6th column means online)\e[0m\n'
+tailscale status --json | jq -r '.Self,.Peer[] | .Tags[] + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + .Relay + " " + (.Online|tostring) + " " + .OS' | sort -V | column -t | \
+    while read line; do
+	echo "$line" $(tailscale whois --json $(echo $line | cut -d' ' -f2) | jq -r '.Node.Hostinfo | .Distro + " " + .DistroVersion + " " + .DeviceModel');
+    done
 echo


### PR DESCRIPTION
Substantially more informative than `tailscale status`, if a bit slower.

If in future this VPN status table's size/slowness proves too unwieldy, its functionality could be removed from `/usr/bin/iiab-vpn` into a separate command, if really necessary.

Tested on Debian 12.7 on x86_64.

Refines:

- PR #3800

Related:

- PR #3798
- PR #3802