### PR TITLE
`nodocs: True` in local_vars_unittest.yml

### DIFF
--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -222,7 +222,7 @@ nginx_high_php_limits: False
 apache_allow_sudo: False
 
 # Toggle iiab-refresh-wiki-docs scraping for offline docs (http://box/info)
-nodocs: False
+nodocs: True
 
 
 # 5-XO-SERVICES


### PR DESCRIPTION
To speed up unit testing.

Some may also want to set these manually in `/etc/iiab/local_vars.yml` — for even faster unit-testing:

```
network_install: False
network_enabled: False
```

Tangentially related:

- iiab/calibre-web#260