### PR TITLE
[code] fix vars misplacing at f808e35 ["Code on the Go"]

### DIFF
--- a/.github/workflows/tests/expected_state_medium.yml
+++ b/.github/workflows/tests/expected_state_medium.yml
@@ -24,3 +24,4 @@ awstats_installed: True
 matomo_installed: True
 captiveportal_installed: True
 calibreweb_installed: True
+code_installed: True

--- a/roles/0-init/tasks/disallow_install_false_with_enabled_true.yml
+++ b/roles/0-init/tasks/disallow_install_false_with_enabled_true.yml
@@ -262,6 +262,12 @@
     fail_msg: "DISALLOWED: 'calibre_install: False' WITH 'calibre_enabled: True' -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 variable values e.g. in /etc/iiab/local_vars.yml, and other places variables are defined?"
     quiet: yes
 
+- name: "DISALLOW 'code_install: False' WITH 'code_enabled: True'"
+  assert:
+    that: code_install or not code_enabled
+    fail_msg: "DISALLOWED: 'code_install: False' WITH 'code_enabled: True' -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 variable values e.g. in /etc/iiab/local_vars.yml, and other places variables are defined?"
+    quiet: yes
+
 - name: "DISALLOW 'pbx_install: False' WITH 'pbx_enabled: True'"
   assert:
     that: pbx_install or not pbx_enabled

--- a/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
+++ b/roles/0-init/tasks/disallow_install_false_with_installed_defined.yml
@@ -267,6 +267,12 @@
     fail_msg: "DISALLOWED: 'calibre_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'calibre_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
     quiet: yes
 
+- name: "DISALLOW 'code_install: False' WHEN code_installed is defined"
+  assert:
+    that: code_install or code_installed is undefined
+    fail_msg: "DISALLOWED: 'code_install: False' (e.g. in /etc/iiab/local_vars.yml) WHEN 'code_installed' is defined (e.g. in /etc/iiab/iiab_state.yml) -- IIAB DOES NOT SUPPORT UNINSTALLS -- please verify those 2 files especially, and other places variables are defined?"
+    quiet: yes
+
 - name: "DISALLOW 'pbx_install: False' WHEN pbx_installed is defined"
   assert:
     that: pbx_install or pbx_installed is undefined

--- a/roles/0-init/tasks/validate_enabled_vars_boolean.yml
+++ b/roles/0-init/tasks/validate_enabled_vars_boolean.yml
@@ -262,6 +262,12 @@
     fail_msg: "VARIABLE MUST BE BOOLEAN: 'calibre_enabled' now has type '{{ calibre_enabled | type_debug }}' and value '{{ calibre_enabled }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var code_enabled is type boolean (NOT type string, which can invert logic!)
+  assert:
+    that: code_enabled | type_debug == 'bool'
+    fail_msg: "VARIABLE MUST BE BOOLEAN: 'code_enabled' now has type '{{ code_enabled | type_debug }}' and value '{{ code_enabled }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var pbx_enabled is type boolean (NOT type string, which can invert logic!)
   assert:
     that: pbx_enabled | type_debug == 'bool'

--- a/roles/0-init/tasks/validate_enabled_vars_defined.yml
+++ b/roles/0-init/tasks/validate_enabled_vars_defined.yml
@@ -262,6 +262,12 @@
     fail_msg: "VARIABLE MUST BE DEFINED: 'calibre_enabled' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var code_enabled is defined
+  assert:
+    that: code_enabled is defined
+    fail_msg: "VARIABLE MUST BE DEFINED: 'code_enabled' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var pbx_enabled is defined
   assert:
     that: pbx_enabled is defined

--- a/roles/0-init/tasks/validate_install_vars_boolean.yml
+++ b/roles/0-init/tasks/validate_install_vars_boolean.yml
@@ -262,6 +262,12 @@
     fail_msg: "VARIABLE MUST BE BOOLEAN: 'calibre_install' now has type '{{ lookup('vars', 'calibre_install') | type_debug }}' and value '{{ lookup('vars', 'calibre_install') }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var code_install is type boolean (NOT type string, which can invert logic!)
