### PR TITLE
Fixed key-order[task] violations for ansible-lint

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -47,7 +47,6 @@ skip_list:
   - command-instead-of-shell # 12 instances, specific
   - role-name # 14 instances, talk to Adam
   - var-naming[no-role-prefix] # 65 instances, talk to Adam
-  - key-order # 5 instances
   - yaml[empty-lines] # 84 instances
   - yaml[trailing-spaces]
 

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -169,6 +169,7 @@
 - debug:
     msg: 5-STANZA BLOCK FOLLOWS, TO FORCE INSTALL libssl1.1 -- runs *IF* mandated mongodb_version ({{ mongodb_version }}) < 6.0 (i.e. for aarch64/arm64) on Ubuntu 22.04+ or Debian 12+ -- whereas Linux Mint should never need libssl1.1
 
+  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
 - block:
 
     - name: Install OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
@@ -200,7 +201,6 @@
         state: absent
       when: is_ubuntu
 
-  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
 
 - debug:
     msg: 5-STANZA BLOCK ABOVE, RAN *IF* FORCED INSTALL OF libssl1.1 WAS NEEDED

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -169,8 +169,7 @@
 - debug:
     msg: 5-STANZA BLOCK FOLLOWS, TO FORCE INSTALL libssl1.1 -- runs *IF* mandated mongodb_version ({{ mongodb_version }}) < 6.0 (i.e. for aarch64/arm64) on Ubuntu 22.04+ or Debian 12+ -- whereas Linux Mint should never need libssl1.1
 
-  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
-- block:
+- block: # noqa: key-order[task]
 
     - name: Install OLD source/repo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main" at /etc/apt/sources.list.d/ports_ubuntu_com_ubuntu_ports.list if Ubuntu
       apt_repository:
@@ -201,6 +200,7 @@
         state: absent
       when: is_ubuntu
 
+  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
 
 - debug:
     msg: 5-STANZA BLOCK ABOVE, RAN *IF* FORCED INSTALL OF libssl1.1 WAS NEEDED

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -35,6 +35,7 @@
 
 
 - name: Configuring Network if enabled
+  when: network_installed is defined and network_enabled
   block:
 
   # 2022-07-22: Is './runrole --reinstall network' the new way to make this run?
@@ -102,8 +103,6 @@
     - name: Restart services (and clone wifi to create ap0 if necessary)
       include_tasks: restart.yml
 
-  # end block
-  when: network_installed is defined and network_enabled
 
 - name: Select RPi firmware mode
   include_role:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -103,6 +103,8 @@
     - name: Restart services (and clone wifi to create ap0 if necessary)
       include_tasks: restart.yml
 
+    # end block
+
 
 - name: Select RPi firmware mode
   include_role:

--- a/roles/pbx/tasks/enable-or-disable.yml
+++ b/roles/pbx/tasks/enable-or-disable.yml
@@ -39,7 +39,7 @@
 # iiab-gen-tables may not be set up, until/if roles/network runs later.
 
 
-- block:
+- block: # noqa: key-order[task]
 
     - name: EITHER - TURN ON 4 SETTINGS FOR NGINX - if pbx_use_nginx and pbx_enabled
       meta: noop
@@ -65,7 +65,7 @@
 
   when: pbx_use_nginx and pbx_enabled
 
-- block:
+- block: # noqa: key-order[task]
 
     - name: OR ELSE - TURN OFF 3 SETTINGS FOR NGINX (1st of 4 above settings too hard!) - if not (pbx_use_nginx and pbx_enabled)
       meta: noop

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -11,8 +11,7 @@
     state: present
 
 
-  when: transmission_compile_latest
-- block:
+- block: # noqa: key-order[task]
 
     - name: "TRY TO COMPILE & INSTALL very latest Transmission, installing ~5 binaries in /usr/local/bin to take precedence over above ~6 binaries in /usr/bin (attempt surgery on systemd unit file from apt install above!)"
       meta: noop
@@ -55,6 +54,7 @@
         sed -i 's/--log-error/--log-level=error/' /lib/systemd/system/transmission-daemon.service    # --log-error deprecated since ~2020
         sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
 
+  when: transmission_compile_latest
 
 
 - name: Create download dir {{ transmission_download_dir }}, owned by {{ transmission_user }}:{{ transmission_group }}

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -11,6 +11,7 @@
     state: present
 
 
+  when: transmission_compile_latest
 - block:
 
     - name: "TRY TO COMPILE & INSTALL very latest Transmission, installing ~5 binaries in /usr/local/bin to take precedence over above ~6 binaries in /usr/bin (attempt surgery on systemd unit file from apt install above!)"
@@ -54,7 +55,6 @@
         sed -i 's/--log-error/--log-level=error/' /lib/systemd/system/transmission-daemon.service    # --log-error deprecated since ~2020
         sed -i 's#/usr/bin/transmission#/usr/local/bin/transmission#' /lib/systemd/system/transmission-daemon.service    # daemon_reload handled by enable-or-disable.yml
 
-  when: transmission_compile_latest
 
 
 - name: Create download dir {{ transmission_download_dir }}, owned by {{ transmission_user }}:{{ transmission_group }}


### PR DESCRIPTION
### Description of changes proposed in this pull request:
"This rule recommends reordering key names in ansible content to make code easier to maintain and less prone to errors."

All of them were Ansible block keys that were followed by when keys. ansible-lint has made the decision that when keys should be before block:

"Try to remember that in real life, block/rescue/always have the habit to grow due to the number of tasks they host inside, making them exceed what a single screen. This would move the when task further away from the rest of the task properties. A when from the last task inside the block can easily be confused as being at the block level, or the reverse. When tasks are moved from one location to another, there is a real risk of moving the block level when with it.

By putting the when before the block, we avoid that kind of risk. The same risk applies to any simple property at the task level, so that is why we concluded that the block keys must be the last ones."

https://ansible.readthedocs.io/projects/lint/rules/key-order/#reasoning

It seems to be working. I will note that 2 of the 5 violations came in the same file, and I couldn't fix it. Maybe because I am just not the most knowledgeable about Ansible. Currently, they are being ignored with the # noqa: key-order[task] comment, but if you can find a way to fix them for this rule that would be cool.

Also, we could decided we don't want to follow this lint rule at all. I think what they are saying makes sense though.

### Smoke-tested on which OS or OS's:
Ubuntu 24.04, Debian 12 and RasPiOS on Zero 2 W. This one may require some more testing.

### Mention a team member @username e.g. to help with code review:
@holta 
