### PR TITLE
Pin to ansible-core 2.18.7 for now (due to 2.19 issues, see #4030)

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -284,7 +284,7 @@ EOF
     # messes -- and obviating the need for these 2: (above, both commented out)
     # - 'apt -y install libffi-dev python3-dev'
     # - painstaking pinning of cryptography or cffi (etc) to older version #s
-    /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core
+    /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core==2.18.7
     echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
     cd /usr/local/ansible/bin
     for bin in ansible*; do


### PR DESCRIPTION
### Fixes bug:

- #4030

### Description of changes proposed in this pull request:

Pin to ansible-core 2.18.7 just for now.

### Smoke-tested on which OS or OS's:

Ubuntu 24.04 / Trisquel 12.

### Mention a team member @username e.g. to help with code review:

@EMG70