### PR TITLE
Set internal routing for /stream/

### DIFF
--- a/roles/calibre-web/templates/calibre-web-nginx.conf.j2
+++ b/roles/calibre-web/templates/calibre-web-nginx.conf.j2
@@ -27,7 +27,7 @@ location {{ calibreweb_url3 }}/ {
     proxy_pass http://127.0.0.1:8083;
 }
 
-location /stream/ {
+location /protected-stream/ {
     internal;
     alias /library/calibre-web/;
 }

--- a/roles/calibre-web/templates/calibre-web-nginx.conf.j2
+++ b/roles/calibre-web/templates/calibre-web-nginx.conf.j2
@@ -26,3 +26,8 @@ location {{ calibreweb_url3 }}/ {
     proxy_set_header        X-Script-Name   "{{ calibreweb_url3 }}";
     proxy_pass http://127.0.0.1:8083;
 }
+
+location /stream/ {
+    internal;
+    alias /library/calibre-web/;
+}


### PR DESCRIPTION
This PR adds adds an internal `/stream/` location with an alias for `/library/calibre/web/`.
Works with https://github.com/iiab/calibre-web/pull/315
Smoke-tested on Ubuntu 24.04

@holta @ZachLiebl 
