### PR TITLE
(1) Debian 13 requires python3-packaging for JupyterHub (2) python3-psutil is currently not necessary

### DIFF
--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -18,9 +18,11 @@
   register: df1
 
 
-- name: "Install package: python3-psutil"
+- name: "Install package: python3-packaging"
   package:
-    name: python3-psutil
+    name:
+      - python3-packaging    # 2025-02-15: Debian 13 needs python3-packaging and does NOT need python3-psutil.  Debian 12 doesn't need python3-packaging OR python3-psutil.  Ubuntu 24.04+ comes with python3-packaging pre-installed.
+      #- python3-psutil      # 2023-04-26 thanks to @jvonau: Workaround for a wheel that is not available from PyPI for Python 3.11: https://github.com/iiab/iiab/pull/3554#issuecomment-1523358501
     state: present
 
 - name: Remove previous virtual environment {{ jupyterhub_venv }}


### PR DESCRIPTION
### Fixes bug:

- #3945

### Description of changes proposed in this pull request:

Mandate installation of apt package `python3-packaging` rather than `python3-psutil`.

### Smoke-tested on which OS or OS's:

Ubuntu 24.04, Debian 12, Debian 13 (latest pre-release).

Still needs testing on RasPiOS 12 (and eventually RasPiOS 13, later this year).

### Mention a team member @username e.g. to help with code review:

@jvonau with the original python3-venv and python3-psutil discussion from April 2023 here:

- PR #3554