### PR TITLE
Pin to new ansible-core 2.18.8

### DIFF
--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.18.7]
-GOOD_VER=2.18.7       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.18.8]
+GOOD_VER=2.18.8       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -284,7 +284,7 @@ EOF
     # messes -- and obviating the need for these 2: (above, both commented out)
     # - 'apt -y install libffi-dev python3-dev'
     # - painstaking pinning of cryptography or cffi (etc) to older version #s
-    /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core==2.18.7
+    /usr/local/ansible/bin/python3 -m pip install --prefer-binary --upgrade ansible-core==2.18.8
     echo -e "\nCreate symlinks /usr/local/bin/ansible* -> /usr/local/ansible/bin/ansible*"
     cd /usr/local/ansible/bin
     for bin in ansible*; do


### PR DESCRIPTION
Announcement:

- "New Release: ansible-core v2.18.8:"
https://forum.ansible.com/t/new-release-ansible-core-v2-18-8/44277

Good enough until the ansible-core 2.19.x issues are more fully resolved in coming months:

- #4030

Building on:

- PR #4041
- PR #4049

CI (GitHub Actions) testing should be enough in coming minutes.  Noting that several of us will also reconfirm (after merging) while testing larger IIAB installs on Raspberry Pi later today.