### PR TITLE
iiab-summary: Clean output, when tailscale has no IP

### DIFF
--- a/scripts/iiab-summary
+++ b/scripts/iiab-summary
@@ -81,7 +81,8 @@ echo "$(df -h /)      ZIMs: $(ls /library/zims/content/ | wc -l) OER2Go: $(ls /l
 echo
 #grep "^openvpn_handle:" /etc/iiab/local_vars.yml
 #grep "^tailscale_installed:" /etc/iiab/iiab_state.yml
-if [[ $(command -v /usr/bin/tailscale) ]]; then
+#if [[ $(command -v /usr/bin/tailscale) ]]; then
+if tailscale ip &> /dev/null; then
     #echo "VPN: $(tailscale ip) $(tailscale whois --json $(tailscale ip -1) | jq -r .Node.Tags[])"
     echo "VPN: $(tailscale ip) $(tailscale status --json | jq -r .Self.Tags[])"
 fi


### PR DESCRIPTION
`iiab-summary` command output was ugly, when Tailscale is not install and/or Tailscale does not "yet" have an IP address, e.g. the ~20 lines of output would end with:

```
no current Tailscale IPs; state: NeedsLogin
jq: error (at <stdin>:42): Cannot iterate over null (null)
VPN:
lo enp5s0 enp6s0 tailscale0
box u2410.lxd
10.181.233.160 192.168.0.246 fd42:fb6b:9c93:d2f1:5054:ff:feda:ad3e
```

So this PR eliminates the 3 ugly/useless upper lines, above.

As tested on Debian 12 and Ubuntu 24.10

Refining:

- PR #3798

Related:

- PR #3802
- PR #3816