### PR TITLE
'iw' must be installed for detected_network.yml (DRAFT)

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,6 +109,14 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
+# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
+# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
+# not run network/tasks/install.yml as is normal when 'network_install: False'.
+# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
+# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
+- name: Intentionally fail if 'iw' executable is not installed
+  command: which iw
+
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
+  include_tasks: install.yml
+  when: network_install and network_installed is undefined
+
 - name: detected_network
   include_tasks: detected_network.yml
 
@@ -28,10 +32,6 @@
   with_items:
     - hostapd/iiab-hotspot-on
     - hostapd/iiab-hotspot-off
-
-- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
-  include_tasks: install.yml
-  when: network_install and network_installed is undefined
 
 
 - name: Configuring Network if enabled


### PR DESCRIPTION
### Fixes bug:

See roles/network/tasks/detected_network.yml in this PR for explanation (excerpted here...)

```
# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
# not run network/tasks/install.yml as is normal when 'network_install: False'.
# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
```

### Description of changes proposed in this pull request:

1. Try to ensure 'iw' is installed prior to running roles/network/tasks/detected_network.yml
2. Fail intentionally when 'iw' is not installed.

### Smoke-tested on which OS or OS's:

Prelim testing on Ubuntu Server 25.10 pre-release on x86_64 bare metal, with more testing ongoing.

### Mention a team member @username e.g. to help with code review:

@avni @jvonau