### PR TITLE
iiab-diagnostics more resilient

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -52,12 +52,6 @@
     state: link
     #force: yes
 
-- name: Create globally-writable directory /etc/iiab/diag (0777) so non-root users can run 'iiab-diagnostics'
-  file:
-    state: directory
-    path: /etc/iiab/diag
-    mode: '0777'
-
 
 - name: Pre-check that IIAB's "XYZ_install" + "XYZ_enabled" vars (1) are defined, (2) are boolean-not-string variables, and (3) contain plausible values.  Also checks that "XYZ_install" is True when "XYZ_installed" is defined.
   include_tasks: validate_vars.yml

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -35,6 +35,7 @@ fi
 
 # Build up a meaningful shared filename for DEV / IMPLEM / LEARNING team(s)
 mkdir -p /etc/iiab/diag
+chmod 777 /etc/iiab/diag
 outfile=/etc/iiab/diag/${IIAB_RELEASE}_${OS_VER}_${YMDT}_$nickname
 
 # System "snapshots" (time-stamped output from this 'iiab-diagnostics' command)

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -35,7 +35,7 @@ fi
 
 # Build up a meaningful shared filename for DEV / IMPLEM / LEARNING team(s)
 mkdir -p /etc/iiab/diag
-chmod 777 /etc/iiab/diag
+chmod 777 /etc/iiab/diag    # So non-root users can run 'iiab-diagnostics'
 outfile=/etc/iiab/diag/${IIAB_RELEASE}_${OS_VER}_${YMDT}_$nickname
 
 # System "snapshots" (time-stamped output from this 'iiab-diagnostics' command)

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -34,6 +34,7 @@ if [[ $nickname == "" ]]; then
 fi
 
 # Build up a meaningful shared filename for DEV / IMPLEM / LEARNING team(s)
+mkdir -p /etc/iiab/diag
 outfile=/etc/iiab/diag/${IIAB_RELEASE}_${OS_VER}_${YMDT}_$nickname
 
 # System "snapshots" (time-stamped output from this 'iiab-diagnostics' command)


### PR DESCRIPTION
Allows iiab-diagnostics to run in more situations, e.g. even when many IIAB components are not yet in place, by making the command more self-sufficient. ✅