### PR TITLE
iiab-diagnostics: Cleaner output if COMMAND NOT FOUND

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -101,10 +101,18 @@ function cat_cmd() {    # $1 = command + params, $2 = explanation
     spc_params=$(echo "$1" | sed 's/^\s*\S\S*\s*/ /;s/\s*$//')    # Drop command on left; Keep a single space + params on right; RTrim
     #spc_params=$(echo "$1" | sed 's/^\s*\S*//;s/\s*$//;s/^\s\s*/ /')    # LTrim + drop original path + command on left; RTrim; Compress whitespace in between
     #spc_params=$(echo "$1" | sed 's/^[[:blank:]]*[^[:blank:]]*//;s/[[:blank:]]*$//;s/^[[:blank:]][[:blank:]]*/ /')    # Equivalent (POSIX compliant)
-    if [[ $2 == "" ]]; then
-	echo "COMMAND: $path_cmd$spc_params" >> $outfile
+    if [[ $path_cmd == "" ]]; then
+	if [[ $2 == "" ]]; then
+            echo "COMMAND: $1" >> $outfile
+	else
+            echo "COMMAND: $1    # $2" >> $outfile
+	fi
     else
-	echo "COMMAND: $path_cmd$spc_params    # $2" >> $outfile
+	if [[ $2 == "" ]]; then
+	    echo "COMMAND: $path_cmd$spc_params" >> $outfile
+	else
+	    echo "COMMAND: $path_cmd$spc_params    # $2" >> $outfile
+	fi
     fi
     echo >> $outfile
     if [[ $path_cmd == "" ]]; then

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -66,4 +66,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 127-256 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 135-268 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Longstanding and very minor bug.  Now fixed.

Tested on Ubuntu 25.04 pre-release.

Tangentially related:

- PR #3899