### PR TITLE
Ubuntu 25.10 has now caught up to Debian 13: Luanti modernized

### DIFF
--- a/roles/luanti/tasks/main.yml
+++ b/roles/luanti/tasks/main.yml
@@ -30,12 +30,12 @@
       register: luanti_server_renamed
       ignore_errors: yes
 
-    - name: Revert {luanti_deb_and_systemd_name, luanti_config_file, luanti_working_dir} to older Minetest values -- if apt package 'luanti-server' isn't available OR Ubuntu 25.10 (OS IN TRANSITION!)
+    - name: Revert {luanti_deb_and_systemd_name, luanti_config_file, luanti_working_dir} to older Minetest values -- if apt package 'luanti-server' isn't available
       set_fact:
         luanti_deb_and_systemd_name: minetest-server       # OVERRIDE luanti-server (set above)
         luanti_config_file: /etc/minetest/minetest.conf    # OVERRIDE /etc/luanti/default.conf (set in defaults/main.yml)
         luanti_working_dir: /usr/share/games/minetest      # OVERRIDE /usr/share/luanti (set in default_vars.yml)
-      when: luanti_server_renamed.failed or (is_ubuntu and os_ver is version('ubuntu-2604', '<'))    # 2025-05-11: luanti-server is a virtual package on Ubuntu 25.10 -- that doesn't yet work :/ "minetest-server.service: Start request repeated too quickly"
+      when: luanti_server_renamed.failed    # or (is_ubuntu and os_ver is version('ubuntu-2604', '<'))    # 2025-05-11: luanti-server was a virtual package on Ubuntu 25.10 -- that didn't yet work :/ "minetest-server.service: Start request repeated too quickly"
       #when: (is_raspbian and os_ver is version('raspbian-13', '<')) or (is_debian and not is_raspbian and os_ver is version('debian-13', '<')) or (is_ubuntu and os_ver is version('ubuntu-2510', '<'))    # Gratuitous parens for clarity
 
     - name: Install Luanti if 'luanti_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml


### PR DESCRIPTION
Allowing us to now revert the patch from earlier this month:

- PR #4012

Tested on latest Ubuntu 25.10 pre-release.