### PR TITLE
Refine PR #3866 to unblock WiFi hotspot on newer RasPiOS with NM (NetworkManager)

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -68,6 +68,11 @@
   #### End services
 
   #### Start network layout
+  - name: Unblock WiFi on RaspiOS
+    shell: raspi-config nonint do_wifi_country {{ host_country_code }}
+    ignore_errors: True
+    when: is_raspbian
+
   #- name: Redhat networking
   #  include_tasks: ifcfg_mods.yml
   #  when: is_redhat

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -68,10 +68,12 @@
   #### End services
 
   #### Start network layout
-  - name: Unblock WiFi on RaspiOS
-    shell: raspi-config nonint do_wifi_country {{ host_country_code }}
-    ignore_errors: True
+
+  # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml isn't enough, especially with NM (NetworkManager)
+  - name: Run 'raspi-config nonint do_wifi_country {{ host_country_code }}' (using var host_country_code) to unblock WiFi, if RasPiOS
+    command: raspi-config nonint do_wifi_country {{ host_country_code }}
     when: is_raspbian
+    #ignore_errors: True
 
   #- name: Redhat networking
   #  include_tasks: ifcfg_mods.yml

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -69,7 +69,7 @@
 
   #### Start network layout
 
-  # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml isn't enough, especially with NM (NetworkManager)
+  # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml wasn't enough, especially with NM (NetworkManager)
   - name: Run 'raspi-config nonint do_wifi_country {{ host_country_code }}' (using var host_country_code) to unblock WiFi, if RasPiOS
     command: raspi-config nonint do_wifi_country {{ host_country_code }}
     when: is_raspbian

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -53,11 +53,6 @@
     line: country={{ host_country_code }}
   when: country_code.stdout is defined and country_code.stdout | length == 0
 
-# This should go away, should only be unblocked by raspi-config
-- name: Enable the WiFi with rfkill
-  shell: rfkill unblock wifi
-  ignore_errors: True
-
 - name: Copy the bridge script for RPi
   template:
     dest: /etc/network/interfaces.d/iiab

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -53,6 +53,12 @@
     line: country={{ host_country_code }}
   when: country_code.stdout is defined and country_code.stdout | length == 0
 
+# 2024-12-18: SEE 'raspi-config nonint do_wifi_country {{ host_country_code }}' in roles/network/tasks/main.yml
+# # This should go away, should only be unblocked by raspi-config
+# - name: Enable the WiFi with rfkill
+#   shell: rfkill unblock wifi
+#   ignore_errors: True
+
 - name: Copy the bridge script for RPi
   template:
     dest: /etc/network/interfaces.d/iiab


### PR DESCRIPTION
### Fixes bug:

At the very least, this PR improves the implementer UX situation (no clear solution with Raspberry Pi Imager) around:

- #3856

By refining @jvonau's PR #3866 with a couple safeguards, and explanations.

Thanks to @tim-moody for verifying key facts making this possible.

### Description of changes proposed in this pull request:

WIth this PR, execution of roles/network/tasks/main.yml (equivalent to running iiab-network) intentionally stops if variable `host_country_code` was set to a bogus country value (or was not set to any value at all!)  In conjunction with raspi-config's underlying command [iw reg set "$REGDOMAIN"](https://github.com/RPi-Distro/raspi-config/blob/8a1fad85fdbdc5fc006aee8585ddccdb8eecf295/raspi-config#L889) which fails when $REGDOMAIN is not a valid country code (FYI current country code setting can be read back using `iw reg get`).

Example of execution intentionally failing with this PR, so that the operator is notified: (using intentional bogus country code `XX` in this example!)

> TASK [network : Run 'raspi-config nonint do_wifi_country XX' (using var host_country_code) to unblock WiFi, if RasPiOS] ****
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": ["raspi-config", "nonint", "do_wifi_country", "XX"], "delta": "0:00:00.060765", "end": "2024-12-18 19:50:12.751273", "msg": "non-zero return code", "rc": 1, "start": "2024-12-18 19:50:12.690508", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
>
> PLAY RECAP *****************************************************************************************************************
127.0.0.1                  : ok=69   changed=10   unreachable=0    failed=1    skipped=47   rescued=0    ignored=0

### Smoke-tested on which OS or OS's:

Latest 64-bit Raspberry Pi OS (graphical version) on RPi 4.

Other country code logic pasted in here to help us keep track of it all...

