### PR TITLE
Add xklb-patch script

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -117,7 +117,8 @@
         # https://github.com/yt-dlp/yt-dlp-nightly-builds/releases
         # https://pypi.org/project/yt-dlp/#history
         cp {{ calibreweb_venv_path }}/scripts/lb-wrapper /usr/local/bin/
-        chmod a+x /usr/local/bin/lb-wrapper
+        cp {{ calibreweb_venv_path }}/scripts/xklb-patch /usr/local/bin/
+        chmod a+x /usr/local/bin/lb-wrapper /usr/local/bin/xklb-patch
     fi
 
 - name: Download Calibre-Web dependencies from 'requirements.txt' into python3 virtual environment {{ calibreweb_venv_path }}


### PR DESCRIPTION
Adds xklb-patch script to be run on Calibre-Web [re]start.

In support of https://github.com/iiab/calibre-web/pull/265

- [ ] Tested on Ubuntu 24.04
- [ ] Tested on Raspberry PI OS Lite 64bit

@holta
