### PR TITLE
Use bind-dynamic for all distros in dnsmasq config (fixes #4099)

### DIFF
--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -5,6 +5,7 @@
 #   #ignore_errors: True # pre 17.10 doesn't use netplan
 #   when: is_ubuntu
 
+
 - name: Restart wpa_supplicant service
   systemd:
     name: "{{ item }}"

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -5,7 +5,6 @@
 #   #ignore_errors: True # pre 17.10 doesn't use netplan
 #   when: is_ubuntu
 
-
 - name: Restart wpa_supplicant service
   systemd:
     name: "{{ item }}"
@@ -90,7 +89,7 @@
     name: avahi-daemon
     state: restarted
 
-#netplan de-configures pre-created bridged interfaces 
+#netplan de-configures pre-created bridged interfaces
 #- name: Reload netplan when Wifi is not gateway on Ubuntu 18+
 #  shell: netplan apply
 #  when: not no_net_restart and is_ubuntu and netplan.stdout.find("yaml") != -1
@@ -103,7 +102,7 @@
 
 - name: Checking if WiFi slave is active
   shell: bridge -d link | grep {{ iiab_wireless_lan_iface }} | wc -l
-#  when: hostapd_enabled and discovered_wireless_iface != iiab_wan_iface and iiab_lan_iface == "br0"
+  #  when: hostapd_enabled and discovered_wireless_iface != iiab_wan_iface and iiab_lan_iface == "br0"
   when: hostapd_enabled and iiab_lan_iface == "br0"
   register: wifi_slave
 
@@ -113,6 +112,10 @@
     state: restarted
   when: hostapd_enabled and not no_net_restart and wifi_slave.stdout is defined and wifi_slave.stdout == 0
 
+# GitHub Actions detects Appliance mode (no interfaces) → restart skipped → safe
+# IMPORTANT: dnsmasq restart by network mode (GitHub issue #4099)
+# Appliance: No LAN, restart SKIPPED
+# LanController/Gateway: Have LAN, restart REQUIRED (uses bind-dynamic to avoid race condition)
 #systemd-networkd should have br0 available if hostapd was started and Appliance lacks br0
 #keep an eye on legacy wifi installs where br0 is present but not 'online' with an ip address
 #due to hostapd didn't go to a carrier state. All others should get dnsmasq restarted

--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,16 +1,3 @@
-# #IIAB
-# {% if is_raspbian %}
-# bind-dynamic
-# {% else %}
-# bind-interfaces
-# {% endif %}
-# {% if wan_nameserver is not none %}
-# # Wan nameserver if manually set
-# no-resolv
-# server={{ wan_nameserver }}
-# {% endif %}
-
-
 
 #IIAB
 # Use bind-dynamic for all distros (fixes GitHub issue #4099)

--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,4 +1,3 @@
-
 #IIAB
 # Use bind-dynamic for all distros (fixes GitHub issue #4099)
 # Allows dnsmasq to bind to br0 even if interface lacks IP yet

--- a/roles/network/templates/network/dnsmasq-iiab
+++ b/roles/network/templates/network/dnsmasq-iiab
@@ -1,9 +1,21 @@
+# #IIAB
+# {% if is_raspbian %}
+# bind-dynamic
+# {% else %}
+# bind-interfaces
+# {% endif %}
+# {% if wan_nameserver is not none %}
+# # Wan nameserver if manually set
+# no-resolv
+# server={{ wan_nameserver }}
+# {% endif %}
+
+
+
 #IIAB
-{% if is_raspbian %}
+# Use bind-dynamic for all distros (fixes GitHub issue #4099)
+# Allows dnsmasq to bind to br0 even if interface lacks IP yet
 bind-dynamic
-{% else %}
-bind-interfaces
-{% endif %}
 {% if wan_nameserver is not none %}
 # Wan nameserver if manually set
 no-resolv


### PR DESCRIPTION
- Remove conditional bind-dynamic/bind-interfaces logic for Raspbian vs other distros
- Apply bind-dynamic universally to resolve dnsmasq restart race condition
- Allows dnsmasq to bind to br0 even when interface lacks IP address yet
- Addresses intermittent "Unable to restart service dnsmasq" failures during MEDIUM installations
- Alternative to arbitrary wait times: bind-dynamic performs soft bind that doesn't require fully functional interface.
@jvonau Are there any other improvements or considerations I should address?

fixes issue :1st_place_medal: https://github.com/iiab/iiab/issues/4099