```
root@raspberrypi:/opt/iiab/iiab/roles/network# grep -rni country
templates/hostapd/iiab-test-wifi.j2:40:# WiFi country code progress on arm64 OS's discussed on #3078
templates/hostapd/iiab-test-wifi.j2:46:    REG_DOM=$(grep country /run/netplan/wpa-$IFACE.conf | awk -F = '{ print $2 }')
templates/hostapd/iiab-test-wifi.j2:49:        echo "cover netplan wifi client lack of country= setting to {{ host_country_code }}"
templates/hostapd/iiab-test-wifi.j2:50:        sed -i "s|ctrl_interface=/run/wpa_supplicant|&\ncountry={{ host_country_code }}|" /run/netplan/wpa-$IFACE.conf
templates/hostapd/iiab-test-wifi.j2:52:        echo "set hostapd wifi country to $REG_DOM"
templates/hostapd/iiab-test-wifi.j2:54:            sed -i "s|^country.*|country_code=$REG_DOM|" /etc/hostapd/hostapd.conf.iiab
templates/hostapd/iiab-test-wifi.j2:90:    # This one handles the changing of the country code from above
templates/hostapd/50-hostapd:2:    WPA=$(grep country /etc/wpa_supplicant/wpa_supplicant.conf | awk -F = '{print $2}')
templates/hostapd/50-hostapd:3:    AP=$(grep country_code /etc/hostapd/hostapd.conf | awk -F = '{print $2}')
templates/hostapd/50-hostapd:5:        sed -i -e "s/^country_code.*/country_code=$WPA /" /etc/hostapd/hostapd.conf
templates/hostapd/50-hostapd:6:        echo "50-iiab set country_code $WPA"
templates/hostapd/50-hostapd:7:        syslog info "50-iiab set country_code $WPA"
templates/hostapd/50-hostapd:9:        syslog info "THIS MACHINE SHOULD BE REBOOTED 50-iiab country_code"
templates/hostapd/hostapd.conf.j2:18:country_code={{ host_country_code }}
templates/hostapd/hostapd.conf.j2:19:# limit emissions to what is legal in country
defaults/main.yml:19:# host_country_code: US
tasks/rpi_debian.yml:38:- name: New Raspbian requires country code -- check for it
tasks/rpi_debian.yml:39:  shell: grep country /etc/wpa_supplicant/wpa_supplicant.conf | awk -F = '{print $2}'
tasks/rpi_debian.yml:40:  register: country_code
tasks/rpi_debian.yml:44:- name: Set country code for hostapd to value found in /etc/wpa_supplicant/wpa_supplicant.conf
tasks/rpi_debian.yml:46:    host_country_code: "{{ country_code.stdout }}"
tasks/rpi_debian.yml:47:  when: country_code.stdout is defined and country_code.stdout | length > 0
tasks/rpi_debian.yml:49:- name: Put country code ({{ host_country_code }}) in /etc/wpa_supplicant/wpa_supplicant.conf if nec
tasks/rpi_debian.yml:52:    regexp: "^country.*"
tasks/rpi_debian.yml:53:    line: country={{ host_country_code }}
tasks/rpi_debian.yml:54:  when: country_code.stdout is defined and country_code.stdout | length == 0
tasks/rpi_debian.yml:56:# 2024-12-18: SEE 'raspi-config nonint do_wifi_country {{ host_country_code }}' in roles/network/tasks/main.yml
tasks/main.yml:73:  - name: Run 'raspi-config nonint do_wifi_country {{ host_country_code }}' (using var host_country_code) to unblock WiFi, if RasPiOS
tasks/main.yml:74:    command: raspi-config nonint do_wifi_country {{ host_country_code }}
tasks/hostapd.yml:12:- name: Detect WiFi country code in use
tasks/hostapd.yml:13:  shell: iw reg get | grep country | grep -v UNSET | awk '{print $2}' | sed "s|:||"
tasks/hostapd.yml:18:- name: Set Wifi Region country code for hostapd when present
tasks/hostapd.yml:20:    host_country_code: "{{ REG_DOM.stdout }}"
tasks/hostapd.yml:115:- name: Record host_country_code_applied and host_channel in network of {{ iiab_ini_file }}
tasks/hostapd.yml:130:    - option: host_country_code_applied
tasks/hostapd.yml:131:      value: "{{ host_country_code }}"
```