### PR TITLE
Restore both GitHub Actions workflows simulating Raspberry Pi

### DIFF
--- a/roles/usb_lib/tasks/main.yml
+++ b/roles/usb_lib/tasks/main.yml
@@ -77,7 +77,7 @@
     - option: name
       value: USB_LIB
     - option: description
-      value: '"USB_LIB automounts Teacher Content on USB drives to /library/www/html/local_content, so students can browse it almost immediately at http://box/usb"'
+      value: '"USB_LIB automounts Teacher Content on USB sticks to /library/www/html/local_content, so students can browse the USB AND upload their work to the USB, all at http://box/usb"'
     - option: usb_lib_install
       value: "{{ usb_lib_install }}"
     - option: usb_lib_enabled

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -30,8 +30,10 @@
 # 1) Try spawning these "guyot/arm-runner-action@v2" GHA workflows with...  use_systemd_nspawn: true
 # 2) Weaken timedatectl command just below, trying this instead...  shell: readlink /etc/localtime | sed 's#^/usr/share/zoneinfo/##'
 
-- name: Extract Time Zone from symlink /etc/localtime &/or text file /etc/timezone (or lack thereof!)
-  command: timedatectl show -p Timezone --value
+#- name: Extract Time Zone from symlink /etc/localtime &/or text file /etc/timezone (or lack thereof!)
+#  command: timedatectl show -p Timezone --value
+- name: Extract Time Zone from symlink /etc/localtime, or declare UTC
+  shell: tmp=$(readlink /etc/localtime) && echo $tmp | sed 's|^/usr/share/zoneinfo/||' || echo UTC
   register: tz_cli
 
 - name: Store 'date.timezone = {{ tz_cli.stdout }}' (from above) in /etc/php/{{ php_version }}/fpm/php.ini and /etc/php/{{ php_version }}/cli/php.ini

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -30,10 +30,10 @@
 # 1) Try spawning these "guyot/arm-runner-action@v2" GHA workflows with...  use_systemd_nspawn: true
 # 2) Weaken timedatectl command just below, trying this instead...  shell: readlink /etc/localtime | sed 's#^/usr/share/zoneinfo/##'
 
-#- name: Extract Time Zone from symlink /etc/localtime &/or text file /etc/timezone (or lack thereof!)
-#  command: timedatectl show -p Timezone --value
-- name: Extract Time Zone from symlink /etc/localtime, or declare UTC
-  shell: tmp=$(readlink /etc/localtime) && echo $tmp | sed 's|^/usr/share/zoneinfo/||' || echo UTC
+- name: Extract Time Zone from symlink /etc/localtime, text file /etc/timezone, or if all else fails declare Etc/UTC
+  # command: timedatectl show -p Timezone --value
+  # 2025-02-01: "guyot/arm-runner-action@v2" GHA workflows don't seem to work with "use_systemd_nspawn: true", so hack in the equivalent of timedatectl...
+  shell: tmp=$(readlink /etc/localtime) && echo $tmp | sed 's|^/usr/share/zoneinfo/||' || cat /etc/timezone || echo Etc/UTC
   register: tz_cli
 
 - name: Store 'date.timezone = {{ tz_cli.stdout }}' (from above) in /etc/php/{{ php_version }}/fpm/php.ini and /etc/php/{{ php_version }}/cli/php.ini


### PR DESCRIPTION
### Fixes bug:

While not absolutely necessary it can't hurt to run these two CI tests simulating RPi 3 and RPi Zero 2 W?

So this TZ (Time Zone) hack works around the PR #3927 problem in php-settings.yml, as originally outlined at: https://github.com/iiab/iiab/commit/4da759a84b9913a04186c97c4e30c73cbf4784a8

### Description of changes proposed in this pull request:

- Shell hack does the equivalent of `timedatectl show -p Timezone --value` to extract the actual TZ from all the correct places in /etc — so this can be populated into PHP
- Updates the description of USB_LIB for iiab.ini in roles/usb_lib/tasks/main.yml

### Smoke-tested on which OS or OS's:

All 3 GitHub Actions workflows (Ubuntu 24.04, debian12 on RPi 3, RasPiOS on Zero 2 W).