### PR TITLE
Fix iiab-vpn output, when tag:username is missing from any Tailscale peer/node (IP address) — avoiding jq error "Cannot iterate over null (null)"

### DIFF
--- a/roles/tailscale/templates/iiab-vpn
+++ b/roles/tailscale/templates/iiab-vpn
@@ -62,7 +62,8 @@ echo -e "    tailscale logout\n"
 #tailscale status --json | jq -r '.Self,.Peer[] | .Tags[] + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + .OS + " " + .Relay + " " + (.Online|tostring)' | sort -V | column -t
 #echo -e '\e[44;1mVPN peers: ("true" in 6th column means online)\e[0m\n'
 echo -e '\e[44;1mVPN peers: (6th column = online/offline)\e[0m\n'
-tailscale status --json | jq -r '.Self,.Peer[] | (if .Tags[] == "" then "-" else .Tags[] end) + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + (if .Relay == "" then "-" else .Relay end) + " XXX" + (.Online|tostring) + "XXX " + .OS' | sort -V | column -t | \
+# (try .Tags[] catch "-") is safer than (.Tags[]? // "-") according to: https://stackoverflow.com/questions/54794749/jq-error-at-stdin0-cannot-iterate-over-null-null
+tailscale status --json | jq -r '.Self,.Peer[] | (try .Tags[] catch "-") + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + (if .Relay == "" then "-" else .Relay end) + " XXX" + (.Online|tostring) + "XXX " + .OS' | sort -V | column -t | \
     while read l; do
         line=$(echo "$l" | sed 's/ XXXtrueXXX /\\e[0;32m ✅\\e[0m/ ; s/ XXXfalseXXX /\\e[0;31m ❌ \\e[0m/')
         echo -e "$line" $(tailscale whois --json $(echo $line | cut -d' ' -f2) | jq -r '.Node.Hostinfo | .Distro + " " + .DistroVersion + " " + .DeviceModel');


### PR DESCRIPTION
This PR resolves [jq](https://medium.com/@buczynski.rafal/exploring-jq-a-guide-to-essential-techniques-and-tools-for-professionals-b9df9db490de) error "Cannot iterate over null (null)" in the following PR from 2 weeks ago, that was insufficiently tested!

- PR #3813

As tested on Ubuntu 24.10

Building on original Tailscale work from a month ago:

- PR #3798
- PR #3800
- PR #3802