### PR TITLE
Fixed octal-values for ansible-lint

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -48,7 +48,6 @@ skip_list:
   - role-name # 14 instances, talk to Adam
   - var-naming[no-role-prefix] # 65 instances, talk to Adam
   - key-order # 5 instances
-  - yaml[octal-values] # 44 instances
   - yaml[empty-lines] # 84 instances
   - yaml[trailing-spaces]
 

--- a/roles/2-common/tasks/iiab-startup.yml
+++ b/roles/2-common/tasks/iiab-startup.yml
@@ -7,7 +7,7 @@
   template:
     src: iiab-startup.sh
     dest: /usr/libexec/
-    mode: 0755
+    mode: "0755"
   when: not startup_script.stat.exists
 
 - name: Install {{ systemd_location }}/iiab-startup.service from template

--- a/roles/azuracast/tasks/install.yml
+++ b/roles/azuracast/tasks/install.yml
@@ -49,7 +49,7 @@
   get_url:
     url: "{{ docker_sh_url }}"
     dest: "{{ azuracast_host_dir }}/"
-    mode: 0755
+    mode: "0755"
     timeout: "{{ download_timeout }}"
 
 #- name: AzuraCast - Make changes to docker.sh script so it runs headless

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -28,7 +28,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   with_items:
     - { src: 'bt-agent.service.j2', dest: '/etc/systemd/system/bt-agent.service' }
     - { src: 'bt-pan.service.j2', dest: '/etc/systemd/system/bt-pan.service' }
@@ -42,7 +42,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   with_items:
     - { src: 'iiab-bt-pan-on.j2', dest: '/usr/bin/iiab-bt-pan-on' }
     - { src: 'iiab-bt-pan-off.j2', dest: '/usr/bin/iiab-bt-pan-off' }

--- a/roles/calibre/tasks/py-installer.yml
+++ b/roles/calibre/tasks/py-installer.yml
@@ -7,7 +7,7 @@
   get_url:
     url: "{{ calibre_src_url }}"
     dest: "{{ downloads_dir }}/calibre-installer.py"
-    mode: 0755
+    mode: "0755"
     force: yes
     backup: yes
     timeout: "{{ download_timeout }}"

--- a/roles/cups/tasks/install.yml
+++ b/roles/cups/tasks/install.yml
@@ -34,7 +34,7 @@
     dest: /etc/cups/cupsd.conf
     owner: root
     group: lp
-    mode: 0640
+    mode: "0640"
     backup: yes
 
 # 2021-07-12: lineinfile fails to insert the needed lines, as these same 2 lines

--- a/roles/gitea/tasks/install.yml
+++ b/roles/gitea/tasks/install.yml
@@ -52,7 +52,7 @@
   get_url:
     url: "{{ gitea_download_url }}"
     dest: "{{ gitea_install_path }}"    # e.g. /library/gitea/bin/gitea-1.21
-    mode: 0775
+    mode: "0775"
     timeout: "{{ download_timeout }}"
 
 - name: Download Gitea GPG signature {{ gitea_integrity_url }} to {{ gitea_checksum_path }}
@@ -89,7 +89,7 @@
     path: /etc/gitea
     owner: root
     group: gitea
-    mode: 0770
+    mode: "0770"
 
 - name: Install /etc/gitea/app.ini from template (0664)
   template:
@@ -97,7 +97,7 @@
     dest: /etc/gitea/app.ini
     owner: root
     group: gitea
-    mode: 0664
+    mode: "0664"
 
 
 # 4. Create systemd service & prepare NGINX for http://box/gitea

--- a/roles/iiab-admin/tasks/sudo-prereqs.yml
+++ b/roles/iiab-admin/tasks/sudo-prereqs.yml
@@ -5,7 +5,7 @@
 - name: Temporarily make file /etc/sudoers editable (0640)
   file:
     path: /etc/sudoers
-    mode: 0640
+    mode: "0640"
 
 - name: '/etc/sudoers: Have sudo log all commands to /var/log/sudo.log -- in addition to the lengthier /var/log/auth.log'
   lineinfile:
