### PR TITLE
Move rpi-swap to 'sudo iiab' & make 'pi_swap_file_size: 1536' official

### DIFF
--- a/roles/1-prep/tasks/raspberry_pi.yml
+++ b/roles/1-prep/tasks/raspberry_pi.yml
@@ -28,24 +28,28 @@
     state: present
 
 
-- name: Configure rpi-swap's /etc/rpi/swap.conf, if RasPiOS >= 13 -- ENACTED ON REBOOT
-  when: is_raspbian and os_ver is version('raspbian-13', '>=')
-  block:
-    - name: Set Mechanism=swapfile -- overriding default Mechanism=auto (i.e. Mechanism=zram+file) -- in future might Mechanism=zram+file coexist with the large swap file we need?
-      ini_file:
-        path: /etc/rpi/swap.conf
-        section: Main
-        option: Mechanism
-        value: swapfile
-        no_extra_spaces: true
+# 2025-10-06: swap needs to be enabled EARLY on during IIAB software installs,
+# especially given RasPiOS 13 Trixie now mandating a reboot to make it happen,
+# so this was moved to: https://github.com/iiab/iiab-factory/blob/master/iiab
 
-    - name: Increase swap file size (to FixedSizeMiB={{ pi_swap_file_size }}) -- e.g. to avoid kiwix-serve fails on Raspberry Pi Zero 2 W, with large ZIM files
-      ini_file:
-        path: /etc/rpi/swap.conf
-        section: File
-        option: FixedSizeMiB
-        value: "{{ pi_swap_file_size }}"
-        no_extra_spaces: true
+# - name: Configure rpi-swap's /etc/rpi/swap.conf, if RasPiOS >= 13 -- ENACTED ON REBOOT
+#   when: is_raspbian and os_ver is version('raspbian-13', '>=')
+#   block:
+#     - name: Set Mechanism=swapfile -- overriding default Mechanism=auto (i.e. Mechanism=zram+file) -- in future might Mechanism=zram+file coexist with the large swap file we need?
+#       ini_file:
+#         path: /etc/rpi/swap.conf
+#         section: Main
+#         option: Mechanism
+#         value: swapfile
+#         no_extra_spaces: true
+
+#     - name: Increase swap file size (to FixedSizeMiB={{ pi_swap_file_size }}) -- e.g. to avoid kiwix-serve fails on Raspberry Pi Zero 2 W, with large ZIM files
+#       ini_file:
+#         path: /etc/rpi/swap.conf
+#         section: File
+#         option: FixedSizeMiB
+#         value: "{{ pi_swap_file_size }}"
+#         no_extra_spaces: true
 
 - name: Install and configure dphys-swapfile, if RasPiOS <= 12
   when: is_raspbian and os_ver is version('raspbian-12', '<=')
@@ -72,9 +76,9 @@
 #   ignore_errors: true
 
 
-#- name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
-#  lineinfile:
-#    path: /boot/firmware/syscfg.txt
-#    regexp: '^include*'
-#    line: 'include btcfg.txt'
-#  when: is_ubuntu
+# - name: Enable bluetooth in /boot/firmware/syscfg.txt on Ubuntu (needs reboot)
+#   lineinfile:
+#     path: /boot/firmware/syscfg.txt
+#     regexp: '^include*'
+#     line: 'include btcfg.txt'
+#   when: is_ubuntu

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -245,7 +245,7 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3/4/5.
+# Some prefer 512MB for Zero W; others prefer 2048MB or higher for RPi 3/4/5.
 # kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
 pi_swap_file_size: 1536
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -155,9 +155,9 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 1024
+# Some prefer 512MB for Zero W; others prefer 2048MB or higher for RPi 3/4/5.
+# kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
+pi_swap_file_size: 1536
 
 
 # 2-COMMON

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -155,9 +155,9 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 1024
+# Some prefer 512MB for Zero W; others prefer 2048MB or higher for RPi 3/4/5.
+# kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
+pi_swap_file_size: 1536
 
 
 # 2-COMMON

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -155,9 +155,9 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 1024
+# Some prefer 512MB for Zero W; others prefer 2048MB or higher for RPi 3/4/5.
+# kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
+pi_swap_file_size: 1536
 
 
 # 2-COMMON

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -161,9 +161,9 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # (The full network stage runs after 9-LOCAL-ADDONS.  Or manually run
 # "sudo iiab-network").  Design under discussion: #2876
 
-# Some prefer 512MB for Zero W, others prefer 2048MB or higher for RPi 3 and 4.
-# Please see recommendations at: https://itsfoss.com/swap-size/
-pi_swap_file_size: 1024
+# Some prefer 512MB for Zero W; others prefer 2048MB or higher for RPi 3/4/5.
+# kiwix-serve needs >= 1024MB on Zero 2 W.  Tips: https://itsfoss.com/swap-size
+pi_swap_file_size: 1536
 
 
 # 2-COMMON


### PR DESCRIPTION
### Fixes bug:

- #4108

### Description of changes proposed in this pull request:

See companion PR:

- PR iiab/iiab-factory#252

Building on:

- PR #4094

### Smoke-tested on which OS or OS's:

Zero 2 W.

### Mention a team member @username e.g. to help with code review:

@tim-moody @chapmanjacobd @jvonau