### PR TITLE
[Upload2USB] Revert Upload button (and associated docs) to be 'Upload to USB'

### DIFF
--- a/roles/usb_lib/README.rst
+++ b/roles/usb_lib/README.rst
@@ -7,7 +7,7 @@ usb_lib README
 This role (1) implements functionality similar to LibraryBox, to mount "teacher content" from USB sticks / drives for students, and (2) allows students to upload their work to the teacher's USB stick / drive:
 
 #. Students should have nearly immediate access to "teacher content" (on all inserted USB sticks) by browsing to http://box/usb.
-#. Students can also click the "Upload" button on top of this same page (http://box/usb), to upload their work to the teacher's USB stick.  (FYI student uploads appear in folders like ``UPLOADS.YYYY-MM-DD`` within the root of the teacher's USB stick).
+#. Students can also click the "Upload to USB" button on top of this same page (http://box/usb), to upload their work to the teacher's USB stick.  (FYI student uploads appear in folders like ``UPLOADS.YYYY-MM-DD`` within the root of the teacher's USB stick).
 
 As of January 2025, automount is handled by usbmount: (`devmon included with udevil <https://ignorantguru.github.io/udevil/>`_ might be considered in future)
 

--- a/roles/usb_lib/files/upload2usb/upload-simple.php
+++ b/roles/usb_lib/files/upload2usb/upload-simple.php
@@ -92,7 +92,7 @@ if (array_key_exists("query", $url_components)) {
 <div class="container">
     <form action="/upload2usb/upload-file.php" id="upload2usb_form" method="post" enctype="multipart/form-data">
         <input type="file" name="uploaded_file" id="uploaded_file" onChange="this.form.submit();" style="display:none;">
-	<button name="upload_btn" type="button" onClick="uploadFile();">Upload</button>
+	<button name="upload_btn" type="button" onClick="uploadFile();">Upload to USB</button>
         <span><?php echo $file_count ?> files uploaded today!</span>
 	<?php echo $upload_msg ?>
     </form>


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Revert Upload button (and associated docs) to be 'Upload to USB' so as to provide context to user where they are uploading to. 

### Smoke-tested on which OS or OS's:

RPi400 Raspberry Pi OS Desktop

### Mention a team member @username e.g. to help with code review:
@holta 