@@ -23,4 +23,4 @@
 - name: End editing file /etc/sudoers -- protect it again (0440)
   file:
     path: /etc/sudoers
-    mode: 0440
+    mode: "0440"

--- a/roles/jupyterhub/tasks/install.yml
+++ b/roles/jupyterhub/tasks/install.yml
@@ -103,7 +103,7 @@
   template:
     src: patch-http-warning.sh.j2
     dest: "{{ jupyterhub_venv }}/bin/patch_http-warning.sh"
-    mode: 0755
+    mode: "0755"
 
 - name: "Now run it: {{ jupyterhub_venv }}/bin/patch_http-warning.sh"
   command: "{{ jupyterhub_venv }}/bin/patch_http-warning.sh"

--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -125,7 +125,7 @@
     dest: "{{ lokole_confd }}"
     group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
-    mode: 0644
+    mode: "0644"
   with_items:
     - { src: 'lokole_gunicorn.conf' }
     - { src: 'lokole_celery_beat.conf' }

--- a/roles/luanti/NotUsed/rpi_minetest_install.yml
+++ b/roles/luanti/NotUsed/rpi_minetest_install.yml
@@ -18,7 +18,7 @@
     path: "{{ item }}"
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   with_items:
     - /etc/minetest
     - /var/log/minetest
@@ -45,7 +45,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   with_items:
     - { src: 'minetest.conf.j2', dest: '/etc/minetest/minetest.conf' }
     - { src: 'minetest-server.service.j2', dest: '/etc/systemd/system/minetest-server.service' }

--- a/roles/luanti/tasks/luanti_install.yml
+++ b/roles/luanti/tasks/luanti_install.yml
@@ -30,6 +30,6 @@
     path: "{{ item }}"
     owner: "{{ luanti_runas_user }}"
     group: "{{ luanti_runas_group }}"
-    mode: 0755
+    mode: "0755"
   with_items:
     - "{{ luanti_world_dir }}"

--- a/roles/luanti/tasks/luanti_install_mods.yml
+++ b/roles/luanti/tasks/luanti_install_mods.yml
@@ -7,7 +7,7 @@
   get_url:
     url: "{{ item.url }}"
     dest: "{{ downloads_dir }}/{{ item.name }}.zip"
-    mode: 0440
+    mode: "0440"
     timeout: "{{ download_timeout }}"
   when: not luanti_mod.stat.exists
 

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -164,7 +164,7 @@
   template:
     src: moodle_installer
     dest: "{{ moodle_base }}"
-    mode: 0755
+    mode: "0755"
 
 - name: Execute {{ moodle_base }}/moodle_installer IF {{ moodle_base }}/config.php doesn't yet exist -- REQUIRES 'max_input_vars = 5000' (or higher) in /etc/php/{{ php_version }}/cli/php.ini IF PHP 8+ (as set up by www_options/tasks/main.yml) -- WHEREAS LATER ON Moodle uses /etc/php/{{ php_version }}/fpm/php.ini during regular operation
   shell: "{{ moodle_base }}/moodle_installer"

--- a/roles/network/tasks/NM-debian.yml
+++ b/roles/network/tasks/NM-debian.yml
@@ -21,14 +21,14 @@
   template:
     dest: /etc/NetworkManager/conf.d/ap0-manage.conf
     src: network/ap0-manage.conf
-    mode: 0644
+    mode: "0644"
   when: discovered_wireless_iface != "none" and wifi_up_down
 
 - name: Copy manage.conf for NetworkManager when wifi_up_down False
   template:
     dest: /etc/NetworkManager/conf.d/wifi-manage.conf
     src: network/manage.conf.j2
-    mode: 0644
+    mode: "0644"
   when: discovered_wireless_iface != "none" and not wifi_up_down
 
 - name: Remove manage.conf for NetworkManager when wifi_up_down True
@@ -67,7 +67,7 @@
   template:
     dest: /etc/NetworkManager/system-connections/iiab-static
     src: network/NM-static.j2
