### PR TITLE
local_vars_unittest.yml: SKIP roles/network, for FASTER UNIT TESTING

### DIFF
--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -12,6 +12,12 @@
 # CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See "wifi_up_down: True" below.
 
 
+# We SKIP roles/network, for FASTER UNIT TESTING!  (so IF an internal hotspot
+# is later desired, change these two lines to 'True', then run 'iiab-network')
+network_install: False
+network_enabled: False
+
+
 # Ansible's default timeout for "get_url:" downloads (10 seconds) often fails
 download_timeout: 100
 


### PR DESCRIPTION
To help IIAB's QA community _**focus like a laser**_ on extremely rapid testing (of specific PRs, of specific apps, or whatever!)

As recommended by @deldesir, @EMG70 and others.

The risks of course are real... as new QA volunteers (who type 0 for a "ZERO-sized" IIAB install) will inevitably sometimes get confused... by these 2 key facts:

- [local_vars_unittest.yml](https://github.com/iiab/iiab/blob/master/vars/local_vars_unittest.yml) will NOT install-or-customize any networking, beyond what the OS itself has already arranged!
- [local_vars_unittest.yml](https://github.com/iiab/iiab/blob/master/vars/local_vars_unittest.yml) does NOT install Admin Console, so IIAB's home page DOES NOT appear!

Building on:

- PR #3810