### PR TITLE
[Upload2USB] upload2usb/header.php: update swing logo to point to /usb/ 

### DIFF
--- a/roles/usb_lib/files/upload2usb/header.php
+++ b/roles/usb_lib/files/upload2usb/header.php
@@ -28,5 +28,5 @@ include("upload2usb.php");
             <div class="row">
 		<div class="col-sm-6 offset-sm-3 text-center" style="padding:15px;">
 
-                    <a href="/upload2usb/"><img class="mb-4" src="uk-swing.png" alt="" width="75"></a>
+                    <a href="/usb/"><img class="mb-4" src="uk-swing.png" alt="" width="75"></a>
                     <h1 class="h3 mb-3 font-weight-normal"><?php echo $title ?></h1>


### PR DESCRIPTION
upload2usb/header.php: update swing logo to point to /usb/ instead of /upload2usb/

### Description of changes proposed in this pull request:
Link Change

### Smoke-tested on which OS or OS's:
RPi500 running Debian v12 (bookworm)

### Mention a team member @username e.g. to help with code review:
@holta 