### PR TITLE
Stronger roles/network hack: SUDO_UID=1000 for raspi-config do_wifi_country (needed for RasPiOS with desktop)

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -92,6 +92,7 @@
     # https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
     - name: Run "sudo -u '#1000' sudo raspi-config nonint do_wifi_country {{ host_country_code }}" (using var host_country_code) to unblock WiFi, if RasPiOS -- this sets SUDO_UID=1000 (otherwise raspi-config often fails on RasPiOS with desktop)
       command: sudo -u '#1000' sudo raspi-config nonint do_wifi_country {{ host_country_code }}
+      when: is_raspbian
 
     - name: systemd-networkd in use
       include_tasks: sysd-netd-debian.yml

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -77,12 +77,21 @@
     #     problematic side effects with other/past/future WiFi firmware -- or on
     #     other hardware -- perhaps making IIAB microSD cards less portable.
 
-    # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml wasn't enough, especially with NM (NetworkManager)
-    - name: Run 'raspi-config nonint do_wifi_country {{ host_country_code }}' (using var host_country_code) to unblock WiFi, if RasPiOS
-      command: sudo raspi-config nonint do_wifi_country {{ host_country_code }}
-      when: is_raspbian
-      become: true
-      become_user: "{{ iiab_admin_user }}"    # 2025-07-18: Sneaky but it works (with yet another sudo 3 lines above) to restore $SUDO_UID to the correct value (typically 1000) for raspi-config -> do_wifi_country -> /usr/bin/wfpanelctl netman cset -> D-Bus -- the raspi-config command was failing due to Ansible's (e.g. ansible-core 2.18.7) SUDO_UID=0 on RasPiOS with desktop: "Failed to open connection to \"session\" message bus: Failed to connect to socket /run/user/0/bus: No such file or directory" -- arising from original commit "Update panel wifi country flag after setting" of Feb 16, 2024: https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
+    # 2024-12-18: As `rfkill unblock wifi` formerly in rpi_debian.yml wasn't
+    # enough, especially with NM (NetworkManager)
+    # 2025-07-19: Use 2 additional sudo's below, for RasPiOS with desktop, to
+    # restore $SUDO_UID to the correct value (1000 for default graphical
+    # session) required by raspi-config -> do_wifi_country ->
+    # /usr/bin/wfpanelctl netman cset -> D-Bus -- otherwise the raspi-config
+    # command often fails (e.g. when operator's run sudo, via
+    # /usr/local/bin/iiab-network etc) -- leading Ansible to convey an
+    # unworkable SUDO_UID=0 or SUDO_UID=1001 ETC: "Failed to open connection to
+    # \"session\" message bus: Failed to connect to socket /run/user/0/bus: No
+    # such file or directory" -- arising from original commit "Update panel
+    # wifi country flag after setting" of Feb 16, 2024:
+    # https://github.com/RPi-Distro/raspi-config/commit/654184f40ffdbad093fd1017c08bf261abb49e7c
+    - name: Run "sudo -u '#1000' sudo raspi-config nonint do_wifi_country {{ host_country_code }}" (using var host_country_code) to unblock WiFi, if RasPiOS -- this sets SUDO_UID=1000 (otherwise raspi-config often fails on RasPiOS with desktop)
+      command: sudo -u '#1000' sudo raspi-config nonint do_wifi_country {{ host_country_code }}
 
     - name: systemd-networkd in use
       include_tasks: sysd-netd-debian.yml


### PR DESCRIPTION
### Fixes bug:

Stronger & cleaner hack, building on:

- PR #4045

### Description of changes proposed in this pull request:

See explanation inlined (comments in code).

### Smoke-tested on which OS or OS's:

64-bit RasPiOS "Lite" and "with desktop", each on RPi 4.

### Mention a team member @username e.g. to help with code review:

@EMG70 I should merge this very shortly: if you can redo [your same test (what failed yesterday)](https://github.com/iiab/iiab/pull/4045#issuecomment-3090331108) in coming days, that would be much appreciated!