### PR TITLE
Networking cleanup, building on #4064 & #4067

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,6 +109,14 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
+# 2025-08-29: If 'network_install: False' then network/tasks/install.yml
+# still hasn't run.  So let's mandate 'iw' be installed, prior to it being
+# invoked 3 times below (cleanly understandable code = much more maintainable).
+- name: Require 'iw' package install, used in 3 different places below
+  package:
+    name: iw
+    state: present
+
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,14 +109,6 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
-# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
-# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
-# not run network/tasks/install.yml as is normal when 'network_install: False'.
-# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
-# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
-- name: Intentionally fail if 'iw' executable is not installed
-  command: which iw
-
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,6 +109,14 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
+# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
+# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
+# not run network/tasks/install.yml as is normal when 'network_install: False'.
+# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
+# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
+- name: Intentionally fail if 'iw' executable is not installed
+  command: which iw
+
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -20,10 +20,10 @@
 - name: computed_network
   include_tasks: computed_network.yml
 
-# 2022-07-22: @jvonau asks for this to be (1) BELOW computed_network.yml
-# (what goes into iiab-hotspot-on|off depends on can_be_ap and wifi_up_down)
-# AND (2) ABOVE install.yml for some reason?  REQUIREMENT: Admin Console reads
-# iiab_network_mode from /etc/iiab/iiab.ini + uses /usr/bin/iiab-hotspot-on|off
+# 2022-07-22: @jvonau asks for this to be BELOW computed_network.yml (what goes
+# into iiab-hotspot-on|off depends on can_be_ap, wifi_up_down, etc).
+# REQUIREMENT: Admin Console reads iiab_network_mode from /etc/iiab/iiab.ini
+# and uses /usr/bin/iiab-hotspot-on|off
 - name: Install /usr/bin/iiab-hotspot-on|off from template (root:root by default)
   template:
     src: "{{ item }}"

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
+  include_tasks: install.yml
+  when: network_install and network_installed is undefined
+
 - name: detected_network
   include_tasks: detected_network.yml
 
@@ -28,10 +32,6 @@
   with_items:
     - hostapd/iiab-hotspot-on
     - hostapd/iiab-hotspot-off
-
-- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
-  include_tasks: install.yml
-  when: network_install and network_installed is undefined
 
 
 - name: Configuring Network if enabled

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -14,10 +14,10 @@ systemctl stop hostapd
 systemctl disable iiab-clone-wifi.service
 systemctl disable iiab-wifi-test.service
 systemctl stop iiab-clone-wifi.service
-echo -e "\nIIAB hotspot access point Disabled.\n"
+echo -e "\nIIAB hotspot (Wi-Fi access point) Disabled.\n"
 #exit 0
 {% else %}
-echo -e "\nIIAB hotspot access point Disabled.\n"
+echo -e "\nIIAB hotspot (Wi-Fi access point) Disabled.\n"
 {% if dhcpcd_result == "enabled" %}
 # hotspot-off before ap0_updown
 sed -i "s/^denyinterfaces/#denyinterfaces/" /etc/dhcpcd.conf

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -14,7 +14,7 @@ systemctl stop hostapd
 systemctl disable iiab-clone-wifi.service
 systemctl disable iiab-wifi-test.service
 systemctl stop iiab-clone-wifi.service
-echo " IIAB hotspot access point Disabled"
+echo -e "\nIIAB hotspot access point Disabled.\n"
 #exit 0
 {% else %}
 echo " IIAB hotspot access point Disabled"

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -5,7 +5,7 @@ echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
 {% if not network_enabled %}
 echo -e "Networking role disabled\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
-echo -e "Networking may not be installed check network_install in local_vars.yml\n"
+echo -e "Networking not installed? Check network_install in /etc/iiab/local_vars.yml\n"
 {% else %}
 sed -i "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=False/" {{ iiab_env_file }}
 systemctl disable hostapd

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -1,7 +1,11 @@
 #!/bin/bash
+{% if iiab_wireless_lan_iface is undefined %}
+echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
+{% else %}
 {% if not network_enabled %}
 echo -e "Networking role disabled\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
+echo -e "Networking may not be installed check network_install in local_vars.yml\n"
 {% else %}
 sed -i "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=False/" {{ iiab_env_file }}
 systemctl disable hostapd
@@ -42,3 +46,5 @@ echo -e "\nIf you're enabling upstream WiFi, please reboot now.\n"
 #wifi_up_down
 {% endif %}
 #network_enabled
+{% endif %}
+#Wifi not found

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -4,7 +4,7 @@ echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
 {% else %}
 {% if not network_enabled %}
 echo -e "IIAB networking is disabled:\n"
-echo -e "Check network_install and network_enabled in /etc/iiab/local_vars.yml\n"
+echo -e "If you want to enable it, check network_install and network_enabled in /etc/iiab/local_vars.yml and then run: sudo iiab-network\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
 {% else %}
 sed -i "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=False/" {{ iiab_env_file }}

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -3,9 +3,9 @@
 echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
 {% else %}
 {% if not network_enabled %}
