### PR TITLE
Defer initial install of Transmission... on Ubuntu 25.04 too!

### DIFF
--- a/roles/8-mgmt-tools/tasks/main.yml
+++ b/roles/8-mgmt-tools/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: TRANSMISSION
   include_role:
     name: transmission
-  when: transmission_install and not (is_ubuntu_2404 or is_ubuntu_2410)    # Also excludes is_linuxmint_22, for #3756 (whereas Debian 13 works great!)
+  when: transmission_install and not (is_ubuntu_2404 or is_ubuntu_2410 or is_ubuntu_2504)    # Also excludes is_linuxmint_22, for #3756 (whereas Debian 13 works great!)
 
 - name: AWSTATS
   include_role:


### PR DESCRIPTION
As the following longstanding Transmission bug (only affects Ubuntu-like distros??) also affects Ubuntu 25.04 pre-releases:

- #3756

Example, after this problem interrupted a LARGE-sized install of IIAB on the latest Ubuntu 25.04:

```
root@u2504-large:/opt/iiab/iiab# systemctl status transmission-daemon.service
× transmission-daemon.service - Transmission BitTorrent Daemon
     Loaded: loaded (/usr/lib/systemd/system/transmission-daemon.service; enabled; preset: enabled)
     Active: failed (Result: timeout) since Sat 2024-11-16 17:14:21 EST; 1h 0min ago
 Invocation: c5d7a5f47a77408e86d44a8bb2978f04
       Docs: man:transmission-daemon(1)
    Process: 57663 ExecStart=/usr/bin/transmission-daemon -f --log-level=error (code=exited, status=0/SUCCESS)
   Main PID: 57663 (code=exited, status=0/SUCCESS)
   Mem peak: 5.7M
        CPU: 309ms

Nov 16 17:12:50 box systemd[1]: Starting transmission-daemon.service - Transmission BitTorrent Daemon...
Nov 16 17:14:20 box systemd[1]: transmission-daemon.service: start operation timed out. Terminating.
Nov 16 17:14:21 box transmission-daemon[57663]: Closing transmission session... done.
Nov 16 17:14:21 box systemd[1]: transmission-daemon.service: Failed with result 'timeout'.
Nov 16 17:14:21 box systemd[1]: Failed to start transmission-daemon.service - Transmission BitTorrent Daemon.
```