### PR TITLE
Update some map data and switch to new download source.

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -4,7 +4,7 @@
 maps_dot_black_small_assets_url: https://v1.maps.black
 maps_dot_black_tiles_url: https://maps.black
 unpkg_url: https://unpkg.com
-s3_url: https://iiab-maps.danielkrol.com/0
+iiab_map_host_url: https://iiab.switnet.org/maps/0
 
 # TODO I wonder if it should go under /library/maps/vector_tiles and symlink from the www directory.
 # That way it would be near the search data. It would be easier to find everything.
@@ -73,8 +73,8 @@ maps_dot_black_vector_tiles:
   osm-full:
     name: openstreetmap-openmaptiles-full.pmtiles
     filename: openstreetmap-openmaptiles-full.pmtiles # NOTE - saves as different filename than the source URL to make room for the symlink
-    src_url: "{{ maps_dot_black_tiles_url }}/openstreetmap-openmaptiles.pmtiles"
-    sha256sum: 340eaa51be2717faa23c5e6ee1c444b4e3c9064e79faf1f3ba1782b9ac1903cf
+    src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles.pmtiles"
+    sha256sum: 95b90ef180b15f6496d01f7437a9ed058d2a1b61ac5dba32f43790010acba77c
 
   # "medium res" osm, up to zoom level 9 (original file has 14). 1.9GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
@@ -82,8 +82,8 @@ maps_dot_black_vector_tiles:
   osm-z9:
     name: openstreetmap-openmaptiles-zoom_0-09.pmtiles
     filename: openstreetmap-openmaptiles-zoom_0-09.pmtiles
-    src_url: "{{ s3_url }}/openstreetmap-openmaptiles-zoom_0-09.pmtiles"
-    sha256sum: 3295bce449ff523c82b319a3ca0c4f49d613ba9d55a90ba2b8db3df9d66403b7
+    src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles-zoom_0-09.pmtiles"
+    sha256sum: 32fc190bd9009c54b8fc826e215ea4a73ee34de4bbac500cf4fe56eee4f12bdc
 
   # "low res" - mostly borders, rivers, country names, large roads. 85MB
   # maps_vector_quality = "ne"
@@ -101,7 +101,7 @@ maps_dot_black_satellite_tiles:
   7:
     name: s2maps-sentinel2-2023-zoom_0-07.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-07.pmtiles
-    src_url: "{{ s3_url }}/s2maps-sentinel2-2023-zoom_0-07.pmtiles"
+    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-07.pmtiles"
     sha256sum: a97e35ac88e7e99bf467eef921f5af9955844ecf74f399eec4bdb36f37108f4f
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13), 1.2GiB
@@ -109,7 +109,7 @@ maps_dot_black_satellite_tiles:
   9:
     name: s2maps-sentinel2-2023-zoom_0-09.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-09.pmtiles
-    src_url: "{{ s3_url }}/s2maps-sentinel2-2023-zoom_0-09.pmtiles"
+    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-09.pmtiles"
     sha256sum: 544cec6533aca91a504ee274ea3dc64c39cc401b464f6470dd3e7bf2e55a3943
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13), 21GiB
@@ -117,7 +117,7 @@ maps_dot_black_satellite_tiles:
   11:
     name: s2maps-sentinel2-2023-zoom_0-11.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-11.pmtiles
-    src_url: "{{ s3_url }}/s2maps-sentinel2-2023-zoom_0-11.pmtiles"
+    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-11.pmtiles"
     sha256sum: e7215559fcbfb48a0d45452931f6e258834eeb2d8a6acc927a7e4b49b8fb0116
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13), 80GiB
@@ -125,7 +125,7 @@ maps_dot_black_satellite_tiles:
   12:
     name: s2maps-sentinel2-2023-zoom_0-12.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-12.pmtiles
-    src_url: "{{ s3_url }}/s2maps-sentinel2-2023-zoom_0-12.pmtiles"
+    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-12.pmtiles"
     sha256sum: 81aa6eb7ed64714e8bc58596bcb1e1c0cf345cb211a78ccf1fd3145466b97c83
 
 nominatim_db_symlink_name: mydb.sqlite
@@ -138,7 +138,7 @@ nominatim_data:
   False:
     name: "{{ nominatim_db_basic_name }}"
     filename: "{{ nominatim_db_basic_name }}"
-    src_url: "{{ s3_url }}/{{ nominatim_db_basic_name }}"
+    src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_basic_name }}"
     # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
     # TODO - Make a basic small whole-world map, at least as good as previous maps
     sha256sum: 4c87584c9f8e58fdf9072257d7f25605132ef613a1aa1e922525d52b9be7a8e2
@@ -148,5 +148,5 @@ nominatim_data:
   True:
     name: "{{ nominatim_db_full_name }}"
     filename: "{{ nominatim_db_full_name }}"
-    src_url: "{{ s3_url }}/{{ nominatim_db_full_name }}"
+    src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_full_name }}"
     sha256sum: bb9e95c644298aca3154bf6436939bbb305511dde4563d2a1743916e819864fc


### PR DESCRIPTION

### Fixes bug:

* sha256sum errors when installing "osm-full" vector tiles
    * maps.black has been (thankfully!) seemingly updating its vector map tiles about once a month.
* My impending S3 bill, for all of the other downloads associated with the map.

### Description of changes proposed in this pull request:

* Change map data download source from S3 bucket to switnet.org for all items currently in S3 bucket
* Change map data download source from maps.black to switnet.org for full osm vector map
    * If we control the data and update cadence ourselves, we prevent needing to update checksums every month.
* Update sha256sums for osm-full and osm-z9 (I made a new osm-z9 for good measure to make sure its data matches osm-full)
    * Both updated files have been uploaded to switnet already

### Smoke-tested on which OS or OS's:

I tried a few of the downloads via Ansible on Trixie on a Pi 500. I still need to try the very biggest files: vector osm-full and satellite 12, assuming you want those tested before merging.

### Mention a team member @username e.g. to help with code review:
@holta 