### PR TITLE
nginx_high_php_limits: apply large defaults for upload2usb

### DIFF
--- a/roles/nginx/templates/iiab.conf.j2
+++ b/roles/nginx/templates/iiab.conf.j2
@@ -9,6 +9,13 @@ location /usb {
 }
 
 location ~ ^/upload2usb/(.*)\.php$ {
+    fastcgi_request_buffering off;
+    client_max_body_size      2G;
+    client_body_buffer_size   512K;
+    client_body_timeout       3600;
+    fastcgi_read_timeout      3600;
+    send_timeout              3600;
+
     alias /library/www/html/upload2usb/$1.php;
     proxy_set_header X-Real-IP  $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -62,10 +62,10 @@
 - name: "Enact 'nginx_high_php_limits: False' in */php.ini for medium-sized workloads"
   loop:
     # upload size limits
-    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
-    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
-    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
-    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
+    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
+    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
+    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
+    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
     # time and memory limits
     - { conf: fpm, regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
     - { conf: fpm, regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
@@ -79,12 +79,12 @@
 - name: "Enact 'nginx_high_php_limits: True' in */php.ini for large-sized workloads"
   loop:
     # upload size limits
-    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
-    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
-    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
-    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
-    - { conf: fpm, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-    - { conf: cli, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G    ; default is 2M' }
+    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G    ; default is 2M' }
+    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 10G    ; default is 8M' }
+    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 10G    ; default is 8M' }
+    - { conf: fpm, regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    - { conf: cli, regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
     # time and memory limits
     - { conf: fpm, regexp: '^max_execution_time', line: 'max_execution_time = 3600    ; default is 30' }
     - { conf: fpm, regexp: '^max_input_time', line: 'max_input_time = 3600    ; default is 60' }

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -59,61 +59,40 @@
 # regular operation it uses:     .../fpm/php.ini
 # And in the past it used:       .../apache2/php.ini
 
-
-#
-# --- CLI and FPM Limits Increased
-#
-
-- name: "Enact 'nginx_high_php_limits: False' in */php.ini for medium-sized uploads"
+- name: "Enact 'nginx_high_php_limits: False' in */php.ini for medium-sized workloads"
   loop:
+    # upload size limits
     - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
     - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
     - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
     - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
+    # time and memory limits
+    - { conf: fpm, regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
+    - { conf: fpm, regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
+    - { conf: fpm, regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
   lineinfile:
     path: /etc/php/{{ php_version }}/{{ item.conf }}/php.ini
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
 
-- name: "Enact 'nginx_high_php_limits: True' in */php.ini for large-sized uploads"
+- name: "Enact 'nginx_high_php_limits: True' in */php.ini for large-sized workloads"
   loop:
+    # upload size limits
     - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
     - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
     - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
     - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
     - { conf: fpm, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
     - { conf: cli, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    # time and memory limits
+    - { conf: fpm, regexp: '^max_execution_time', line: 'max_execution_time = 3600    ; default is 30' }
+    - { conf: fpm, regexp: '^max_input_time', line: 'max_input_time = 3600    ; default is 60' }
+    - { conf: fpm, regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
   lineinfile:
     path: /etc/php/{{ php_version }}/{{ item.conf }}/php.ini
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
-  when: nginx_high_php_limits or moodle_install or nextcloud_install
-
-#
-# --- FPM Only; CLI defaults (unlimited) are preserved
-#
-
-- name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (100s timeouts, memory_limit = 128M for Nextcloud)"
-  lineinfile:
-    path: /etc/php/{{ php_version }}/fpm/php.ini
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
-  when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
-
-- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (3600s timeouts, memory_limit = 512M for Nextcloud)"
-  lineinfile:
-    path: /etc/php/{{ php_version }}/fpm/php.ini
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 3600    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 3600    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
   when: nginx_high_php_limits or moodle_install or nextcloud_install
 
 

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -60,61 +60,65 @@
 # And in the past it used:       .../apache2/php.ini
 
 
-- name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow file size up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+#
+# --- CLI and FPM Limits Increased
+#
+
+- name: "Enact 'nginx_high_php_limits: False' in */php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow file size up to 100MB, max_input_vars = 1000)"
+  loop:
+    - fpm
+    - cli
   lineinfile:
-    path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
+    path: /etc/php/{{ php_version }}/{{ item }}/php.ini
+    regexp: "{{ php_item.regexp }}"
+    line: "{{ php_item.line }}"
+  loop_control:
+    loop_var: php_item
   with_items:
     - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
     - { regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
-    - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
   when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
 
-- name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/cli/php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow file size up to 100MB, 100s timeouts, with 2 PHP system defaults: memory_limit = 128M, max_input_vars = 1000)"
+- name: "Enact 'nginx_high_php_limits: True' in */php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow file size up to 10GB, max_input_vars = 5000 for Moodle)"
+  loop:
+    - fpm
+    - cli
   lineinfile:
-    path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
+    path: /etc/php/{{ php_version }}/{{ item }}/php.ini
+    regexp: "{{ php_item.regexp }}"
+    line: "{{ php_item.line }}"
+  loop_control:
+    loop_var: php_item
   with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
-    - { regexp: '^max_input_vars', line: 'max_input_vars = 1000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
-  when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
-
-
-- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow file size up to 10000MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
-  lineinfile:
-    path: /etc/php/{{ php_version }}/fpm/php.ini    # COMPARE /etc/php/{{ php_version }}/cli/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10000M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 10000M    ; default is 8M' }
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
+    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G    ; default is 2M' }
+    - { regexp: '^post_max_size', line: 'post_max_size = 10G    ; default is 8M' }
     - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
   when: nginx_high_php_limits or moodle_install or nextcloud_install
 
-- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/cli/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow file size up to 10000MB, 300s timeouts, memory_limit = 512M for Nextcloud, max_input_vars = 5000 for Moodle)"
+#
+# --- FPM Only; CLI defaults (unlimited) are preserved
+#
+
+- name: "Enact 'nginx_high_php_limits: False' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (100s timeouts, memory_limit = 128M for Nextcloud)"
   lineinfile:
-    path: /etc/php/{{ php_version }}/cli/php.ini    # COMPARE /etc/php/{{ php_version }}/fpm/php.ini AND /etc/php/{{ php_version }}/apache2/php.ini
+    path: /etc/php/{{ php_version }}/fpm/php.ini
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10000M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 10000M    ; default is 8M' }
-    - { regexp: '^max_execution_time', line: 'max_execution_time = 300    ; default is 30' }
-    - { regexp: '^max_input_time', line: 'max_input_time = 300    ; default is 60' }
-    - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is -1 (i.e. no limit) / Nextcloud requests 512M' }
-    - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    - { regexp: '^max_execution_time', line: 'max_execution_time = 100    ; default is 30' }
+    - { regexp: '^max_input_time', line: 'max_input_time = 100    ; default is 60' }
+    - { regexp: '^memory_limit', line: 'memory_limit = 128M    ; default is 128M / Nextcloud requests 512M' }
+  when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
+
+- name: "Enact 'nginx_high_php_limits: True' in /etc/php/{{ php_version }}/fpm/php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (3600s timeouts, memory_limit = 512M for Nextcloud)"
+  lineinfile:
+    path: /etc/php/{{ php_version }}/fpm/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regexp: '^max_execution_time', line: 'max_execution_time = 3600    ; default is 30' }
+    - { regexp: '^max_input_time', line: 'max_input_time = 3600    ; default is 60' }
+    - { regexp: '^memory_limit', line: 'memory_limit = 512M    ; default is 128M / Nextcloud requests 512M' }
   when: nginx_high_php_limits or moodle_install or nextcloud_install
 
 

--- a/roles/www_options/tasks/php-settings.yml
+++ b/roles/www_options/tasks/php-settings.yml
@@ -64,35 +64,30 @@
 # --- CLI and FPM Limits Increased
 #
 
-- name: "Enact 'nginx_high_php_limits: False' in */php.ini for LIGHTWEIGHT use of Matomo/Nextcloud/PBX/WordPress (allow file size up to 100MB, max_input_vars = 1000)"
+- name: "Enact 'nginx_high_php_limits: False' in */php.ini for medium-sized uploads"
   loop:
-    - fpm
-    - cli
+    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
+    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M  ; default is 2M' }
+    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
+    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 100M  ; default is 8M' }
   lineinfile:
-    path: /etc/php/{{ php_version }}/{{ item }}/php.ini
-    regexp: "{{ php_item.regexp }}"
-    line: "{{ php_item.line }}"
-  loop_control:
-    loop_var: php_item
-  with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 100M    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 100M    ; default is 8M' }
+    path: /etc/php/{{ php_version }}/{{ item.conf }}/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
   when: not nginx_high_php_limits and not moodle_install and not nextcloud_install
 
-- name: "Enact 'nginx_high_php_limits: True' in */php.ini for Moodle/Nextcloud or INTENSIVE use of Matomo/PBX/WordPress (allow file size up to 10GB, max_input_vars = 5000 for Moodle)"
+- name: "Enact 'nginx_high_php_limits: True' in */php.ini for large-sized uploads"
   loop:
-    - fpm
-    - cli
+    - { conf: fpm, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
+    - { conf: cli, regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G  ; default is 2M' }
+    - { conf: fpm, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
+    - { conf: cli, regexp: '^post_max_size', line: 'post_max_size = 10G  ; default is 8M' }
+    - { conf: fpm, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    - { conf: cli, regexp: '^max_input_vars', line: 'max_input_vars = 5000  ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
   lineinfile:
-    path: /etc/php/{{ php_version }}/{{ item }}/php.ini
-    regexp: "{{ php_item.regexp }}"
-    line: "{{ php_item.line }}"
-  loop_control:
-    loop_var: php_item
-  with_items:
-    - { regexp: '^upload_max_filesize', line: 'upload_max_filesize = 10G    ; default is 2M' }
-    - { regexp: '^post_max_size', line: 'post_max_size = 10G    ; default is 8M' }
-    - { regexp: '^max_input_vars', line: 'max_input_vars = 5000    ; default is 1000 / Moodle 3.11+ requires 5000+ with PHP 8+' }
+    path: /etc/php/{{ php_version }}/{{ item.conf }}/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
   when: nginx_high_php_limits or moodle_install or nextcloud_install
 
 #


### PR DESCRIPTION
### Fixes bug:

related to #3924, #4086

### Description of changes proposed in this pull request:

Copy ideal configuration [found by Luis](https://github.com/iiab/iiab/pull/4086#issuecomment-3350140744) for uploading large files to USB

I discovered that we are currently capping the CLI php.ini which will be unexpected and may be dangerous. Preserving some of the defaults for CLI scripts seems like a saner choice as we don't want a long-running migration script to suddenly fail, etc.

### Smoke-tested on which OS or OS's:

in progress

### Mention a team member @username e.g. to help with code review:

@Ark74