### PR TITLE
update temp_dir php_value for upload2usb

### DIFF
--- a/roles/2-common/tasks/fl.yml
+++ b/roles/2-common/tasks/fl.yml
@@ -24,6 +24,7 @@
     - "{{ iiab_zim_path }}/content"    # /library/zims
     - "{{ iiab_zim_path }}/index"
     - "{{ doc_root }}/local_content"    # /library/www/html
+    - "{{ doc_root }}/local_content/USB0"
     - "{{ doc_root }}/modules"
     - "{{ doc_root }}/common/css"
     - "{{ doc_root }}/common/js"

--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -2,10 +2,6 @@ location / {
     rewrite ^/$ $1{{ iiab_home_url }};
 }
 
-upstream php-usb0 {
-    server unix:/run/php/php{{ php_version }}-fpm-usb0.sock;
-}
-
 location /usb {
     alias /library/www/html/local_content/;
     fancyindex on;    # autoindex on;

--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -13,12 +13,11 @@ location ~ ^/upload2usb/(.*)\.php$ {
     proxy_set_header X-Real-IP  $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host $host;
-    fastcgi_pass php;
+    fastcgi_pass unix:/run/php/php{{ php_version }}-fpm-local_content.sock;
     fastcgi_index index.php;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
     fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
-    fastcgi_param   PHP_VALUE          "upload_tmp_dir=/library/www/html/local_content";
     include fastcgi_params;
 }
 

--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -18,6 +18,7 @@ location ~ ^/upload2usb/(.*)\.php$ {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
     fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
+    fastcgi_param   PHP_VALUE          "upload_tmp_dir=/library/www/html/local_content";
     include fastcgi_params;
 }
 

--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -2,6 +2,10 @@ location / {
     rewrite ^/$ $1{{ iiab_home_url }};
 }
 
+upstream php-usb0 {
+    server unix:/run/php/php{{ php_version }}-fpm-usb0.sock;
+}
+
 location /usb {
     alias /library/www/html/local_content/;
     fancyindex on;    # autoindex on;
@@ -13,7 +17,7 @@ location ~ ^/upload2usb/(.*)\.php$ {
     proxy_set_header X-Real-IP  $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host $host;
-    fastcgi_pass unix:/run/php/php{{ php_version }}-fpm-local_content.sock;
+    fastcgi_pass php-usb0;
     fastcgi_index index.php;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -104,5 +104,10 @@ http {
     upstream php {
         server unix:/run/php/php{{ php_version }}-fpm.sock;
     }
-           
+
+    # define the upstream backend fastcgi for Upload2USB
+    upstream php-usb0 {
+        server unix:/run/php/php{{ php_version }}-fpm-usb0.sock;
+    }
+
 }

--- a/roles/usb_lib/tasks/nginx.yml
+++ b/roles/usb_lib/tasks/nginx.yml
@@ -30,6 +30,16 @@
 #     state: absent
 #   when: not usb_lib_enabled
 
+- name: Install /etc/php/{{ php_version }}/fpm/pool.d/USB0.conf
+  copy:
+    src: roles/usb_lib/templates/USB0.conf
+    dest: /etc/php/{{ php_version }}/fpm/pool.d/USB0.conf
+
+- name: Restart 'php-fpm' systemd service
+  systemd:
+    name: php{{ php_version }}-fpm
+    state: restarted
+
 - name: Restart 'nginx' systemd service
   systemd:
     name: nginx

--- a/roles/usb_lib/tasks/nginx.yml
+++ b/roles/usb_lib/tasks/nginx.yml
@@ -30,10 +30,10 @@
 #     state: absent
 #   when: not usb_lib_enabled
 
-- name: Install /etc/php/{{ php_version }}/fpm/pool.d/USB0.conf
+- name: Install /etc/php/{{ php_version }}/fpm/pool.d/usb0.conf
   copy:
-    src: roles/usb_lib/templates/USB0.conf
-    dest: /etc/php/{{ php_version }}/fpm/pool.d/USB0.conf
+    src: roles/usb_lib/templates/usb0.conf
+    dest: /etc/php/{{ php_version }}/fpm/pool.d/usb0.conf
 
 - name: Restart 'php-fpm' systemd service
   systemd:

--- a/roles/usb_lib/tasks/nginx.yml
+++ b/roles/usb_lib/tasks/nginx.yml
@@ -35,9 +35,9 @@
     src: roles/usb_lib/templates/usb0.conf
     dest: /etc/php/{{ php_version }}/fpm/pool.d/usb0.conf
 
-- name: Restart 'php-fpm' systemd service
+- name: Restart php{{ php_version }}-fpm systemd service
   systemd:
-    name: php{{ php_version }}-fpm
+    name: "php{{ php_version }}-fpm"
     state: restarted
 
 - name: Restart 'nginx' systemd service

--- a/roles/usb_lib/tasks/nginx.yml
+++ b/roles/usb_lib/tasks/nginx.yml
@@ -31,7 +31,7 @@
 #   when: not usb_lib_enabled
 
 - name: Install /etc/php/{{ php_version }}/fpm/pool.d/usb0.conf
-  copy:
+  template:
     src: roles/usb_lib/templates/usb0.conf
     dest: /etc/php/{{ php_version }}/fpm/pool.d/usb0.conf
 

--- a/roles/usb_lib/templates/USB0.conf
+++ b/roles/usb_lib/templates/USB0.conf
@@ -1,0 +1,14 @@
+[local_content]
+
+user = www-data
+group = www-data
+
+listen = /run/php/php{{ php_version }}-fpm-local_content.sock
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_servers = 1
+pm.max_spare_servers = 2
+
+php_admin_value[upload_tmp_dir] = /library/www/html/local_content/USB0

--- a/roles/usb_lib/templates/iiab-clean-usb.sh
+++ b/roles/usb_lib/templates/iiab-clean-usb.sh
@@ -12,3 +12,5 @@ if [ -L $CONTENT_LINK ]; then
     /usr/bin/rm $CONTENT_LINK
     logger -t "usb_lib (iiab-clean-usb.sh)" "Symlink $CONTENT_LINK removed, as auto-created earlier by usbmount."
 fi
+
+mkdir $CONTENT_LINK

--- a/roles/usb_lib/templates/usb0.conf
+++ b/roles/usb_lib/templates/usb0.conf
@@ -1,9 +1,9 @@
-[local_content]
+[usb0]
 
 user = www-data
 group = www-data
 
-listen = /run/php/php{{ php_version }}-fpm-local_content.sock
+listen = /run/php/php{{ php_version }}-fpm-usb0.sock
 
 pm = dynamic
 pm.max_children = 5

--- a/roles/usb_lib/templates/usb0.conf
+++ b/roles/usb_lib/templates/usb0.conf
@@ -8,7 +8,7 @@ listen = /run/php/php{{ php_version }}-fpm-usb0.sock
 pm = dynamic
 pm.max_children = 5
 pm.start_servers = 1
-pm.min_servers = 1
+pm.min_spare_servers = 1
 pm.max_spare_servers = 2
 
 php_admin_value[upload_tmp_dir] = /library/www/html/local_content/USB0


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/issues/3924

### Description of changes proposed in this pull request:

`/library/www/html/local_content` seems like it might be a safe place to put the temp folder. If the drive is mounted this should link to the `/media/usb?` location.

1. I'm not sure if nginx will follow the symbolic link but I assume since FancyIndex is working then `upload_tmp_dir` will work
2. I'm not sure if [move_uploaded_file](https://www.php.net/manual/en/function.move-uploaded-file.php) will like if `from` and `to` are the same file. (If the destination file already exists, it will be overwritten--but this was already the case without this PR). I'm not sure what PHP will name the temp files... But since upload2usb is always moving to a sub-folder as a final destination anyways this is possibly a non-problem.
3. I've avoided having a temp sub-folder (eg. `USB:/upload2usb_temp/`) because it adds (unnecessary [hopefully]) clutter. Though it would be better to follow the POSIX atomic steps (write to a temporary file, synchronize the data and directory to disk, and then atomically rename the temporary file to replace the original, etc). PHP might be handling this for us. I'm not sure yet.
4. It also depends _when_ PHP is looking up the local_content folder--the process might be "getting the inode number" too early for it to know about the re-link to /media, etc

### Smoke-tested on which OS or OS's:

This is totally untested

### Mention a team member @username e.g. to help with code review:

@holta