-    mode: 0600
+    mode: "0600"
   when: wan_ip != "dhcp"
 
 - name: Use systemd-networkd to handle br0

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -11,7 +11,7 @@
     dest: /etc/avahi/services/schoolserver.service
     owner: avahi
     group: avahi
-    mode: 0640
+    mode: "0640"
   #when: 'gui_wan == True'
   when: ports_externally_visible|int >= 2
   # Where "2" means "ssh + http-or-https (for Admin Console's box.lan/admin too)"

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -40,7 +40,7 @@
   template:
     src: roles/network/templates/network/dnsmasq.sh.j2
     dest: /etc/networkd-dispatcher/routable.d/dnsmasq.sh
-    mode: 0755
+    mode: "0755"
   when: nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and nd_enabled is defined and nd_enabled.stdout == "enabled" and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
@@ -113,7 +113,7 @@
   template:
     src: gateway/iiab-gen-iptables
     dest: /usr/bin/iiab-gen-iptables
-    mode: 0755
+    mode: "0755"
 
 
 - name: Add 'squid' variable values to {{ iiab_ini_file }} - if squid_installed is defined

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -44,7 +44,7 @@
     dest: /etc/systemd/system/hostapd.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   when: not wifi_up_down and can_be_ap
 
 # 2022-07-11: Install of iiab-hotspot-on|off moved to network/tasks/main.yml
@@ -88,7 +88,7 @@
   template:
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -102,7 +102,7 @@
   template:
     src: "{{ item }}"
     dest: /usr/bin/
-    mode: 0755
+    mode: "0755"
   with_items:
     - roles/network/templates/gateway/iiab-internet-on     # Invoked by 1-prep (so full path needed)
     - roles/network/templates/gateway/iiab-internet-off    # Invoked by 1-prep (so full path needed)

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -24,7 +24,7 @@
   template:
     src: "{{ item }}"
     dest: /usr/bin/
-    mode: 0755
+    mode: "0755"
   with_items:
     - hostapd/iiab-hotspot-on
     - hostapd/iiab-hotspot-off

--- a/roles/network/tasks/netwarn.yml
+++ b/roles/network/tasks/netwarn.yml
@@ -43,5 +43,5 @@
   template:
     src: roles/network/templates/netwarn/iiab-netwarn    # Invoked by 1-prep (so full path needed)
     dest: /usr/local/sbin/
-    mode: 0755
+    mode: "0755"
   when: (labwc_dir.stat.exists and labwc_dir.stat.isdir) or (mate_dir.stat.exists and mate_dir.stat.isdir)

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -26,7 +26,7 @@
     dest: /lib/dhcpcd/dhcpcd-hooks/50-hostapd
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   when: wifi_up_down
 
 - name: Remove dhcpcd hook for hostapd if WiFi is not split using ap0

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -42,7 +42,7 @@
     path: /library/cache
     owner: "{{ proxy_user }}"
     group: "{{ proxy_user }}"
-    mode: 0750
+    mode: "0750"
 
 - name: "Install site allowlists /etc/{{ proxy }}/allow_dst_domains, /etc/{{ proxy }}/allow_url_regexs from template (root:root, 0644 by default) -- activated for HTTP/80 if you set 'gw_squid_whitelist: True' in /etc/iiab/local_vars.yml -- SEE https://wiki.squid-cache.org/SquidFaq/SquidAcl"
   template:

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -63,7 +63,7 @@
   template:
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
@@ -79,7 +79,7 @@
   template:
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:

--- a/roles/nodered/tasks/settings.yml
+++ b/roles/nodered/tasks/settings.yml
@@ -16,7 +16,7 @@
     state: directory
     owner: "{{ nodered_linux_user }}"
     group: "{{ nodered_linux_user }}"
-    mode: 0775
+    mode: "0775"
 
 
 # - name: Install /home/{{ nodered_linux_user }}/.node-red/settings.js from template, with authentication

