### PR TITLE
Internet access test... more relevant / more targeted... for live scraping of IIAB docs during IIAB installs (i.e. /usr/bin/iiab-refresh-wiki-docs)

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -94,10 +94,12 @@
 
 
 # 2022-06-30: internet_available var removed
-- name: 'Test for Internet access, using: {{ iiab_download_url }}/heart-beat.txt'
+- name: 'Test for Internet access, using: https://wiki.iiab.io'
   get_url:
-    url: "{{ iiab_download_url }}/heart-beat.txt"
-    dest: /tmp/heart-beat.txt
+    #url: "{{ iiab_download_url }}/heart-beat.txt"
+    url: https://wiki.iiab.io
+    #dest: /tmp/heart-beat.txt
+    dest: /tmp/internet_access_test.html
     #timeout: "{{ download_timeout }}"
     # @jvonau recommends: 100sec is too much (keep 10sec default)
   ignore_errors: True
@@ -105,9 +107,9 @@
   #poll: 2
   register: internet_access_test
 
-- name: Remove downloaded Internet test file /tmp/heart-beat.txt
+- name: Remove downloaded Internet test file /tmp/internet_access_test.html
   file:
-    path: /tmp/heart-beat.txt
+    path: /tmp/internet_access_test.html
     state: absent
 
 - name: Run /usr/bin/iiab-refresh-wiki-docs (scraper script) to create http://box/info offline documentation.  (This script was installed in Stage 3 = roles/3-base-server/tasks/main.yml, which ran roles/www_base/tasks/main.yml)


### PR DESCRIPTION
Help to make IIAB installs more resilient when iiab.io is very occasionally unreachable / down / etc.

Tested on Ubuntu 24.10 (pre-release).

Tangentially related:

- https://github.com/iiab/calibre-web/issues/260#issuecomment-2380658083