### PR TITLE
scripts/trisquel-profile-setup.sh: add transmission aa setup

### DIFF
--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -24,7 +24,7 @@ if [ "$VALID_TRISQUEL_VER" != 1 ]; then
 fi
 
 # Prevent apparmor profiles breaking server packages.
-for i in php-fpm transmission
+for i in php-fpm
 do
     if [ -f "$APPARMOR_DISABLED_DIR/$i" ]; then
         echo "- $i apparmor profile disabled, moving on."

--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -28,8 +28,11 @@ fi
 if [ -f "$PHP_APPARMOR_DISABLED" ]; then
     echo "- php-fpm apparmor profile disabled, moving on."
 elif [ ! -f "$PHP_APPARMOR_DISABLED" ] && [ -f "$PHP_APPARMOR" ]; then
-    ln -s /etc/apparmor.d/php-fpm /etc/apparmor.d/disable/
-    apparmor_parser -R /etc/apparmor.d/php-fpm
+    for i in php-fpm transmission
+    do
+        ln -s /etc/apparmor.d/$i /etc/apparmor.d/disable/
+        apparmor_parser -R /etc/apparmor.d/$i
+    done
 fi
 
 gpg --keyserver keyserver.ubuntu.com --recv-keys "$REPO_GPGKEY"


### PR DESCRIPTION
### Fixes bug:

Attempt to work around Trisquel 12 (based on Ubuntu 24.04) for #3756

### Description of changes proposed in this pull request:
- Transmission packages were [patched](https://gitlab.trisquel.org/trisquel/package-helpers/-/commit/171264a6fd8037b661e29a40ef9ae1da9b2718e3) at Trisquel's repo.
- The appamor profile got adjusted to avoid execution issues

### Smoke-tested on which OS or OS's:

1.  Install trisquel 12 headless getting the netinstall (text installer) with:
```
tar_netinstall="debian-installer-images_20250515+12.0trisquel18.10.testing_amd64.tar.gz"
wget https://builds.trisquel.org/debian-installer-images/"$tar_netinstall" -P /tmp/
tar --wildcards -zxvf  "/tmp/$tar_netinstall"  \
    "./installer-amd64/*/images/netboot/mini.iso" -O > \
    ~/trisquel-netinst_12.0_amd64.iso
rm /tmp/"$tar_netinstall"
```
2. For a headless install at the `tasksel` setup install step select:
- `openssh` &
-  `trisquel-console`.

3. Clone/test this MR at `/opt/iiab/iiab`
4. Install any size you prefer. 1, 2, 3
5. Install role:
```
# cd /opt/iiab/iiab
# ./runrole transmission
```
6. Open $ip_box:9091 on web browser:
```
user: Admin
password: changeme
```

7. Download any .torrent file.

### Mention a team member @username e.g. to help with code review:
@holta 