### PR TITLE
RIP apt package `wireless-tools` (Ansible output will auto-highlight distros like Ubuntu 24.10+ that increasingly deprecate it, to help us monitor Debian 13/14/etc)

### DIFF
--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -18,7 +18,7 @@
 # total download size) and they can help IIAB field operators with BOTH
 # (1) internal WiFi AND (2) USB WiFi devices inserted anytime/later.
 
-- name: 'Install 12 network packages: avahi-daemon, hostapd, iproute2, iptables-persistent, iw, libnss-mdns, netmask, net-tools, networkd-dispatcher, rfkill, wireless-tools, wpasupplicant -- later used by https://github.com/iiab/iiab/tree/master/roles/network'
+- name: 'Install 11 network packages: avahi-daemon, hostapd, iproute2, iptables-persistent, iw, libnss-mdns, netmask, net-tools, networkd-dispatcher, rfkill, wpasupplicant -- later used by https://github.com/iiab/iiab/tree/master/roles/network'
   package:
     name:
       - avahi-daemon           #   97kB download: RasPiOS (and package libnss-mnds, below) install this regardless -- holdover from the XO days and used to advertise ssh/admin-console being available via avahi-daemon -- used with https://github.com/iiab/iiab/blob/master/roles/network/tasks/avahi.yml
@@ -32,9 +32,17 @@
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
-      - wireless-tools         #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
+
+# 2024-10-02: Legacy apt package 'wireless-tools' no longer offered by Ubuntu
+# 24.10+ (#3805) but FYI: https://en.wikipedia.org/wiki/Wireless_tools_for_Linux
+- name: "Install legacy apt package wireless-tools, if OS still supports it -- or intentionally show (HARMLESS!) red error -- helping to monitor Linux's evolution"
+  package:
+    name: wireless-tools       #  112kB download: RasPiOS installs this regardless -- manipulate Linux Wireless Extensions
+    state: present
+  ignore_errors: True    # Intentionally show red error, and continue.
+  #failed_when: False    # Hides red errors (stronger than 'ignore_errors: yes')
 
 # 2021-08-17: Debian ignores this, according to 2013 post:
 # https://serverfault.com/questions/511099/debian-ignores-etc-network-if-pre-up-d-iptables


### PR DESCRIPTION
Recap:

- Ubuntu 24.10 removed (no longer offers) legacy apt package `wireless-tools` as explained in #3805.

- This PR intentionally highlights the absence (inability to install) apt package `wireless-tools` in Ansible's output, with an intentionally bright + intentionally harmless red error — to help us all monitor Linux/distros as they continue to evolve year-by-year... (e.g. increasingly deprecate in this case?)

- In the meantime, legacy apt package `wireless-tools` will continue to be installed as part of many/most IIAB's, in cases where the underlying OS still offers it.

Tested with a LARGE-sized IIAB install on Ubuntu 24.10.