### PR TITLE
Swap [Q: what to do about RasPiOS apt pkg `dphys-swapfile` forcing apt pkg `systemd-zram-generator` to be "auto-removable" ? A: Migrate to new apt pkg `rpi-swap`]

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -39,7 +39,7 @@
         value: swapfile
         no_extra_spaces: true
 
-    - name: Increase swap file size (to FixedSizeMiB={{ pi_swap_file_size }}) -- e.g. to avoid kiwix-serve fails on Zero 2 W, with large ZIM files
+    - name: Increase swap file size (to FixedSizeMiB={{ pi_swap_file_size }}) -- e.g. to avoid kiwix-serve fails on Raspberry Pi Zero 2 W, with large ZIM files
       ini_file:
         path: /etc/rpi/swap.conf
         section: File

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -22,25 +22,30 @@
   when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, starting in 2020 especially
 
 
-- name: 'Install packages: fake-hwclock, dphys-swapfile'
+- name: 'Install package: fake-hwclock'
   package:
     name:
       - fake-hwclock      # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
-      - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to autogenerate and use a swap file (below).
     state: present
+
+- name: 'Install package: dphys-swapfile'
+  package:
+      - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
+  when: os_ver != "raspbian-13"
 
 - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
   lineinfile:
     path: "{{ etc_path }}/dphys-swapfile"
     regexp: "^CONF_SWAPSIZE"
     line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
+  when: os_ver != "raspbian-13"
 
 - name: Restart swap service "dphys-swapfile"
   #command: /etc/init.d/dphys-swapfile restart
   systemd:    # Had been...a rare/legacy service that was NOT systemd
     name: dphys-swapfile
     state: restarted
-
+  when: os_ver != "raspbian-13"
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -24,8 +24,7 @@
 
 - name: 'Install package: fake-hwclock'
   package:
-    name:
-      - fake-hwclock      # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
+    name: fake-hwclock    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
     state: present
 
 - name: Install and configure dphys-swapfile

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -33,8 +33,7 @@
   block:
     - name: 'Install package: dphys-swapfile'
       package:
-        name:
-          - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
+        name: dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
         state: present
 
     - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -27,8 +27,8 @@
     name: fake-hwclock    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
     state: present
 
-- name: Install and configure dphys-swapfile
-  when: is_raspbian and os_ver is version('raspbian-13', '<')
+- name: Install and configure dphys-swapfile, if RasPiOS <= 12
+  when: is_raspbian and os_ver is version('raspbian-12', '<=')
   block:
     - name: 'Install package: dphys-swapfile'
       package:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -28,24 +28,25 @@
       - fake-hwclock      # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
     state: present
 
-- name: 'Install package: dphys-swapfile'
-  package:
-      - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
+- name: Install and configure dphys-swapfile
   when: os_ver != "raspbian-13"
+  block:
 
-- name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
-  lineinfile:
-    path: "{{ etc_path }}/dphys-swapfile"
-    regexp: "^CONF_SWAPSIZE"
-    line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
-  when: os_ver != "raspbian-13"
+  - name: 'Install package: dphys-swapfile'
+    package:
+        - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
 
-- name: Restart swap service "dphys-swapfile"
-  #command: /etc/init.d/dphys-swapfile restart
-  systemd:    # Had been...a rare/legacy service that was NOT systemd
-    name: dphys-swapfile
-    state: restarted
-  when: os_ver != "raspbian-13"
+  - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
+    lineinfile:
+      path: "{{ etc_path }}/dphys-swapfile"
+      regexp: "^CONF_SWAPSIZE"
+      line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
+
+  - name: Restart swap service "dphys-swapfile"
+    #command: /etc/init.d/dphys-swapfile restart
+    systemd:    # Had been...a rare/legacy service that was NOT systemd
+      name: dphys-swapfile
+      state: restarted
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -29,7 +29,7 @@
     state: present
 
 - name: Install and configure dphys-swapfile
-  when: os_ver != "raspbian-13"
+  when: is_raspbian and os_ver is version('raspbian-13', '<')
   block:
     - name: 'Install package: dphys-swapfile'
       package:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -31,22 +31,23 @@
 - name: Install and configure dphys-swapfile
   when: os_ver != "raspbian-13"
   block:
+    - name: 'Install package: dphys-swapfile'
+      package:
+        name:
+          - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
+        state: present
 
-  - name: 'Install package: dphys-swapfile'
-    package:
-        - dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
+    - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
+      lineinfile:
+        path: "{{ etc_path }}/dphys-swapfile"
+        regexp: "^CONF_SWAPSIZE"
+        line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
 
-  - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
-    lineinfile:
-      path: "{{ etc_path }}/dphys-swapfile"
-      regexp: "^CONF_SWAPSIZE"
-      line: "CONF_SWAPSIZE={{ pi_swap_file_size }}"
-
-  - name: Restart swap service "dphys-swapfile"
-    #command: /etc/init.d/dphys-swapfile restart
-    systemd:    # Had been...a rare/legacy service that was NOT systemd
-      name: dphys-swapfile
-      state: restarted
+    - name: Restart swap service "dphys-swapfile"
+      #command: /etc/init.d/dphys-swapfile restart
+      systemd:    # Had been...a rare/legacy service that was NOT systemd
+        name: dphys-swapfile
+        state: restarted
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -36,7 +36,7 @@
         name: dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
         state: present
 
-    - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) as kalite pip download fails
+    - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) e.g. kalite pip download failed
       lineinfile:
         path: "{{ etc_path }}/dphys-swapfile"
         regexp: "^CONF_SWAPSIZE"

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -27,6 +27,26 @@
     name: fake-hwclock    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS installs this regardless -- to save/restore system clock on machines w/o working RTC (above).
     state: present
 
+
+- name: Configure rpi-swap's /etc/rpi/swap.conf, if RasPiOS >= 13 -- ENACTED ON REBOOT
+  when: is_raspbian and os_ver is version('raspbian-13', '>=')
+  block:
+    - name: Set Mechanism=swapfile -- overriding default Mechanism=auto (i.e. Mechanism=zram+file) -- in future might Mechanism=zram+file coexist with the large swap file we need?
+      ini_file:
+        path: /etc/rpi/swap.conf
+        section: Main
+        option: Mechanism
+        value: swapfile
+        no_extra_spaces: true
+
+    - name: Increase swap file size (to FixedSizeMiB={{ pi_swap_file_size }}) -- e.g. to avoid kiwix-serve fails on Zero 2 W, with large ZIM files
+      ini_file:
+        path: /etc/rpi/swap.conf
+        section: File
+        option: FixedSizeMiB
+        value: "{{ pi_swap_file_size }}"
+        no_extra_spaces: true
+
 - name: Install and configure dphys-swapfile, if RasPiOS <= 12
   when: is_raspbian and os_ver is version('raspbian-12', '<=')
   block:
@@ -35,7 +55,7 @@
         name: dphys-swapfile    # 2021-03-15: Missing on Ubuntu etc.  RasPiOS uses zram now -- to autogenerate and use a swap file (below).
         state: present
 
-    - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) e.g. kalite pip download failed
+    - name: Increase swap file size (to CONF_SWAPSIZE={{ pi_swap_file_size }} in /etc/dphys-swapfile) -- e.g. kalite pip download failed
       lineinfile:
         path: "{{ etc_path }}/dphys-swapfile"
         regexp: "^CONF_SWAPSIZE"
@@ -46,6 +66,7 @@
       systemd:    # Had been...a rare/legacy service that was NOT systemd
         name: dphys-swapfile
         state: restarted
+
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -247,7 +247,7 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 
 # Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
 # Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 1024
+pi_swap_file_size: 2048
 
 
 # 2-COMMON

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -245,9 +245,9 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 2048
+# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3/4/5.
+# kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
+pi_swap_file_size: 1536
 
 
 # 2-COMMON


### PR DESCRIPTION
### Fixes bug:
https://github.com/iiab/iiab/pull/4087#issuecomment-3326921491
### Description of changes proposed in this pull request:
RasPi hardware is the only place where dphys-swapfile is installed, exclude dphys-swapfile on RasPiOS trixie
### Smoke-tested on which OS or OS's:
pending
### Mention a team member @username e.g. to help with code review:
