### PR TITLE
trisquel-profile-setup.sh FIX for arm64, e.g. for IIAB VMs on new Macs

### DIFF
--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -37,13 +37,13 @@ gpg --export "$REPO_GPGKEY" | gpg --dearmour > "$UPSTREAM_GPGKEY"
 
 echo "
 # For amd64
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM} main universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-updates main universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-security main universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM} main universe
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-updates main universe
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-security main universe
 # For arm64
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM} main universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-updates main universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-security main universe multiverse" | \
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM} main universe
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-updates main universe
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-security main universe" | \
 sudo tee $UPSTREAM_REPO
 
 echo "

--- a/scripts/trisquel-profile-setup.sh
+++ b/scripts/trisquel-profile-setup.sh
@@ -36,9 +36,14 @@ gpg --keyserver keyserver.ubuntu.com --recv-keys "$REPO_GPGKEY"
 gpg --export "$REPO_GPGKEY" | gpg --dearmour > "$UPSTREAM_GPGKEY"
 
 echo "
-deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM} main universe
-deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-updates main universe
-deb http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-security main universe" | \
+# For amd64
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM} main universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-updates main universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${UPSTREAM}-security main universe multiverse
+# For arm64
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM} main universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-updates main universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ ${UPSTREAM}-security main universe multiverse" | \
 sudo tee $UPSTREAM_REPO
 
 echo "


### PR DESCRIPTION
### Fixes bug:

The `apt update` command was failing, while trying to run [/opt/iiab/iiab/scripts/ansible](https://github.com/iiab/iiab/blob/master/scripts/ansible) on "Trisquelized" Ubuntu 24.04 VMs on a new Mac, i.e. with Apple's new silicon (arm64) CPUs.

### Description of changes proposed in this pull request:

Fix (refine) the apt sources file for both leading CPU architectures — preserving `archive.ubuntu.com` for amd64, while adding `ports.ubuntu.com` for arm64 — modeling this after:

https://www.reddit.com/r/Ubuntu/comments/1jxo3uy/how_to_add_arm64_repositories_to_ubuntu_x64_noble/

### Smoke-tested on which OS or OS's:

Tested on a Ubuntu 24.04 LTS VM that was "Trisquelized" using `multipass launch 24.04 --cloud-init https://iiab.io/trisquelize.yml` — all of which was running on a new Mac (with arm64 CPU).

### Mention a team member @username e.g. to help with code review:

@Ark74 can you review / confirm this looks good, allowing this to be merged immediately if possible?