### PR TITLE
familiar zoom and scroll control on maps

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -389,7 +389,10 @@
         </script>
     </head>
     <body>
-        <maps-black loader="pmtiles" navigationcontrol="true"></maps-black>
+	<!-- cooperativegestures (true by default) would require two-finger scroll, three finger tilt on phone,
+	     and ctrl-mouse-wheel to zoom on desktop. I guess these are useful for small maps widgets on a page to
+	     avoid accidental scrolling and whatnot. -->
+        <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false"></maps-black>
         <script>
           mb = document.getElementsByTagName("maps-black")[0];
           readHash()


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/pull/4120#issuecomment-3506892482

### Description of changes proposed in this pull request:

Restore the map's scrolling and zooming controls to what we all know and love. One finger to scroll and two to tilt on phone, ctrl key no longer needed to zoom on desktop.

So now we have:

* **Phone**: **one** finger scroll, **two** finger rotate, zoom and tilt
* **Desktop**: mouse drag to scroll, mouse-wheel to zoom, **ctrl**-drag to tilt and rotate

Previously we had:

* **Phone**: **two** finger scroll, rotate, and zoom, **three** finger tilt
* **Desktop**: mouse drag to scroll, **ctrl**-mouse-wheel to zoom, **ctrl**-drag to tilt and rotate

It turns out that there's this thing called "Cooperative Gestures" that was turned on by default in maps.black. It gave us the more bureaucratic zoom and scroll and tilt controls. There's a good use for it though. If you have a small map in the middle of a blog post, you don't want to suddenly be scrolling or zooming the map when you're trying to scroll down the page.

### Smoke-tested on which OS or OS's:

* Vanadium browser on GrapheneOS
* Firefox on Linux
* Safari on iPad

### Mention a team member @username e.g. to help with code review:
@holta @avni 