### PR TITLE
Revert "apt-mark systemd-zram-generator as manually installed, if installed [FOR NOW: as dphys-swapfile mysteriously sets systemd-zram-generator to "auto-removable" on RPi, or at least on RasPiOS?]"

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -67,6 +67,10 @@
         name: dphys-swapfile
         state: restarted
 
+# - name: "2025-10-03: Mark systemd-zram-generator as manually installed for now -- until RasPiOS (or their upstream?) cleans up packaging conflict with dphys-swapfile (PR #4087, PR #4094, PR #4104)"
+#   command: apt-mark manual systemd-zram-generator
+#   ignore_errors: true
+
 
 #- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
 #  lineinfile:

--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -21,9 +21,6 @@
     state: present
   when: rtc_id is defined and rtc_id != "none" and is_ubuntu    # CLARIF: Ubuntu runs increasingly well on RPi hardware, starting in 2020 especially
 
-- name: "2025-10-03: Mark systemd-zram-generator as manually installed for now -- until RasPiOS (or their upstream?) cleans up packaging conflict with dphys-swapfile (PR #4087, PR #4094, PR #4104)"
-  command: apt-mark manual systemd-zram-generator
-  ignore_errors: true
 
 - name: 'Install package: fake-hwclock'
   package:


### PR DESCRIPTION
Reverts iiab/iiab#4104

(No longer needed, with the following PR now merged...)

- PR #4094