### PR TITLE
vars/* and usb_lib/*: rename usb_lib_umask0000_for_kolibri

### DIFF
--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 76 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L76>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If however you prefer to restore usbmount's default, set ``usb_lib_umask0000_for_kolibri: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri and other app exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
 
 Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/tags>`_ documentation:
 

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -2,30 +2,28 @@
 usb_lib README
 ==============
 
-**PLEASE SEE "Can teachers display their own content?" WITHIN https://FAQ.IIAB.IO FOR UP-TO-DATE DOCUMENTATION.**
+**PLEASE SEE** `"Can teachers display their own content?" <https://wiki.iiab.io/go/FAQ#Can_teachers_display_their_own_content?>`_ **AND** `"Can students upload their own work?" <https://wiki.iiab.io/go/FAQ#Can_students_upload_their_own_work?>`_ **WITHIN https://FAQ.IIAB.IO FOR UP-TO-DATE DOCUMENTATION!**
 
-This role implements functionality similar to LibraryBox, to mount "teacher content" from USB drives.
+This role (1) implements functionality similar to LibraryBox, to mount "teacher content" from USB sticks / drives for students, and (2) allows students to upload their work to the teacher's USB stick / drive:
 
-Users should have nearly immediate access to this "teacher content" (on all inserted USB drives) by browsing to http://box/usb
+#. Students should have nearly immediate access to "teacher content" (on all inserted USB sticks) by browsing to http://box/usb.
+#. Students can also click the "Upload to USB" button on top of this same page (http://box/usb), to upload their work to the teacher's USB stick.  (FYI student uploads appear in folders like ``UPLOADS.YYYY-MM-DD`` within the root of the teacher's USB stick).
 
-Automount is handled by usbmount, and scripts in this role look in the root of the mounted drive for...
+As of January 2025, automount is handled by usbmount: (`devmon included with udevil <https://ignorantguru.github.io/udevil/>`_ might be considered in future)
 
-* /usb
-* /USB
-* /share
-* /Share
-* /Piratebox/Share
+* A script in this role (/etc/usbmount/mount.d/70-usb-library) looks in the root of the mounted USB stick for folder /PUBLIC and if found, creates a symlink of the form /library/www/html/local_content/USBn pointing to /media/usbn/PUBLIC — where n is generally one of {0, 1, 2, 3, 4, 5, 6, 7}.  *RESULT: Only documents within /PUBLIC are browsable by students.*  This option is very useful to **prevent students from copying uploaded homework!**
+* If however folder /PUBLIC is not found, the symlink is created to the root of the mounted USB stick.  *RESULT: EVERYTHING on the USB stick is browsable by students — just like with a traditional community bulletin board.*  This option is very useful when students are uploading artwork, photo essays, personal audio recordings and **science projects that are intended to be shared!**
 
-...and if found, creates a symlink of the form /library/www/html/local_content/USBn pointing to /media/usbn — where n is generally one of {0, 1, 2, 3, 4, 5, 6, 7}.
+Technical Details:
 
-USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 76 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L76>`_
+* USB sticks / drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 100 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L100>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
+* IIAB will generally mount USB sticks / drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/pull/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB sticks, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  This ``umask=0000`` is also required for students to upload to the teachers's VFAT/FAT32, NTFS and exFAT USB sticks, as introduced in January 2025 (`PR #3875 <https://github.com/iiab/iiab/pull/3875>`_).  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ — please do this prior to installing IIAB — so you don't have to run: ``cd /opt/iiab/iiab ; ./runrole --reinstall usb_lib``
 
-Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/tags>`_ documentation:
+* Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/tags>`_ documentation:
 
-* https://github.com/hfuchs/usbmount/blob/master/README (2010-08-11)
-* https://github.com/rbrito/usbmount/blob/master/README.md (2018-08-10)
-* https://github.com/rbrito/usbmount/blob/master/usbmount.conf (2010-04-25)
+  * https://github.com/hfuchs/usbmount/blob/master/README (2010-08-11)
+  * https://github.com/rbrito/usbmount/blob/master/README.md (2018-08-10)
+  * https://github.com/rbrito/usbmount/blob/master/usbmount.conf (2010-04-25)
 
-Legacy warning: There is also a patch for problems with automount on Fedora 21+.  Please note that as of 4.1.8-200.fc22.x86_64 not all USB drives will mount, even with this patch.
+* Dev Notes at the top of: https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -20,7 +20,7 @@ Automount is handled by usbmount, and scripts in this role look in the root of t
 
 USB drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 76 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L76>`_
 
-IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri and other app exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
+IIAB will generally mount USB drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/issues/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB drives, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ (preferably do this prior to installing IIAB).
 
 Official `usbmount 0.0.22 (2011-08-08) <https://github.com/rbrito/usbmount/tags>`_ documentation:
 

--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -16,7 +16,7 @@ As of January 2025, automount is handled by usbmount: (`devmon included with ude
 
 Technical Details:
 
-* USB sticks / drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 100 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L100>`_
+* USB sticks / drives must be formatted with one of the filesystems listed under "FILESYSTEMS=" at ``/etc/usbmount/usbmount.conf`` — these are specified on/around Line 103 of: `/opt/iiab/iiab/roles/usb_lib/tasks/install.yml <https://github.com/iiab/iiab/blob/master/roles/usb_lib/tasks/install.yml#L103>`_
 
 * IIAB will generally mount USB sticks / drives 'rw' allowing root to both read and write to them.  In addition, in March 2021 (`PR #2715 <https://github.com/iiab/iiab/pull/2715>`_) Kolibri exports were enabled by also giving non-root users read and write access to VFAT/FAT32, NTFS and exFAT USB sticks, using ``umask=0000`` (in /etc/usbmount/usbmount.conf) to override the ``umask=0022`` default.  This ``umask=0000`` is also required for students to upload to the teachers's VFAT/FAT32, NTFS and exFAT USB sticks, as introduced in January 2025 (`PR #3875 <https://github.com/iiab/iiab/pull/3875>`_).  If, however, you prefer to restore usbmount's default, set ``usb_lib_writable_sticks: False`` in `/etc/iiab/local_vars.yml <http://FAQ.IIAB.IO/#What_is_local_vars.yml_and_how_do_I_customize_it%3F>`_ — please do this prior to installing IIAB — so you don't have to run: ``cd /opt/iiab/iiab ; ./runrole --reinstall usb_lib``
 

--- a/roles/usb_lib/defaults/main.yml
+++ b/roles/usb_lib/defaults/main.yml
@@ -4,8 +4,8 @@
 # Show entire contents of USB sticks/drives (at http://box/usb)
 # iiab_usb_lib_show_all: True
 
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 # usb_lib_writable_sticks: True
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml

--- a/roles/usb_lib/defaults/main.yml
+++ b/roles/usb_lib/defaults/main.yml
@@ -1,9 +1,6 @@
 # usb_lib_install: True
 # usb_lib_enabled: True
 
-# Show entire contents of USB sticks/drives (at http://box/usb)
-# iiab_usb_lib_show_all: True
-
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
 # Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 # usb_lib_writable_sticks: True

--- a/roles/usb_lib/defaults/main.yml
+++ b/roles/usb_lib/defaults/main.yml
@@ -5,8 +5,8 @@
 # iiab_usb_lib_show_all: True
 
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-# usb_lib_umask0000_for_kolibri: True
+# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+# usb_lib_writable_sticks: True
 
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!

--- a/roles/usb_lib/files/upload/upload2usb.php
+++ b/roles/usb_lib/files/upload/upload2usb.php
@@ -42,7 +42,7 @@ function getTargetFolderPath ($create_folder_p) {
          $target_folder_path = $parent_dir . $today_folder_name;
 
          if (!file_exists($target_folder_path) && $create_folder_p) {
-	      mkdir($target_folder_path, 0777) or throw new RuntimeException("Not able to create upload directory. <br/>Make sure 'usb_lib_umask0000_for_kolibri' is set to 'True'. <br/><br/>");
+	      mkdir($target_folder_path, 0777) or throw new RuntimeException("Not able to create upload directory. <br/>Make sure 'usb_lib_writable_sticks' is set to 'True'. <br/><br/>");
         }
         return $target_folder_path;
 }

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -7,8 +7,8 @@
 # https://github.com/rbrito/usbmount/blob/master/README.md (2018-08-10)
 # https://github.com/rbrito/usbmount/blob/master/usbmount.conf (2010-04-25)
 
-# usb_lib_writable_sticks (e.g., in /etc/iiab/local_vars.yml) must be set to true in order to be able to write to mounted USB sticks
-# If you are still not able to write to a mounted USB stick, you can unmount the drive (sudo umount <mountpoint>) and then remount it setting umask to 0000 manually (sudo mount -o umask=0000 <device name> <mountpoint>). 
+# usb_lib_writable_sticks (e.g., in /etc/iiab/local_vars.yml) must be set to true in order for non-root users to be able to write to VFAT/FAT32, NTFS and exFAT USB sticks.
+# If you are still not able to write to a mounted USB stick, try unmounting the drive (sudo umount <mountpoint>) and then remount it setting umask to 0000 manually (sudo mount -o umask=0000 <device name> <mountpoint>). 
 
 
 - name: Record (initial) disk space used

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -7,7 +7,7 @@
 # https://github.com/rbrito/usbmount/blob/master/README.md (2018-08-10)
 # https://github.com/rbrito/usbmount/blob/master/usbmount.conf (2010-04-25)
 
-# usb_lib_umask0000_for_kolibri (e.g., in /etc/iiab/local_vars.yml) must be set to true in order to be able to write to mounted USB sticks
+# usb_lib_writable_sticks (e.g., in /etc/iiab/local_vars.yml) must be set to true in order to be able to write to mounted USB sticks
 # If you are still not able to write to a mounted USB stick, you can unmount the drive (sudo umount <mountpoint>) and then remount it setting umask to 0000 manually (sudo mount -o umask=0000 <device name> <mountpoint>). 
 
 

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -32,28 +32,28 @@
 
 # If setup.yml becomes the norm in future, put the 2-3 stanzas below in there:
 
-- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri, upload2usb, and other app exports work"
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
     path: /etc/usbmount/usbmount.conf
-  when: usb_lib_umask0000_for_kolibri
+  when: usb_lib_writable_sticks
 
 # Setting 'umask=0000' for all filesystems: (much the same thing as above, as
 # the mount command does not use this umask setting for filesystems like ext4)
-#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
+#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri, upload2usb, and other app exports work"
 #  lineinfile:
 #    regexp: '^MOUNTOPTIONS=.*'
 #    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'
 #    path: /etc/usbmount/usbmount.conf
-#  when: usb_lib_umask0000_for_kolibri
+#  when: usb_lib_writable_sticks
 
 - name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, e.g. for runrole
     path: /etc/usbmount/usbmount.conf
-  when: not usb_lib_umask0000_for_kolibri
+  when: not usb_lib_writable_sticks
 
 
 - name: Enable/Disable/Restart NGINX
@@ -88,5 +88,5 @@
       value: "{{ usb_lib_install }}"
     - option: usb_lib_enabled
       value: "{{ usb_lib_enabled }}"
-    - option: usb_lib_umask0000_for_kolibri
-      value: "{{ usb_lib_umask0000_for_kolibri }}"
+    - option: usb_lib_writable_sticks
+      value: "{{ usb_lib_writable_sticks }}"

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -32,7 +32,7 @@
 
 # If setup.yml becomes the norm in future, put the 2-3 stanzas below in there:
 
-- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf, so Kolibri, upload2usb, and other app exports work"
+- name: "Set 'umask=0000' for {VFAT/FAT32, NTFS, exFAT} using var FS_MOUNTOPTIONS in /etc/usbmount/usbmount.conf -- for Kolibri exports AND student uploads to teacher's USB stick (using http://box/usb)"
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS="-fstype=vfat,umask=0000 -fstype=ntfs,umask=0000 -fstype=exfat,umask=0000"'
@@ -41,7 +41,7 @@
 
 # Setting 'umask=0000' for all filesystems: (much the same thing as above, as
 # the mount command does not use this umask setting for filesystems like ext4)
-#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri, upload2usb, and other app exports work"
+#- name: "Add ',umask=0000' to MOUNTOPTIONS var in /etc/usbmount/usbmount.conf, so Kolibri exports work"
 #  lineinfile:
 #    regexp: '^MOUNTOPTIONS=.*'
 #    line: 'MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,umask=0000"'

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -48,7 +48,7 @@
 #    path: /etc/usbmount/usbmount.conf
 #  when: usb_lib_writable_sticks
 
-- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf, e.g. if Kolibri will not be used'
+- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf -- e.g. Kolibri exports AND student uploads to teacher's USB stick are not needed'
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, e.g. for runrole

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -66,12 +66,6 @@
     path: /etc/usbmount/mount.d/00_create_model_symlink
     state: absent
 
-- name: Put variable in iiab.env that enables display of content at root of USB
-  lineinfile:
-    path: "{{ iiab_env_file }}"
-    regexp: "^IIAB_USB_LIB_SHOW_ALL.*"
-    line: "IIAB_USB_LIB_SHOW_ALL={{ iiab_usb_lib_show_all }}"
-
 
 - name: Add 'usb_lib' variable values to {{ iiab_ini_file }}
   ini_file:

--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -48,7 +48,7 @@
 #    path: /etc/usbmount/usbmount.conf
 #  when: usb_lib_writable_sticks
 
-- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf -- e.g. Kolibri exports AND student uploads to teacher's USB stick are not needed'
+- name: 'Set FS_MOUNTOPTIONS="" in /etc/usbmount/usbmount.conf -- e.g. if Kolibri exports AND student uploads to teacher USB stick are not needed'
   lineinfile:
     regexp: '^FS_MOUNTOPTIONS=.*'
     line: 'FS_MOUNTOPTIONS=""'    # Restore apt pkg default, e.g. for runrole

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -310,8 +310,8 @@ usb_lib_enabled: True
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Kolibri, upload2usb, and other apps  can export & import channels to USB sticks/drive:
+usb_lib_writable_sticks: True
 systemd_location: /lib/systemd/system    # 2-common iiab-startup also uses
 
 # Common UNIX Printing System (CUPS)

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -307,10 +307,8 @@ bluetooth_term_enabled: False
 # USB_LIB
 usb_lib_install: True
 usb_lib_enabled: True
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri, upload2usb, and other apps  can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 systemd_location: /lib/systemd/system    # 2-common iiab-startup also uses
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -195,8 +195,8 @@ bluetooth_term_enabled: False
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)
 cups_install: True

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -192,10 +192,8 @@ bluetooth_install: True
 bluetooth_enabled: False
 bluetooth_term_enabled: False
 
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)

--- a/vars/local_vars_medical.yml
+++ b/vars/local_vars_medical.yml
@@ -12,7 +12,7 @@ munin_install: True
 munin_enabled: True
 vnstat_install: True
 vnstat_enabled: True
-usb_lib_umask0000_for_kolibri: False
+usb_lib_writable_sticks: False
 allow_www_data_poweroff: False
 # By default
 # kiwix

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -195,8 +195,8 @@ bluetooth_term_enabled: False
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)
 cups_install: False

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -192,10 +192,8 @@ bluetooth_install: True
 bluetooth_enabled: False
 bluetooth_term_enabled: False
 
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri, upload2usb, and other apps can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -192,10 +192,8 @@ bluetooth_install: True
 bluetooth_enabled: False
 bluetooth_term_enabled: False
 
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri, upload2usb, and other apps  can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -195,8 +195,8 @@ bluetooth_term_enabled: False
 # Show entire contents of USB sticks/drives (at http://box/usb)
 iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+# Kolibri, upload2usb, and other apps  can export & import channels to USB sticks/drive:
+usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)
 cups_install: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -202,7 +202,7 @@ bluetooth_term_enabled: False
 iiab_usb_lib_show_all: True
 # Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
 # Kolibri can export & import channels to USB sticks/drive:
-usb_lib_umask0000_for_kolibri: True
+usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)
 cups_install: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -198,10 +198,8 @@ bluetooth_install: False
 bluetooth_enabled: False
 bluetooth_term_enabled: False
 
-# Show entire contents of USB sticks/drives (at http://box/usb)
-iiab_usb_lib_show_all: True
-# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf so
-# Kolibri can export & import channels to USB sticks/drive:
+# Set umask=0000 for VFAT, NTFS and exFAT in /etc/usbmount/usbmount.conf for
+# Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
 # Common UNIX Printing System (CUPS)


### PR DESCRIPTION
Addresses #3907 

### Description of changes proposed in this pull request:
renames usb_lib_umask0000_for_kolibri to usb_lib_writable_sticks so it is more generally applicable. modifies multiple files in vars/ and roles/usb_lib/

### Smoke-tested on which OS or OS's:
smoke-tested on RPi4 by exporting Kolibri channel and uploading a few files in upload2usb app. 

### Mention a team member @username e.g. to help with code review:
@holta 