### PR TITLE
new maps: initial view shows all of the continents once

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -43,6 +43,7 @@
 
             // set immediately after the tag is defined
             let mb = null
+            let shouldSetDefaultView = false
 
             // Defining these hash get/set functions outside of the window load because we
             // need to run some of it earlier. Again, the overall code layout sucks and we
@@ -74,19 +75,38 @@
             // when it's set.
             function readHash() {
                 const [lat, lon, pitch, bearing, zoom, globe, _mapStyleChoice] = window.location.hash.slice(1).split('/')
-                mb.lat = lat || 0
-                mb.lon = lon || 0
-                mb.pitch = pitch || 0
-                mb.bearing = bearing || 0
-                mb.zoom = zoom || 0
 
+                // Set this whether or not we have the hash, unlike the other parameters.
+                // We still need to set a default here.
                 mapStyleChoice = _mapStyleChoice || "natural"
+
+                if (window.location.hash) {
+                    mb.lat = lat || 0
+                    mb.lon = lon || 0
+                    mb.pitch = pitch || 0
+                    mb.bearing = bearing || 0
+                    mb.zoom = zoom || 0
+                } else {
+                    // If there's no initial hash, set the default view once the map loads
+                    shouldSetDefaultView = true
+                }
             }
             function readHashGlobe() {
                 const [lat, lon, pitch, bearing, zoom, globe, _mapStyleChoice] = window.location.hash.slice(1).split('/')
                 mb.globe = globe === 'g'
             }
 
+            function setDefaultView() {
+                // Setting the default view to show all the continents once, and have a decent vertical center.
+                //
+                // The default view is easiest set using fitBounds, which requires the map to be active.
+                // Setting maps.black's parameters (as in readHash) with the same goal would require
+                // calculating optimal zoom and location, which would be difficult.
+                if (shouldSetDefaultView) {
+                    mb.map.fitBounds([[-180, 30], [180, 30] ], {maxDuration: 0.1});
+                    shouldSetDefaultView = false
+                }
+            }
             window.addEventListener("load", () => {
                 function _setStyle() {
                     mb.mapstyle = {
@@ -358,6 +378,8 @@
                         // Future changes in orientation should also be reflected in the hash:
                         mb.map.off('moveend', setHash) // unsetting first, in case it's already there from a previous refresh
                         mb.map.on('moveend', setHash)
+
+                        setDefaultView()
                     } else {
                         // For now try periodically until it's ready.
                         setUpMapTimeout = setTimeout(setUpMap, 100)


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/pull/4120#issuecomment-3506880994

### Description of changes proposed in this pull request:

Create an "initial view" / "default view" of the map that shows all of the continents and has a "decent" centering of the map. 0 latitude didn't seem great, I went with 30.

This is used if there's no "hash" in the URL, i.e. the user just visits box/maps or box/maps/. The hash gets added to the URL immediately after, so any reloads of the page will go by the location in the hash rather than this new default.

### Smoke-tested on which OS or OS's:

Firefox on Linux: it seemed fine.

Vanadium (Chromium fork) on GrapheneOS on Pixel 7:

* In vertical mode, it starts zoomed out all the way, but it's not wide enough to even fully show all of the continents. It's centered on western Africa.
* In horizontal mode, it appears a bit further north than I thought it would. I realized that this is because my phone, when horizontal, is too short to fit the minimum height of the map element! I.e. the attribution on the bottom right doesn't show up. This is an issue irrespective of the default view. I wonder if it's maps.black or maplibregl?

### Mention a team member @username e.g. to help with code review:

@holta 