### PR TITLE
[Upload2USB] Modify runtime exception thrown to use new format

### DIFF
--- a/roles/usb_lib/files/upload2usb/upload-file.php
+++ b/roles/usb_lib/files/upload2usb/upload-file.php
@@ -44,8 +44,13 @@ if ($upload_ok == 0) {
     $upload_msg = "&#x1F60A; &#x2705; Your file <span style=\"font-weight:bold; font-style:italic;\">". htmlspecialchars( $uploaded_filename ). "</span> was successfully uploaded!";
     $upload_msg_short = "&#x2705; Your file was uploaded!"; 
   } else {
-    $upload_ok = 0; 
-    throw new RuntimeException('There was an error uploading your file. <br/><br/>');
+    $upload_ok = 0;
+    $exception_data = [
+      'usb_count' => -1,
+      'exception_msg' => 'There was an error uploading your file. <br/><br/>'
+    ];
+
+    throw new RuntimeException(json_encode($exception_data));
   }
 }
 


### PR DESCRIPTION
[Upload2USB] Modify runtime exception thrown to use new format introduced in #4059

### Fixes bug:
From the changes in #4059, exceptions thrown are required to be pass an array with two parameters to the exception handler. This thrown Runtime Exception was a straggler I forgot to update - it was using the old format. This fix updates the call to use the new format and will remove this bug from the nginx error log. 

```
Stack trace:
#0 {main}; PHP message: PHP Warning:  Trying to access array offset on null in /library/www/html/upload2usb/upload2usb.php on line 11; PHP message: PHP Warning:  Trying to access array offset on null in /library/www/html/upload2usb/upload2usb.php on line 12" while reading response header from upstream, client: 127.0.0.1, server: box, request: "POST /upload2usb/upload-file.php HTTP/1.1", upstream: "fastcgi://unix:/run/php/php8.3-fpm.sock:", host: "box", referrer: "http://box/usb/"

```  


### Description of changes proposed in this pull request:
- Modify upload-file.php to use new array format (with 2 name/value pairs) for throwing an exception vs the old format which only had a single parameter for message
- No user-facing impact

### Smoke-tested on which OS or OS's:
Ubuntu 24.04 Desktop

### Mention a team member @username e.g. to help with code review:
@holta 
