### PR TITLE
apt-mark systemd-zram-generator as manually installed, if installed [FOR NOW: as dphys-swapfile mysteriously sets systemd-zram-generator to "auto-removable" on RPi, or at least on RasPiOS?]

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -21,6 +21,11 @@
     state: present
   when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, starting in 2020 especially
 
+- name: Mark systemd-zram-generator as manually installed
+  apt_mark:
+    package: systemd-zram-generator
+    state: manual
+  ignore_errors: true
 
 - name: 'Install packages: fake-hwclock, dphys-swapfile'
   package:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -21,10 +21,8 @@
     state: present
   when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, starting in 2020 especially
 
-- name: Mark systemd-zram-generator as manually installed
-  apt_mark:
-    package: systemd-zram-generator
-    state: manual
+- name: "2025-10-03: Mark systemd-zram-generator as manually installed for now -- until RasPiOS (or their upstream?) cleans up packaging conflict with dphys-swapfile (PR #4087, PR #4094, PR #4104)"
+  command: apt-mark manual systemd-zram-generator
   ignore_errors: true
 
 - name: 'Install packages: fake-hwclock, dphys-swapfile'


### PR DESCRIPTION
### Fixes bug:

related to https://github.com/iiab/iiab/pull/4094

### Description of changes proposed in this pull request:

Marks systemd-zram-generator as manually installed

### Smoke-tested on which OS or OS's:

`apt mark` won't do anything (it won't even exit nonzero) if the package to mark is not installed

We should test this on Raspberry Pi 5 and Pi Zero 2

### Mention a team member @username e.g. to help with code review:

@holta