-echo -e "Networking role disabled\n"
+echo -e "IIAB networking is disabled:\n"
+echo -e "Check network_install and network_enabled in /etc/iiab/local_vars.yml\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
-echo -e "Networking not installed? Check network_install in /etc/iiab/local_vars.yml\n"
 {% else %}
 sed -i "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=False/" {{ iiab_env_file }}
 systemctl disable hostapd

--- a/roles/network/templates/hostapd/iiab-hotspot-off
+++ b/roles/network/templates/hostapd/iiab-hotspot-off
@@ -17,7 +17,7 @@ systemctl stop iiab-clone-wifi.service
 echo -e "\nIIAB hotspot access point Disabled.\n"
 #exit 0
 {% else %}
-echo " IIAB hotspot access point Disabled"
+echo -e "\nIIAB hotspot access point Disabled.\n"
 {% if dhcpcd_result == "enabled" %}
 # hotspot-off before ap0_updown
 sed -i "s/^denyinterfaces/#denyinterfaces/" /etc/dhcpcd.conf

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -1,7 +1,12 @@
 #!/bin/bash
+{% if iiab_wireless_lan_iface is undefined %}
+echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
+echo -e "If you add Wi-Fi hardware, run 'cd /opt/iiab/iiab' then 'sudo ./iiab-network'\n"
+{% else %}
 {% if not network_enabled %}
 echo -e "Networking role disabled\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
+echo -e "Networking may not be installed check network_install in local_vars.yml\n"
 {% else %}
 {% if not can_be_ap %}
 echo -e "\nUH-OH: Your Wi-Fi firmware doesn't support AP mode, according to 'iw list'\n"
@@ -47,9 +52,10 @@ systemctl enable hostapd
 #if dhcpcd_result == "enabled"
 {% endif %}
 #wifi_up_down
+echo -e "\nPlease reboot to activate hostapd feature.\n"
 {% endif %}
 #can_be_ap
 {% endif %}
 #network_enabled
-
-echo -e "\nPlease reboot to activate hostapd feature.\n"
+{% endif %}
+#Wifi not found

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -6,7 +6,7 @@ echo -e "If you add Wi-Fi hardware, run 'cd /opt/iiab/iiab' then 'sudo ./iiab-ne
 {% if not network_enabled %}
 echo -e "Networking role disabled\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
-echo -e "Networking may not be installed check network_install in local_vars.yml\n"
+echo -e "Networking not installed? Check network_install in /etc/iiab/local_vars.yml\n"
 {% else %}
 {% if not can_be_ap %}
 echo -e "\nUH-OH: Your Wi-Fi firmware doesn't support AP mode, according to 'iw list'\n"

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -5,7 +5,7 @@ echo -e "If you add Wi-Fi hardware, run 'cd /opt/iiab/iiab' then 'sudo ./iiab-ne
 {% else %}
 {% if not network_enabled %}
 echo -e "IIAB networking is disabled:\n"
-echo -e "Check network_install and network_enabled in /etc/iiab/local_vars.yml\n"
+echo -e "Check network_install and network_enabled in /etc/iiab/local_vars.yml and then run: sudo iiab-network\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
 {% else %}
 {% if not can_be_ap %}

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -52,7 +52,7 @@ systemctl enable hostapd
 #if dhcpcd_result == "enabled"
 {% endif %}
 #wifi_up_down
-echo -e "\nPlease reboot to activate hostapd feature.\n"
+echo -e "\nPlease reboot to activate IIAB hotspot (Wi-Fi access point) via hostapd.\n"
 {% endif %}
 #can_be_ap
 {% endif %}

--- a/roles/network/templates/hostapd/iiab-hotspot-on
+++ b/roles/network/templates/hostapd/iiab-hotspot-on
@@ -4,9 +4,9 @@ echo -e "\nUH-OH: Your Wi-Fi hardware was not found'\n"
 echo -e "If you add Wi-Fi hardware, run 'cd /opt/iiab/iiab' then 'sudo ./iiab-network'\n"
 {% else %}
 {% if not network_enabled %}
-echo -e "Networking role disabled\n"
+echo -e "IIAB networking is disabled:\n"
+echo -e "Check network_install and network_enabled in /etc/iiab/local_vars.yml\n"
 echo -e "For details, see: https://github.com/iiab/iiab/pull/3302\n"
-echo -e "Networking not installed? Check network_install in /etc/iiab/local_vars.yml\n"
 {% else %}
 {% if not can_be_ap %}
 echo -e "\nUH-OH: Your Wi-Fi firmware doesn't support AP mode, according to 'iw list'\n"


### PR DESCRIPTION
### Fixes bug:

Thanks to @jvonau and @avni for making this possible.  Background in these 2 PR's:

- PR #4064
- PR #4067

### Description of changes proposed in this pull request:

- Cleaner & more maintainable code.
- Very intentionally _requires_ 'iw' be installed before it's invoked.
- Thereby allowing `./iiab-install` to complete cleanly & legibly — in cases when implementer chooses to set `network_install: False` in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?)

### Smoke-tested on which OS or OS's:

Ubuntu Server 25.10

### Mention a team member @username e.g. to help with code review:

@jvonau @avni