### PR TITLE
TEMPORARY: Auto-install Kolibri 0.18.0 Beta 4 if Python >= 3.13

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -133,9 +133,9 @@
 #     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
 #   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
-- name: '2025-04-08 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.18.0 Beta 3+ if Python >= 3.13 -- kolibri-proposed PPA should do this automatically in future!'
+- name: '2025-04-08 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.18.0 Beta 4+ if Python >= 3.13 -- kolibri-proposed PPA should do this automatically in future!'
   set_fact:
-    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.18.0-beta3/kolibri_0.18.0b3-0ubuntu1_all.deb
+    kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.18.0-beta4/kolibri_0.18.0b4-0ubuntu1_all.deb
   when: python_version is version('3.13', '>=')    # For Ubuntu 25.04+, Debian 13+, etc.  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -133,7 +133,7 @@
 #     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.17.0/kolibri_0.17.0-0ubuntu1_all.deb
 #   when: python_version is version('3.12', '>=')    # For Ubuntu 24.04, Mint 22, pre-releases of Ubuntu 24.10, and Debian 13 (even if/when "Trixie" changes from Python 3.12 to 3.13!)  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892
 
-- name: '2025-04-08 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.18.0 Beta 4+ if Python >= 3.13 -- kolibri-proposed PPA should do this automatically in future!'
+- name: '2025-04-15 TEMPORARY HACK: Hard code kolibri_deb_url to Kolibri 0.18.0 Beta 4+ if Python >= 3.13 -- kolibri-proposed PPA should do this automatically in future!'
   set_fact:
     kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.18.0-beta4/kolibri_0.18.0b4-0ubuntu1_all.deb
   when: python_version is version('3.13', '>=')    # For Ubuntu 25.04+, Debian 13+, etc.  Regarding PPA kolibri-proposed not quite being ready yet, see: learningequality/kolibri#11316 -> learningequality/kolibri#11892


### PR DESCRIPTION
ANNC: https://github.com/learningequality/kolibri/releases/tag/v0.18.0-beta4

Building on:

- PR #3983
- PR #3989