### PR TITLE
Fix tailscale tab completion, when /etc/bash_completion.d does not yet exist

### DIFF
--- a/roles/tailscale/tasks/install.yml
+++ b/roles/tailscale/tasks/install.yml
@@ -19,7 +19,7 @@
     update_cache: yes
 
 - name: Set up tab completion for 'tailscale' at the command-line
-  shell: tailscale completion bash > /etc/bash_completion.d/tailscale
+  shell: mkdir -p /etc/bash_completion.d && tailscale completion bash > /etc/bash_completion.d/tailscale
 
 - name: "Install ssh public keys for remote support (only runs if 'tailscale_install: True')"
   lineinfile:


### PR DESCRIPTION
Tested on Ubuntu 24.04.

Building on:

- PR #3798