### PR TITLE
Begin Debian transition (Bookworm -> Trixie -> Forky) + update 4 CI workflows [& discussion of KA Lite -> Kolibri content downloading issues]

### DIFF
--- a/.github/workflows/10min-iiab-unittest-ubuntu.yml
+++ b/.github/workflows/10min-iiab-unittest-ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
       #    GITHUB_CONTEXT: ${{ toJSON(github) }}
       #  run: echo "$GITHUB_CONTEXT"
       - name: Check out repository code    # Clones repo onto github runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.  FYI "fetch-depth: 0" works but is way too greedy, downloading all branches.  The ideal would've been "fetch-depth: 10000" with "fetch-tags: true" -- but this remains broken as of actions/checkout@v4 on 2025-03-26: see issues #217, #338, PR #1396, #1467, #1471, #1662 in https://github.com/actions/checkout -- Dec 2020 background: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
       - run: echo "🍏 This job's status [SO FAR!] is ${{ job.status }}."

--- a/.github/workflows/20min-iiab-medium-ubuntu.yml
+++ b/.github/workflows/20min-iiab-medium-ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
       - name: Set up /opt/iiab/iiab

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
-      - uses: pguyot/arm-runner-action@v2.6.5
+      - uses: pguyot/arm-runner-action@v2
         with:
           image_additional_mb: 1024
           base_image: ${{ matrix.base_image }}

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           MATRIX_CONTEXT: ${{ toJSON(matrix) }}
         run: echo "$MATRIX_CONTEXT"
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
       - uses: pguyot/arm-runner-action@v2.6.5

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -51,7 +51,7 @@ jobs:
           copy_repository_path: /opt/iiab/iiab
           commands: |
               echo "🍏 This job's status is ${{ job.status }}."
-              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action?tab=readme-ov-file#cpu_info
+              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action#cpu_info
               # grep Model /proc/cpuinfo
               uname -a    # uname -srm
               whoami      # Typically 'root' instead of 'runner'

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -18,7 +18,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: [debian12]
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
-      - uses: pguyot/arm-runner-action@v2
+      - uses: pguyot/arm-runner-action@v2.6.5
         with:
           image_additional_mb: 1024
           base_image: ${{ matrix.base_image }}

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           MATRIX_CONTEXT: ${{ toJSON(matrix) }}
         run: echo "$MATRIX_CONTEXT"
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
       - uses: pguyot/arm-runner-action@v2.6.5

--- a/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
+++ b/.github/workflows/40min-iiab-none-deb12-on-rpi3.yml
@@ -51,7 +51,8 @@ jobs:
           copy_repository_path: /opt/iiab/iiab
           commands: |
               echo "🍏 This job's status is ${{ job.status }}."
-              grep Model /proc/cpuinfo
+              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action?tab=readme-ov-file#cpu_info
+              # grep Model /proc/cpuinfo
               uname -a    # uname -srm
               whoami      # Typically 'root' instead of 'runner'
               pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}

--- a/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
+++ b/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
-      - uses: pguyot/arm-runner-action@v2.6.5
+      - uses: pguyot/arm-runner-action@v2
         with:
           image_additional_mb: 1024
           base_image: ${{ matrix.base_image }}

--- a/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
+++ b/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
@@ -63,7 +63,8 @@ jobs:
           commands: |
               echo "🍏 This job's status is ${{ job.status }}."
               #test `uname -m` = ${{ matrix.arch }}
-              grep Model /proc/cpuinfo
+              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action?tab=readme-ov-file#cpu_info
+              # grep Model /proc/cpuinfo
               uname -a    # uname -srm
               whoami      # Typically 'root' instead of 'runner'
               pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}

--- a/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
+++ b/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
@@ -18,7 +18,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: [aarch64] #[zero_raspbian, zero_raspios, zero2_raspios, aarch64]
@@ -50,10 +50,10 @@ jobs:
         env:
           MATRIX_CONTEXT: ${{ toJSON(matrix) }}
         run: echo "$MATRIX_CONTEXT"
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
-      - uses: pguyot/arm-runner-action@v2
+      - uses: pguyot/arm-runner-action@v2.6.5
         with:
           image_additional_mb: 1024
           base_image: ${{ matrix.base_image }}

--- a/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
+++ b/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
@@ -63,7 +63,7 @@ jobs:
           commands: |
               echo "🍏 This job's status is ${{ job.status }}."
               #test `uname -m` = ${{ matrix.arch }}
-              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action?tab=readme-ov-file#cpu_info
+              # /proc/cpuinfo not available on ubuntu-24.04 runner, per https://github.com/pguyot/arm-runner-action#cpu_info
               # grep Model /proc/cpuinfo
               uname -a    # uname -srm
               whoami      # Typically 'root' instead of 'runner'

--- a/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
+++ b/.github/workflows/40min-iiab-unittest-raspios-on-zero2w.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           MATRIX_CONTEXT: ${{ toJSON(matrix) }}
         run: echo "$MATRIX_CONTEXT"
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.
       - uses: pguyot/arm-runner-action@v2.6.5

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,6 +64,7 @@ OS_VER="$OS-$VERSION_ID"
     #"debian-9"     | \
     #"debian-10"    | \
     #"debian-11"    | \
+    #"debian-12"    | \
     #"ubuntu-16"    | \
     #"ubuntu-17"    | \
     #"ubuntu-18"    | \
@@ -87,8 +88,8 @@ OS_VER="$OS-$VERSION_ID"
 # this line to its /etc/os-release before installing IIAB: VERSION_ID="13"
 
 case $OS_VER in
-    "debian-12"    | \
     "debian-13"    | \
+    "debian-14"    | \
     "trisquel-12"  | \
     "ubuntu-2404"  | \
     "ubuntu-2504"  | \

--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -64,7 +64,6 @@ OS_VER="$OS-$VERSION_ID"
     #"debian-9"     | \
     #"debian-10"    | \
     #"debian-11"    | \
-    #"debian-12"    | \
     #"ubuntu-16"    | \
     #"ubuntu-17"    | \
     #"ubuntu-18"    | \
@@ -88,6 +87,7 @@ OS_VER="$OS-$VERSION_ID"
 # this line to its /etc/os-release before installing IIAB: VERSION_ID="13"
 
 case $OS_VER in
+    "debian-12"    | \
     "debian-13"    | \
     "debian-14"    | \
     "trisquel-12"  | \

--- a/vars/debian-14.yml
+++ b/vars/debian-14.yml
@@ -1,0 +1,5 @@
+# Every is_<OS_VER> var is initially set to 'False' at the bottom of
+# /opt/iiab/iiab/vars/default_vars.yml -- these 'True' lines override that:
+is_debuntu: True
+is_debian: True    # Opposite of is_ubuntu for now
+is_debian_14: True

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -791,6 +791,7 @@ is_trisquel: False    # Subset of is_ubuntu
 is_trisquel_12: False
 
 is_debian: False    # Covers both: Debian, Raspberry Pi OS (Raspbian)
+is_debian_14: False
 is_debian_13: False
 is_debian_12: False
 #is_debian_11: False


### PR DESCRIPTION
WARNING: IIAB will begin transitioning away from Debian 12 "Bookworm" very shortly now, to Debian 13 "Trixie" — and also with early prep in support of Debian 14 "Forky" pre-releases.

In keeping with IIAB's longstanding policy to work primarily with recent OS's, making that transition quickly after 15 days have passed since the release of the latest LTS OS (in this case Debian 13 Trixie was released on 2025-08-09).

In this case, partial support for Debian 12 "Bookworm" will be preserved for a few weeks or so, e.g. for those who want to manually force support in [/opt/iiab/iiab/scripts/local_facts.fact](https://github.com/iiab/iiab/blob/master/scripts/local_facts.fact)

Somewhat Related:

- #3034 
- #3045
- #3691
- #4058