### PR TITLE
Have syslog write nginx error logs to modern systemd / journalctl log

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -49,10 +49,14 @@ http {
     '"$http_user_agent" "http_x_forwarded_for"';
 
     access_log {{ nginx_log_dir }}/access.log awstats;
-    error_log {{ nginx_log_dir }}/error.log;
+
+    # 2025-04-20 Have syslog write nginx error logs to modern systemd / journalctl logs
+    # error_log {{ nginx_log_dir }}/error.log;
+    error_log syslog:server=unix:/dev/log;
 
     log_format scripts '$request > $document_root$fastcgi_script_name $fastcgi_path_info';
     access_log {{ nginx_log_dir }}/scripts.log scripts;
+
 
     ##
     # Gzip Settings

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -251,6 +251,7 @@ cat_cmd 'lspci -nn' 'Devices on PCI buses'
 cat_cmd 'env' 'Environment variables'
 cat_cmd 'node -v' 'Node.js version'
 cat_cmd 'npm -v' 'npm version'
+cat_cmd 'sudo journalctl -u nginx -n 20' 'nginx error log' 
 cat_cmd '/opt/iiab/kiwix/bin/kiwix-serve --version' 'kiwix-tools'
 cat_cmd 'cd /usr/local/calibre-web-py3; sudo git log --graph --oneline --decorate | head -50' 'Calibre-Web version'
 cat_cmd 'sudo lb --version' 'xklb version'
@@ -261,9 +262,6 @@ cat_tail /var/log/calibre-web.log 100
 cat_tail /var/log/xklb.log 300
 cat_cmd 'sudo journalctl -t IIAB-CMDSRV' 'Admin Console CMDSRV log'
 #cat_cmd 'ansible localhost -m setup 2>/dev/null' 'All Ansible facts'    # For cleaner scraping of Ansible vars, consider "./runrole all-vars /tmp/all-ansible-vars" 27-31 lines above?
-
-# 2025-04-20 add last 20 lines of nginx logging
-cat_cmd 'sudo journalctl -u nginx | tail -20' 'nginx systemd log' 
 
 echo -e "\n  5. Firewall Rules:\n"
 echo -e "\n\n\n5. FIREWALL RULES\n" >> $outfile

--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -262,6 +262,9 @@ cat_tail /var/log/xklb.log 300
 cat_cmd 'sudo journalctl -t IIAB-CMDSRV' 'Admin Console CMDSRV log'
 #cat_cmd 'ansible localhost -m setup 2>/dev/null' 'All Ansible facts'    # For cleaner scraping of Ansible vars, consider "./runrole all-vars /tmp/all-ansible-vars" 27-31 lines above?
 
+# 2025-04-20 add last 20 lines of nginx logging
+cat_cmd 'sudo journalctl -u nginx | tail -20' 'nginx systemd log' 
+
 echo -e "\n  5. Firewall Rules:\n"
 echo -e "\n\n\n5. FIREWALL RULES\n" >> $outfile
 #cat_file /usr/bin/iiab-gen-iptables

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -66,4 +66,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 137-280 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 137-281 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
### Description of changes proposed in this pull request:
Have syslog write nginx error logs to modern systemd / journalctl logs; Update `iiab-diagnostics` to include last 20 lines of nginx error log. 

This also removes error logging from going into `/var/log/nginx/error.log`. 

### Smoke-tested on which OS or OS's:
Raspberry Pi 400 Raspberry Pi OS

Example `iiab-diagnostics` output containing last 20 lines of nginx log: https://paste.centos.org/view/f554ec2e


### Mention a team member @username e.g. to help with code review:
@holta 