### PR TITLE
Add attribution from the new maps app to our credits page.

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -1,8 +1,0 @@
-Extra attributions:
-
-* Front end tiles: https://github.com/maps-black/maps.black?tab=MIT-1-ov-file#readme
-  * Specific styles and data sets are attributed in the UI. Note: 2023 satellite photos are under a non-commercial license.
-* Search UI
-  * https://github.com/maplibre/maplibre-gl-js
-  * https://github.com/maplibre/maplibre-gl-geocoder?tab=ISC-1-ov-file#readme
-* Search (for now): https://github.com/osm-search/Nominatim?tab=GPL-3.0-1-ov-file#readme

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -1,0 +1,7 @@
+Extra attributions:
+
+* UI
+  * https://github.com/maps-black/maps.black?tab=MIT-1-ov-file#readme
+  * https://github.com/maplibre/maplibre-gl-js
+  * https://github.com/maplibre/maplibre-gl-geocoder?tab=ISC-1-ov-file#readme
+* Search (for now): https://github.com/osm-search/Nominatim?tab=GPL-3.0-1-ov-file#readme

--- a/roles/www_base/files/html/html/credits.html
+++ b/roles/www_base/files/html/html/credits.html
@@ -33,12 +33,18 @@
   All HealthPhone content is available for free at  <a href="http://www.healthphone.org/">www.healthphone.org</a>.<br>
   All Centers for Disease Control content is available for free at  <a href="https://www.cdc.gov/">www.cdc.gov</a>.<br>
   All Global Emergency Medicine Wiki content is available for free at  <a href="https://wikem.org/wiki/Main_Page">wikem.org/wiki/Main_Page</a>.<br><br>
+  All OpenStreetMap data is available for free at  <a href="https://www.openstreetmap.org/">www.openstreetmap.org</a>.<br><br>
+  All Natural Earth data is available for free at  <a href="https://www.naturalearthdata.com">www.naturalearthdata.com</a>.<br><br>
+  All Sentinel-2 satellite content is available for free (some under a non-commercial license) at <a href="https://s2maps.eu">s2maps.eu</a>.<br><br>
   
   Internet-in-a-Box also includes the work of content aggregators which we gratefully acknowledge:<br><br>
 
   Kiwix is a ZIM server and repository of Wikimedia and other content in a compressed ZIM file format at  <a href="https://www.kiwix.org/">www.kiwix.org</a>.<br>
   KA Lite is a server and repository of Khan Academy content in various languages at  <a href="https://learningequality.org/ka-lite/">learningequality.org/ka-lite</a>.<br><br>
   OER2Go/RACHEL is a curation of selected offline content at  <a href="https://rachel.worldpossible.org/content">rachel.worldpossible.org/content</a>.<br>
+  MapLibre is a set of mapping libraries available at <a href="https://maplibre.org">maplibre.org</>
+  Maps.black is a wrapper around MapLibre and curation and integration of OpenStreetMap, Natural Earth, and Sentinel-2 data at <a href="https://maps.black">maps.black</>
+  Nominatim is a geocoder for OpenStreetMap data at <a href="https://nominatim.org">nominatim.org</>
 
   Internet-in-a-Box also contains a number of applications each of which has its own attribution information, which is included.<br><br>
 

--- a/roles/www_base/files/html/html/credits.html
+++ b/roles/www_base/files/html/html/credits.html
@@ -32,19 +32,17 @@
   All Music Theory content is available for free at  <a href="https://www.musictheory.net/">www.musictheory.net</a>.<br>
   All HealthPhone content is available for free at  <a href="http://www.healthphone.org/">www.healthphone.org</a>.<br>
   All Centers for Disease Control content is available for free at  <a href="https://www.cdc.gov/">www.cdc.gov</a>.<br>
-  All Global Emergency Medicine Wiki content is available for free at  <a href="https://wikem.org/wiki/Main_Page">wikem.org/wiki/Main_Page</a>.<br><br>
-  All OpenStreetMap data is available for free at  <a href="https://www.openstreetmap.org/">www.openstreetmap.org</a>.<br><br>
-  All Natural Earth data is available for free at  <a href="https://www.naturalearthdata.com">www.naturalearthdata.com</a>.<br><br>
+  All Global Emergency Medicine Wiki content is available for free at  <a href="https://wikem.org/wiki/Main_Page">wikem.org/wiki/Main_Page</a>.<br>
+  All OpenStreetMap data is available for free at  <a href="https://www.openstreetmap.org/">www.openstreetmap.org</a>.<br>
+  All Natural Earth data is available for free at  <a href="https://www.naturalearthdata.com">www.naturalearthdata.com</a>.<br>
   All Sentinel-2 satellite content is available for free (some under a non-commercial license) at <a href="https://s2maps.eu">s2maps.eu</a>.<br><br>
   
   Internet-in-a-Box also includes the work of content aggregators which we gratefully acknowledge:<br><br>
 
   Kiwix is a ZIM server and repository of Wikimedia and other content in a compressed ZIM file format at  <a href="https://www.kiwix.org/">www.kiwix.org</a>.<br>
-  KA Lite is a server and repository of Khan Academy content in various languages at  <a href="https://learningequality.org/ka-lite/">learningequality.org/ka-lite</a>.<br><br>
+  KA Lite is a server and repository of Khan Academy content in various languages at  <a href="https://learningequality.org/ka-lite/">learningequality.org/ka-lite</a>.<br>
   OER2Go/RACHEL is a curation of selected offline content at  <a href="https://rachel.worldpossible.org/content">rachel.worldpossible.org/content</a>.<br>
-  MapLibre is a set of mapping libraries available at <a href="https://maplibre.org">maplibre.org</>
-  Maps.black is a wrapper around MapLibre and curation and integration of OpenStreetMap, Natural Earth, and Sentinel-2 data at <a href="https://maps.black">maps.black</>
-  Nominatim is a geocoder for OpenStreetMap data at <a href="https://nominatim.org">nominatim.org</>
+  Maps.black is a wrapper around MapLibre and curation and integration of OpenStreetMap, Natural Earth, and Sentinel-2 data at <a href="https://maps.black">maps.black</a><br><br>
 
   Internet-in-a-Box also contains a number of applications each of which has its own attribution information, which is included.<br><br>
 


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/pull/4120#issuecomment-3506929129

### Description of changes proposed in this pull request:

Add attribution from the new maps app to our credits page.

I may have given more info than needed, happy to revise.

I wonder where to draw the line. maps.black (for instance) uses WikiData to translate names of places (though it's supposedly a very permissive license). There might be more little source of data it uses. But surely this credits file is not comprehensive as it is.

### Mention a team member @username e.g. to help with code review:

@holta 