### PR TITLE
scripts/iiab-update: Also update /usr/bin/iiab-vpn

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -38,9 +38,14 @@
     fi
     echo -e "\n\n\e[4mNow running: git pull https://github.com/iiab/iiab --no-rebase --no-edit\e[0m\n"
     git pull https://github.com/iiab/iiab --no-rebase --no-edit
+    echo
+    if grep -q 'tailscale_installed: True' /etc/iiab/iiab_state.yml; then
+        echo -e "\e[4mNow running: cp -u roles/tailscale/templates/iiab-vpn /usr/bin\e[0m\n"
+        cp -u roles/tailscale/templates/iiab-vpn /usr/bin
+    fi
     if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise ./runrole does it below! (as Ansible runs roles/0-init)
         cd scripts
-        echo -e "\n\e[4mNow running: cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin\e[0m\n"
+        echo -e "\e[4mNow running: cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin\e[0m\n"
         cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin
     fi
 


### PR DESCRIPTION
QA volunteers need better tooling, to keep laser focus on [unit testing](https://github.com/iiab/iiab/blob/master/vars/local_vars_unittest.yml) the PR at hand (or whatever ;) with no other distractions!

This PR helps push commands like `/usr/bin/iiab-update -f` (i.e. fast) and `/usr/bin/iiab-update` a bit further down that road.

As tested on Debian 12.

Related:

- PR #3768
- PR #3798