### PR TITLE
[Upload2USB] move app out of local_content, relax mime type requirements, link swing back to homepage

### DIFF
--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -5,11 +5,11 @@ location / {
 location /usb {
     alias /library/www/html/local_content/;
     fancyindex on;    # autoindex on;
-    add_before_body /usb/upload/button.html;    
+    add_before_body /upload2usb/button.html;
 }
 
-location ~ ^/usb/upload/(.*)\.php$ {
-    alias /library/www/html/local_content/upload/$1.php;
+location ~ ^/upload2usb/(.*)\.php$ {
+    alias /library/www/html/upload2usb/$1.php;
     proxy_set_header X-Real-IP  $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host $host;
@@ -23,7 +23,7 @@ location ~ ^/usb/upload/(.*)\.php$ {
 
 location /local_content/ {
     fancyindex on;    # autoindex on;
-    add_before_body /usb/upload/button.html;
+    add_before_body /upload2usb/button.html;
 }
 
 location /info {

--- a/roles/usb_lib/files/upload/button.html
+++ b/roles/usb_lib/files/upload/button.html
@@ -16,4 +16,4 @@
   color: #ddd;
 }
 </style>
-<a class="button" href="/usb/upload/">Upload to USB</a>
+<a class="button" href="/upload2usb/">Upload to USB</a>

--- a/roles/usb_lib/files/upload/header.php
+++ b/roles/usb_lib/files/upload/header.php
@@ -28,5 +28,5 @@ include("upload2usb.php");
             <div class="row">
 		<div class="col-sm-6 offset-sm-3 text-center" style="padding:15px;">
 
-                    <img class="mb-4" src="uk-swing.png" alt="" width="75">
+                    <a href="/upload2usb/"><img class="mb-4" src="uk-swing.png" alt="" width="75"></a>
                     <h1 class="h3 mb-3 font-weight-normal"><?php echo $title ?></h1>

--- a/roles/usb_lib/files/upload/upload2usb.php
+++ b/roles/usb_lib/files/upload/upload2usb.php
@@ -55,7 +55,7 @@ function getFileCount ($folder_path) {
 //check if file mimetype is acceptable for upload
 function isFileMimeTypeAcceptable ($file) {
 	 $mimetype = strtolower(mime_content_type($file));
-	 $invalid_mimetypes_str = array ("compress", "image/svg+xml", "octet", "text/xml", "xhtml+xml", "zip");
+	 $invalid_mimetypes_str = array ("compress", "image/svg+xml", "octet", "text/xml", "xhtml+xml");
 	 foreach ($invalid_mimetypes_str as $invalid_mt_str) {
 	 	 if (str_contains($mimetype, $invalid_mt_str)) {
 	            error_log('UPLOAD2USB ERROR - MIMETYPE: ' . $mimetype);

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -79,18 +79,18 @@
     - { src: 'iiab-usb_lib-show-all-off', dest: '/usr/bin/', mode: '0755' }
     - { src: 'iiab-clean-usb.sh', dest: '/usr/sbin/', mode: '0755' }
 
-- name: '2025-01-05: Add upload2usb app (#3875) directory to local_content'
+- name: '2025-01-05: Add upload2usb app (#3875) directory to doc_root'
   file:
     state: directory
-    path: "{{ doc_root }}/local_content/upload"
+    path: "{{ doc_root }}/upload2usb"
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"    
     mode: 0755
 
-- name: '2025-01-05: Copy upload2usb app (#3875) files from files/upload/ to local_content'
+- name: '2025-01-05: Copy upload2usb app (#3875) files from files/upload/ to upload2usb'
   copy:
     src: "{{ item }}"
-    dest: "{{ doc_root }}/local_content/upload" # /library/www/html
+    dest: "{{ doc_root }}/upload2usb" # /library/www/html
   with_fileglob:
     - upload/*
 


### PR DESCRIPTION
### Description of changes proposed in this pull request:
- move app out of local_content and into /library/www/html/
- allow zip files given some MacOS files, e.g., Pages files, have a mimetype of application/zip
- link swing image back to upload2usb main page

### Smoke-tested on which OS or OS's:
RPi 5

### Mention a team member @username e.g. to help with code review:
@holta 