### PR TITLE
Cleaner warn_fw_crash.yml for OS's like Debian where /sys/class/ieee80211/ can be empty

### DIFF
--- a/roles/firmware/tasks/warn_fw_crash.yml
+++ b/roles/firmware/tasks/warn_fw_crash.yml
@@ -4,8 +4,8 @@
 # (just below NM-debian.yml) and at https://github.com/iiab/iiab/pull/3965
 
 
-- name: Did WiFi firmware crash since boot? Run '[ -d /sys/class/ieee80211/ ] && ls /sys/class/ieee80211/ | head -1' to check
-  shell: '[ -d /sys/class/ieee80211/ ] && ls /sys/class/ieee80211/ | head -1'
+- name: Did WiFi firmware crash since boot? Try to record phyname in /sys/class/ieee80211/ to check below
+  shell: ls /sys/class/ieee80211/ | head -1
   register: phyname
   failed_when: False    # Stronger than 'ignore_errors: yes' (defer red errors until below!)
 
@@ -15,13 +15,13 @@
   failed_when: False
 
 
-- name: WARN if WiFi firmware appears to have crashed since boot (intentionally show red error)
+- name: WARN if phyname indicates WiFi firmware crashed since boot (intentionally show red error)
   fail:
     msg: "WARNING: /sys/class/ieee80211/{{ phyname.stdout }} (normally phy0) SUGGESTS YOUR WIFI FIRMWARE CRASHED SINCE BOOT."
-  when: phyname.rc == 0 and phyname.stdout != "phy0"
+  when: phyname.stdout != "" and phyname.stdout != "phy0"
   ignore_errors: yes
 
-- name: WARN if WiFi firmware appears to have crashed since boot (intentionally show red error)
+- name: WARN if dmesg output indicates WiFi firmware crashed since boot (intentionally show red error)
   fail:
     msg: "WARNING: dmesg SHOWS WIFI FIRMWARE CRASH(ES) SINCE BOOT... {{ dmesg_fw_crash.stdout }}"
   when: dmesg_fw_crash.rc == 0
@@ -30,9 +30,9 @@
 
 - fail:    # Also intentionally red, with a 1 minute pause below, for extra emphasis
     msg: "PLEASE CONSIDER: (1) adding 'brcmfmac.debug=0x100000' to /boot/firmware/cmdline.txt (and then reboot) to provide much more logging, (2) running 'sudo iiab-diagnostics' to submit a bug report, (3) reading https://github.com/iiab/iiab/pull/3965 to learn more."
-  when: phyname.rc == 0 and phyname.stdout != "phy0" or dmesg_fw_crash.rc == 0
+  when: phyname.stdout != "" and phyname.stdout != "phy0" or dmesg_fw_crash.rc == 0
   ignore_errors: yes
 
 - pause:
     minutes: 1
-  when: phyname.rc == 0 and phyname.stdout != "phy0" or dmesg_fw_crash.rc == 0
+  when: phyname.stdout != "" and phyname.stdout != "phy0" or dmesg_fw_crash.rc == 0


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Cleans up roles/firmware/tasks/warn_fw_crash.yml to reduce red message alarmism on OS's like Debian where empty directory /sys/class/ieee80211/ can exist.  Unlike on Ubuntu, where the empty directory typically does not exist (presumably until an internal WiFi device is actually detected, etc).

### Smoke-tested on which OS or OS's:

Debian 13 Trixie.

### Building on:

- PR #3965