### PR TITLE
Future: Use one line installer from https://tailscale.com/download/linux

### DIFF
--- a/roles/tailscale/tasks/install.yml
+++ b/roles/tailscale/tasks/install.yml
@@ -3,20 +3,16 @@
   register: df1
 
 
-- name: "Set up apt source (jammy) in /etc/apt/sources.list.d/tailscale.list and its key /usr/share/keyrings/tailscale-archive-keyring.gpg, to install Tailscale"
-  shell: |
-    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg > /usr/share/keyrings/tailscale-archive-keyring.gpg
-    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list > /etc/apt/sources.list.d/tailscale.list
-
-- name: "Install packages: jq, sudo, tailscale"
+- name: "Install packages: jq, sudo"
   package:
     name:
-      #- ncat    # Newer versions of NMap do not include NCat, WAS needed to announce openvpn_handle (if Debian > 9 or Ubuntu > 18)
-      #- nmap
       - jq      # JSON parser used by /usr/bin/iiab-support == /usr/bin/iiab-vpn
       - sudo    # (1) Should be installed prior to installing IIAB, (2) Can also be installed by 1-prep here, (3) Is definitely installed by 1-prep's roles/iiab-admin/tasks/sudo-prereqs.yml, (4) Used to be installed by roles/2-common/tasks/packages.yml (but that's too late!)
-      - tailscale
     update_cache: yes
+
+- name: "Run one line installer to install Tailscale"
+  shell: |
+    curl -fsSL https://tailscale.com/install.sh | sh
 
 - name: Set up tab completion for 'tailscale' at the command-line
   shell: mkdir -p /etc/bash_completion.d && tailscale completion bash > /etc/bash_completion.d/tailscale


### PR DESCRIPTION
### Fixes bug:
Matches upstream usage to auto detect supported distros instead of using older binaries from a distro that IIAB has dropped support for. ie U22.04 jammy 
### Description of changes proposed in this pull request:
make use of one liner found at https://tailscale.com/download/linux
### Smoke-tested on which OS or OS's:
Pending on Ubuntu VM

### Mention a team member @username e.g. to help with code review:
https://github.com/tailscale/tailscale/blob/main/scripts/installer.sh#L397
https://pkgs.tailscale.com/stable/debian/trixie/installer-supported returns OK as supported
https://pkgs.tailscale.com/stable/raspbian/buster/installer-supported returns OK as supported
https://pkgs.tailscale.com/stable/raspbian/trixie/installer-supported returns 404 as unsupported 

This has to wait will upstream adds support for the newest RasPiOS..