### PR TITLE
pip install {pymysql, psycopg, passlib} to Ansible venv, on demand — to fix 6 IIAB Apps with new `interpreter_python=/usr/local/ansible/bin/python3` in ansible.cfg

### DIFF
--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -9,7 +9,7 @@
     name: net.ipv6.conf.all.disable_ipv6
     value: 0
 
-- name: "Install 5 packages: libcgi-fast-perl, munin, munin-node, munin-plugins-extra, python3-passlib"
+- name: "Install 4 packages: libcgi-fast-perl, munin, munin-node, munin-plugins-extra"
   package:
     name:
       #- libapache2-mod-fcgid
@@ -17,8 +17,14 @@
       - munin
       - munin-node
       - munin-plugins-extra
-      - python3-passlib    # For Ansible module 'htpasswd' in Ansible collection community.general -- used just below
+      #- python3-passlib    # For Ansible module 'htpasswd' in Ansible collection community.general -- used just below
     state: present
+
+- name: pip install 'passlib' into venv /usr/local/ansible -- for Ansible module 'htpasswd' in Ansible collection community.general -- used just below
+  pip:
+    name: passlib
+    virtualenv: /usr/local/ansible
+    extra_args: "--upgrade --no-cache-dir --prefer-binary"    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 # SEE ALSO roles/network/tasks/install.yml
 - name: RESTORE net.ipv6.conf.all.disable_ipv6 to 1 in /etc/sysctl.conf for #3434

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -3,15 +3,21 @@
   register: df1
 
 
-- name: 'Install MySQL packages: mariadb-server, mariadb-client, php{{ php_version }}-mysql, python3-pymysql'
+- name: 'Install MySQL packages: mariadb-server, mariadb-client, php{{ php_version }}-mysql'
   package:
     name:
       - mariadb-server
       - mariadb-client
       #- php{{ php_version }}-common    # Auto-installed as an apt dependency.  REGARDLESS: php{{ php_version }}-common superset php{{ php_version }}-cli is auto-installed by php{{ php_version }}-fpm in nginx/tasks/install.yml
       - php{{ php_version }}-mysql      # Likewise installed in nextcloud/tasks/install.yml, pbx/tasks/freepbx.yml, wordpress/tasks/install.yml
-      - python3-pymysql                 # For Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in MySQL roles {mediawiki, nextcloud, wordpress} and possibly {elgg, pbx}
+      #- python3-pymysql                # For Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in MySQL roles {mediawiki, nextcloud, wordpress} and possibly {elgg, pbx}
     state: present
+
+- name: pip install 'pymysql' into venv /usr/local/ansible -- for Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in roles {mediawiki, nextcloud, wordpress, matomo, pbx}
+  pip:
+    name: pymysql
+    virtualenv: /usr/local/ansible
+    extra_args: "--upgrade --no-cache-dir --prefer-binary"    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 # 2020-07-11: 10 PHP package installs moved to roles/www_base/tasks/main.yml
 # php{{ php_version }}-sqlite3 install moved to roles/osm-vector-maps/tasks/install.yml

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -13,9 +13,9 @@
       #- python3-pymysql                # For Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in MySQL roles {mediawiki, nextcloud, wordpress} and possibly {elgg, pbx}
     state: present
 
-- name: pip install 'pymysql' into venv /usr/local/ansible -- for Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in roles {mediawiki, nextcloud, wordpress, matomo, pbx}
+- name: pip install 'PyMySQL' into venv /usr/local/ansible -- for Ansible modules {mysql_db, mysql_user} in Ansible collection community.mysql -- used in roles {mediawiki, nextcloud, wordpress, matomo, pbx}
   pip:
-    name: pymysql
+    name: PyMySQL
     virtualenv: /usr/local/ansible
     extra_args: "--upgrade --no-cache-dir --prefer-binary"    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 

--- a/roles/postgresql/tasks/install.yml
+++ b/roles/postgresql/tasks/install.yml
@@ -3,13 +3,19 @@
   register: df1
 
 
-- name: 'Install packages: postgresql, postgresql-client, python3-psycopg2'
+- name: 'Install packages: postgresql, postgresql-client'
   package:
     name:
       - postgresql
       - postgresql-client
-      - python3-psycopg2    # For Ansible modules {postgresql_db, postgresql_user} in Ansible collection community.postgresql -- used in moodle/tasks/install.yml
+      #- python3-psycopg2    # For Ansible modules {postgresql_db, postgresql_user} in Ansible collection community.postgresql -- used in moodle/tasks/install.yml
     state: present
+
+- name: pip install 'psycopg' into venv /usr/local/ansible -- for Ansible modules {postgresql_db, postgresql_user} in Ansible collection community.postgresql -- used in moodle/tasks/install.yml
+  pip:
+    name: psycopg
+    virtualenv: /usr/local/ansible
+    extra_args: "--upgrade --no-cache-dir --prefer-binary"    # 2023-10-01: Lifesaver when recent wheels (e.g. piwheels.org) are inevitably not yet built!  SEE #3560
 
 - name: Run shell command "pg_config --version" to extract MAJOR version number -- strip off MINOR/PATCH version number(s)
   shell: pg_config --version | sed 's/^[^0-9]*//; s/[^0-9].*//'


### PR DESCRIPTION
### Fixes bug:

Resolves 6 IIAB App regressions, arising from /opt/iiab/iiab/ansible.cfg's change from `interpreter_python=/usr/bin/python3` to `interpreter_python=/usr/local/ansible/bin/python3` as outlined here:

- https://github.com/iiab/iiab/pull/3948#issuecomment-2661845405

Originally arising from:

- #3945

### Description of changes proposed in this pull request:

pip install each of the 3 on-demand...

1. `pymysql` for MySQL for {mediawiki, nextcloud, wordpress, matomo, pbx}
2. `psycopg` for PostgreSQL for Moodle
3. `passlib` for Munin

...on demand, instead of apt/deb installing each of the 3 python3-XXX packages system-wide.

psycopg2 is replaced with `psycopg` — which is really the new psycopg3.

pip flag `--upgrade` is added to try to allow for (some!) after-the-fact upgrades of Ansible, e.g. so things _aren't quite as fragile (while not perfect!)_ if an IIAB field implementer later runs: `sudo /opt/iiab/iiab/scripts/ansible`

### Smoke-tested on which OS or OS's:

Ubuntu 25.04 but needs other tests...

### Mention a team member @username e.g. to help with code review:

@jvonau