### PR TITLE
Rust-based sudo-rs on Ubuntu 25.10 reports "unknown setting: 'logfile'"

### DIFF
--- a/roles/iiab-admin/tasks/sudo-prereqs.yml
+++ b/roles/iiab-admin/tasks/sudo-prereqs.yml
@@ -7,11 +7,12 @@
     path: /etc/sudoers
     mode: "0640"
 
-- name: '/etc/sudoers: Have sudo log all commands to /var/log/sudo.log -- in addition to the lengthier /var/log/auth.log'
-  lineinfile:
-    path: /etc/sudoers
-    regexp: logfile
-    line: "Defaults     logfile = /var/log/sudo.log"
+# 2025-08-29: Rust-based sudo-rs on Ubuntu 25.10 reports "unknown setting: 'logfile'"
+# - name: '/etc/sudoers: Have sudo log all commands to /var/log/sudo.log -- in addition to the lengthier /var/log/auth.log'
+#   lineinfile:
+#     path: /etc/sudoers
+#     regexp: logfile
+#     line: "Defaults     logfile = /var/log/sudo.log"
 
 # Not nec (heavyhanded removal of customizations+comments) given sudo defaults.
 #- name: Remove all lines that contain 'requiretty'

--- a/roles/iiab-admin/tasks/sudo-prereqs.yml
+++ b/roles/iiab-admin/tasks/sudo-prereqs.yml
@@ -2,10 +2,10 @@
   package:
     name: sudo    # (1) Should be installed prior to installing IIAB, (2) Can be installed by 1-prep's roles/tailscale/tasks/install.yml, (3) Can be installed by 1-prep's roles/iiab-admin/tasks/sudo-prereqs.yml here, (4) Used to be installed by roles/2-common/tasks/packages.yml (but that's too late!)
 
-- name: Temporarily make file /etc/sudoers editable (0640)
-  file:
-    path: "{{ etc_path }}/sudoers"
-    mode: "0640"
+# - name: Temporarily make file /etc/sudoers editable (0640)
+#   file:
+#     path: "{{ etc_path }}/sudoers"
+#     mode: "0640"
 
 # 2025-08-29: Rust-based sudo-rs on Ubuntu 25.10 reports "unknown setting: 'logfile'"
 # - name: '/etc/sudoers: Have sudo log all commands to /var/log/sudo.log -- in addition to the lengthier /var/log/auth.log'
@@ -21,7 +21,7 @@
 #    regexp: requiretty
 #    state: absent
 
-- name: End editing file /etc/sudoers -- protect it again (0440)
-  file:
-    path: "{{ etc_path }}/sudoers"
-    mode: "0440"
+# - name: End editing file /etc/sudoers -- protect it again (0440)
+#   file:
+#     path: "{{ etc_path }}/sudoers"
+#     mode: "0440"


### PR DESCRIPTION
### Fixes bug:

Ubuntu 25.10 uses `sudo-rs` in the place of `sudo` — which has been problematic for many recent days — due to this line that IIAB has been adding to `/etc/sudoers` for about a decade:

https://github.com/iiab/iiab/blob/d0db8009d907c32ef0711d25640ae10ec14347ca/roles/iiab-admin/tasks/sudo-prereqs.yml#L14

### Description of changes proposed in this pull request:

Comment out entire stanza for now?  In other words, eliminating the above line from `/etc/sudoers`

### Smoke-tested on which OS or OS's:

Certainly this PR works on Ubuntu 25.10 pre-releases as of late August 2025.

Whether it's a workaround or long-term solution remains to be seen (:

### Mention a team member @username e.g. to help with code review:

@Ark74 any idea if (in your opinion!) we should wait for Ubuntu 25.10's `sudo-rs` to stabilize?

(Or maybe merge this PR promptly in coming days — to clean up the CLI experience even prior to Ubuntu 25.10 "Questing Quokka" final release Oct 9 — if `/var/log/sudo.log` is just no longer needed ;-)

Related:

- #4060