### PR TITLE
Dnsmasq.sh ["move install timing to allow dnsmasq start trigger file to be installed", for RPi Zero 2 W hostapd / WiFi hotspot]

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,14 +109,6 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
-# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
-# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
-# not run network/tasks/install.yml as is normal when 'network_install: False'.
-# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
-# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
-- name: Intentionally fail if 'iw' executable is not installed
-  command: which iw
-
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -109,6 +109,14 @@
   set_fact:
     num_wifi_interfaces: "{{ count_wifi_interfaces.stdout | int }}"
 
+# 2025-08-27: 'iw' command is needed, in 3 places below.  So let's enforce that
+# prereq.  Otherwise erroneous results arise, e.g. in cases where 1-prep had
+# not run network/tasks/install.yml as is normal when 'network_install: False'.
+# RECAP: This led to problems, e.g. when @avni ran iiab-hotspot-on, and it
+# falsely claimed "Your Wi-Fi firmware doesn't support AP mode".
+- name: Intentionally fail if 'iw' executable is not installed
+  command: which iw
+
 - block:
     - name: Run 'iw list' to check for Access Point capability -- if discovered_wireless_iface ({{ discovered_wireless_iface }}) != "none"
       # shell: iw list | grep -v AP: | grep AP | wc -l    # False positives 'EAP' etc

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -32,6 +32,7 @@
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
+      - networkd-dispatcher    # moved from sysd-netd-debian.yml
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
 

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -32,7 +32,7 @@
       - netmask                #   25kB download: Handy utility -- helps determine network masks
       - net-tools              #  248kB download: RasPiOS installs this regardless -- @jvonau suggests possibly deleting this...unless oldtimers really want these older commands in iiab-diagnostics output?
       - rfkill                 #   87kB download: RasPiOS installs this regardless -- enable & disable wireless devices
-      - networkd-dispatcher    # moved from sysd-netd-debian.yml
+      - networkd-dispatcher    #   15kB download: Dispatcher service for systemd-networkd connection status changes -- moved from sysd-netd-debian.yml
       - wpasupplicant          # 1188kB download: RasPiOS installs this regardless -- client library for connections to a WiFi AP
     state: present
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
+  include_tasks: install.yml
+  when: network_install and network_installed is undefined
+
 - name: detected_network
   include_tasks: detected_network.yml
 
@@ -28,10 +32,6 @@
   with_items:
     - hostapd/iiab-hotspot-on
     - hostapd/iiab-hotspot-off
-
-- name: Install network packages (including many WiFi tools, and also iptables-persistent for firewall)
-  include_tasks: install.yml
-  when: network_install and network_installed is undefined
 
 
 - name: Configuring Network if enabled

--- a/roles/network/tasks/sysd-netd-debian.yml
+++ b/roles/network/tasks/sysd-netd-debian.yml
@@ -1,7 +1,7 @@
 # sysd-netd-debian.yml
-- name: Install networkd-dispatcher
-  package:
-    name: networkd-dispatcher    #  15kB download: Dispatcher service for systemd-networkd connection status changes
+#- name: Install networkd-dispatcher
+#  package:
+#    name: networkd-dispatcher    #  15kB download: Dispatcher service for systemd-networkd connection status changes
 
 # 2023-10-14 #3657, #3658, #3659: New RasPiOS 12/Bookworm issue.
 # FWIW Ubuntu >= 22.10 offers 'systemd-resolved' as a distinct apt package.


### PR DESCRIPTION
### Fixes bug:
#4090
### Description of changes proposed in this pull request:
move install timing to allow dnsmasq start trigger file to be installed
### Smoke-tested on which OS or OS's:
hand tested fix to identify missing file.
### Mention a team member @username e.g. to help with code review:
@tim-moody 
