### PR TITLE
iiab-update quick fix: Copy utility scripts into position in /usr/bin in all cases

### DIFF
--- a/scripts/iiab-update
+++ b/scripts/iiab-update
@@ -43,11 +43,8 @@
         echo -e "\e[4mNow running: cp -u roles/tailscale/templates/iiab-vpn /usr/bin\e[0m\n"
         cp -u roles/tailscale/templates/iiab-vpn /usr/bin
     fi
-    if [[ $1 == "-f" || $1 == "--fast" ]]; then    # Otherwise ./runrole does it below! (as Ansible runs roles/0-init)
-        cd scripts
-        echo -e "\e[4mNow running: cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin\e[0m\n"
-        cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin
-    fi
+    echo -e "\e[4mNow running: cp -u iiab-update iiab-summary iiab-diagnostics iiab-root-login /usr/bin\e[0m\n"
+    cp -u scripts/iiab-update scripts/iiab-summary scripts/iiab-diagnostics scripts/iiab-root-login /usr/bin    # Ah well, ./runrole below might repeat this (as Ansible runs roles/0-init)
 
     if [[ $1 == "-f" || $1 == "--fast" ]]; then
         echo -e "\n\e[33m'iiab-update -f' DOES NOT upgrade Ansible.\e[0m\n\n"


### PR DESCRIPTION
### Fixes bug:

Quick fix, to handle a corner case where a few /opt/iiab/iiab/scripts were being updated from online Git repo, but were not being copied over to /usr/bin