### PR TITLE
runrole: Accept CLI arguments (and `--reinstall` flag) in any position

### DIFF
--- a/runrole
+++ b/runrole
@@ -30,14 +30,20 @@ while [[ $# -gt 0 ]]; do
         *)
             if [ ! -v ROLE_NAME ]; then    # Test whether var is not yet set
                 ROLE_NAME="$1"
-                export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
-            else
+            elif [ ! -v ANSIBLE_LOG_PATH ]; then
                 export ANSIBLE_LOG_PATH="$1"
+            else
+                echo "Too many argunments (ROLE_NAME and ANSIBLE_LOG_PATH already specified!)"
+                exit 1
             fi
             ;;
     esac
     shift
 done
+
+if [ -v ANSIBLE_LOG_PATH ]; then
+    export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"    # Default log file location
+fi
 
 if [ ! -v ROLE_NAME ]; then    # Test whether var is STILL not set!
     echo "Usage: ./runrole <name of role>"
@@ -45,7 +51,7 @@ if [ ! -v ROLE_NAME ]; then    # Test whether var is STILL not set!
     echo
     echo "Optional 2nd parameter is full PATH/FILENAME for logging."
     echo "If omitted, <current directory>/iiab-debug.log is used."
-    exit 0
+    exit 1
 fi
 
 
@@ -85,7 +91,7 @@ cp scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
 
 # Ansible role name & var name sometimes differ :/
-if [ $ROLE_NAME == "calibre-web" ]; then 
+if [ $ROLE_NAME == "calibre-web" ]; then
     ROLE_VAR=calibreweb
 #elif [ $ROLE_NAME == "httpd" ]; then
 #    ROLE_VAR=apache

--- a/runrole
+++ b/runrole
@@ -21,11 +21,10 @@ fi
 
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash/14203146#14203146
 while [[ $# -gt 0 ]]; do
-    case $1 in
+    case $1 in    # if-else would do the job, but case statement allows for future changes...
         --reinstall)
             ARGS="$ARGS\"reinstall\":True,"    # Needs boolean not string so use JSON list
             REINSTALL=true
-            shift
             ;;
         *)
             if [ ! -v ROLE_NAME ]; then    # Test whether var is not yet set
@@ -34,9 +33,9 @@ while [[ $# -gt 0 ]]; do
             else
                 export ANSIBLE_LOG_PATH="$1"
             fi
-            shift
             ;;
     esac
+    shift
 done
 
 if [ ! -v ROLE_NAME ]; then    # Test whether var is STILL not set!

--- a/runrole
+++ b/runrole
@@ -3,8 +3,9 @@
 DEFAULT_VARS_FILE=/opt/iiab/iiab/vars/default_vars.yml
 LOCAL_VARS_FILE=/etc/iiab/local_vars.yml
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
-#ROLE_NAME=""    # Don't initialize this
-#ROLE_VAR=""     # No need to initialize this
+#ROLE_NAME=""           # Don't initialize this
+#ROLE_VAR=""            # No need to initialize this
+#ANSIBLE_LOG_PATH=""    # Don't initialize this
 INSTALL=false
 ENABLED=false
 REINSTALL=false

--- a/runrole
+++ b/runrole
@@ -3,7 +3,8 @@
 DEFAULT_VARS_FILE=/opt/iiab/iiab/vars/default_vars.yml
 LOCAL_VARS_FILE=/etc/iiab/local_vars.yml
 IIAB_STATE_FILE=/etc/iiab/iiab_state.yml
-ROLE_VAR=""
+#ROLE_NAME=""    # Don't initialize this
+#ROLE_VAR=""     # No need to initialize this
 INSTALL=false
 ENABLED=false
 REINSTALL=false
@@ -90,6 +91,8 @@ if [ $ROLE_NAME == "calibre-web" ]; then
 #    ROLE_VAR=apache
 elif [ $ROLE_NAME == "osm-vector-maps" ]; then    # TO BE REMOVED in 2026/2027
     ROLE_VAR=osm_vector_maps
+else
+    ROLE_VAR="$ROLE_NAME"
 fi
 
 echo

--- a/runrole
+++ b/runrole
@@ -19,19 +19,33 @@ if [ ! -f $PLAYBOOK ]; then
     exit 1
 fi
 
-if [ $# -eq 0 ] || [ "$2" == "--reinstall" ] || [ "$3" == "--reinstall" ]; then
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash/14203146#14203146
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --reinstall)
+            ARGS="$ARGS\"reinstall\":True,"    # Needs boolean not string so use JSON list
+            REINSTALL=true
+            shift
+            ;;
+        *)
+            if [ ! -v ROLE_NAME ]; then    # Test whether var is not yet set
+                ROLE_NAME="$1"
+                export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
+            else
+                export ANSIBLE_LOG_PATH="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ ! -v ROLE_NAME ]; then    # Test whether var is STILL not set!
     echo "Usage: ./runrole <name of role>"
-    echo "Usage: ./runrole --reinstall <name of role>"
+    echo "Usage: ./runrole <name of role> --reinstall"
     echo
     echo "Optional 2nd parameter is full PATH/FILENAME for logging."
     echo "If omitted, <current directory>/iiab-debug.log is used."
     exit 0
-fi
-
-if [ "$1" == "--reinstall" ]; then
-    ARGS="$ARGS\"reinstall\":True,"    # Needs boolean not string so use JSON list
-    REINSTALL=true
-    shift
 fi
 
 
@@ -61,7 +75,7 @@ if [ ! -f  $IIAB_STATE_FILE ]; then    # touch $IIAB_STATE_FILE
 EOF
 fi
 
-if ! [[ $(command -v ansible) ]]; then
+if ! command -v ansible > /dev/null; then
     echo -e "\n\e[1mPlease install Ansible, by running:\n\nsudo /opt/iiab/iiab/scripts/ansible\e[0m\n"
     exit 1
 fi
@@ -70,12 +84,12 @@ mkdir -p /etc/ansible/facts.d
 cp scripts/local_facts.fact /etc/ansible/facts.d/local_facts.fact
 
 
-ROLE_VAR=$1    # Ansible role name & var name sometimes differ :/
-if [ $1 == "calibre-web" ]; then 
+# Ansible role name & var name sometimes differ :/
+if [ $ROLE_NAME == "calibre-web" ]; then 
     ROLE_VAR=calibreweb
-elif [ $1 == "httpd" ]; then
-    ROLE_VAR=apache
-elif [ $1 == "osm-vector-maps" ]; then
+#elif [ $ROLE_NAME == "httpd" ]; then
+#    ROLE_VAR=apache
+elif [ $ROLE_NAME == "osm-vector-maps" ]; then    # TO BE REMOVED in 2026/2027
     ROLE_VAR=osm_vector_maps
 fi
 
@@ -126,13 +140,7 @@ if ! $INSTALL; then
 fi
 
 
-if [ $# -eq 2 ]; then
-   export ANSIBLE_LOG_PATH="$2"
-else
-   export ANSIBLE_LOG_PATH="$CWD/iiab-debug.log"
-fi
-
-ARGS="$ARGS\"role_to_run\":\"$1\"}"    # $1 works like \"$1\" if str type validated
+ARGS="$ARGS\"role_to_run\":\"$ROLE_NAME\"}"    # $ROLE_NAME works like \"$ROLE_NAME\" if str type validated
 CMD="ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local $ARGS"
 echo -e "\e[1mbash will now run this, adding single quotes around the {...} curly braces:\e[0m\n\n$CMD\n"
 ansible -m setup -i $INVENTORY localhost --connection=local | grep python


### PR DESCRIPTION
### Fixes bug:

- https://github.com/iiab/iiab/pull/4145#issuecomment-3519537501

### Description of changes proposed in this pull request:

Refactor command-line argument parsing and update logging path handling.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 (latest pre-release) but needs more testing!  @muthuri-dev can you help?

Please see https://FAQ.IIAB.IO for an explanation (& examples) on how to use the `./runrole <IIAB ROLE>` command (as root!) after you run: `cd /opt/iiab/iiab`

### Mention a team member @username e.g. to help with code review:

@orblivion @muthuri-dev