--- a/roles/osm-vector-maps/tasks/install.yml
+++ b/roles/osm-vector-maps/tasks/install.yml
@@ -188,7 +188,7 @@
   get_url:
     url: "{{ osm_repo_url }}/{{ maps_branch }}/osm-source/pages/viewer/scripts/{{ item }}"
     dest: /usr/bin/
-    mode: 0755
+    mode: "0755"
     timeout: "{{ download_timeout }}"
   with_items:
     - iiab-install-map-region

--- a/roles/postgresql/tasks/install.yml
+++ b/roles/postgresql/tasks/install.yml
@@ -36,7 +36,7 @@
     path: /library/pgsql-iiab
     owner: postgres
     group: postgres
-    mode: 0700
+    mode: "0700"
 
 - name: Make sure locale {{ postgresql_locale }} is enabled    # en_US.UTF-8
   lineinfile:
@@ -70,7 +70,7 @@
     dest: /library/pgsql-iiab/postgresql.conf
     owner: postgres
     group: postgres
-    mode: 0640
+    mode: "0640"
 
 - name: Disable & Stop stock 'postgresql' (parent) systemd service
   systemd:

--- a/roles/pylibs/tasks/main.yml
+++ b/roles/pylibs/tasks/main.yml
@@ -9,7 +9,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   with_items:
     - { src: 'iiab_const.py.j2', dest: '{{ py3_dist_path }}/iiab/iiab_const.py' }
     - { src: 'iiab_lib.py', dest: '{{ py3_dist_path }}/iiab/iiab_lib.py' }

--- a/roles/remoteit/tasks/install.yml
+++ b/roles/remoteit/tasks/install.yml
@@ -104,13 +104,13 @@
   template:
     src: iiab-remoteit
     dest: /usr/bin
-    mode: 0755
+    mode: "0755"
 
 - name: Install /usr/bin/iiab-remoteit-off from template -- so IIAB operators can quickly turn off AND disable remote.it services on this IIAB
   template:
     src: iiab-remoteit-off
     dest: /usr/bin
-    mode: 0755
+    mode: "0755"
 
 
 # 2023-07-26: Remote.It CLI used to coexist fine with their "Device Package"

--- a/roles/usb_lib/tasks/install.yml
+++ b/roles/usb_lib/tasks/install.yml
@@ -28,7 +28,7 @@
     dest: /etc/systemd/system/systemd-udevd.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   when: udev_unit.stat.exists is defined and udev_unit.stat.exists
 
 - name: Change MountFlags from slave to shared
@@ -66,13 +66,13 @@
     path: "{{ doc_root }}/local_content"    # /library/www/html
     owner: "{{ apache_user }}"    # www-data
     group: "{{ apache_user }}"    # 2020-02-13: changed from iiab_admin_user, after discussion on weekly call (#1228, #2222)
-    mode: 0775
+    mode: "0775"
 
 - name: Set up dirs /etc/usbmount/mount.d, /etc/usbmount/umount.d, /media/usb0-7
   file:
     state: directory
     path: "{{ item }}"
-    mode: 0755
+    mode: "0755"
   with_items:
     - /etc/usbmount/mount.d
     - /etc/usbmount/umount.d
@@ -110,7 +110,7 @@
     path: "{{ doc_root }}/upload2usb"
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
-    mode: 0755
+    mode: "0755"
 
 - name: Copy files from files/upload2usb/ into {{ doc_root }}/upload2usb/
   copy:


### PR DESCRIPTION
### Description of changes proposed in this pull request:
According to ansible-lint's documentation, this is what they claim "Using integers or octal values in YAML can result in unexpected behavior. For example, the YAML loader interprets `0644` as the decimal number `420` but putting `644` there will produce very different results."

This is because Yaml has done a lot of weird things with octal values in the past

Here is an example:
0644 -> "0644"

### Smoke-tested on which OS or OS's:
Ubuntu 24.04, Debian 12, RasPiOS on Zero 2 W

### Mention a team member @username e.g. to help with code review:
@holta 
