### PR TITLE
Transition to Node.js 24.x

### DIFF
--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -9,10 +9,10 @@
   include_role:
     name: nodejs
 
-- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }}) <= 22.x
+- name: Assert that 10.x <= nodejs_version ({{ nodejs_version }})
   assert:
-    that: nodejs_version is version('10.x', '>=') and nodejs_version is version('22.x', '<=')
-    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10.x - 22.x, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
+    that: nodejs_version is version('10.x', '>=')
+    fail_msg: "Internet Archive install cannot proceed, as it currently requires Node.js 10+, and your nodejs_version is set to {{ nodejs_version }}.  Please check the value of nodejs_version in /opt/iiab/iiab/vars/default_vars.yml and possibly also /etc/iiab/local_vars.yml"
     quiet: yes
 
 - name: "Set 'yarn_install: True' and 'yarn_enabled: True'"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -432,7 +432,7 @@ mosquitto_port: 1883
 # JupyterHub, nodered (Node-RED), pbx (Asterix, FreePBX) &/or Sugarizer:
 nodejs_install: False
 nodejs_enabled: False
-nodejs_version: 22.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20, 18.x til 2023-05-20, 20.x til 2024-05-03
+nodejs_version: 24.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20, 18.x til 2023-05-20, 20.x til 2024-05-03, 22.x til 2025-05-29
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
Annual upgrade, building on:

- PR #3738

As tested on Ubuntu 25.10 pre-release with...

```
# node -v
v24.1.0
```

Node.js 24 announcements:
https://nodejs.org/en/blog/release/v24.0.0
https://blog.logrocket.com/node-js-24-new/