### PR TITLE
drop netifaces workaround - replaced with netifaces-plus

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -26,7 +26,7 @@
     name:
       - imagemagick
       #- python3-cryptography    # Was needed on Raspberry Pi OS (SEE iiab/calibre-web#260, janeczku/calibre-web#3183)
-      - python3-netifaces
+      #- python3-netifaces
     state: present
 
 # https://github.com/iiab/iiab/pull/3496#issuecomment-1475094542
@@ -125,7 +125,8 @@
     requirements: "{{ calibreweb_venv_path }}/requirements.txt"
     virtualenv: "{{ calibreweb_venv_path }}"    # /usr/local/calibre-web-py3
     #virtualenv_site_packages: no
-    virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
+    #virtualenv_command: python3 -m venv --system-site-packages {{ calibreweb_venv_path }}
+    virtualenv_command: python3 -m venv {{ calibreweb_venv_path }}
     extra_args: --prefer-binary    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 # 2023-10-11: RasPiOS Bookworm doc for Python with venv (PEP 668 now enforced!)


### PR DESCRIPTION
### Fixes bug:
just keeping up with changes to requirements,txt upstream  
### Description of changes proposed in this pull request:
drop workaround for failure to compile package
### Smoke-tested on which OS or OS's:
24.04 vm installs clean but no functional testing preformed.
### Mention a team member @username e.g. to help with code review:
