### PR TITLE
 [Upload2USB] remove extra exception thrown in getTargetFolderPath; linting

### DIFF
--- a/roles/usb_lib/files/upload2usb/upload2usb.php
+++ b/roles/usb_lib/files/upload2usb/upload2usb.php
@@ -23,26 +23,26 @@ function getTargetUSBDriveLocation () {
          $rmv_usb_path_count = shell_exec('lsblk --output NAME,TRAN,RM,MOUNTPOINT --pairs | cut -d " " -f 4 | grep "^MOUNTPOINT=\"/media" | wc -l');
 
          if ($rmv_usb_path_count == 0) {
-	         $exception_data = [
+             $exception_data = [
                'usb_count' => 0,
                'exception_msg' => '0 USB sticks found. <br/><br/>'
-	         ];
+             ];
              throw new RuntimeException(json_encode($exception_data));
          } elseif ($rmv_usb_path_count > 1) {
-	         $exception_data = [
+             $exception_data = [
                'usb_count' => $rmv_usb_path_count,
                'exception_msg' => 'More than 1 USB stick installed. <br/><br/>'
-	         ];
+             ];
              throw new RuntimeException(json_encode($exception_data));
          }
 
          $rmv_usb_path = trim(str_replace('"', '', shell_exec('lsblk --output NAME,TRAN,RM,MOUNTPOINT --pairs | cut -d " " -f 4 | grep "^MOUNTPOINT=\"/media" | cut -d "=" -f 2')));
 
          if (empty($rmv_usb_path)) {
-	         $exception_data = [
+             $exception_data = [
                'usb_count' => -1, 
                'exception_msg' => 'Not able to find USB stick. <br/><br/>'
-	         ];
+             ];
              throw new RuntimeException(json_encode($exception_data));
          } else {
              return $rmv_usb_path . "/";
@@ -58,11 +58,10 @@ function getTargetFolderPath ($create_folder_p) {
 
          if (!file_exists($target_folder_path) && $create_folder_p) {
 
-	         $exception_data = [
+             $exception_data = [
                'usb_count' => -1, 
                'exception_msg' => "Not able to create upload directory. <br/>Make sure 'usb_lib_writable_sticks' is set to 'True'. <br/><br/>"
-	         ];
-             throw new RuntimeException(json_encode($exception_data));
+             ];
 	 
              mkdir($target_folder_path, 0777) or throw new RuntimeException(json_encode($exception_data));
          }


### PR DESCRIPTION
### Fixes bug:
Removing extra exception thrown in upload2usb.php in the getTargetFolderPath function that was accidentally added in #4059 

### Smoke-tested on which OS or OS's:
[RasPiOS pre-release based on] Debian 13 (trixie) on Raspberry Pi 500

### Mention a team member @username e.g. to help with code review:
@holta, @EMG70, @lohengramm