### PR TITLE
phpMyAdmin 5.2.2

### DIFF
--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -4,7 +4,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-phpmyadmin_version: 5.2.1
+phpmyadmin_version: 5.2.2
 phpmyadmin_name: "phpMyAdmin-{{ phpmyadmin_version }}-all-languages"
 phpmyadmin_dl_url: "https://files.phpmyadmin.net/phpMyAdmin/{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"
 phpmyadmin_name_zip: "{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"


### PR DESCRIPTION
Includes many fixes. Announcement & details:

> Released 2025-01-21.

> Current version compatible with PHP 7.2 and newer and MySQL/MariaDB 5.5 and newer.

https://github.com/phpmyadmin/phpmyadmin/releases/tag/RELEASE_5_2_2
https://www.phpmyadmin.net/files/5.2.2/

Building on:

- PR #3474