### PR TITLE
Set `TS_NO_LOGS_NO_SUPPORT=true` in /etc/default/tailscaled -- to reduce Tailscale telemetry risks

### DIFF
--- a/roles/tailscale/tasks/install.yml
+++ b/roles/tailscale/tasks/install.yml
@@ -21,6 +21,13 @@
 - name: Set up tab completion for 'tailscale' at the command-line
   shell: mkdir -p /etc/bash_completion.d && tailscale completion bash > /etc/bash_completion.d/tailscale
 
+- name: Set 'TS_NO_LOGS_NO_SUPPORT=true' in /etc/default/tailscaled -- as tailscale "telemetry" calls home too often (#4058, $4095)
+  lineinfile:
+    path: /etc/default/tailscaled
+    regexp: '^TS_NO_LOGS_NO_SUPPORT='
+    line: 'TS_NO_LOGS_NO_SUPPORT=true'
+    state: present
+
 - name: "Install ssh public keys for remote support (only runs if 'tailscale_install: True')"
   lineinfile:
     line: "{{ item.pubkey }}"


### PR DESCRIPTION
### Fixes bug:

Tailscale is calling home too often even when a VPN is not enabled, creating surveillance risks, as outlined here:

- https://github.com/iiab/iiab/issues/4058#issuecomment-3222172316
- PR #4095

### Description of changes proposed in this pull request:

Don't clobber Tailscale's own `/etc/default/tailscaled` (that creates serious-looking problems!) but do append `TS_NO_LOGS_NO_SUPPORT=true` to it immediately after installing Tailscale, to reduce (and hopefully avoid) telemetry risks (after tailscaled is restarted).

Background:

- https://tailscale.com/kb/1011/log-mesh-traffic#opting-out-of-client-logging
- https://www.reddit.com/r/Tailscale/comments/1alhs71/why_does_tailscale_keep_pinging_logtailscaleio/

This related PR might also be considered:

- #4095

(Conversely these 2 PRs serve a very similar purpose, so both may not be needed.)

### Smoke-tested on which OS or OS's:

Ubuntu Server 25.10

### Mention a team member @username e.g. to help with code review:

@jvonau @chapmanjacobd