### PR TITLE
PHP's own defaults are Way Too Low, so run www_options/tasks/php-settings.yml every time

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -69,7 +69,8 @@
 # WordPress) so './runrole <ROLE>' and similar are fully self-sufficient!
 - name: "Run php-settings.yml -- allows post-install toggling of nginx_high_php_limits in /etc/iiab/local_vars.yml -- if you run './runrole www_options'"
   include_tasks: php-settings.yml
-  when: nginx_high_php_limits or matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
+  # 2025-01-29: PHP's own defaults (presumably from the 1990s?) were Way Too Low -- for usb-lib's upload2usb, and in general -- so let's run php-settings.yml every time!
+  # when: nginx_high_php_limits or matomo_install or moodle_install or nextcloud_install or pbx_install or wordpress_install
 
 
 # 'Is a "Rapid Power Off" button possible for low-electricity environments?'


### PR DESCRIPTION
This simplification was probably long overdue, providing much more practical PHP defaults for smaller IIAB installs, that also helps streamline unit-testing of student uploads to teacher's USB stick, e.g. things like:

- PR #3875
- PR #3913
- PR #3914
- PR #3916
- PR #3918 
- PR #3919
- PR #3923