### PR TITLE
roles/network: Ansible hack to fix SUDO_UID for raspi-config wifi country code (required for Raspberry Pi OS with desktop)

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -82,7 +82,7 @@
       command: sudo raspi-config nonint do_wifi_country {{ host_country_code }}
       when: is_raspbian
       become: true
-      become_user: "{{ iiab_admin_user }}"    # 2025-07-18: Sneaky but it works (with yet another sudo 3 lines above) to restore $SUDO_UID to the correct value (typically 1000) for raspi-config -> do_wifi_country -> /usr/bin/wfpanelctl netman cset -> D-Bus -- the raspi-config command was failing due to Ansible's SUDO_UID=0 on RasPiOS with desktop: "Failed to open connection to \"session\" message bus: Failed to connect to socket /run/user/0/bus: No such file or directory" arising from original commit "Update panel wifi country flag after setting" of Feb 11, 2024: https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
+      become_user: "{{ iiab_admin_user }}"    # 2025-07-18: Sneaky but it works (with yet another sudo 3 lines above) to restore $SUDO_UID to the correct value (typically 1000) for raspi-config -> do_wifi_country -> /usr/bin/wfpanelctl netman cset -> D-Bus -- the raspi-config command was failing due to Ansible's (e.g. ansible-core 2.18.7) SUDO_UID=0 on RasPiOS with desktop: "Failed to open connection to \"session\" message bus: Failed to connect to socket /run/user/0/bus: No such file or directory" -- arising from original commit "Update panel wifi country flag after setting" of Feb 16, 2024: https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
 
     - name: systemd-networkd in use
       include_tasks: sysd-netd-debian.yml

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -79,8 +79,10 @@
 
     # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml wasn't enough, especially with NM (NetworkManager)
     - name: Run 'raspi-config nonint do_wifi_country {{ host_country_code }}' (using var host_country_code) to unblock WiFi, if RasPiOS
-      command: raspi-config nonint do_wifi_country {{ host_country_code }}
+      command: sudo raspi-config nonint do_wifi_country {{ host_country_code }}
       when: is_raspbian
+      become: true
+      become_user: "{{ iiab_admin_user }}"    # 2025-07-18: Sneaky but it works (with yet another sudo 3 lines above) to restore $SUDO_UID to the correct value (typically 1000) for raspi-config -> do_wifi_country -> /usr/bin/wfpanelctl netman cset -> D-Bus -- the raspi-config command was failing due to Ansible's SUDO_UID=0 on RasPiOS with desktop: "Failed to open connection to \"session\" message bus: Failed to connect to socket /run/user/0/bus: No such file or directory" arising from original commit "Update panel wifi country flag after setting" of Feb 11, 2024: https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
 
     - name: systemd-networkd in use
       include_tasks: sysd-netd-debian.yml


### PR DESCRIPTION
### Fixes bug:

roles/network fails on RasPiOS with desktop.

### Description of changes proposed in this pull request:

See comment/clarifications in code.

### Smoke-tested on which OS or OS's:

64-bit Raspberry Pi OS with desktop on RPi 4.

### Mention a team member @username e.g. to help with code review:

@EMG70 it would be great if you can reconfirm this on 64-bit RasPiOS Lite too (e.g. after I merge it!)