### PR TITLE
Moodle 5.1 requires NGINX doc root /opt/iiab/moodle/public

### DIFF
--- a/roles/moodle/templates/moodle-nginx.conf.j2
+++ b/roles/moodle/templates/moodle-nginx.conf.j2
@@ -14,7 +14,7 @@ location /dataroot/ {
 }
 
 location ~ ^/moodle(.*)\.php(.*)$ {
-    alias {{ moodle_base }}$1.php$2;
+    alias {{ moodle_base }}/public$1.php$2;
 
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_index index.php;


### PR DESCRIPTION
### Fixes bug:

- https://docs.moodle.org/501/en/Upgrading#Code_directories_restructure
- https://docs.moodle.org/501/en/Nginx#Nginx

### Description of changes proposed in this pull request:

In the template that creates `/etc/nginx/conf.d/moodle-nginx.conf`, change...

```
alias /opt/iiab/moodle$1.php$2;
```

...to...

```
alias /opt/iiab/moodle/public$1.php$2;
```

### Smoke-tested on which OS or OS's:

Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:

@deldesir

Related:

- PR #4110