### PR TITLE
Map style changes: Make "hybrid" style the default, better choices for other style options

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -78,7 +78,7 @@
 
                 // Set this whether or not we have the hash, unlike the other parameters.
                 // We still need to set a default here.
-                mapStyleChoice = _mapStyleChoice || "natural"
+                mapStyleChoice = _mapStyleChoice || "hybrid"
 
                 if (window.location.hash) {
                     mb.lat = lat || 0

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -112,13 +112,13 @@
                     mb.mapstyle = {
                         // Has nicely colored regions, and buildings
                         natural: {
-                            true:  "openstreetmap-openmaptiles/maputnik/liberty",
-                            false: "naturalearth-openmaptiles/maputnik/liberty",
+                            true:  "openstreetmap-openmaptiles/openfreemap/liberty",
+                            false: "naturalearth-openmaptiles/openfreemap/liberty",
                         },
                         // Has more clearly defined political boundaries
                         // TODO - find something like this with buildings too?
                         political:  {
-                            true:  "openstreetmap-openmaptiles/openmaptiles/basic",
+                            true:  "openstreetmap-openmaptiles/qwant/basic",
                             false: undefined, // We will hide this option for naturalearth since it's not great for political maps - TODO Extract a low res osm for political map.
                         },
                         hybrid:  {

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -389,9 +389,7 @@
         </script>
     </head>
     <body>
-	<!-- cooperativegestures (true by default) would require two-finger scroll, three finger tilt on phone,
-	     and ctrl-mouse-wheel to zoom on desktop. I guess these are useful for small maps widgets on a page to
-	     avoid accidental scrolling and whatnot. -->
+        {# `cooperativegestures=false` provides familiar zoom/scroll/tilt controls for fullscreen #}
         <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false"></maps-black>
         <script>
           mb = document.getElementsByTagName("maps-black")[0];


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

* Set the initial view (i.e. no "hash" in the URL) to "hybrid" (aka Satellite + Map). This is similar to the previous (osm-vector-maps, 2020) map app. It is arguably more "impressive" to our target audience to see this right away. (to be clear, unlike the below changes, this **does not change** how the hybrid view looks, it just makes it the initial view)
* Change how the "natural" and "political" maps look. I changed the "mapstyle" for both. IMHO they are improvements.
    * "natural" map: The previous version had location names in English (assuming you're using English settings in your browser, at least), but I noticed a lot of the local language names were not there, particularly in the middle east and Africa. This new version fixes this. It otherwise looks very similar from what I can tell.
    * "political" map: This one actually looks different. The colors have a higher contrast. And maybe some better labeling for US states, sometimes. It can be improved further with more work, but this was a simple improvement for now.

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
