### PR TITLE
New Moodle 5.0, if OS PHP < 8.5

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -8,11 +8,11 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 
-# October 2024: Currently testing Moodle's main branch is mandatory if your
-# OS PHP >= 8.4, see moodle/tasks/install.yml for detail!  OR, *IF* your
-# OS PHP < 8.4, then {{ moodle_version }} will be attempted:
-moodle_version: MOODLE_405_STABLE    # Moodle 4.5
-#moodle_version: main                # e.g. to try Moodle's "weekly" 5.0dev pre-release *EVEN IF* OS PHP < 8.4
+# April 2025: Currently testing Moodle's main branch is mandatory if your...
+# OS PHP >= 8.5, see moodle/tasks/install.yml for detail!  OR, *IF* your...
+# OS PHP < 8.5, then {{ moodle_version }} will be attempted:
+moodle_version: MOODLE_500_STABLE    # Moodle 5.0
+#moodle_version: main                # e.g. to try Moodle's "weekly" 5.1dev pre-release *EVEN IF* OS PHP < 8.5
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!
 

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -91,26 +91,26 @@
   command: dpkg --print-architecture
   register: dpkg_arch
 
-- name: "2023-04-30: MOODLE 4.2+ REQUIRES PHP 8 AND *FULL* 64-BIT OPERATION -- SO WE REVERT TO TRYING THE OLDER MOODLE 4.1 LTS WHEN NECESSARY -- NOTE PHP 7.x END-OF-LIFE WAS NOVEMBER 2022"
-  set_fact:
-    moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
-  when: php_version is version('8.0', '<') or not dpkg_arch.stdout is search("64")
+# - name: "2023-04-30: MOODLE 4.2+ REQUIRES PHP 8 AND *FULL* 64-BIT OPERATION -- SO WE REVERT TO TRYING THE OLDER MOODLE 4.1 LTS WHEN NECESSARY -- NOTE PHP 7.x END-OF-LIFE WAS NOVEMBER 2022"
+#   set_fact:
+#     moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
+#   when: php_version is version('8.0', '<') or not dpkg_arch.stdout is search("64")
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} < 8.4
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} < 8.5
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
-    version: "{{ moodle_version }}"    # e.g. MOODLE_404_STABLE (Moodle 4.4)
-  when: php_version is version('8.4', '<')
+    version: "{{ moodle_version }}"    # e.g. MOODLE_500_STABLE (Moodle 5.0)
+  when: php_version is version('8.5', '<')
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'main' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} >= 8.4"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'main' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} >= 8.5"
   git:
     repo: "{{ moodle_repo_url }}"
     dest: "{{ moodle_base }}"
     depth: 1
     version: main    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023, 4.4dev in Oct 2023, 4.5dev in Apr 2024, 5.0dev in Oct 2024)
-  when: php_version is version('8.4', '>=')
+  when: php_version is version('8.5', '>=')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:


### PR DESCRIPTION
Smoke-tested with basic functionality testing on Ubuntu 25.04:

- https://paste.centos.org/view/c3fbcd7e

Could use a stronger evaluation / confirmation over coming weeks, to see if any software dependencies (&/or Moodle plugins, configuration etc) need small adjustments.

Building on:

- PR #3656
- PR #3791
- PR #3826