### PR TITLE
Added yamllint configuration for ansible-lint. Added ansible-lint to 10min-iiab-unittest-ubuntu.yml

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -24,7 +24,7 @@ loop_var_prefix: "^(__|{role}_)"
 # to skip_list.
 var_naming_pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
 
-use_default_rules: true
+use_default_rules: True
 # Load custom rules from this specific folder
 # rulesdir:
 #   - ./rule/directory/
@@ -39,8 +39,6 @@ use_default_rules: true
 # still visible, making it easier to address later.
 skip_list:
   - yaml[comments] # ignore comments without leading space
-  - yaml[truthy] # ignore values that are True / False instead of true / false
-  - yaml[line-length] # 338 instances, but we probably don't care about this so much
   - name[missing] # 140 instances
   - name[template] # 354 instances
   - name[casing] # 47 instances
@@ -77,7 +75,7 @@ warn_list:
 write_list: ["none"]
 
 # Offline mode disables installation of requirements.yml and schema refreshing
-offline: true
+offline: True
 
 # Define required Ansible's variables to satisfy syntax check
 # extra_vars:

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -50,10 +50,10 @@ jobs:
           # local_vars_unittest.yml installs a quite minimal IIAB, without IIAB Apps
           sudo cp /opt/iiab/iiab/vars/local_vars_unittest.yml /etc/iiab/local_vars.yml
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Installs Ansible
+      - name: Install ansible-lint
+        run: sudo apt install ansible-lint
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
-        with:
-          working_directory: /opt/iiab/iiab
+        run: ansible-lint
       - run: sudo ./iiab-install                    # Installs IIAB!
         working-directory: /opt/iiab/iiab
       - run: iiab-summary

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -31,8 +31,6 @@ jobs:
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.  FYI "fetch-depth: 0" works but is way too greedy, downloading all branches.  The ideal would've been "fetch-depth: 10000" with "fetch-tags: true" -- but this remains broken as of actions/checkout@v4 on 2025-03-26: see issues #217, #338, PR #1396, #1467, #1471, #1662 in https://github.com/actions/checkout -- Dec 2020 background: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
       - run: echo "🍏 This job's status [SO FAR!] is ${{ job.status }}."
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
       - name: GitHub Actions "runner" environment
         run: |
           uname -a    # uname -srm
@@ -52,6 +50,8 @@ jobs:
           # local_vars_unittest.yml installs a quite minimal IIAB, without IIAB Apps
           sudo cp /opt/iiab/iiab/vars/local_vars_unittest.yml /etc/iiab/local_vars.yml
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Installs Ansible
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
       - run: sudo ./iiab-install                    # Installs IIAB!
         working-directory: /opt/iiab/iiab
       - run: iiab-summary

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
           sudo cp /opt/iiab/iiab/vars/local_vars_unittest.yml /etc/iiab/local_vars.yml
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Installs Ansible
       - name: Install ansible-lint
-        run: sudo apt install ansible-lint
+        run: pip install ansible-lint
       - name: Run ansible-lint
         run: ansible-lint
       - run: sudo ./iiab-install                    # Installs IIAB!

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -54,6 +54,7 @@ jobs:
         run: pip install ansible-lint
       - name: Run ansible-lint
         run: ansible-lint
+        working-directory: /opt/iiab/iiab
       - run: sudo ./iiab-install                    # Installs IIAB!
         working-directory: /opt/iiab/iiab
       - run: iiab-summary

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.  FYI "fetch-depth: 0" works but is way too greedy, downloading all branches.  The ideal would've been "fetch-depth: 10000" with "fetch-tags: true" -- but this remains broken as of actions/checkout@v4 on 2025-03-26: see issues #217, #338, PR #1396, #1467, #1471, #1662 in https://github.com/actions/checkout -- Dec 2020 background: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
       - run: echo "🍏 This job's status [SO FAR!] is ${{ job.status }}."
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
       - name: GitHub Actions "runner" environment
         run: |
           uname -a    # uname -srm

--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -52,6 +52,8 @@ jobs:
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Installs Ansible
       - name: Run ansible-lint
         uses: ansible/ansible-lint@main
+        with:
+          working_directory: /opt/iiab/iiab
       - run: sudo ./iiab-install                    # Installs IIAB!
         working-directory: /opt/iiab/iiab
       - run: iiab-summary

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,24 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 1000
+
+  truthy:
+    allowed-values: ["True", "False", "yes", "no", "true", "false"]
+    check-keys: True
+
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+  comments:
+    min-spaces-from-content: 1
+
+  comments-indentation: False
+  document-start: disable
+
+  octal-values:
+    forbid-implicit-octal: True
+    forbid-explicit-octal: True


### PR DESCRIPTION
### Description of changes proposed in this pull request:
First, properly configured yamllint to make ansible-lint a bit more configurable. Then I added an ansible-lint install step from and an ansible-lint run step for 10min-iiab-unittest-ubuntu.yml. We could make our our workflow just for ansible lint if we wanted, but it doesn't make sense to put it in multiple workflows - either ansible-lint find errors and then fails or it doesn't. We don't need multiple reports of the same information in that regard.

You may have noticed we did not use the ansible-lint GitHub Action. This is because the Action made by the ansible-lint team is a bit limiting in how it works. Specifically, it wants a requirements.txt to install Ansible and other dependencies, but we don't install our dependencies that way. It is just easier to install our dependencies our way, install ansible-lint with pip and then run ansible-lint. 

The yamllint configuration doesn't do much for us right this moment. My hope was to get a way to enforce specific truthy values as it seems we use the nonstandard True / False the most. However,  we also use true / false and yes / no. Its not the highest priority on my list to change these truthy values, but when it happens we can change the yamllint config to enforce the subset of them. Yamllint also allows us to enforce a specific max line length, currently I have set this to 1000 characters as we have one line that is > 900 characters. I suggested to Adam Holt that at some point we put a line length limit of 400 characters (still a lot mind you), and he seemed open to the idea.

### Smoke-tested on which OS or OS's:
Ubuntu 24.04, Debian 12 and RasPiOS

### Mention a team member @username e.g. to help with code review:
@holta 