### PR TITLE
all bridge members should not have IPv6 enabled [Bluetooth fix]

### DIFF
--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -34,6 +34,7 @@
     - { src: 'bt-pan.service.j2', dest: '/etc/systemd/system/bt-pan.service' }
     - { src: 'bt-term.service.j2', dest: '/etc/systemd/system/bt-term.service' }
     - { src: 'network.conf.j2', dest: '/etc/bluetooth/network.conf' }
+    - { src: '99-iiab.conf.j2', dest: '/etc/sysctl.d/99-iiab.conf' }
 
 - name: Create bluetooth utility scripts
   template:

--- a/roles/bluetooth/templates/99-iiab.conf.j2
+++ b/roles/bluetooth/templates/99-iiab.conf.j2
@@ -1,0 +1,1 @@
+net.ipv6.conf.bnep0.disable_ipv6=1


### PR DESCRIPTION
### Fixes bug:
DNS client issue when connect from an Android phone, got IP but no dns resolution.
### Description of changes proposed in this pull request:
disable IPv6 on the BlueTooth bridge member
### Smoke-tested on which OS or OS's:
RasPiOS trixie
### Mention a team member @username e.g. to help with code review:
@tim-moody  

https://paste.centos.org/view/0fba970f
