### PR TITLE
phpMyAdmin 5.2.3 (new release)

### DIFF
--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -4,7 +4,7 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-phpmyadmin_version: 5.2.2
+phpmyadmin_version: 5.2.3
 phpmyadmin_name: "phpMyAdmin-{{ phpmyadmin_version }}-all-languages"
 phpmyadmin_dl_url: "https://files.phpmyadmin.net/phpMyAdmin/{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"
 phpmyadmin_name_zip: "{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"


### PR DESCRIPTION
ANNC:

- https://www.phpmyadmin.net/news/2025/10/8/phpmyadmin-523-is-released/
- https://github.com/phpmyadmin/phpmyadmin/blob/RELEASE_5_2_3/ChangeLog
- https://github.com/phpmyadmin/phpmyadmin/releases/tag/RELEASE_5_2_3
- https://www.phpmyadmin.net/files/5.2.3/
- https://github.com/phpmyadmin/phpmyadmin/issues?q=is%3Aclosed+is%3Aissue+milestone%3A5.2.3

Building on:

- PR #3988