### PR TITLE
add zram-swap ansible role [+ q's about swap partition & pi_swap_file_size]

### DIFF
--- a/roles/0-init/tasks/disallow_install_false_with_enabled_true.yml
+++ b/roles/0-init/tasks/disallow_install_false_with_enabled_true.yml
@@ -46,6 +46,12 @@
     fail_msg: "DISALLOWED: 'squid_install: False' WITH 'squid_enabled: True' -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 variable values e.g. in /etc/iiab/local_vars.yml, and other places variables are defined?"
     quiet: yes
 
+- name: "DISALLOW 'zram_install: False' WITH 'zram_enabled: True'"
+  assert:
+    that: zram_install or not zram_enabled
+    fail_msg: "DISALLOWED: 'zram_install: False' WITH 'zram_enabled: True' -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 variable values e.g. in /etc/iiab/local_vars.yml, and other places variables are defined?"
+    quiet: yes
+
 - name: "DISALLOW 'cups_install: False' WITH 'cups_enabled: True'"
   assert:
     that: cups_install or not cups_enabled

--- a/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
+++ b/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
@@ -46,6 +46,12 @@
     fail_msg: "DISALLOWED: 'squid_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'squid_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
     quiet: yes
 
+- name: "DISALLOW 'zram_install: False' WHEN zram_enabled is defined"
+  assert:
+    that: zram_install or zram_installed is undefined
+    fail_msg: "DISALLOWED: 'zram_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'zram_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
+    quiet: yes
+
 - name: "DISALLOW 'cups_install: False' WHEN cups_enabled is defined"
   assert:
     that: cups_install or cups_installed is undefined

--- a/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
+++ b/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
@@ -46,7 +46,7 @@
     fail_msg: "DISALLOWED: 'squid_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'squid_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
     quiet: yes
 
-- name: "DISALLOW 'zram_install: False' WHEN zram_enabled is defined"
+- name: "DISALLOW 'zram_install: False' WHEN zram_installed is defined"
   assert:
     that: zram_install or zram_installed is undefined
     fail_msg: "DISALLOWED: 'zram_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'zram_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"

--- a/roles/0-init/tasks/validate_install_vars_boolean.yml
+++ b/roles/0-init/tasks/validate_install_vars_boolean.yml
@@ -46,6 +46,12 @@
     fail_msg: "VARIABLE MUST BE BOOLEAN: 'squid_install' now has type '{{ lookup('vars', 'squid_install') | type_debug }}' and value '{{ lookup('vars', 'squid_install') }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var zram_install is type boolean (NOT type string, which can invert logic!)
+  assert:
+    that: zram_install | type_debug == 'bool'
+    fail_msg: "VARIABLE MUST BE BOOLEAN: 'zram_install' now has type '{{ lookup('vars', 'zram_install') | type_debug }}' and value '{{ lookup('vars', 'zram_install') }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var cups_install is type boolean (NOT type string, which can invert logic!)
   assert:
     that: cups_install | type_debug == 'bool'

--- a/roles/0-init/tasks/validate_install_vars_defined.yml
+++ b/roles/0-init/tasks/validate_install_vars_defined.yml
@@ -46,6 +46,12 @@
     fail_msg: "VARIABLE MUST BE DEFINED: 'squid_install' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var zram_install is defined
+  assert:
+    that: zram_install is defined
+    fail_msg: "VARIABLE MUST BE DEFINED: 'zram_install' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var cups_install is defined
   assert:
     that: cups_install is defined

--- a/roles/4-server-options/tasks/main.yml
+++ b/roles/4-server-options/tasks/main.yml
@@ -29,6 +29,11 @@
     name: usb_lib
   when: usb_lib_install
 
+- name: zram
+  include_role:
+    name: zram
+  when: zram_install
+
 - name: CUPS
   include_role:
     name: cups

--- a/roles/zram/main.yml
+++ b/roles/zram/main.yml
@@ -1,0 +1,55 @@
+- name: Record (initial) disk space used
+  shell: df -B1 --output=used / | tail -1
+  register: df1
+
+# https://github.com/foundObjects/zram-swap/issues/8
+- name: Install linux-modules-extra if Ubuntu
+  package:
+    name: linux-modules-extra
+    state: present
+  when: is_ubuntu and ansible_architecture == "x86_64"
+
+- name: Install linux-modules-extra-raspi if Ubuntu on Raspberry Pi
+  package:
+    name: linux-modules-extra-raspi
+    state: present
+  when: is_ubuntu and ansible_architecture != "x86_64"
+
+
+- name: Git clone https://github.com/foundObjects/zram-swap.git to /opt/iiab/zram
+  git:
+    repo: https://github.com/foundObjects/zram-swap
+    dest: /opt/iiab/zram
+    version: v02
+    depth: 1
+    force: yes
+
+- name: Install zram-swap
+  shell: |
+    cd /opt/iiab/zram
+    ./install.sh
+
+
+
+# RECORD zram AS INSTALLED
+
+- name: Record (final) disk space used
+  shell: df -B1 --output=used / | tail -1
+  register: df2
+
+- name: Add 'zram_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
+  ini_file:
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+    section: zram
+    option: zram_disk_usage
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
+
+- name: "Set 'zram_installed: True'"
+  set_fact:
+    zram_installed: True
+
+- name: "Add 'zram_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^zram_installed'
+    line: 'zram_installed: True'

--- a/roles/zram/main.yml
+++ b/roles/zram/main.yml
@@ -2,33 +2,28 @@
   shell: df -B1 --output=used / | tail -1
   register: df1
 
-# https://github.com/foundObjects/zram-swap/issues/8
-- name: Install linux-modules-extra if Ubuntu
+
+- name: Install systemd-zram-generator
   package:
-    name: linux-modules-extra
+    name: systemd-zram-generator
     state: present
-  when: is_ubuntu and ansible_architecture == "x86_64"
 
-- name: Install linux-modules-extra-raspi if Ubuntu on Raspberry Pi
-  package:
-    name: linux-modules-extra-raspi
-    state: present
-  when: is_ubuntu and ansible_architecture != "x86_64"
+- name: Enable and start systemd-zram-generator
+  systemd:
+    name: systemd-zram-setup@zram0.service
+    enabled: true
+    state: started
 
 
-- name: Git clone https://github.com/foundObjects/zram-swap.git to /opt/iiab/zram
-  git:
-    repo: https://github.com/foundObjects/zram-swap
-    dest: /opt/iiab/zram
-    version: v02
-    depth: 1
-    force: yes
-
-- name: Install zram-swap
-  shell: |
-    cd /opt/iiab/zram
-    ./install.sh
-
+- name: Configure zram sysctl parameters
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { key: "vm.swappiness", value: "120" }
+    - { key: "vm.watermark_boost_factor", value: "0" }
+    - { key: "vm.watermark_scale_factor", value: "125" }
+    - { key: "vm.page-cluster", value: "0" }
 
 
 # RECORD zram AS INSTALLED

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -3,17 +3,23 @@
   register: df1
 
 
-- name: Install linux-modules-extra if Ubuntu
-  package:
-    name: linux-image-generic
-    state: present
-  when: is_ubuntu and ansible_architecture == "x86_64"
 
-- name: Install linux-modules-extra-raspi if Ubuntu on Raspberry Pi
-  package:
-    name: linux-image-raspi
+- name: Install HWE kernel metapackage if Ubuntu
+  ansible.builtin.package:
+    name: "{{ item }}"
     state: present
-  when: is_ubuntu and ansible_architecture != "x86_64"
+  loop:
+    - linux-image-generic-hwe
+    - "linux-image-generic-hwe-{{ ansible_distribution_version }}"
+    - linux-raspi
+  ignore_errors: yes
+  when: is_ubuntu
+
+# fail early so that the problem is easier to debug
+- name: Load zram kernel module
+  community.general.modprobe:
+    name: zram
+    state: present
 
 
 
@@ -22,15 +28,10 @@
     name: systemd-zram-generator
     state: present
 
-- name: Trigger /lib/systemd/system-generators/zram-generator
-  command: systemctl daemon-reexec
-  become: true
-  changed_when: false
-
-- name: Enable and start systemd-zram-generator
+- name: Enable systemd-zram-generator
   systemd:
+    daemon_reexec: true  # trigger /lib/systemd/system-generators/zram-generator
     name: systemd-zram-setup@zram0.service
-    enabled: true
     state: started
 
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -42,17 +42,15 @@
         - "linux-modules-extra-raspi"  # to use zram immediately
         # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
 
-# fail early so that the problem is easier to debug
-- name: Load zram kernel module
-  command: modprobe zram
-  become: true
-
-
-
 - name: Install systemd-zram-generator
   package:
     name: systemd-zram-generator
     state: present
+
+# fail early so that the problem is easier to debug
+- name: Load zram kernel module
+  command: modprobe zram
+  become: true
 
 - name: Enable systemd-zram-generator
   systemd:

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -3,6 +3,20 @@
   register: df1
 
 
+- name: Install linux-modules-extra if Ubuntu
+  package:
+    name: linux-modules-extra
+    state: present
+  when: is_ubuntu and ansible_architecture == "x86_64"
+
+- name: Install linux-modules-extra-raspi if Ubuntu on Raspberry Pi
+  package:
+    name: linux-modules-extra-raspi
+    state: present
+  when: is_ubuntu and ansible_architecture != "x86_64"
+
+
+
 - name: Install systemd-zram-generator
   package:
     name: systemd-zram-generator
@@ -20,18 +34,19 @@
     state: started
 
 
+
 - name: Configure zram sysctl parameters
   sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
   with_items:
     # https://docs.kernel.org/admin-guide/sysctl/vm.html#swappiness
-    - { key: "vm.swappiness", value: "120" }
-    #- { key: "vm.watermark_boost_factor", value: "0" }
-    #- { key: "vm.watermark_scale_factor", value: "125" }
-    #- { key: "vm.defrag_mode", value: "1" }
-    #- { key: "vm.extfrag_threshold", value: "350" }
-    #- { key: "vm.page-cluster", value: "0" }
+    - { name: "vm.swappiness", value: "120" }
+    #- { name: "vm.watermark_boost_factor", value: "0" }
+    #- { name: "vm.watermark_scale_factor", value: "125" }
+    #- { name: "vm.defrag_mode", value: "1" }
+    #- { name: "vm.extfrag_threshold", value: "350" }
+    #- { name: "vm.page-cluster", value: "0" }
 
 
 # RECORD zram AS INSTALLED

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -48,17 +48,74 @@
         # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
 
 
+- name: Log modprobe
+  block:
+    - name: Rebuild module dependency map
+      command: depmod -a
+      become: true
+      ignore_errors: true
+
+    - name: Try loading zram module
+      command: modprobe zram
+      become: true
+      register: modprobe_result
+      ignore_errors: true
+      changed_when: false
+
+    - name: Show zram module status
+      command: lsmod | grep zram
+      become: true
+      ignore_errors: true
+      register: lsmod_result
+      changed_when: false
+
+    - name: Log zram modprobe and lsmod output
+      debug:
+        msg: |
+          modprobe result: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
+          lsmod result: {{ lsmod_result.stdout }}
+
+
 
 - name: Install systemd-zram-generator
   package:
     name: systemd-zram-generator
     state: present
 
-- name: Enable systemd-zram-generator
+- name: Start systemd-zram-generator
   systemd:
     daemon_reexec: true  # trigger /lib/systemd/system-generators/zram-generator
     name: systemd-zram-setup@zram0.service
     state: started
+
+
+
+- name: Log modprobe again
+  block:
+    - name: Rebuild module dependency map
+      command: depmod -a
+      become: true
+      ignore_errors: true
+
+    - name: Try loading zram module
+      command: modprobe zram
+      become: true
+      register: modprobe_result
+      ignore_errors: true
+      changed_when: false
+
+    - name: Show zram module status
+      command: lsmod | grep zram
+      become: true
+      ignore_errors: true
+      register: lsmod_result
+      changed_when: false
+
+    - name: Log zram modprobe and lsmod output
+      debug:
+        msg: |
+          modprobe result: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
+          lsmod result: {{ lsmod_result.stdout }}
 
 
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -8,12 +8,11 @@
   ignore_errors: yes
   block:
     # to pull in linux-modules-extra during kernel updates
-    - name: Check if HWE exists
-      stat:
+    - stat:
         path: /bin/hwe-support-status
       register: hwe
 
-    - name: Install kernel metapackage if Ubuntu w/ latest HWE enabled
+    - name: Install kernel meta-package if Ubuntu w/ latest HWE enabled
       package:
         name: "{{ item }}"
         state: present
@@ -23,7 +22,7 @@
         # to use zram immediately--when linux-image-generic does not match what is currently running
         - "linux-modules-extra-{{ ansible_kernel }}"
 
-    - name: Install kernel metapackage if Ubuntu LTS kernel
+    - name: Install kernel meta-package if Ubuntu LTS kernel
       package:
         name: "{{ item }}"
         state: present
@@ -33,7 +32,7 @@
         - "linux-image-generic-{{ ansible_distribution_version }}"
         - "linux-modules-extra-{{ ansible_kernel }}"  # to use zram immediately
 
-    - name: Install kernel metapackage if Ubuntu Raspberry Pi
+    - name: Install kernel meta-package if Ubuntu Raspberry Pi
       package:
         name: "{{ item }}"
         state: present
@@ -45,9 +44,8 @@
 
 # fail early so that the problem is easier to debug
 - name: Load zram kernel module
-  community.general.modprobe:
-    name: zram
-    state: present
+  command: modprobe zram
+  become: true
 
 
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -5,13 +5,16 @@
 
 
 - name: Install HWE kernel metapackage if Ubuntu
-  ansible.builtin.package:
+  package:
     name: "{{ item }}"
     state: present
   loop:
-    - linux-image-generic-hwe
+    # for kernel updates
     - "linux-image-generic-hwe-{{ ansible_distribution_version }}"
+    # for Raspberry Pi
     - linux-raspi
+    # to use zram immediately--when linux-image-generic-hwe does not match what is currently running
+    - "linux-modules-extra-{{ ansible_kernel }}"
   ignore_errors: yes
   when: is_ubuntu
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -69,11 +69,20 @@
       register: lsmod_result
       changed_when: false
 
+    - name: Show active swaps
+      command: cat /proc/swaps
+      become: true
+      register: swaps_result
+      changed_when: false
+
     - name: Log zram modprobe and lsmod output
       debug:
         msg: |
-          modprobe result: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
-          lsmod result: {{ lsmod_result.stdout }}
+          modprobe: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
+          lsmod:
+          {{ lsmod_result.stdout }}
+          /proc/swaps:
+          {{ swaps_result.stdout }}
 
 
 
@@ -111,12 +120,27 @@
       register: lsmod_result
       changed_when: false
 
+    - name: Show active swaps
+      command: cat /proc/swaps
+      become: true
+      register: swaps_result
+      changed_when: false
+
     - name: Log zram modprobe and lsmod output
       debug:
         msg: |
-          modprobe result: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
-          lsmod result: {{ lsmod_result.stdout }}
+          modprobe: {{ modprobe_result.rc }} {{ modprobe_result.stdout }} {{ modprobe_result.stderr }}
+          lsmod:
+          {{ lsmod_result.stdout }}
+          /proc/swaps:
+          {{ swaps_result.stdout }}
 
+    - name: Assert that /dev/zram0 is active swap
+      assert:
+        that:
+          - "'/dev/zram0' in swaps_result.stdout"
+        fail_msg: "zram device /dev/zram0 is missing from /proc/swaps"
+        success_msg: "zram swap device /dev/zram0 is active"
 
 
 - name: Configure zram sysctl parameters

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -3,7 +3,7 @@
   register: df1
 
 
-- name: add zram module
+- name: add zram module to Ubuntu
   when: is_ubuntu
   ignore_errors: yes
   block:
@@ -42,15 +42,12 @@
         - "linux-modules-extra-raspi"  # to use zram immediately
         # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
 
+
+
 - name: Install systemd-zram-generator
   package:
     name: systemd-zram-generator
     state: present
-
-# fail early so that the problem is easier to debug
-- name: Load zram kernel module
-  command: modprobe zram
-  become: true
 
 - name: Enable systemd-zram-generator
   systemd:

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -5,13 +5,13 @@
 
 - name: Install linux-modules-extra if Ubuntu
   package:
-    name: linux-modules-extra
+    name: linux-image-generic
     state: present
   when: is_ubuntu and ansible_architecture == "x86_64"
 
 - name: Install linux-modules-extra-raspi if Ubuntu on Raspberry Pi
   package:
-    name: linux-modules-extra-raspi
+    name: linux-image-raspi
     state: present
   when: is_ubuntu and ansible_architecture != "x86_64"
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -3,22 +3,45 @@
   register: df1
 
 
-
-- name: Install kernel metapackage if Ubuntu
-  package:
-    name: "{{ item }}"
-    state: present
-  loop:
-    # to pull in linux-modules-extra during kernel updates
-    - "linux-image-generic"
-    # to use zram immediately--when linux-image-generic does not match what is currently running
-    - "linux-modules-extra-{{ ansible_kernel }}"
-    # same for Raspberry Pi
-    - linux-raspi
-    - "linux-modules-extra-raspi"
-    # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
-  ignore_errors: yes
+- name: add zram module
   when: is_ubuntu
+  ignore_errors: yes
+  block:
+    # to pull in linux-modules-extra during kernel updates
+    - name: Check if HWE exists
+      stat:
+        path: /bin/hwe-support-status
+      register: hwe
+
+    - name: Install kernel metapackage if Ubuntu w/ latest HWE enabled
+      package:
+        name: "{{ item }}"
+        state: present
+      when: hwe.stat.exists and rpi_model == "none"
+      loop:
+        - "linux-image-generic-hwe-{{ ansible_distribution_version }}"
+        # to use zram immediately--when linux-image-generic does not match what is currently running
+        - "linux-modules-extra-{{ ansible_kernel }}"
+
+    - name: Install kernel metapackage if Ubuntu LTS kernel
+      package:
+        name: "{{ item }}"
+        state: present
+      when: not hwe.stat.exists and rpi_model == "none"
+      loop:
+        - linux-image-generic
+        - "linux-image-generic-{{ ansible_distribution_version }}"
+        - "linux-modules-extra-{{ ansible_kernel }}"  # to use zram immediately
+
+    - name: Install kernel metapackage if Ubuntu Raspberry Pi
+      package:
+        name: "{{ item }}"
+        state: present
+      when: not hwe.stat.exists and rpi_model != "none"
+      loop:
+        - "linux-raspi"
+        - "linux-modules-extra-raspi"  # to use zram immediately
+        # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
 
 # fail early so that the problem is easier to debug
 - name: Load zram kernel module

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -4,17 +4,19 @@
 
 
 
-- name: Install HWE kernel metapackage if Ubuntu
+- name: Install kernel metapackage if Ubuntu
   package:
     name: "{{ item }}"
     state: present
   loop:
-    # for kernel updates
-    - "linux-image-generic-hwe-{{ ansible_distribution_version }}"
-    # for Raspberry Pi
-    - linux-raspi
-    # to use zram immediately--when linux-image-generic-hwe does not match what is currently running
+    # to pull in linux-modules-extra during kernel updates
+    - "linux-image-generic"
+    # to use zram immediately--when linux-image-generic does not match what is currently running
     - "linux-modules-extra-{{ ansible_kernel }}"
+    # same for Raspberry Pi
+    - linux-raspi
+    - "linux-modules-extra-raspi"
+    # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
   ignore_errors: yes
   when: is_ubuntu
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -7,17 +7,23 @@
   when: is_ubuntu
   ignore_errors: yes
   block:
-    # to pull in linux-modules-extra during kernel updates
-    - stat:
-        path: /bin/hwe-support-status
-      register: hwe
+    - name: Check if HWE kernel is installed
+      shell: |
+        dpkg-query -W -f='${Package}\n' 'linux-image-generic-hwe*' 2>/dev/null | grep '^linux-image-generic-hwe'
+      register: hwe_kernel_check
+      changed_when: false
+      failed_when: false
+    - name: Set fact if HWE kernel is installed
+      set_fact:
+        hwe_installed: "{{ hwe_kernel_check.stdout | length > 0 }}"
 
     - name: Install kernel meta-package if Ubuntu w/ latest HWE enabled
       package:
         name: "{{ item }}"
         state: present
-      when: hwe.stat.exists and rpi_model == "none"
+      when: hwe_installed and rpi_model == "none"
       loop:
+        # to pull in linux-modules-extra during kernel updates
         - "linux-image-generic-hwe-{{ ansible_distribution_version }}"
         # to use zram immediately--when linux-image-generic does not match what is currently running
         - "linux-modules-extra-{{ ansible_kernel }}"
@@ -26,17 +32,17 @@
       package:
         name: "{{ item }}"
         state: present
-      when: not hwe.stat.exists and rpi_model == "none"
+      when: not hwe_installed and rpi_model == "none"
       loop:
         - linux-image-generic
-        - "linux-image-generic-{{ ansible_distribution_version }}"
-        - "linux-modules-extra-{{ ansible_kernel }}"  # to use zram immediately
+        # - "linux-image-generic-{{ ansible_distribution_version }}"
+        - "linux-modules-extra-{{ ansible_kernel }}"
 
     - name: Install kernel meta-package if Ubuntu Raspberry Pi
       package:
         name: "{{ item }}"
         state: present
-      when: not hwe.stat.exists and rpi_model != "none"
+      when: rpi_model != "none"
       loop:
         - "linux-raspi"
         - "linux-modules-extra-raspi"  # to use zram immediately

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -158,12 +158,6 @@
           /proc/swaps:
           {{ swaps_result.stdout }}
 
-    - name: Assert that /dev/zram0 is active swap
-      assert:
-        that:
-          - "'/dev/zram0' in swaps_result.stdout"
-        fail_msg: "zram device /dev/zram0 is missing from /proc/swaps"
-        success_msg: "zram swap device /dev/zram0 is active"
 
 
 - name: Configure zram sysctl parameters

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -8,6 +8,11 @@
     name: systemd-zram-generator
     state: present
 
+- name: Trigger /lib/systemd/system-generators/zram-generator
+  command: systemctl daemon-reexec
+  become: true
+  changed_when: false
+
 - name: Enable and start systemd-zram-generator
   systemd:
     name: systemd-zram-setup@zram0.service

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -69,9 +69,3 @@
 - name: "Set 'zram_installed: True'"
   set_fact:
     zram_installed: True
-
-- name: "Add 'zram_installed: True' to {{ iiab_state_file }}"
-  lineinfile:
-    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
-    regexp: '^zram_installed'
-    line: 'zram_installed: True'

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -20,10 +20,13 @@
     name: "{{ item.name }}"
     value: "{{ item.value }}"
   with_items:
+    # https://docs.kernel.org/admin-guide/sysctl/vm.html#swappiness
     - { key: "vm.swappiness", value: "120" }
-    - { key: "vm.watermark_boost_factor", value: "0" }
-    - { key: "vm.watermark_scale_factor", value: "125" }
-    - { key: "vm.page-cluster", value: "0" }
+    #- { key: "vm.watermark_boost_factor", value: "0" }
+    #- { key: "vm.watermark_scale_factor", value: "125" }
+    #- { key: "vm.defrag_mode", value: "1" }
+    #- { key: "vm.extfrag_threshold", value: "350" }
+    #- { key: "vm.page-cluster", value: "0" }
 
 
 # RECORD zram AS INSTALLED

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -47,6 +47,28 @@
         - "linux-modules-extra-raspi"  # to use zram immediately
         # - "linux-modules-extra-raspi-{{ ansible_kernel }}"
 
+- name: add zram module to other Debian
+  when: not is_ubuntu
+  ignore_errors: yes
+  block:
+    - name: Install kernel meta-package
+      package:
+        name: "{{ item }}"
+        state: present
+      when: rpi_model == "none"
+      loop:
+        - linux-image-generic
+        - "linux-image-{{ ansible_kernel }}"  # for immediate use, should already exist tho!
+
+    - name: Install kernel meta-package if Raspberry Pi OS
+      package:
+        name: "{{ item }}"
+        state: present
+      when: rpi_model != "none"
+      loop:
+        - "raspberrypi-kernel"
+
+
 
 - name: Log modprobe
   block:
@@ -94,6 +116,7 @@
 - name: Start systemd-zram-generator
   systemd:
     daemon_reexec: true  # trigger /lib/systemd/system-generators/zram-generator
+    daemon_reload: true  # should not be needed given above; testing
     name: systemd-zram-setup@zram0.service
     state: started
 

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -7,15 +7,14 @@
   when: is_ubuntu
   ignore_errors: yes
   block:
-    - name: Check if HWE kernel is installed
-      shell: |
-        dpkg-query -W -f='${Package}\n' 'linux-image-generic-hwe*' 2>/dev/null | grep '^linux-image-generic-hwe'
+    - name: Check for HWE kernel installation
+      shell: dpkg-query -W -f='${Package}\n' 'linux-image-generic-hwe*' 2>/dev/null | grep '^linux-image-generic-hwe'
       register: hwe_kernel_check
       changed_when: false
-      failed_when: false
+      ignore_errors: true
     - name: Set fact if HWE kernel is installed
       set_fact:
-        hwe_installed: "{{ hwe_kernel_check.stdout | length > 0 }}"
+        hwe_installed: "{{ hwe_kernel_check.rc == 0 }}"
 
     - name: Install kernel meta-package if Ubuntu w/ latest HWE enabled
       package:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -313,6 +313,10 @@ usb_lib_enabled: True
 usb_lib_writable_sticks: True
 systemd_location: /lib/systemd/system    # 2-common iiab-startup also uses
 
+# ZRAM Swap
+zram_install: True
+zram_enabled: True
+
 # Common UNIX Printing System (CUPS)
 cups_install: False
 cups_enabled: False

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -196,6 +196,10 @@ bluetooth_term_enabled: False
 # Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
+# ZRAM Swap
+zram_install: True
+zram_enabled: True
+
 # Common UNIX Printing System (CUPS)
 cups_install: True
 cups_enabled: True

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -196,6 +196,10 @@ bluetooth_term_enabled: False
 # Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
+# ZRAM Swap
+zram_install: True
+zram_enabled: True
+
 # Common UNIX Printing System (CUPS)
 cups_install: False
 cups_enabled: False

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -196,6 +196,10 @@ bluetooth_term_enabled: False
 # Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
+# ZRAM Swap
+zram_install: True
+zram_enabled: True
+
 # Common UNIX Printing System (CUPS)
 cups_install: False
 cups_enabled: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -202,6 +202,10 @@ bluetooth_term_enabled: False
 # Kolibri exports, and student uploads to teacher's USB stick (http://box/usb)
 usb_lib_writable_sticks: True
 
+# ZRAM Swap
+zram_install: False
+zram_enabled: False
+
 # Common UNIX Printing System (CUPS)
 cups_install: False
 cups_enabled: False

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -203,8 +203,8 @@ bluetooth_term_enabled: False
 usb_lib_writable_sticks: True
 
 # ZRAM Swap
-zram_install: False
-zram_enabled: False
+zram_install: True
+zram_enabled: True
 
 # Common UNIX Printing System (CUPS)
 cups_install: False


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/issues/2414

re: kernel parameters

The defaults kernel parameters seem to be reasonable and not need adjustment (at least on Debian):

    dirty_ratio=20, swappiness=60

```
sudo sysctl -n vm.dirty_background_ratio
10
sudo sysctl -n vm.dirty_ratio
20
sudo sysctl -n vm.vfs_cache_pressure
100
sudo sysctl -n vm.swappiness
60
```

### Description of changes proposed in this pull request:

Add zram config via https://github.com/foundObjects/zram-swap/

It might be good to enable/install early in the process to help with large package installs on limited systems.

For very limited systems that heavily rely on using _actual_ swap on disk, it looks like [Zswap](https://superuser.com/questions/1727160/zram-vs-zswap-for-lower-end-hardware) will work even better--but zram is more universally adopted and will work better on systems that don't heavily use disk swap.

### Smoke-tested on which OS or OS's:

not sure how to test single ansible roles... on Debian 13 I tried this:

```
sudoedit /etc/iiab/local_vars.yml
```

add these lines:

```
# ZRAM Swap
zram_install: True
zram_enabled: True
```

```
sudo ./runrole zram
```

### Mention a team member @username e.g. to help with code review:

@Ark74