### PR TITLE
Revert PR #3815: python3-cryptography no longer needed

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -21,11 +21,11 @@
 # Official upstream instructions:
 # apt install python3-pip python3-venv
 # https://github.com/janeczku/calibre-web/wiki/Manual-installation
-- name: "Install packages: imagemagick, python3-cryptography, python3-netifaces"
+- name: "Install packages: imagemagick, python3-netifaces"
   package:
     name:
       - imagemagick
-      - python3-cryptography    # Required on Raspberry Pi OS (see iiab/calibre-web#260)
+      #- python3-cryptography    # Was needed on Raspberry Pi OS (SEE iiab/calibre-web#260, janeczku/calibre-web#3183)
       - python3-netifaces
     state: present
 


### PR DESCRIPTION
Pulling together conclusion from a month ago, thanks to new upstream cleanup:

- PR #3815 
- janeczku/calibre-web#3183
- iiab/calibre-web#264
- PR iiab/calibre-web#275