### PR TITLE
iiab-diagnostics: Highlight failed systemd services & journalctl errors

### DIFF
--- a/scripts/iiab-diagnostics
+++ b/scripts/iiab-diagnostics
@@ -279,6 +279,8 @@ cat_tail /opt/iiab/iiab/iiab-network.log 100
 cat_tail /opt/iiab/iiab-admin-console/admin-install.log 100
 cat_tail /var/log/messages 100
 cat_tail /var/log/syslog 100
+cat_cmd 'sudo journalctl -p3 -n100' 'Show errors (and higher priority messages) from recent boots'
+cat_cmd 'systemctl --failed' 'Show systemd services that failed'
 
 linecount=$(wc -l $outfile | sed 's/\s.*$//')
 sizecount=$(du -h $outfile | sed 's/\s.*$//')

--- a/scripts/iiab-diagnostics.README.md
+++ b/scripts/iiab-diagnostics.README.md
@@ -66,4 +66,4 @@ But first off, the file is compiled by harvesting 1 + 6 kinds of things:
 
 ## Source Code
 
-Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 137-281 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.
+Please look over the bottom of [iiab-diagnostics](iiab-diagnostics) (lines 137-283 especially) to learn more about which common IIAB files and commands make this rapid troubleshooting possible.


### PR DESCRIPTION
Better `journalctl -p3 -n100` and `systemctl --failed` output for iiab-diagnostics, to help make boot-time and systemd debugging of services more efficient in general.

Tangentially related:

- PR #4078