### PR TITLE
Switching to etc_path for /etc in roles/iiab-admin [also in roles/lokole & roles/transmission]

### DIFF
--- a/roles/iiab-admin/tasks/pwd-warnings.yml
+++ b/roles/iiab-admin/tasks/pwd-warnings.yml
@@ -5,7 +5,7 @@
 - name: Install /etc/profile.d/iiab-pwdwarn-profile.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
   template:
     src: iiab-pwdwarn-profile.sh.j2
-    dest: /etc/profile.d/iiab-pwdwarn-profile.sh
+    dest: "{{ etc_path }}/profile.d/iiab-pwdwarn-profile.sh"
     mode: '0644'
 
 - name: Does directory /home/{{ iiab_admin_user }}/.config/labwc/ exist?

--- a/roles/iiab-admin/tasks/sudo-prereqs.yml
+++ b/roles/iiab-admin/tasks/sudo-prereqs.yml
@@ -4,12 +4,12 @@
 
 - name: Temporarily make file /etc/sudoers editable (0640)
   file:
-    path: /etc/sudoers
+    path: "{{ etc_path }}/sudoers"
     mode: "0640"
 
 - name: '/etc/sudoers: Have sudo log all commands to /var/log/sudo.log -- in addition to the lengthier /var/log/auth.log'
   lineinfile:
-    path: /etc/sudoers
+    path: "{{ etc_path }}/sudoers"
     regexp: logfile
     line: "Defaults     logfile = /var/log/sudo.log"
 
@@ -22,5 +22,5 @@
 
 - name: End editing file /etc/sudoers -- protect it again (0440)
   file:
-    path: /etc/sudoers
+    path: "{{ etc_path }}/sudoers"
     mode: "0440"

--- a/roles/iiab-admin/templates/iiab-pwdwarn-labwc.j2
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-labwc.j2
@@ -30,7 +30,7 @@ check_user_pwd() {
     # 2022-09-21 #3368: Sets field2 to "" if sudo -n fails to read /etc/shadow
     # 2022-10-18 #3404: Redirect stderr to /dev/null, as RasPiOS might one day
     # force an annoying pop-up, as Mint did (due to sshpwd-profile-iiab.sh.j2)
-    field2=$(sudo -n grep "^$1:" /etc/shadow 2>/dev/null | cut -d: -f2)
+    field2=$(sudo -n grep "^$1:" {{ etc_path }}/shadow 2>/dev/null | cut -d: -f2)
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
@@ -29,7 +29,7 @@ check_user_pwd() {
 
     # 2022-09-21 #3368: Sets field2 to "" if sudo -n fails to read /etc/shadow
     # 2022-10-18 #3404: Redirect stderr to /dev/null, to avoid Mint pop-up
-    field2=$(sudo -n grep "^$1:" /etc/shadow 2> /dev/null | cut -d: -f2)
+    field2=$(sudo -n grep "^$1:" {{ etc_path }}/shadow 2> /dev/null | cut -d: -f2)
     [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
 
     # # $meth (hashing method) is typically '6' which implies 5000 rounds

--- a/roles/lokole/defaults/main.yml
+++ b/roles/lokole/defaults/main.yml
@@ -21,7 +21,7 @@ lokole_admin_password: changeme
 
 lokole_install_path: "{{ content_base }}/lokole"    # /library/lokole
 lokole_venv: "{{ lokole_install_path }}/venv"       # /library/lokole/venv
-lokole_confd: /etc/supervisor/conf.d
+lokole_confd: "{{ etc_path }}/supervisor/conf.d"
 
 # Info needed to run Lokole:
 lokole_user: lokole

--- a/roles/transmission/tasks/install.yml
+++ b/roles/transmission/tasks/install.yml
@@ -75,8 +75,8 @@
 
 - name: Back up prior /etc/transmission-daemon/settings.json (file originally from apt, or new symlink contents) to /etc/transmission-daemon/settings.json.old*
   copy:
-    src: /etc/transmission-daemon/settings.json
-    dest: /etc/transmission-daemon/settings.json.old
+    src: "{{ etc_path }}/transmission-daemon/settings.json"
+    dest: "{{ etc_path }}/transmission-daemon/settings.json.old"
     mode: preserve
     owner: "{{ transmission_user }}"     # debian-transmission
     group: "{{ transmission_group }}"    # debian-transmission
@@ -86,7 +86,7 @@
 - name: "Back up IIAB's templated version to /etc/transmission-daemon/settings.json.iiab"
   template:
     src: settings.json.j2
-    dest: /etc/transmission-daemon/settings.json.iiab
+    dest: "{{ etc_path }}/transmission-daemon/settings.json.iiab"
     owner: "{{ transmission_user }}"     # debian-transmission
     group: "{{ transmission_group }}"    # debian-transmission
     mode: '0600'
@@ -101,7 +101,7 @@
 
 - name: "Reverse Transmission's fragile OOTB symlink -- instead we establish /etc/transmission-daemon/settings.json -> /var/lib/transmission-daemon/.config/transmission-daemon/settings.json -- REASON: /etc/transmission-daemon/settings.json was intermittently being IGNORED, as Transmission sometimes breaks its own symlink from /var/lib/transmission-daemon/.config/transmission-daemon/settings.json (by turning it into a file instead)"
   file:
-    path: /etc/transmission-daemon/settings.json
+    path: "{{ etc_path }}/transmission-daemon/settings.json"
     src: /var/lib/transmission-daemon/.config/transmission-daemon/settings.json    # Symlink /var/lib/transmission-daemon/home/settings.json also points to this
     state: link
     force: yes


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request: Getting ready for IIAB on Android. The blast radius was slightly larger than just roles/iiab-admin/tasks/sudo-prereqs.yml but maybe I included files that are disabled elsewhere

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
