### PR TITLE
add trisquel12 support 

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -123,6 +123,10 @@ if [ ! -f /etc/debian_version ]; then    # e.g. RasPiOS, Ubuntu, Mint & Debian
     exit 1
 fi
 
+# If OS is Trisquel, make python3-pip-whl available, and change AppArmor to enable php-fpm writing to disk
+grep -qx 'ID=trisquel' /etc/os-release && \
+/opt/iiab/iiab/scripts/trisquel-profile-setup.sh
+
 # 2021-04-26: JV & @holta WIP.  The apt-key command is going away, and the past
 # practice of putting keys in /etc/apt/trusted.gpg.d is considered insecure:
 # https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -123,7 +123,8 @@ if [ ! -f /etc/debian_version ]; then    # e.g. RasPiOS, Ubuntu, Mint & Debian
     exit 1
 fi
 
-# If OS is Trisquel, make python3-pip-whl available, and change AppArmor to enable php-fpm writing to disk
+# If OS is Trisquel, make python3-pip and python3-pip-whl ("what's really
+# needed") available, and change AppArmor to enable php-fpm writing to disk.
 grep -qx 'ID=trisquel' /etc/os-release && \
 /opt/iiab/iiab/scripts/trisquel-profile-setup.sh
 

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -51,8 +51,8 @@ if tmp=$(grep ^VERSION_ID= /etc/os-release); then
     VERSION_ID=${VERSION_ID//\"/}    # Remove all '"'
     [[ $OS == "ubuntu" ]] &&             # e.g. '22.04' -> '2204'
         VERSION_ID=${VERSION_ID//\./}    # Remove all '.'
-    [[ $OS == "linuxmint" || "trisquel" ]] &&         # e.g. '20.2' -> '20'
-        VERSION_ID=${VERSION_ID%%.*}    # Remove all '.' & stuff to the right
+    [[ $OS == "linuxmint" || "trisquel" ]] &&    # e.g. '20.2' -> '20'
+        VERSION_ID=${VERSION_ID%%.*}     # Remove all '.' & stuff to the right
 fi
 OS_VER="$OS-$VERSION_ID"
 

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -51,7 +51,7 @@ if tmp=$(grep ^VERSION_ID= /etc/os-release); then
     VERSION_ID=${VERSION_ID//\"/}    # Remove all '"'
     [[ $OS == "ubuntu" ]] &&             # e.g. '22.04' -> '2204'
         VERSION_ID=${VERSION_ID//\./}    # Remove all '.'
-    [[ $OS == "linuxmint" ]] &&         # e.g. '20.2' -> '20'
+    [[ $OS == "linuxmint" || "trisquel" ]] &&         # e.g. '20.2' -> '20'
         VERSION_ID=${VERSION_ID%%.*}    # Remove all '.' & stuff to the right
 fi
 OS_VER="$OS-$VERSION_ID"
@@ -88,6 +88,7 @@ OS_VER="$OS-$VERSION_ID"
 case $OS_VER in
     "debian-12"    | \
     "debian-13"    | \
+    "trisquel-12"  | \
     "ubuntu-2404"  | \
     "ubuntu-2410"  | \
     "ubuntu-2504"  | \

--- a/scripts/trisquel-pip-setup.sh
+++ b/scripts/trisquel-pip-setup.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]; then
+   echo "This script must be run as root"
+   exit 1
+fi
+
+. /etc/os-release
+UPSTREAM_REPO="/etc/apt/sources.list.d/upstream_repo.list"
+UPSTREAM_PIN="/etc/apt/preferences.d/python3-pip"
+UPSTREAM_GPGKEY="/etc/apt/trusted.gpg.d/upstream_repo.gpg"
+PHP_APPARMOR=/etc/apparmor.d/php-fpm
+PHP_APPARMOR_DISABLED=/etc/apparmor.d/disable/php-fpm
+
+# Cleaning previos attempts
+rm -f $UPSTREAM_REPO $UPSTREAM_PIN
+
+[ $VERSION_CODENAME = ecne ] && UPSTREAM=noble && REPO_GPGKEY="871920D1991BC93C" && VALID=1
+
+if [ "$VALID" != 1 ]; then
+    echo "Not valid codename"
+    exit 1
+fi
+
+# Prevent apparmor profiles breaking server packages.
+apt-get -y install curl
+if [ -f "$PHP_APPARMOR_DISABLED" ];  then
+   echo "- php-fpm apparmor profile disabled, moving on."
+elif [ ! -f "$PHP_APPARMOR_DISABLED" ] && [ -f "$PHP_APPARMOR" ]; then
+    ln -s /etc/apparmor.d/php-fpm /etc/apparmor.d/disable/
+    apparmor_parser -R /etc/apparmor.d/php-fpm
+fi
+
+gpg --keyserver keyserver.ubuntu.com --recv-keys "$REPO_GPGKEY"
+gpg --export "$REPO_GPGKEY" | gpg --dearmour > "$UPSTREAM_GPGKEY"
+
+echo "
+deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM} main universe
+deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-updates main universe
+deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-security main universe" | \
+sudo tee $UPSTREAM_REPO
+
+echo "
+Package: python3-pip
+Pin: release n=$UPSTREAM
+Pin-Priority: 500
+
+Package: python3-pip-whl
+Pin: release n=$UPSTREAM
+Pin-Priority: 500
+
+Package: *
+Pin: release n=$UPSTREAM
+Pin-Priority: -1" | \
+sudo tee $UPSTREAM_PIN

--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ "$EUID" -ne 0 ]; then
-   echo "This script must be run as root"
-   exit 1
+    echo "This script must be run as root"
+    exit 1
 fi
 
 . /etc/os-release
@@ -12,13 +12,14 @@ UPSTREAM_GPGKEY="/etc/apt/trusted.gpg.d/upstream_repo.gpg"
 PHP_APPARMOR=/etc/apparmor.d/php-fpm
 PHP_APPARMOR_DISABLED=/etc/apparmor.d/disable/php-fpm
 
-# Cleaning previos attempts
+# Cleaning previous attempts
 rm -f $UPSTREAM_REPO $UPSTREAM_PIN
 
-[ $VERSION_CODENAME = ecne ] && UPSTREAM=noble && REPO_GPGKEY="871920D1991BC93C" && VALID=1
+# There might be multiple such lines in future, e.g. if Trisquel 12 and 13 and both supported during a transitional period
+[ $VERSION_CODENAME = ecne ] && UPSTREAM=noble && REPO_GPGKEY="871920D1991BC93C" && VALID_TRISQUEL_VER=1
 
-if [ "$VALID" != 1 ]; then
-    echo "Not valid codename"
+if [ "$VALID_TRISQUEL_VER" != 1 ]; then
+    echo "IIAB supports only Trisquel 12 (Ecne) for now!"
     exit 1
 fi
 
@@ -26,8 +27,8 @@ fi
 apt-get -y install curl
 # Prevent apparmor profiles breaking server packages.
 ## php-fpm profile
-if [ -f "$PHP_APPARMOR_DISABLED" ];  then
-   echo "- php-fpm apparmor profile disabled, moving on."
+if [ -f "$PHP_APPARMOR_DISABLED" ]; then
+    echo "- php-fpm apparmor profile disabled, moving on."
 elif [ ! -f "$PHP_APPARMOR_DISABLED" ] && [ -f "$PHP_APPARMOR" ]; then
     ln -s /etc/apparmor.d/php-fpm /etc/apparmor.d/disable/
     apparmor_parser -R /etc/apparmor.d/php-fpm

--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -22,8 +22,10 @@ if [ "$VALID" != 1 ]; then
     exit 1
 fi
 
-# Prevent apparmor profiles breaking server packages.
+# Make sure basic necessary packages are in place for further steps
 apt-get -y install curl
+# Prevent apparmor profiles breaking server packages.
+## php-fpm profile
 if [ -f "$PHP_APPARMOR_DISABLED" ];  then
    echo "- php-fpm apparmor profile disabled, moving on."
 elif [ ! -f "$PHP_APPARMOR_DISABLED" ] && [ -f "$PHP_APPARMOR" ]; then

--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -23,8 +23,6 @@ if [ "$VALID_TRISQUEL_VER" != 1 ]; then
     exit 1
 fi
 
-# Make sure basic necessary packages are in place for further steps
-apt-get -y install curl
 # Prevent apparmor profiles breaking server packages.
 ## php-fpm profile
 if [ -f "$PHP_APPARMOR_DISABLED" ]; then

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -784,6 +784,9 @@ is_linuxmint_22: False
 #is_linuxmint_21: False
 #is_linuxmint_20: False
 
+is_trisquel: False    # Subset of is_ubuntu
+is_trisquel_12: False
+
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
 is_debian_13: False
 is_debian_12: False

--- a/vars/trisquel-12.yml
+++ b/vars/trisquel-12.yml
@@ -1,0 +1,7 @@
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_ubuntu: True    # Opposite of is_debian for now
+is_ubuntu_2404: True
+is_trisquel: True
+is_trisquel_12: True


### PR DESCRIPTION
### Fixes bug:
Not having Trisquel 12 as a supported :)

### Description of changes proposed in this pull request:
This MR adds a profile with the minimum changes required to get a headless trisquel 12 machine to work with the current IIAB installer.

This MR is companion of https://github.com/iiab/iiab-factory/pull/247 MR.

### Smoke-tested on which OS or OS's:
Trisquel 12, tested sizes 1, 2, 3.

### Mention a team member @username e.g. to help with code review:
@holta 