### PR TITLE
Auto-install Kolibri 0.18.0 Beta 2 if Python >= 3.13 for Ubuntu 25.04, Debian 13, RasPiOS 13, etc (TEMPORARY!)

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -133,6 +133,11 @@
 #     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
 #   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
+- name: '2025-04-02 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.18.0 Beta 2+ if Python >= 3.13 -- kolibri-proposed PPA should do this automatically in future!'
+  set_fact:
+    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.18.0-beta2/kolibri_0.18.0b2-0ubuntu1_all.deb
+  when: python_version is version('3.13', '>=')    # For Ubuntu 25.04+, Debian 13+, etc.  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
+
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
   apt:
     name: kolibri


### PR DESCRIPTION
_Big step forward thanks to [Kolibri 0.18.0 Beta 2](https://github.com/learningequality/kolibri/releases/tag/v0.18.0-beta2) just posted!_

### Description of changes proposed in this pull request:

Auto-install a working version of Kolibri 0.18.0 (Beta 2 for now) if Python => 3.13 is auto-detected — to allow IIAB with Kolibri on 2025 OS's — e.g. the imminent Ubuntu 25.04 Plucky Puffin, and coming soon Debian 13 Trixie, Raspberry Pi OS 13 / Trixie, Etc.

### Smoke-tested on which OS or OS's:

Ubuntu Server 25.04 (near-final pre-release; OS ETA is April 17)

### Mention a team member @username e.g. to help with code review:

@EMG70

### Warning:

As an ASIDE, note that testing benefits from a completely fresh/clean OS — as just FYI manual attempts to uninstall Kolibri using `apt purge kolibri` (and removing it from /etc/iiab/iiab_state.yml) followed by `./runrole kolibri` results in the following problem...

> TASK [kolibri : Provision Kolibri, while setting: facility name, admin acnt / password, preset type, and language] **************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "\"/usr/bin/kolibri\" manage provisiondevice --facility \"Kolibri-in-a-Box\" --superusername \"Admin\" --superuserpassword \"changeme\" --preset \"formal\" --language_id \"en\" #--preset \"formal\" --language_id \"en\" --verbosity 0 --noinput\n", "delta": "0:00:03.903807", "end": "2025-04-02 14:03:57.306276", "msg": "non-zero return code", "rc": 1, "start": "2025-04-02 14:03:53.402469", "stderr": "/usr/lib/python3/dist-packages/kolibri/dist/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!\n  warnings.warn(\"urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported \"\n/usr/lib/python3/dist-packages/kolibri/dist/magicbus/process.py:25: SyntaxWarning: invalid escape sequence '\\ '\n  \\         A\n/usr/lib/python3/dist-packages/kolibri/dist/magicbus/plugins/servers.py:20: SyntaxWarning: invalid escape sequence '\\ '\n  There are also Flup\\ **F**\\ CGIServer and Flup\\ **S**\\ CGIServer classes in\nTraceback (most recent call last):\n  File \"/usr/bin/kolibri\", line 33, in <module>\n    sys.exit(load_entry_point('kolibri==0.18.0b2', 'console_scripts', 'kolibri')())\n             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1128, in __call__\n    return self.main(*args, **kwargs)\n           ~~~~~~~~~^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1053, in main\n    rv = self.invoke(ctx)\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1659, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/utils/cli.py\", line 205, in invoke\n    return super(KolibriDjangoCommand, self).invoke(ctx)\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1395, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 754, in invoke\n    return __callback(*args, **kwargs)\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/decorators.py\", line 26, in new_func\n    return f(get_current_context(), *args, **kwargs)\n  File \"/usr/lib/python3/dist-packages/kolibri/utils/cli.py\", line 378, in manage\n    execute_from_command_line([\"kolibri manage\"] + ctx.args)\n    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/__init__.py\", line 419, in execute_from_command_line\n    utility.execute()\n    ~~~~~~~~~~~~~~~^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/__init__.py\", line 413, in execute\n    self.fetch_command(subcommand).run_from_argv(self.argv)\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/base.py\", line 354, in run_from_argv\n    self.execute(*args, **cmd_options)\n    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/base.py\", line 398, in execute\n    output = self.handle(*args, **options)\n  File \"/usr/lib/python3/dist-packages/kolibri/core/device/management/commands/provisiondevice.py\", line 196, in handle\n    setup_device_and_facility(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~^\n        facility,\n        ^^^^^^^^^\n    ...<5 lines>...\n        password,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/usr/lib/python3/dist-packages/kolibri/core/device/utils.py\", line 270, in setup_device_and_facility\n    provision_device(**device_settings)\n    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/kolibri/core/device/utils.py\", line 123, in provision_device\n    raise DeviceAlreadyProvisioned(\"Device has already been provisioned.\")\nkolibri.core.device.utils.DeviceAlreadyProvisioned: Device has already been provisioned.", "stderr_lines": ["/usr/lib/python3/dist-packages/kolibri/dist/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!", "  warnings.warn(\"urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported \"", "/usr/lib/python3/dist-packages/kolibri/dist/magicbus/process.py:25: SyntaxWarning: invalid escape sequence '\\ '", "  \\         A", "/usr/lib/python3/dist-packages/kolibri/dist/magicbus/plugins/servers.py:20: SyntaxWarning: invalid escape sequence '\\ '", "  There are also Flup\\ **F**\\ CGIServer and Flup\\ **S**\\ CGIServer classes in", "Traceback (most recent call last):", "  File \"/usr/bin/kolibri\", line 33, in <module>", "    sys.exit(load_entry_point('kolibri==0.18.0b2', 'console_scripts', 'kolibri')())", "             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1128, in __call__", "    return self.main(*args, **kwargs)", "           ~~~~~~~~~^^^^^^^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1053, in main", "    rv = self.invoke(ctx)", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1659, in invoke", "    return _process_result(sub_ctx.command.invoke(sub_ctx))", "                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/utils/cli.py\", line 205, in invoke", "    return super(KolibriDjangoCommand, self).invoke(ctx)", "           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 1395, in invoke", "    return ctx.invoke(self.callback, **ctx.params)", "           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/core.py\", line 754, in invoke", "    return __callback(*args, **kwargs)", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/click/decorators.py\", line 26, in new_func", "    return f(get_current_context(), *args, **kwargs)", "  File \"/usr/lib/python3/dist-packages/kolibri/utils/cli.py\", line 378, in manage", "    execute_from_command_line([\"kolibri manage\"] + ctx.args)", "    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/__init__.py\", line 419, in execute_from_command_line", "    utility.execute()", "    ~~~~~~~~~~~~~~~^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/__init__.py\", line 413, in execute", "    self.fetch_command(subcommand).run_from_argv(self.argv)", "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/base.py\", line 354, in run_from_argv", "    self.execute(*args, **cmd_options)", "    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/dist/django/core/management/base.py\", line 398, in execute", "    output = self.handle(*args, **options)", "  File \"/usr/lib/python3/dist-packages/kolibri/core/device/management/commands/provisiondevice.py\", line 196, in handle", "    setup_device_and_facility(", "    ~~~~~~~~~~~~~~~~~~~~~~~~~^", "        facility,", "        ^^^^^^^^^", "    ...<5 lines>...", "        password,", "        ^^^^^^^^^", "    )", "    ^", "  File \"/usr/lib/python3/dist-packages/kolibri/core/device/utils.py\", line 270, in setup_device_and_facility", "    provision_device(**device_settings)", "    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^", "  File \"/usr/lib/python3/dist-packages/kolibri/core/device/utils.py\", line 123, in provision_device", "    raise DeviceAlreadyProvisioned(\"Device has already been provisioned.\")", "kolibri.core.device.utils.DeviceAlreadyProvisioned: Device has already been provisioned."], "stdout": "\u001b[37mINFO     2025-04-02 14:03:54,710 Option DEBUG in section [Server] being overridden by environment variable KOLIBRI_DEBUG\u001b[0m\n\u001b[37mINFO     2025-04-02 14:03:54,710 Option DEBUG_LOG_DATABASE in section [Server] being overridden by environment variable KOLIBRI_DEBUG_LOG_DATABASE\u001b[0m\n\u001b[37mINFO     2025-04-02 14:03:55,448 Running Kolibri with the following settings: kolibri.deployment.default.settings.base\u001b[0m\n\u001b[37mINFO     2025-04-02 14:03:55,786 Invoking command provisiondevice --facility Kolibri-in-a-Box --superusername Admin --superuserpassword changeme --preset formal --language_id en\u001b[0m\n\u001b[33mWARNING  2025-04-02 14:03:55,995 The 'provisiondevice' command is experimental, and the API and behavior will change in a future release\u001b[0m\n\u001b[33mWARNING  2025-04-02 14:03:55,998 Facility with name 'Kolibri-in-a-Box' already exists, not modifying preset.\u001b[0m", "stdout_lines": ["\u001b[37mINFO     2025-04-02 14:03:54,710 Option DEBUG in section [Server] being overridden by environment variable KOLIBRI_DEBUG\u001b[0m", "\u001b[37mINFO     2025-04-02 14:03:54,710 Option DEBUG_LOG_DATABASE in section [Server] being overridden by environment variable KOLIBRI_DEBUG_LOG_DATABASE\u001b[0m", "\u001b[37mINFO     2025-04-02 14:03:55,448 Running Kolibri with the following settings: kolibri.deployment.default.settings.base\u001b[0m", "\u001b[37mINFO     2025-04-02 14:03:55,786 Invoking command provisiondevice --facility Kolibri-in-a-Box --superusername Admin --superuserpassword changeme --preset formal --language_id en\u001b[0m", "\u001b[33mWARNING  2025-04-02 14:03:55,995 The 'provisiondevice' command is experimental, and the API and behavior will change in a future release\u001b[0m", "\u001b[33mWARNING  2025-04-02 14:03:55,998 Facility with name 'Kolibri-in-a-Box' already exists, not modifying preset.\u001b[0m"]}

### Tangentially Related:

- PR #3785