### PR TITLE
iiab-diagnostics: Also record /etc/locale.conf (e.g. for Debian 13 Trixie), in addition to legacy file-or-symlink /etc/default/locale

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -173,13 +173,13 @@ echo -e "\n\n\n2. REGULAR FILES ETC\n" >> $outfile
 #cat_file /tmp/empty-file             # Empty file test
 #cat_file /usr/bin/iiab-support-on    # Symlink test
 cat_file /.iiab-image
-cat_file /etc/default/locale 'e.g. on Debian 12'
-cat_file /etc/locale.conf 'e.g. on Debian 13+ and Ubuntu'
+cat_file /etc/default/locale    # e.g. on Debian 12
+cat_file /etc/locale.conf       # e.g. on Debian 13+ and Ubuntu
 cat_cmd 'localectl' 'Locale settings'
 cat_cmd 'locale -a' 'Available locales'
 cat_file /etc/iiab/iiab.env
 cat_file /etc/iiab/iiab.ini
-cat_file /etc/iiab/local_vars.yml      # Redacts most passwords above
+cat_file /etc/iiab/local_vars.yml    # Redacts most passwords above
 cat_file /etc/iiab/iiab_state.yml
 cat_file /etc/resolv.conf
 cat_file /etc/network/interfaces

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -173,7 +173,8 @@ echo -e "\n\n\n2. REGULAR FILES ETC\n" >> $outfile
 #cat_file /tmp/empty-file             # Empty file test
 #cat_file /usr/bin/iiab-support-on    # Symlink test
 cat_file /.iiab-image
-cat_file /etc/default/locale
+cat_file /etc/default/locale 'e.g. on Debian 12'
+cat_file /etc/locale.conf 'e.g. on Debian 13'
 cat_cmd 'localectl' 'Locale settings'
 cat_cmd 'locale -a' 'Available locales'
 cat_file /etc/iiab/iiab.env

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -174,7 +174,7 @@ echo -e "\n\n\n2. REGULAR FILES ETC\n" >> $outfile
 #cat_file /usr/bin/iiab-support-on    # Symlink test
 cat_file /.iiab-image
 cat_file /etc/default/locale 'e.g. on Debian 12'
-cat_file /etc/locale.conf 'e.g. on Debian 13'
+cat_file /etc/locale.conf 'e.g. on Debian 13+ and Ubuntu'
 cat_cmd 'localectl' 'Locale settings'
 cat_cmd 'locale -a' 'Available locales'
 cat_file /etc/iiab/iiab.env

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -66,4 +66,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 135-272 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 135-273 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Related:

- https://github.com/iiab/iiab/issues/3882#issuecomment-2692300227
- #3917
- PR #3926
- https://wiki.iiab.io/go/FAQ#What_to_do_if_Raspberry_Pi_OS_messes_up_language_locale?