### PR TITLE
don't restart wpa_supplicant when network_manager_active is set

### DIFF
--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -12,7 +12,7 @@
     state: restarted
   with_items:
     - wpa_supplicant
-  when: wifi_up_down and hostapd_enabled
+  when: wifi_up_down and hostapd_enabled and not network_manager_active
 
 - name: Enable & Restart networkd-dispatcher.service
   systemd:


### PR DESCRIPTION
### Fixes bug:
Noted traceback while reviewing

