### PR TITLE
Recommend ansible-core 2.20.0 [AWStats problem on Ubuntu 26.04 pre-release appears unrelated]

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -11,7 +11,7 @@ CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}    # Remove all '"'
 MIN_RPI_KERN=5.4.0        # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.19.2    # 2025-09-15: ansible-core 2.19 overhauled security, requiring major IIAB code changes (SEE #4030).  ansible-core 2.17 EOL is Nov 2025 per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+MIN_ANSIBLE_VER=2.19.4    # 2025-09-15: ansible-core 2.19 overhauled security, requiring major IIAB code changes (SEE #4030).  ansible-core 2.17 EOL is Nov 2025 per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
 
 REINSTALL=false
 DEBUG=false

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.19.3]
-GOOD_VER=2.19.3       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.20.0]
+GOOD_VER=2.20.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -34,6 +34,8 @@ GOOD_VER=2.20.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # https://www.ansible.com/blog/ansible-3.0.0-qa
 # https://github.com/ansible/ansible/tags
 # https://github.com/ansible/ansible/releases
+# https://github.com/ansible/ansible/commits/stable-2.20
+# https://github.com/ansible/ansible/blob/stable-2.20/changelogs/CHANGELOG-v2.20.rst
 # https://github.com/ansible/ansible/commits/stable-2.19
 # https://github.com/ansible/ansible/blob/stable-2.19/changelogs/CHANGELOG-v2.19.rst
 # https://github.com/ansible/ansible/commits/stable-2.18


### PR DESCRIPTION
ANNC & details:

- https://forum.ansible.com/t/new-release-ansible-core-v2-20-0/44790
- https://github.com/ansible/ansible/releases/tag/v2.20.0
- https://pypi.org/project/ansible-core/v2.20.0/
- https://github.com/ansible/ansible/blob/v2.20.0/changelogs/CHANGELOG-v2.20.rst
- https://docs.ansible.com/ansible/devel//roadmap/ROADMAP_2_20.html

Building on:

- PR #4085
- PR #4109

Tested well on the latest Ubuntu Server 26.04 pre-release, with plenty of warnings we'll address in due course, but only 1 serious error (repeated failure to install AWStats pasted in here...)

> 2025-11-04 19:09:48,905 p=2102 u=root n=ansible INFO| TASK [awstats : Summarize logs up to now: /usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=schoolserver -update] ********************************************************************
2025-11-04 19:09:49,188 p=2102 u=root n=ansible ERROR| [ERROR]: Task failed: Module failed: non-zero return code
Origin: /opt/iiab/iiab/roles/awstats/tasks/install.yml:90:3
>
> 88 #   when: awstats_enabled and not is_debuntu
89
90 - name: "Summarize logs up to now: /usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=schoolserver -update"
    ^ column 3
>
>
>2025-11-04 19:09:49,189 p=2102 u=root n=ansible INFO| fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": ["/usr/bin/perl", "/usr/lib/cgi-bin/awstats.pl", "-config=schoolserver", "-update"], "delta": "0:00:00.033971", "end": "2025-11-04 19:09:49.156962", "msg": "non-zero return code", "rc": 2, "start": "2025-11-04 19:09:49.122991", "stderr": "Can't locate Try/Tiny.pm in @INC (you may need to install the Try::Tiny module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/lib/cgi-bin/awstats.pl line 34.\nBEGIN failed--compilation aborted at /usr/lib/cgi-bin/awstats.pl line 34.", "stderr_lines": ["Can't locate Try/Tiny.pm in @INC (you may need to install the Try::Tiny module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/lib/cgi-bin/awstats.pl line 34.", "BEGIN failed--compilation aborted at /usr/lib/cgi-bin/awstats.pl line 34."], "stdout": "", "stdout_lines": []}
2025-11-04 19:09:49,205 p=2102 u=root n=ansible INFO| TASK [awstats : SEE ERROR ABOVE (skip_role_on_error: False)] *************************************************************************************************************************
2025-11-04 19:09:49,226 p=2102 u=root n=ansible ERROR| [ERROR]: Task failed: Action failed.
Origin: /opt/iiab/iiab/roles/awstats/tasks/main.yml:49:7