### PR TITLE
exclude usb based device that host usbbooted filesytems

### DIFF
--- a/roles/usb_lib/files/upload2usb/upload2usb.php
+++ b/roles/usb_lib/files/upload2usb/upload2usb.php
@@ -18,7 +18,7 @@ function getTargetUSBDriveLocation () {
          // lsblk --output NAME,TRAN,RM,MOUNTPOINT --pairs |grep RM=\"1\" | grep -v MOUNTPOINT=\"\" | cut -d " " -f 4 | cut -d "=" -f 2
 
 	 # error if 1<>usb sticks are installed 
-	 $rmv_usb_path_count = shell_exec('lsblk --output NAME,TRAN,RM,MOUNTPOINT --pairs |grep RM=\"1\" | grep -v MOUNTPOINT=\"\" | cut -d " " -f 4  | wc -l');
+	 $rmv_usb_path_count = shell_exec('lsblk --output NAME,TRAN,RM,MOUNTPOINT --pairs |grep RM=\"1\" | grep -v MOUNTPOINT=\"\" | cut -d " " -f 4  | grep media | wc -l');
 	 if ($rmv_usb_path_count == 0) {
  	    	throw new RuntimeException('0 USB sticks found. <br/><br/>');
 	 } elseif ($rmv_usb_path_count > 1) {

--- a/roles/usb_lib/files/usbmount/usbmount
+++ b/roles/usb_lib/files/usbmount/usbmount
@@ -96,34 +96,30 @@ if [ "$1" = add ]; then
     USAGE=$(echo "$DEVINFO"  | sed 's/.*[[:blank:]]USAGE="\([^"]*\)".*/\1/g; s/[[:blank:]]*//g;')
 
     if ! echo $USAGE | egrep -q "(filesystem|disklabel)"; then
-	log info "/$DEVNAME does not contain a filesystem or disklabel"
+	log debug "/$DEVNAME does not contain a filesystem or disklabel"
 	exit
     fi
 
-    log debug "DEVNAME /$DEVNAME"
+    log debug "/$DEVNAME contains filesystem type $FSTYPE"
     BOOTFW_DEV=$(/usr/bin/findmnt -no source /boot/firmware)
     log debug "BOOTFW_DEV $BOOTFW_DEV"
-    if [ $BOOTFW_DEV = /$DEVNAME ]; then
-	log debug "/$DEVNAME contains filesystem type $FSTYPE"
-	log debug "skipping BOOTFS_DEV $BOOTFS_DEV mounted at /boot/firmware"
-	lockfile-remove /var/run/usbmount/.mount
-	exit
-    fi
     ROOT_DEV=$(/usr/bin/findmnt -no source /)
     log debug "ROOT_DEV $ROOT_DEV"
-    if [ $ROOT_DEV = /$DEVNAME ]; then
-	log debug "/$DEVNAME contains filesystem type $FSTYPE"
-	log debug "skipping ROOT_DEV $ROOT_DEV mounted at /"
-	lockfile-remove /var/run/usbmount/.mount
-	exit
-    fi
     BOOT_DEV=$(/usr/bin/findmnt -no source /boot)
     log debug "BOOT_DEV $BOOT_DEV"
-    if [ $BOOT_DEV = /$DEVNAME ]; then
-	log debug "/$DEVNAME contains filesystem type $FSTYPE"
-	log debug "skipping BOOT_DEV $BOOT_DEV mount as /boot"
-	lockfile-remove /var/run/usbmount/.mount
-	exit
+
+    if [ $BOOTFW_DEV = /$DEVNAME ]; then
+	log debug "skipping BOOTFS_DEV $BOOTFS_DEV mounted at /boot/firmware"
+        lockfile-remove /var/run/usbmount/.mount
+        exit
+    elif [ $ROOT_DEV = /$DEVNAME ]; then
+        log debug "skipping ROOT_DEV $ROOT_DEV mounted at /"
+        lockfile-remove /var/run/usbmount/.mount
+        exit
+    elif [ $BOOT_DEV = /$DEVNAME ]; then
+        log debug "skipping BOOT_DEV $BOOT_DEV mount as /boot"
+        lockfile-remove /var/run/usbmount/.mount
+        exit
     fi
 
     # Try to use specifications in /etc/fstab to skip.
@@ -145,7 +141,7 @@ if [ "$1" = add ]; then
 	    for v in $MOUNTPOINTS; do
 		if [ -d "$v" ] && ! grep -q "^[^ ][^ ]*  *$v " /proc/mounts; then
 		    mountpoint="$v"
-		    log debug "mountpoint $mountpoint is available for $DEVNAME"
+		    log debug "mountpoint $mountpoint is available for /$DEVNAME"
 		    break
 		fi
 	    done

--- a/roles/usb_lib/files/usbmount/usbmount
+++ b/roles/usb_lib/files/usbmount/usbmount
@@ -109,7 +109,7 @@ if [ "$1" = add ]; then
     log debug "BOOT_DEV $BOOT_DEV"
 
     if [ $BOOTFW_DEV = /$DEVNAME ]; then
-	log debug "skipping BOOTFS_DEV $BOOTFS_DEV mounted at /boot/firmware"
+	log debug "skipping BOOTFW_DEV $BOOTFW_DEV mounted at /boot/firmware"
         lockfile-remove /var/run/usbmount/.mount
         exit
     elif [ $ROOT_DEV = /$DEVNAME ]; then

--- a/roles/usb_lib/files/usbmount/usbmount
+++ b/roles/usb_lib/files/usbmount/usbmount
@@ -96,22 +96,41 @@ if [ "$1" = add ]; then
     USAGE=$(echo "$DEVINFO"  | sed 's/.*[[:blank:]]USAGE="\([^"]*\)".*/\1/g; s/[[:blank:]]*//g;')
 
     if ! echo $USAGE | egrep -q "(filesystem|disklabel)"; then
-	log info "$DEVNAME does not contain a filesystem or disklabel"
+	log info "/$DEVNAME does not contain a filesystem or disklabel"
 	exit
     fi
 
-    # Try to use specifications in /etc/fstab first.
+    log debug "DEVNAME /$DEVNAME"
+    BOOTFW_DEV=$(/usr/bin/findmnt -no source /boot/firmware)
+    log debug "BOOTFW_DEV $BOOTFW_DEV"
+    if [ $BOOTFW_DEV = /$DEVNAME ]; then
+	log debug "/$DEVNAME contains filesystem type $FSTYPE"
+	log debug "skipping BOOTFS_DEV $BOOTFS_DEV mounted at /boot/firmware"
+	exit
+    fi
+    ROOT_DEV=$(/usr/bin/findmnt -no source /)
+    log debug "ROOT_DEV $ROOT_DEV"
+    if [ $ROOT_DEV = /$DEVNAME ]; then
+	log debug "/$DEVNAME contains filesystem type $FSTYPE"
+	log debug "skipping ROOT_DEV $ROOT_DEV mounted at /"
+	exit
+    fi
+    BOOT_DEV=$(/usr/bin/findmnt -no source /boot)
+    log debug "BOOT_DEV $BOOT_DEV"
+    if [ $BOOT_DEV = /$DEVNAME ]; then
+	log debug "skipping BOOTFS_DEV $BOOT_DEV mount as /boot"
+	exit
+    fi
+
+    # Try to use specifications in /etc/fstab to skip.
     if egrep -q "^[[:blank:]]*$DEVNAME" /etc/fstab; then
-	log info "executing command: mount $DEVNAME"
-	mount $DEVNAME || log err "mount by DEVNAME with $DEVNAME wasn't successful; return code $?"
-
+	log debug "skipping /$DEVNAME exit"
+	exit
     elif grep -q "^[[:blank:]]*UUID=$UUID" /etc/fstab; then
-        log info "executing command: mount -U $UUID"
-	mount -U $UUID || log err "mount by UUID with $UUID wasn't successful; return code $?"
-
+	log debug "skipping $UUID"
+	exit
     else
-	log debug "$DEVNAME contains filesystem type $FSTYPE"
-
+	log debug "/$DEVNAME contains filesystem type $FSTYPE"
 	fstype=$FSTYPE
 	# Test if the filesystem type is in the list of filesystem
 	# types to mount.

--- a/roles/usb_lib/files/usbmount/usbmount
+++ b/roles/usb_lib/files/usbmount/usbmount
@@ -15,7 +15,7 @@
 # PARTICULAR PURPOSE.
 # https://github.com/iiab/iiab/blob/master/roles/usb_lib/files/usbmount/copyright
 # https://github.com/rbrito/usbmount/blob/master/debian/copyright
-set -e
+#set -e
 exec > /dev/null 2>&1
 
 ######################################################################
@@ -106,6 +106,7 @@ if [ "$1" = add ]; then
     if [ $BOOTFW_DEV = /$DEVNAME ]; then
 	log debug "/$DEVNAME contains filesystem type $FSTYPE"
 	log debug "skipping BOOTFS_DEV $BOOTFS_DEV mounted at /boot/firmware"
+	lockfile-remove /var/run/usbmount/.mount
 	exit
     fi
     ROOT_DEV=$(/usr/bin/findmnt -no source /)
@@ -113,12 +114,15 @@ if [ "$1" = add ]; then
     if [ $ROOT_DEV = /$DEVNAME ]; then
 	log debug "/$DEVNAME contains filesystem type $FSTYPE"
 	log debug "skipping ROOT_DEV $ROOT_DEV mounted at /"
+	lockfile-remove /var/run/usbmount/.mount
 	exit
     fi
     BOOT_DEV=$(/usr/bin/findmnt -no source /boot)
     log debug "BOOT_DEV $BOOT_DEV"
     if [ $BOOT_DEV = /$DEVNAME ]; then
-	log debug "skipping BOOTFS_DEV $BOOT_DEV mount as /boot"
+	log debug "/$DEVNAME contains filesystem type $FSTYPE"
+	log debug "skipping BOOT_DEV $BOOT_DEV mount as /boot"
+	lockfile-remove /var/run/usbmount/.mount
 	exit
     fi
 

--- a/roles/usb_lib/files/usbmount/usbmount
+++ b/roles/usb_lib/files/usbmount/usbmount
@@ -129,9 +129,11 @@ if [ "$1" = add ]; then
     # Try to use specifications in /etc/fstab to skip.
     if egrep -q "^[[:blank:]]*$DEVNAME" /etc/fstab; then
 	log debug "skipping /$DEVNAME exit"
+	lockfile-remove /var/run/usbmount/.mount
 	exit
     elif grep -q "^[[:blank:]]*UUID=$UUID" /etc/fstab; then
 	log debug "skipping $UUID"
+	lockfile-remove /var/run/usbmount/.mount
 	exit
     else
 	log debug "/$DEVNAME contains filesystem type $FSTYPE"

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -53,7 +53,7 @@
 #    deb: "{{ iiab_download_url }}/usbmount_0.0.22_all.deb"
 #  # when: is_debian
 
-- name: Install lockfile-progs and util-linux for usbmount from OS repo
+- name: Install lockfile-progs and util-linux (findmnt blkid) for usbmount from OS repo
   package:
     name:
       - lockfile-progs


### PR DESCRIPTION
### Fixes bug:
Double mounting of usbbooted root filesystems
### Description of changes proposed in this pull request:
see diff
### Smoke-tested on which OS or OS's:
>sudo journalctl -b -l --no-pager | grep usbmount
Feb 11 16:50:58 box systemd[1]: Created slice system-usbmount.slice - Slice /system/usbmount.
Feb 11 16:50:59 box systemd[1]: Started usbmount@dev-sda1.service.
Feb 11 16:50:59 box systemd[1]: Started usbmount@dev-sda2.service.
Feb 11 16:50:59 box usbmount[564]: loaded usbmount configurations
Feb 11 16:50:59 box usbmount[563]: loaded usbmount configurations
Feb 11 16:50:59 box usbmount[567]: /var/run/usbmount exists
Feb 11 16:50:59 box usbmount[568]: /var/run/usbmount exists
Feb 11 16:50:59 box usbmount[571]: trying to acquire lock /var/run/usbmount/.mount.lock
Feb 11 16:50:59 box usbmount[572]: trying to acquire lock /var/run/usbmount/.mount.lock
Feb 11 16:51:00 box usbmount[577]: acquired lock /var/run/usbmount/.mount.lock
Feb 11 16:51:00 box usbmount[597]: DEVNAME /dev/sda2
Feb 11 16:51:00 box usbmount[600]: BOOTFW_DEV /dev/sda1
Feb 11 16:51:00 box usbmount[603]: ROOT_DEV /dev/sda2
Feb 11 16:51:00 box usbmount[605]: /dev/sda2 contains filesystem type ext4
Feb 11 16:51:00 box usbmount[607]: skipping ROOT_DEV /dev/sda2 mounted at /
Feb 11 16:51:04 box usbmount[795]: acquired lock /var/run/usbmount/.mount.lock
Feb 11 16:51:05 box usbmount[809]: DEVNAME /dev/sda1
Feb 11 16:51:05 box usbmount[812]: BOOTFW_DEV /dev/sda1
Feb 11 16:51:05 box usbmount[814]: /dev/sda1 contains filesystem type vfat
Feb 11 16:51:05 box usbmount[816]: skipping BOOTFS_DEV  mounted at /boot/firmware

### Mention a team member @username e.g. to help with code review:
