### PR TITLE
Added fixes for jinja[spacing] from ansible lint

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -52,7 +52,6 @@ skip_list:
   - key-order # 5 instances
   - yaml[octal-values] # 44 instances
   - yaml[empty-lines] # 84 instances
-  - jinja[spacing] # 114 instances
   - yaml[trailing-spaces]
 
 # Ansible-lint does not automatically load rules that have the 'opt-in' tag.

--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -17,47 +17,47 @@
     - name: 1-prep
       include_role:
         name: 1-prep
-      when: ansible_local.local_facts.stage|int < 1
+      when: ansible_local.local_facts.stage | int < 1
 
     - name: 2-common
       include_role:
         name: 2-common
-      when: ansible_local.local_facts.stage|int < 2
+      when: ansible_local.local_facts.stage | int < 2
 
     - name: 3-base-server
       include_role:
         name: 3-base-server
-      when: ansible_local.local_facts.stage|int < 3
+      when: ansible_local.local_facts.stage | int < 3
 
     - name: 4-server-options
       include_role:
         name: 4-server-options
-      when: ansible_local.local_facts.stage|int < 4
+      when: ansible_local.local_facts.stage | int < 4
 
     - name: 5-xo-services
       include_role:
         name: 5-xo-services
-      when: ansible_local.local_facts.stage|int < 5
+      when: ansible_local.local_facts.stage | int < 5
 
     - name: 6-generic-apps
       include_role:
         name: 6-generic-apps
-      when: ansible_local.local_facts.stage|int < 6
+      when: ansible_local.local_facts.stage | int < 6
 
     - name: 7-edu-apps
       include_role:
         name: 7-edu-apps
-      when: ansible_local.local_facts.stage|int < 7
+      when: ansible_local.local_facts.stage | int < 7
 
     - name: 8-mgmt-tools
       include_role:
         name: 8-mgmt-tools
-      when: ansible_local.local_facts.stage|int < 8
+      when: ansible_local.local_facts.stage | int < 8
 
     - name: 9-local-addons
       include_role:
         name: 9-local-addons
-      when: ansible_local.local_facts.stage|int < 9
+      when: ansible_local.local_facts.stage | int < 9
 
     - name: Network
       include_role:

--- a/roles/9-local-addons/tasks/main.yml
+++ b/roles/9-local-addons/tasks/main.yml
@@ -88,12 +88,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add ESTIMATED 'iiab_software_disk_usage = {{ df2.stdout|int - df1|int }}' to {{ iiab_ini_file }}
+- name: Add ESTIMATED 'iiab_software_disk_usage = {{ df2.stdout | int - df1 | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: summary
     option: iiab_software_disk_usage
-    value: "{{ df2.stdout|int - df1|int }}"
+    value: "{{ df2.stdout | int - df1 | int }}"
 
 - name: Recording STAGE 9 HAS COMPLETED ====================
   lineinfile:

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -102,12 +102,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'awstats_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'awstats_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: awstats
     option: awstats_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'awstats_installed: True'"
   set_fact:

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -111,12 +111,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'azuracast_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'azuracast_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: azuracast
     option: azuracast_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'azuracast_installed: True'"
   set_fact:

--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -201,12 +201,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'calibreweb_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'calibreweb_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: calibre-web
     option: calibreweb_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'calibreweb_installed: True'"
   set_fact:

--- a/roles/calibre/tasks/install.yml
+++ b/roles/calibre/tasks/install.yml
@@ -88,12 +88,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'calibre_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'calibre_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: calibre
     option: calibre_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'calibre_installed: True'"
   set_fact:

--- a/roles/captiveportal/tasks/install.yml
+++ b/roles/captiveportal/tasks/install.yml
@@ -60,12 +60,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'captiveportal_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'captiveportal_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: captiveportal
     option: captiveportal_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'captiveportal_installed: True'"
   set_fact:

--- a/roles/cups/tasks/install.yml
+++ b/roles/cups/tasks/install.yml
@@ -148,12 +148,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'cups_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'cups_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: cups
     option: cups_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'cups_installed: True'"
   set_fact:

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -114,12 +114,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'gitea_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'gitea_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: gitea
     option: gitea_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'gitea_installed: True'"
   set_fact:

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -44,12 +44,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'iiab_admin_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'iiab_admin_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: iiab-admin
     option: iiab_admin_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'iiab_admin_installed: True'"
   set_fact:

--- a/roles/internetarchive/tasks/install.yml
+++ b/roles/internetarchive/tasks/install.yml
@@ -73,12 +73,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'internetarchive_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'internetarchive_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: internetarchive
     option: internetarchive_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'internetarchive_installed: True'"
   set_fact:

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -115,12 +115,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'jupyterhub_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'jupyterhub_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: jupyterhub
     option: jupyterhub_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'jupyterhub_installed: True'"
   set_fact:

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -90,12 +90,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'kalite_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'kalite_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: kalite
     option: kalite_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'kalite_installed: True'"
   set_fact:

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -127,12 +127,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'kiwix_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'kiwix_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: kiwix
     option: kiwix_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'kiwix_installed: True'"
   set_fact:

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -235,12 +235,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'kolibri_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'kolibri_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: kolibri
     option: kolibri_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'kolibri_installed: True'"
   set_fact:

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -142,12 +142,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'lokole_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'lokole_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: lokole
     option: lokole_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'lokole_installed: True'"
   set_fact:

--- a/roles/luanti/tasks/install.yml
+++ b/roles/luanti/tasks/install.yml
@@ -64,12 +64,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'luanti_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'luanti_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: luanti
     option: luanti_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'luanti_installed: True'"
   set_fact:

--- a/roles/luanti/tasks/luanti_install_mods.yml
+++ b/roles/luanti/tasks/luanti_install_mods.yml
@@ -5,7 +5,7 @@
 
 - name: Download one Luanti mod
   get_url:
-    url: "{{item.url}}"
+    url: "{{ item.url }}"
     dest: "{{ downloads_dir }}/{{ item.name }}.zip"
     mode: 0440
     timeout: "{{ download_timeout }}"

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -263,12 +263,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'matomo_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'matomo_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: matomo
     option: matomo_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'matomo_installed: True'"
   set_fact:

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -119,12 +119,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'mediawiki_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'mediawiki_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: mediawiki
     option: mediawiki_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'mediawiki_installed: True'"
   set_fact:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -376,12 +376,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'mongodb_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'mongodb_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: mongodb
     option: mongodb_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'mongodb_installed: True'"
   set_fact:

--- a/roles/monit/tasks/install.yml
+++ b/roles/monit/tasks/install.yml
@@ -44,12 +44,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'monit_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'monit_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: monit
     option: monit_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'monit_installed: True'"
   set_fact:

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -218,12 +218,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'moodle_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'moodle_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: moodle
     option: moodle_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'moodle_installed: True'"
   set_fact:

--- a/roles/mosquitto/tasks/install.yml
+++ b/roles/mosquitto/tasks/install.yml
@@ -24,7 +24,7 @@
     mode: "u=rw,g=r,o=r"    # '0644'
 
 - name: Populate /etc/mosquitto/passwd with actual username/password
-  shell: mosquitto_passwd -b /etc/mosquitto/passwd "{{ mosquitto_user }}" "{{ mosquitto_password  }}"
+  shell: mosquitto_passwd -b /etc/mosquitto/passwd "{{ mosquitto_user }}" "{{ mosquitto_password }}"
 
 - name: Install /etc/mosquitto/conf.d/websockets.conf from template
   template:
@@ -41,12 +41,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'mosquitto_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'mosquitto_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: mosquitto
     option: mosquitto_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'mosquitto_installed: True'"
   set_fact:

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -35,7 +35,7 @@
 - name: Establish username/password Admin/changeme in /etc/munin/munin-htpasswd
   htpasswd:
     path: /etc/munin/munin-htpasswd
-    name: "{{ munin_username}}"         # Admin
+    name: "{{ munin_username }}"         # Admin
     password: "{{ munin_password }}"    # changeme
 
 - name: If MySQL is installed, let Munin monitor it
@@ -60,12 +60,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'munin_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'munin_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: munin
     option: munin_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'munin_installed: True'"
   set_fact:

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -76,12 +76,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'mysql_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'mysql_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: mysql
     option: mysql_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'mysql_installed: True'"
   set_fact:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -17,11 +17,11 @@
 - name: We're hosed no work interfaces
   fail:    # FORCE IT RED THIS ONCE!
     msg: "No_network_found"
-  when: adapter_count.stdout|int == 0
+  when: adapter_count.stdout | int == 0
 
 - name: Checking for old device gateway interface for device test
   shell: grep IIAB_WAN_DEVICE {{ iiab_env_file }} | awk -F "=" '{print $2}'
-  when: iiab_stage|int == 9
+  when: iiab_stage | int == 9
   register: prior_gw
 
 - name: Setting device_gw, prior_gw_device
@@ -66,8 +66,8 @@
 - name: Setting wan_in_interfaces
   set_fact:
     wan_in_interfaces: True
-  when: wan_file.stdout|int > 0
-  #when: is_debuntu and (wan_file.stdout|int > 0)
+  when: wan_file.stdout | int > 0
+  #when: is_debuntu and (wan_file.stdout | int > 0)
 
 # WIRELESS -- if any wireless is detected as gateway, it becomes WAN
 - name: Look for any wireless interfaces
@@ -78,9 +78,9 @@
 
 - name: Set the discovered wireless, if found
   set_fact:
-    wifi1: "{{ item|trim }}"
-    discovered_wireless_iface: "{{ item|trim }}"
-  when: item|trim != "" and item|trim != discovered_wan_iface
+    wifi1: "{{ item | trim }}"
+    discovered_wireless_iface: "{{ item | trim }}"
+  when: item | trim != "" and item | trim != discovered_wan_iface
   with_items:
     - "{{ wireless_list1.stdout_lines }}"
 
@@ -94,12 +94,12 @@
 # Last device is used
 - name: Set the discovered wireless, if found (take 2)
   set_fact:
-    wifi2: "{{ item|trim }}"
-    discovered_wireless_iface: "{{ item|trim }}"
-  when: wireless_list2.stdout is defined and item|trim != "ap0"
+    wifi2: "{{ item | trim }}"
+    discovered_wireless_iface: "{{ item | trim }}"
+  when: wireless_list2.stdout is defined and item | trim != "ap0"
   with_items:
     - "{{ wireless_list2.stdout_lines }}"
-#item|trim != discovered_wan_iface
+#item | trim != discovered_wan_iface
 
 - name: Count WiFi ifaces
   shell: "ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}' | grep -v -e ap0 | wc -l"
@@ -107,7 +107,7 @@
 
 - name: Remember number of WiFi devices
   set_fact:
-    num_wifi_interfaces: "{{ count_wifi_interfaces.stdout|int }}"
+    num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
@@ -136,7 +136,7 @@
 - name: "Set 'has_wifi_gateway: True' if WiFi has default gateway detected for discovered_wireless_iface ({{ discovered_wireless_iface }}) -- otherwise leave it undefined"
   set_fact:
     has_wifi_gateway: True
-  when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout|int > 0)
+  when: discovered_wireless_iface != "none" and (wifi_gateway_found.stdout | int > 0)
 
 - name: Detect secondary gateway active on all interfaces
   shell: ip r | grep default | grep -v {{ discovered_wan_iface }} | awk '{print $5}'
@@ -172,7 +172,7 @@
 
 - name: Calculate number of LAN interfaces including WiFi
   set_fact:
-    num_lan_interfaces: "{{ num_lan_interfaces_result.stdout|int }}"
+    num_lan_interfaces: "{{ num_lan_interfaces_result.stdout | int }}"
 
 # LAN - pick non WAN's
 - name: Create list of LAN (non WAN) ifaces
@@ -192,8 +192,8 @@
 # if there is more than one the last one wins
 - name: Set discovered_wired_iface if present
   set_fact:
-    discovered_wired_iface: "{{ item|trim }}"
-  when: lan_list_result.stdout_lines is defined and item|trim != discovered_wireless_iface
+    discovered_wired_iface: "{{ item | trim }}"
+  when: lan_list_result.stdout_lines is defined and item | trim != discovered_wireless_iface
   with_items:
     - "{{ lan_list_result.stdout_lines }}"
 
@@ -216,13 +216,13 @@
 - name: 2 or more devices on the LAN - use bridging
   set_fact:
     iiab_lan_iface: br0
-  when: num_lan_interfaces|int >= 2
+  when: num_lan_interfaces | int >= 2
 
 - name: For Debian, always use bridging
   set_fact:
     iiab_lan_iface: br0
-  when: num_lan_interfaces|int >= 1
-  #when: num_lan_interfaces|int >= 1 and is_debuntu
+  when: num_lan_interfaces | int >= 1
+  #when: num_lan_interfaces | int >= 1 and is_debuntu
 
 - name: WiFi is on the LAN - use bridging
   set_fact:
@@ -366,4 +366,4 @@
 - name: I'm not guessing declare gateway please
   fail:    # FORCE IT RED THIS ONCE!
     msg: "Undetectable gateway or prior gateway for use with static network addressing from admin-console use local_vars to declare user_wan_iface"
-  when: adapter_count.stdout|int >=3 and gui_wan_iface == "unset" and gui_static_wan
+  when: adapter_count.stdout | int >=3 and gui_wan_iface == "unset" and gui_static_wan

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -30,7 +30,7 @@
     group: root
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    mode: "{{ item.mode  }}"
+    mode: "{{ item.mode }}"
   with_items:
     - { src: 'hostapd/hostapd.service.j2', dest: '/etc/systemd/system/hostapd.service', mode: '0644' }
     - { src: 'hostapd/iiab-clone-wifi.service.j2', dest: '/etc/systemd/system/iiab-clone-wifi.service', mode: '0644' }

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -117,12 +117,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'network_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'network_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: network
     option: network_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'network_installed: True'"
   set_fact:

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -31,10 +31,10 @@
 - name: Wired enslaving - Assigns lan_list_results to br0 as wired slaves if present
   template:
     src: network/systemd-br0-slave.j2
-    dest: /etc/systemd/network/IIAB-Slave-{{ item|trim }}.network
+    dest: /etc/systemd/network/IIAB-Slave-{{ item | trim }}.network
   with_items:
     - "{{ lan_list_result.stdout_lines }}"
-  when: iiab_wired_lan_iface is defined and num_lan_interfaces|int >= 1 and not network_manager_active
+  when: iiab_wired_lan_iface is defined and num_lan_interfaces | int >= 1 and not network_manager_active
 
 - name: Remove static WAN template
   file:

--- a/roles/nextcloud/tasks/install.yml
+++ b/roles/nextcloud/tasks/install.yml
@@ -151,12 +151,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'nextcloud_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'nextcloud_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: nextcloud
     option: nextcloud_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'nextcloud_installed: True'"
   set_fact:

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -75,12 +75,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'nginx_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'nginx_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: nginx
     option: nginx_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'nginx_installed: True'"
   set_fact:

--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -186,12 +186,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'nodejs_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'nodejs_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: nodejs
     option: nodejs_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'nodejs_installed: True'"
   set_fact:

--- a/roles/nodered/tasks/install.yml
+++ b/roles/nodered/tasks/install.yml
@@ -147,12 +147,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'nodered_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'nodered_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: nodered
     option: nodered_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'nodered_installed: True'"
   set_fact:

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -205,12 +205,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'osm_vector_maps_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'osm_vector_maps_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: osm-vector-maps
     option: osm_vector_maps_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'osm_vector_maps_installed: True'"
   set_fact:

--- a/roles/pbx/tasks/install.yml
+++ b/roles/pbx/tasks/install.yml
@@ -68,12 +68,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'pbx_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'pbx_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: pbx
     option: pbx_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'pbx_installed: True'"
   set_fact:

--- a/roles/phpmyadmin/tasks/install.yml
+++ b/roles/phpmyadmin/tasks/install.yml
@@ -57,12 +57,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'phpmyadmin_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'phpmyadmin_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: phpmyadmin
     option: phpmyadmin_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'phpmyadmin_installed: True'"
   set_fact:

--- a/roles/postgresql/tasks/install.yml
+++ b/roles/postgresql/tasks/install.yml
@@ -105,12 +105,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'postgresql_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'postgresql_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: postgresql
     option: postgresql_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'postgresql_installed: True'"
   set_fact:

--- a/roles/pylibs/tasks/main.yml
+++ b/roles/pylibs/tasks/main.yml
@@ -22,12 +22,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'pylibs_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'pylibs_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: pylibs
     option: pylibs_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'pylibs_installed: True'"
   set_fact:

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -138,12 +138,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'remoteit_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'remoteit_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: remoteit
     option: remoteit_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'remoteit_installed: True'"
   set_fact:

--- a/roles/samba/tasks/install.yml
+++ b/roles/samba/tasks/install.yml
@@ -40,12 +40,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'samba_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'samba_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: samba
     option: samba_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'samba_installed: True'"
   set_fact:

--- a/roles/sshd/tasks/install.yml
+++ b/roles/sshd/tasks/install.yml
@@ -51,12 +51,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'sshd_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'sshd_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: sshd
     option: sshd_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'sshd_installed: True'"
   set_fact:

--- a/roles/sugarizer/tasks/install.yml
+++ b/roles/sugarizer/tasks/install.yml
@@ -241,12 +241,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'sugarizer_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'sugarizer_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: sugarizer
     option: sugarizer_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'sugarizer_installed: True'"
   set_fact:

--- a/roles/tailscale/tasks/install.yml
+++ b/roles/tailscale/tasks/install.yml
@@ -95,12 +95,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'tailscale_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'tailscale_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: tailscale
     option: tailscale_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'tailscale_installed: True'"
   set_fact:

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -113,12 +113,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'transmission_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'transmission_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: transmission
     option: transmission_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'transmission_installed: True'"
   set_fact:

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -140,12 +140,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'usb_lib_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'usb_lib_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: usb_lib
     option: usb_lib_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'usb_lib_installed: True'"
   set_fact:

--- a/roles/vnstat/tasks/install.yml
+++ b/roles/vnstat/tasks/install.yml
@@ -51,12 +51,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'vnstat_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'vnstat_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: vnstat
     option: vnstat_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'vnstat_installed: True'"
   set_fact:

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -159,12 +159,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'wordpress_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'wordpress_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: wordpress
     option: wordpress_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'wordpress_installed: True'"
   set_fact:

--- a/roles/www_base/tasks/main.yml
+++ b/roles/www_base/tasks/main.yml
@@ -64,12 +64,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'www_base_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'www_base_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: www_base
     option: www_base_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'www_base_installed: True'"
   set_fact:

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -9,7 +9,7 @@
 
 # HOMEPAGE
 
-- name: Create dir {{ doc_root }}{{ iiab_home_url }} just in case variable iiab_home_url was customized.  (Standard path {{doc_root}}/home was created earlier.)
+- name: Create dir {{ doc_root }}{{ iiab_home_url }} just in case variable iiab_home_url was customized.  (Standard path {{ doc_root }}/home was created earlier.)
   file:
     state: directory
     path: "{{ doc_root }}{{ iiab_home_url }}"    # e.g. /library/www/html/home
@@ -139,12 +139,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'www_options_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'www_options_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: www_options
     option: www_options_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'www_options_installed: True'"
   set_fact:

--- a/roles/yarn/tasks/install.yml
+++ b/roles/yarn/tasks/install.yml
@@ -49,12 +49,12 @@
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'yarn_disk_usage = {{ df2.stdout|int - df1.stdout|int }}' to {{ iiab_ini_file }}
+- name: Add 'yarn_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: yarn
     option: yarn_disk_usage
-    value: "{{ df2.stdout|int - df1.stdout|int }}"
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
 
 - name: "Set 'yarn_installed: True'"
   set_fact:


### PR DESCRIPTION
### Description of changes proposed in this pull request:
According to ansible-lint documentation: "when there are no spaces between variables and operators, including filters, like {{ var_name | filter }}. This improves readability and makes it less likely to introduce typos."

An example of Ansible configuration that would violate this rule would be something like 
{{ var_name|filter }} or {{munin_username}}. If there was more than one space between the content inside the jinja template and the brackets, that would also violate it.

### Smoke-tested on which OS or OS's:
Ubuntu 24.04, Debian 12 and RasPiOS. I will also test on a Multipass VM shortly

### Mention a team member @username e.g. to help with code review:
@holta 
