### PR TITLE
Revert to "minetest" naming (not "luanti" naming) on Ubuntu 25.10 for now — fyi 25.10's virtual pkg `luanti-server` exists but needs work

### DIFF
--- a/roles/luanti/tasks/main.yml
+++ b/roles/luanti/tasks/main.yml
@@ -26,16 +26,16 @@
         luanti_deb_and_systemd_name: luanti-server    # Debian 13 renamed deb/apt package TO 'luanti-server': WILL UBUNTU 25.10+ DO LIKEWISE??
 
     - name: Is apt package 'luanti-server' available? (Quite likely if OS is new since mid-2025!) But if not, show red error and continue.
-      command: apt-cache show luanti-server
+      command: apt show luanti-server    # 'apt-cache show luanti-server' works likewise
       register: luanti_server_renamed
       ignore_errors: yes
 
-    - name: Revert {luanti_deb_and_systemd_name, luanti_config_file, luanti_working_dir} to older Minetest values -- if apt package 'luanti-server' isn't available
+    - name: Revert {luanti_deb_and_systemd_name, luanti_config_file, luanti_working_dir} to older Minetest values -- if apt package 'luanti-server' isn't available OR Ubuntu 25.10 (OS IN TRANSITION!)
       set_fact:
         luanti_deb_and_systemd_name: minetest-server       # OVERRIDE luanti-server (set above)
         luanti_config_file: /etc/minetest/minetest.conf    # OVERRIDE /etc/luanti/default.conf (set in defaults/main.yml)
         luanti_working_dir: /usr/share/games/minetest      # OVERRIDE /usr/share/luanti (set in default_vars.yml)
-      when: luanti_server_renamed.failed
+      when: luanti_server_renamed.failed or (is_ubuntu and os_ver is version('ubuntu-2604', '<'))    # 2025-05-11: luanti-server is a virtual package on Ubuntu 25.10 -- that doesn't yet work :/ "minetest-server.service: Start request repeated too quickly"
       #when: (is_raspbian and os_ver is version('raspbian-13', '<')) or (is_debian and not is_raspbian and os_ver is version('debian-13', '<')) or (is_ubuntu and os_ver is version('ubuntu-2510', '<'))    # Gratuitous parens for clarity
 
     - name: Install Luanti if 'luanti_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml


### PR DESCRIPTION
At the moment Ubuntu 25.10 (Questing Quokka) contains a virtual apt package luanti-server, that was tripping up IIAB's thresholding logic (re: old Minetest naming versus new Luanti naming), as least during these very early days of Ubuntu 25.10 pre-releases.

- So this PR allows treats Ubuntu 25.10 as an "old" OS for the sake of Minetest/Luanti, for now — allowing LARGE-sized IIAB installs to at least complete.

- Though unfortunately this OS's package (luanti-server ~= minetest-server) doesn't yet seem to work — the failure is: "minetest-server.service: Start request repeated too quickly"

- So hopefully Ubuntu 25.10 will clean that up in coming months (we should check back prior to 25.10's 2025-10-09 release!)

Related:

- PR #3985
- #4012