### PR TITLE
Bypass /etc/ImageMagick-6/policy.xml PDF surgery if ImageMagick 7+

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -38,6 +38,13 @@
 #    state: present
 #  when: python_version is version('3.10', '>=')
 
+- name: Does /etc/ImageMagick-6/policy.xml exist?
+  stat:
+    path: /etc/ImageMagick-6/policy.xml
+  register: imagemagick6_policy_xml
+
+# 2024-12-16: Debian 13 uses /etc/ImageMagick-7/policy.xml instead, which doesn't need this lineinfile surgery:
+# https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion
 - name: Allow ImageMagick to read PDFs, per /etc/ImageMagick-6/policy.xml, to create book cover thumbnails
   lineinfile:
     path: /etc/ImageMagick-6/policy.xml
@@ -45,8 +52,9 @@
     backrefs: yes
     line: '  <policy domain="coder" rights="read" pattern="PDF" />'
     state: present
+  when: imagemagick6_policy_xml.stat.exists
 
-- name: "Create 3 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_venv_path }}, {{ calibreweb_config }} (all set to {{ calibreweb_user }}:{{ apache_user }}) (default to 0755)"
+- name: "Create 2 Calibre-Web folders to store data and config files: {{ calibreweb_home }}, {{ calibreweb_config }} (each set to {{ calibreweb_user }}:{{ apache_user }}, default to 0755)"
   file:
     state: directory
     path: "{{ item }}"


### PR DESCRIPTION
Thanks @deldesir for uncovering this bug:

Debian 13 pre-releases recently changed from ImageMagick 6 to 7.

And the need for workaround surgery on /etc/ImageMagick-6/policy.xml (from ~5 years ago) is no longer, with /etc/ImageMagick-7/policy.xml especially!  As outlined here:

https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion

FYI this PR/fix was successfully smoke-tested in combination with 2 other PR's on the latest Debian 13 pre-release:

- PR #3852
- PR #3862