### PR TITLE
local_facts.fact: Encourage pre-release testing of Ubuntu 26.04 LTS

### DIFF
--- a/scripts/local_facts.fact
+++ b/scripts/local_facts.fact
@@ -94,6 +94,7 @@ case $OS_VER in
     "ubuntu-2404"  | \
     "ubuntu-2504"  | \
     "ubuntu-2510"  | \
+    "ubuntu-2604"  | \
     "linuxmint-22" | \
     "raspbian-12"  | \
     "raspbian-13")


### PR DESCRIPTION
1. Ubuntu 25.10 is apparently being released today: https://www.omgubuntu.co.uk/2025/10/ubuntu-25-10-new-features

2. So in anticipation of Ubuntu 26.04 LTS pre-releases that will be available (e.g. via Multipass VMs) in less than a month, this PR helps us get ready to test IIAB on early pre-releases of the OS whose final release is expected in April 2026.

Related:

- PR #4035
- #4060
