### PR TITLE
GitHub Actions CI: Revert ARM tests to run on Ubuntu 22.04 (for now)

### DIFF
--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -1,4 +1,4 @@
-name: '"10 min" IIAB test install'
+name: '"10 min" IIAB on Ubuntu 24.04 on x86-64'
 # run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 
 # https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html

--- a/.github/workflows/30min-iiab-test-install-deb12-on-rpi3.yml
+++ b/.github/workflows/30min-iiab-test-install-deb12-on-rpi3.yml
@@ -1,4 +1,4 @@
-name: '"30 min" IIAB test install deb12 on rpi3'
+name: '"30 min" IIAB on Debian 12 on RPi 3'
 # run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 
 # https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html

--- a/.github/workflows/30min-iiab-test-install-deb12-on-rpi3.yml
+++ b/.github/workflows/30min-iiab-test-install-deb12-on-rpi3.yml
@@ -18,7 +18,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-install:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [debian12]

--- a/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
+++ b/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
@@ -1,4 +1,4 @@
-name: '"30 min" IIAB test install raspios'
+name: '"30 min" IIAB test install raspios on zero2w'
 # run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 
 # https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html
@@ -65,13 +65,13 @@ jobs:
               uname -a    # uname -srm
               whoami      # Typically 'root' instead of 'runner'
               pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}
-              sudo apt-get update -y --allow-releaseinfo-change
-              sudo apt-get install --no-install-recommends -y git
+              apt-get update -y --allow-releaseinfo-change
+              apt-get install --no-install-recommends -y git
               ls /opt/iiab/iiab
-              sudo mkdir /etc/iiab
-              sudo cp /opt/iiab/iiab/vars/local_vars_none.yml /etc/iiab/local_vars.yml
-              sudo /opt/iiab/iiab/scripts/ansible
-              sudo ./iiab-install
+              mkdir /etc/iiab
+              cp /opt/iiab/iiab/vars/local_vars_none.yml /etc/iiab/local_vars.yml
+              /opt/iiab/iiab/scripts/ansible
+              ./iiab-install
               cd /opt/iiab/iiab
               iiab-summary
               cat /etc/iiab/iiab_state.yml

--- a/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
+++ b/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
@@ -18,7 +18,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-install:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [aarch64] #[zero_raspbian, zero_raspios, zero2_raspios, aarch64]

--- a/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
+++ b/.github/workflows/30min-iiab-test-install-raspios-on-zero2w.yml
@@ -1,4 +1,4 @@
-name: '"30 min" IIAB test install raspios on zero2w'
+name: '"30 min" IIAB on RasPiOS on Zero 2 W'
 # run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 
 # https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html


### PR DESCRIPTION
It appears GitHub runner `ubuntu-latest` was finally upgraded from 22.04 to 24.04

However, ARM emulator https://github.com/pguyot/arm-runner-action appears to not work properly on Ubuntu 24.04

So. this PR:

- Reverts GHA (GitHub Actions) runner from ubuntu-latest to ubuntu-22.04, in both these 2 cases, for now.
- Renames 30min-iiab-test-install-raspios.yml to 30min-iiab-test-install-raspios-on-zero2w.yml
- Tightens up / Cleans up 30min-iiab-test-install-raspios-on-zero2w.yml

GHA testing of this PR is looking good (right now underway).

FUTURE WORK:

- Run directly on GHA's new arm64 runners?  As was just announced yesterday:
  https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/