### PR TITLE
rpi_debian.yml: rfkill unblock wifi [REC: set country code in advance]

### DIFF
--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -55,7 +55,7 @@
 
 # This should go away, should only be unblocked by raspi-config
 - name: Enable the WiFi with rfkill
-  shell: rfkill unblock 0
+  shell: rfkill unblock wifi
   ignore_errors: True
 
 - name: Copy the bridge script for RPi


### PR DESCRIPTION
### Fixes bug:

Should mitigate the worst of #3856

### Description of changes proposed in this pull request:

Follow rfkill syntax / usage used by RasPiOS within raspi-config.

### Smoke-tested on which OS or OS's:

64-bit Raspberry Pi OS, graphical version.