### PR TITLE
Set `DNSMASQ_EXCEPT="lo"` in `/etc/default/dnsmasq` — to avoid red error in 'systemctl status dnsmasq' output

### DIFF
--- a/roles/network/tasks/dnsmasq.yml
+++ b/roles/network/tasks/dnsmasq.yml
@@ -3,12 +3,10 @@
     name: dnsmasq
     state: present
 
-- name: Install /etc/dnsmasq.d/dnsmasq-iiab, allowing systemd-resolved AND dnsmasq to work (#1306) and custom unit file
+- name: Install /etc/dnsmasq.d/dnsmasq-iiab, allowing systemd-resolved AND dnsmasq to work (#1306) and custom unit file (root:root by default)
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    owner: root
-    group: root
     mode: "{{ item.mode }}"
   with_items:
 #    - { src: 'roles/network/templates/network/dnsmasq.service.u18', dest: '/etc/systemd/system/iiab-dnsmasq.service', mode: '0644' }

--- a/roles/network/tasks/enable_services.yml
+++ b/roles/network/tasks/enable_services.yml
@@ -41,10 +41,21 @@
     src: roles/network/templates/network/dnsmasq.sh.j2
     dest: /etc/networkd-dispatcher/routable.d/dnsmasq.sh
     mode: "0755"
-  when: nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
+  when: nd_dir.stat.exists and nd_dir.stat.isdir and iiab_network_mode != "Appliance"
   #when: dnsmasq_install and dnsmasq_enabled and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and nd_enabled is defined and nd_enabled.stdout == "enabled" and nd_dir.stat.exists and nd_dir.stat.isdir and (iiab_network_mode != "Appliance")
   #when: dnsmasq_install and dnsmasq_enabled and systemd_out.status.UnitFileState == "enabled" and networkd_dir.stat.exists and networkd_dir.stat.isdir and (iiab_network_mode != "Appliance")
+
+# 2025-09-24, as 'systemctl status dnsmasq' showed this red error:
+#   Dropped protocol specifier '.dnsmasq' from 'lo.dnsmasq'. Using 'lo' (ifindex=1).
+#   Failed to set DNS configuration: Link lo is loopback device.
+# https://github.com/iiab/iiab/issues/4039#issuecomment-3331379838
+- name: Set 'DNSMASQ_EXCEPT="lo"' in /etc/default/dnsmasq
+  lineinfile:
+    path: /etc/default/dnsmasq
+    regexp: '^DNSMASQ_EXCEPT='
+    line: 'DNSMASQ_EXCEPT="lo"'
+    state: present
 
 - name: Remove /etc/dnsmasq.d/iiab.conf, when not dnsmasq_enabled or is Appliance
   file:


### PR DESCRIPTION
### Fixes bug:

Mitigates this red error in `systemctl status dnsmasq` output:

>Sep 24 17:11:47 box resolvconf[1242]: Dropped protocol specifier '.dnsmasq' from 'lo.dnsmasq'. Using 'lo' (ifindex=1).
Sep 24 17:11:47 box resolvconf[1242]: Failed to set DNS configuration: Link lo is loopback device.

- https://github.com/iiab/iiab/issues/4039#issuecomment-3331379838

### Description of changes proposed in this pull request:

Set `DNSMASQ_EXCEPT="lo"` in `/etc/default/dnsmasq` as part of roles/network/tasks/enable_services.yml

### Smoke-tested on which OS or OS's:

RasPiOS 13 Trixie (latest pre-release) on RPi 4.

### Mention a team member @username e.g. to help with code review:

@jvonau