### PR TITLE
70-usb-library.j2: Forcibly delete e.g. stale symlink /library/www/html/local_content/USB0 during USB stick insertion

### DIFF
--- a/roles/usb_lib/templates/mount.d/70-usb-library.j2
+++ b/roles/usb_lib/templates/mount.d/70-usb-library.j2
@@ -31,16 +31,16 @@ logger -t "usb_lib (70-usb-library)" "BOOTFW_DEV is: $BOOTFW_DEV"
 
 if [ "$UM_DEV" == "$LIB_DEV" ]; then
     logger -t "usb_lib (70-usb-library)" "Skipping $UM_MOUNTPOINT containing /library"
-    exit
+    exit 1
 elif [ "$UM_DEV" == "$ROOT_DEV" ]; then
     logger -t "usb_lib (70-usb-library)" "Skipping $UM_MOUNTPOINT containing rootfs"
-    exit
+    exit 1
 elif [ "$UM_DEV" == "$BOOT_DEV" ]; then
     logger -t "usb_lib (70-usb-library)" "Skipping $UM_MOUNTPOINT containing /boot"
-    exit
+    exit 1
 elif [ "$UM_DEV" == "$BOOTFW_DEV" ]; then
     logger -t "usb_lib (70-usb-library)" "Skipping $UM_MOUNTPOINT containing /boot/firmware"
-    exit
+    exit 1
 fi
 
 # 2025-01-25: Check for existence of folder PUBLIC on USB stick: if found, the stick will not be completely browsable.
@@ -55,9 +55,13 @@ else
 fi
 
 CONTENT_LINK_USB=$(basename $UM_MOUNTPOINT | awk '{print toupper($0)}')
+if [ -z "$CONTENT_LINK_USB" ]; then
+    logger -t "usb_lib (70-usb-library)" "ERROR: Var CONTENT_LINK_USB is empty ("rm -rf /library/www/html/local_content/" might be dangerous!)"
+    exit 1
+fi
 CONTENT_LINK="{{ doc_root }}/local_content/$CONTENT_LINK_USB"
-logger -t "usb_lib (70-usb-library)" "Creating link from $CONTENT_LINK to $SHARE_DIR"
 # 'rm -rf' even stronger than 'ln -nsf' and 'ln -Tsf'
 # https://serverfault.com/questions/147787/how-to-update-a-symbolic-link-target-ln-f-s-not-working/522483#522483
+logger -t "usb_lib (70-usb-library)" "Creating link from $CONTENT_LINK to $SHARE_DIR"
 rm -rf $CONTENT_LINK
 ln -s $SHARE_DIR $CONTENT_LINK

--- a/roles/usb_lib/templates/mount.d/70-usb-library.j2
+++ b/roles/usb_lib/templates/mount.d/70-usb-library.j2
@@ -57,4 +57,7 @@ fi
 CONTENT_LINK_USB=$(basename $UM_MOUNTPOINT | awk '{print toupper($0)}')
 CONTENT_LINK="{{ doc_root }}/local_content/$CONTENT_LINK_USB"
 logger -t "usb_lib (70-usb-library)" "Creating link from $CONTENT_LINK to $SHARE_DIR"
-ln -sf $SHARE_DIR $CONTENT_LINK
+# 'rm -rf' even stronger than 'ln -nsf' and 'ln -Tsf'
+# https://serverfault.com/questions/147787/how-to-update-a-symbolic-link-target-ln-f-s-not-working/522483#522483
+rm -rf $CONTENT_LINK
+ln -s $SHARE_DIR $CONTENT_LINK

--- a/roles/usb_lib/templates/mount.d/70-usb-library.j2
+++ b/roles/usb_lib/templates/mount.d/70-usb-library.j2
@@ -56,7 +56,7 @@ fi
 
 CONTENT_LINK_USB=$(basename $UM_MOUNTPOINT | awk '{print toupper($0)}')
 if [ -z "$CONTENT_LINK_USB" ]; then
-    logger -t "usb_lib (70-usb-library)" "ERROR: Var CONTENT_LINK_USB is empty ("rm -rf /library/www/html/local_content/" might be dangerous!)"
+    logger -t "usb_lib (70-usb-library)" 'ERROR: Var CONTENT_LINK_USB is empty ("rm -rf /library/www/html/local_content/" would be dangerous!)'
     exit 1
 fi
 CONTENT_LINK="{{ doc_root }}/local_content/$CONTENT_LINK_USB"


### PR DESCRIPTION
### Fixes bug:

Stale symlinks to prior USB sticks[*] were blocking proper creation of the new symlink (upon USB stick insertion or upon IIAB boot) — as needed to hide stick materials outside of a stick's /PUBLIC folder — or to unhide stick materials, e.g. if teacher removes folder /PUBLIC on her/his USB stick, and then re-inserts the stick into IIAB.

[*] Stale Symlinks are common from prior boots, e.g. when IIAB's power is yanked.

### Description of changes proposed in this pull request:

- Delete the appropriate /library/www/html/local_content/USB0 (normally that'd be a symlink to /media/usb0) during /etc/usbmount/mount.d/70-usb-library.

- Adopt `exit 1` more broadly, to exit with return code 1 on various more-or-less common errors.

- Also clarify logging messages.

### Smoke-tested on which OS or OS's:

Raspberry Pi OS spot testing, but could use more testing.

### Mention a team member @username e.g. to help with code review:

@avni

Related:

- PR #3923
- PR #3929