### PR TITLE
Check if older version of 'library' (xklb) is installed

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -99,7 +99,12 @@
     if [ -f {{ calibreweb_venv_path }}/scripts/lb-wrapper ]; then
         apt install ffmpeg pipx -y
         if lb --version; then
-            pipx reinstall library
+            if pipx list | grep -q 'xklb'; then
+                pipx uninstall xklb
+                pipx install library
+            else
+                pipx reinstall library
+            fi
         else
             pipx install library
             ln -sf /root/.local/bin/lb /usr/local/bin/lb

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -107,14 +107,14 @@
             fi
         else
             pipx install library
-            ln -sf /root/.local/bin/lb /usr/local/bin/lb
-            if [ -f /root/.local/share/pipx/venvs/library/bin/yt-dlp ]; then
-                ln -sf /root/.local/share/pipx/venvs/library/bin/yt-dlp /usr/local/bin/yt-dlp
-            elif [ -f /root/.local/pipx/venvs/library/bin/yt-dlp ]; then
-                ln -sf /root/.local/pipx/venvs/library/bin/yt-dlp /usr/local/bin/yt-dlp
-            else
-                echo "ERROR: yt-dlp NOT FOUND"
-            fi
+        fi
+        ln -sf /root/.local/bin/lb /usr/local/bin/lb
+        if [ -f /root/.local/share/pipx/venvs/library/bin/yt-dlp ]; then
+            ln -sf /root/.local/share/pipx/venvs/library/bin/yt-dlp /usr/local/bin/yt-dlp
+        elif [ -f /root/.local/pipx/venvs/library/bin/yt-dlp ]; then
+            ln -sf /root/.local/pipx/venvs/library/bin/yt-dlp /usr/local/bin/yt-dlp
+        else
+            echo "ERROR: yt-dlp NOT FOUND"
         fi
         # NEED BETTER/EXPERIMENTAL YouTube SCRAPING?  UNCOMMENT THE NEXT LINE -- for the latest yt-dlp "nightly" release:
         # pipx inject --pip-args="--upgrade --pre" -f library yt-dlp[default]

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -64,7 +64,7 @@
                 pipx uninstall xklb
             fi
             echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
-            pipx uninstall library
+            pipx uninstall library || true
             echo -e "\n\e[4mNow running: pipx install library      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
             pipx install library
             echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -58,6 +58,11 @@
 
     if grep -q 'calibreweb_installed: True' /etc/iiab/iiab_state.yml; then
         if [[ $1 == "-f" || $1 == "--fast" ]]; then
+            echo -e "\e[4mChecking if an older version of 'library' (formerly 'xklb') exists...\e[0m"
+            if pipx list | grep -q 'xklb'; then
+                echo -e "\e[4mOlder version 'xklb' detected. Now running: pipx uninstall xklb\e[0m"
+                pipx uninstall xklb
+            fi
             echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
             pipx uninstall library
             echo -e "\n\e[4mNow running: pipx install library      # THIS ALSO INSTALLS yt-dlp\e[0m\n"

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -63,12 +63,8 @@
                 echo -e "\e[4mOlder version 'xklb' detected. Now running: pipx uninstall xklb\e[0m"
                 pipx uninstall xklb
             fi
-            if pipx list | grep -q 'library'; then
-                echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
-                pipx uninstall library
-            else
-                echo -e "\e[4m'library' not found. Skipping uninstall.\e[0m\n"
-            fi
+            echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
+            pipx uninstall library || true
             echo -e "\n\e[4mNow running: pipx install library      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
             pipx install library
             echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"

--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -63,8 +63,12 @@
                 echo -e "\e[4mOlder version 'xklb' detected. Now running: pipx uninstall xklb\e[0m"
                 pipx uninstall xklb
             fi
-            echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
-            pipx uninstall library || true
+            if pipx list | grep -q 'library'; then
+                echo -e "\e[4mNow running: pipx uninstall library    # THIS ALSO UNINSTALLS yt-dlp\e[0m\n"
+                pipx uninstall library
+            else
+                echo -e "\e[4m'library' not found. Skipping uninstall.\e[0m\n"
+            fi
             echo -e "\n\e[4mNow running: pipx install library      # THIS ALSO INSTALLS yt-dlp\e[0m\n"
             pipx install library
             echo -e "\n\e[4mNow running: yt-dlp --version\e[0m\n"


### PR DESCRIPTION
### Fixes bug:
Prevents conflict from having `lb` command already tied to older version of 'library' (formerly `xklb`).

### Description of changes proposed in this pull request:
This PR ensures `xklb` is uninstalled first before switching to its renamed version `library`. This case is likely to be encountered in a IIAB VM/machine created prior the renaming.

### Smoke-tested on which OS or OS's:
- [x] Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 