+  assert:
+    that: code_install | type_debug == 'bool'
+    fail_msg: "VARIABLE MUST BE BOOLEAN: 'code_install' now has type '{{ lookup('vars', 'code_install') | type_debug }}' and value '{{ lookup('vars', 'code_install') }}' -- PLEASE SET A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var pbx_install is type boolean (NOT type string, which can invert logic!)
   assert:
     that: pbx_install | type_debug == 'bool'

--- a/roles/0-init/tasks/validate_install_vars_defined.yml
+++ b/roles/0-init/tasks/validate_install_vars_defined.yml
@@ -262,6 +262,12 @@
     fail_msg: "VARIABLE MUST BE DEFINED: 'calibre_install' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
     quiet: yes
 
+- name: Assert that var code_install is defined
+  assert:
+    that: code_install is defined
+    fail_msg: "VARIABLE MUST BE DEFINED: 'code_install' NEEDS A PROPER (UNQUOTED) ANSIBLE BOOLEAN VALUE e.g. IN: /etc/iiab/local_vars.yml"
+    quiet: yes
+
 - name: Assert that var pbx_install is defined
   assert:
     that: pbx_install is defined

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -1,3 +1,21 @@
+- name: "Set 'nginx_install: True' and 'nginx_enabled: True'"
+  set_fact:
+    nginx_install: True
+    nginx_enabled: True
+
+- name: "NGINX - run 'nginx' role (attempt to install & enable nginx)"
+  include_role:
+    name: nginx
+
+- name: FAIL (STOP THE INSTALL) IF 'nginx_installed is undefined'
+  fail:
+    msg: "code install cannot proceed, as nginx is not installed."
+  when: nginx_installed is undefined
+
+- name: Record (initial) disk space used
+  shell: df -B1 --output=used / | tail -1
+  register: df1
+
 - name: Make code directories available
   ansible.builtin.file:
     path: "{{ item }}"
@@ -41,3 +59,27 @@
     - es
 
 - include_tasks: install_apkfile.yml
+
+
+# RECORD CODE AS INSTALLED
+
+- name: Record (final) disk space used
+  shell: df -B1 --output=used / | tail -1
+  register: df2
+
+- name: Add 'code_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
+  ini_file:
+    path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
+    section: code
+    option: code_disk_usage
+    value: "{{ df2.stdout | int - df1.stdout | int }}"
+
+- name: "Set 'code_installed: True'"
+  set_fact:
+    code_installed: True
+
+- name: "Add 'code_installed: True' to {{ iiab_state_file }}"
+  lineinfile:
+    path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
+    regexp: '^code_installed'
+    line: 'code_installed: True'

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -2,6 +2,7 @@
   shell: df -B1 --output=used / | tail -1
   register: df1
 
+
 - name: Make code directories available
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -1,17 +1,3 @@
-- name: "Set 'nginx_install: True' and 'nginx_enabled: True'"
-  set_fact:
-    nginx_install: True
-    nginx_enabled: True
-
-- name: "NGINX - run 'nginx' role (attempt to install & enable nginx)"
-  include_role:
-    name: nginx
-
-- name: FAIL (STOP THE INSTALL) IF 'nginx_installed is undefined'
-  fail:
-    msg: "code install cannot proceed, as nginx is not installed."
-  when: nginx_installed is undefined
-
 - name: Record (initial) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df1

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -420,8 +420,8 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # Code On The Go, is an open source offline Android IDE by the App Dev for All team
-code_install: False
-code_enabled: False
+code_install: True
+code_enabled: True
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -420,8 +420,8 @@ calibre_web_path: calibre  #NEEDS WORK: https://github.com/iiab/iiab/issues/529
 # Avoid URL collisions w/ calibreweb_url1, calibreweb_url2, calibreweb_url3 below!
 
 # Code On The Go, is an open source offline Android IDE by the App Dev for All team
-code_install: True
-code_enabled: True
+code_install: False
+code_enabled: False
 
 # A full-featured PBX (for rural telephony, etc) based on Asterisk and FreePBX.
 # INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/pbx#readme


### PR DESCRIPTION
### Fixes bug:
- Fix misplaced variables when sorting them out at #4159
- ToDo:
  - Add the validate part.
  - Set disk usage impact

### Description of changes proposed in this pull request:
Medium vars size should set code vars as True   
While small should stay small, setting them to False as the original PR #4151 

### Smoke-tested on which OS or OS's:
- Trisquel 12
- Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 

Thanks to @jvonau for noticing the mistake.

Regards o/