### PR TITLE
Fix DEPRECATION WARNINGs introduced in ansible-core 2.20 [in roles/kiwix only, for now!]

### DIFF
--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -37,7 +37,7 @@ kiwix_arch_dict:      # 'dpkg --print-architecture' key would be: (to mitigate #
 # https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837
 # CLAIM: 'ansible_machine might be "i686", whereas ansible_architecture on the same host would be "i386"'
 # https://stackoverflow.com/questions/44713880/how-do-i-make-decision-based-on-arch-in-ansible-playbooks/44714226#44714226
-kiwix_arch: "{{ kiwix_arch_dict[ansible_machine] | default('unsupported') }}"
+kiwix_arch: "{{ kiwix_arch_dict.get((ansible_facts.machine | default('')) | lower, 'unsupported') }}"
 
 # Latest official kiwix-tools release, per Kiwix permalink redirects:
 # https://www.kiwix.org/en/downloads/kiwix-serve/

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -37,7 +37,9 @@ kiwix_arch_dict:      # 'dpkg --print-architecture' key would be: (to mitigate #
 # https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a/66828837#66828837
 # CLAIM: 'ansible_machine might be "i686", whereas ansible_architecture on the same host would be "i386"'
 # https://stackoverflow.com/questions/44713880/how-do-i-make-decision-based-on-arch-in-ansible-playbooks/44714226#44714226
-kiwix_arch: "{{ kiwix_arch_dict.get((ansible_facts.machine | default('')) | lower, 'unsupported') }}"
+#kiwix_arch: "{{ kiwix_arch_dict[ansible_facts.machine] | default('unsupported') }}"
+kiwix_arch: "{{ kiwix_arch_dict.get(ansible_facts.machine, 'unsupported') }}"
+#kiwix_arch: "{{ kiwix_arch_dict.get((ansible_facts.machine | default('')) | lower, 'unsupported') }}"
 
 # Latest official kiwix-tools release, per Kiwix permalink redirects:
 # https://www.kiwix.org/en/downloads/kiwix-serve/

--- a/roles/kiwix/defaults/main.yml
+++ b/roles/kiwix/defaults/main.yml
@@ -39,7 +39,7 @@ kiwix_arch_dict:      # 'dpkg --print-architecture' key would be: (to mitigate #
 # https://stackoverflow.com/questions/44713880/how-do-i-make-decision-based-on-arch-in-ansible-playbooks/44714226#44714226
 #kiwix_arch: "{{ kiwix_arch_dict[ansible_facts.machine] | default('unsupported') }}"
 kiwix_arch: "{{ kiwix_arch_dict.get(ansible_facts.machine, 'unsupported') }}"
-#kiwix_arch: "{{ kiwix_arch_dict.get((ansible_facts.machine | default('')) | lower, 'unsupported') }}"
+#kiwix_arch: "{{ kiwix_arch_dict.get(ansible_facts.machine | default('') | lower, 'unsupported') }}"
 
 # Latest official kiwix-tools release, per Kiwix permalink redirects:
 # https://www.kiwix.org/en/downloads/kiwix-serve/

--- a/roles/kiwix/tasks/install.yml
+++ b/roles/kiwix/tasks/install.yml
@@ -1,8 +1,8 @@
 # 0. VERIFY CPU/OS ARCHITECTURE SUPPORTED
 
-- name: Force Ansible to exit (FAIL) if kiwix-tools appears unavailable for your CPU/OS architecture ({{ ansible_machine }})
+- name: Force Ansible to exit (FAIL) if kiwix-tools appears unavailable for your CPU/OS architecture ({{ ansible_facts.machine }})
   fail:
-    msg: "WARNING: kiwix-tools SOFTWARE APPEARS UNAVAILABLE FOR YOUR {{ ansible_machine }} CPU/OS ARCHITECTURE."
+    msg: "WARNING: kiwix-tools SOFTWARE APPEARS UNAVAILABLE FOR YOUR {{ ansible_facts.machine }} CPU/OS ARCHITECTURE."
   when: kiwix_arch == "unsupported"
 
 


### PR DESCRIPTION
### Fixes bug:   
Initial approach to clean #4138 

### Description of changes proposed in this pull request:   
Upgrade ansible calls to newer syntax, preventing future errors from deprecation.   
Check:
- kiwix - Size 1

### Smoke-tested on which OS or OS's:
* Debian 13
* Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 