### PR TITLE
[Upload2USB] Add check for double mounted drive; Simplify getTargetUSBDriveLocation

### DIFF
--- a/roles/usb_lib/files/upload2usb/upload2usb.php
+++ b/roles/usb_lib/files/upload2usb/upload2usb.php
@@ -15,30 +15,28 @@ set_exception_handler(function (Throwable $exception) {
     include ("error.php");
 });
 
-//return the first removable USB drive location
+//return the first removable USB media location
 function getTargetUSBDriveLocation () {
 
-         // Get the path of the first mounted storage
-	 $rmv_usb_path = trim(shell_exec('lsblk -no MOUNTPOINT | grep "^/media"'));
+         // Get paths to all mounted storage and count of mounted storage
+         $rmv_usb_paths = shell_exec('lsblk -no MOUNTPOINTS | grep "^/media/"');
+         $rmv_usb_paths_count = substr_count($rmv_usb_paths, "\n"); 
 
-         // Get the count of storage mounted at /media, and error if there is <>1 or media is double mounted
-         $rmv_usb_path_count = shell_exec('lsblk -no MOUNTPOINTS | grep -c "^/media"'); 
-
-         if ($rmv_usb_path_count == 0 || empty($rmv_usb_path)) {
+         if ($rmv_usb_paths_count == 0) {
              $exception_data = [
                'usb_count' => 0,
-               'exception_msg' => '0 USB sticks found. <br/><br/>'
+               'exception_msg' => '0 USB drives found. <br/><br/>'
              ];
              throw new RuntimeException(json_encode($exception_data));
-         } elseif ($rmv_usb_path_count > 1) {
+         } elseif ($rmv_usb_paths_count > 1) {
              $exception_data = [
-               'usb_count' => $rmv_usb_path_count,
-               'exception_msg' => 'There is more than 1 USB stick inserted or the USB stick is double mounted. <br/><br/>'
+               'usb_count' => $rmv_usb_paths_count,
+               'exception_msg' => 'There is more than 1 USB drive inserted or the USB drive is double mounted. <br/><br/>'
              ];
              throw new RuntimeException(json_encode($exception_data));
+         } else {
+             return trim($rmv_usb_paths) . "/";
          }
-
-         return $rmv_usb_path . "/";
 }
 
 //returns folder path where file will be stored, if create_folder_p = 1, it will create the folder if it doesn't exist

--- a/roles/usb_lib/files/upload2usb/upload2usb.php
+++ b/roles/usb_lib/files/upload2usb/upload2usb.php
@@ -15,7 +15,7 @@ set_exception_handler(function (Throwable $exception) {
     include ("error.php");
 });
 
-// if there is one USB drive, return the path to it, otherwise act on the exception
+// If there is one USB drive and it is not double mounted, return the path to it, otherwise act on the exception
 function getTargetUSBDriveLocation () {
 
          // Enumerate /media/ mountpoints and count them
@@ -35,7 +35,7 @@ function getTargetUSBDriveLocation () {
              ];
              throw new RuntimeException(json_encode($exception_data));
          } else {
-             // at this point, we know there is only 1 USB drive inserted and it is not double mounted; return the path to it
+             // At this point, we know there is only 1 USB drive inserted and it is not double mounted; return the path to it
              return trim($rmv_usb_paths) . "/"; 
          }
 }

--- a/roles/usb_lib/files/upload2usb/upload2usb.php
+++ b/roles/usb_lib/files/upload2usb/upload2usb.php
@@ -15,10 +15,10 @@ set_exception_handler(function (Throwable $exception) {
     include ("error.php");
 });
 
-//return the first removable USB media location
+// if there is one USB drive, return the path to it, otherwise act on the exception
 function getTargetUSBDriveLocation () {
 
-         // Get paths to all mounted storage and count of mounted storage
+         // Enumerate /media/ mountpoints and count them
          $rmv_usb_paths = shell_exec('lsblk -no MOUNTPOINTS | grep "^/media/"');
          $rmv_usb_paths_count = substr_count($rmv_usb_paths, "\n"); 
 
@@ -35,7 +35,8 @@ function getTargetUSBDriveLocation () {
              ];
              throw new RuntimeException(json_encode($exception_data));
          } else {
-             return trim($rmv_usb_paths) . "/";
+             // at this point, we know there is only 1 USB drive inserted and it is not double mounted; return the path to it
+             return trim($rmv_usb_paths) . "/"; 
          }
 }
 


### PR DESCRIPTION
Upload2USB: Add check and warning for double mounted drive; Simplify getTargetUSBDriveLocation function and lsblk usage

### Description of changes proposed in this pull request:
Provide warning to user if drive is double mounted; 
Use simpler lsblk logic;
Collapse unnecessary if condition;

### Smoke-tested on which OS or OS's:
Raspberry Pi OS 13 (Trixie)

### Mention a team member @username e.g. to help with code review:
@jvonau @chapmanjacobd @holta 