### PR TITLE
[proot] make runrole/runroles safe for proot/android to run.

### DIFF
--- a/run-one-role.yml
+++ b/run-one-role.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
   become: yes
+  gather_facts: false
 
   vars_files:
     - vars/default_vars.yml
@@ -8,6 +9,34 @@
     #- vars/{{ ansible_local.local_facts.os_ver }}.yml
     - /etc/iiab/local_vars.yml
     - /etc/iiab/iiab_state.yml
+
+  pre_tasks:
+    - name: Gather facts without hardware subset # android safe
+      ansible.builtin.setup:
+        gather_subset:
+          - 'all'
+          - '!hardware'
+
+    - name: Compute memory and swap facts when hardware subset is missing
+      when: ansible_swaptotal_mb is not defined or ansible_memtotal_mb is not defined
+      block:
+        - name: Read memtotal and swaptotal from /proc/meminfo
+          ansible.builtin.shell: |
+            awk '
+              /MemTotal:/ {mem=int($2/1024)}
+              /SwapTotal:/ {swap=int($2/1024)}
+              END {
+                if (swap == "") swap = 0
+                print mem, swap
+              }
+            ' /proc/meminfo
+          register: memswap
+          changed_when: false
+
+        - name: Set fallback memtotal and swaptotal facts
+          ansible.builtin.set_fact:
+            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] }}"
+            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] }}"
 
   roles:
     - { role: 0-init }

--- a/runrole
+++ b/runrole
@@ -152,7 +152,7 @@ fi
 ARGS="$ARGS\"role_to_run\":\"$ROLE_NAME\"}"    # $ROLE_NAME works like \"$ROLE_NAME\" if str type validated
 CMD="ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local $ARGS"
 echo -e "\e[1mbash will now run this, adding single quotes around the {...} curly braces:\e[0m\n\n$CMD\n"
-ansible -m setup -i $INVENTORY localhost --connection=local | grep python
+ansible -m ansible.builtin.setup -a 'gather_subset=all,!hardware' -i $INVENTORY localhost --connection=local | grep python
 $CMD
 
 # bash forces (NECESSARY) single quotes around {} at runtime (if $ARGS contains

--- a/runroles-base.yml
+++ b/runroles-base.yml
@@ -1,12 +1,41 @@
 ---
 - hosts: all
   become: yes
+  gather_facts: false
 
   vars_files:
     - vars/default_vars.yml
     # ansible-core 2.19 disallows (thankfully not needed!)
     #- vars/{{ ansible_local.local_facts.os_ver }}.yml
     - /etc/iiab/local_vars.yml
+
+  pre_tasks:
+    - name: Gather facts without hardware subset # android safe
+      ansible.builtin.setup:
+        gather_subset:
+          - 'all'
+          - '!hardware'
+
+    - name: Compute memory and swap facts when hardware subset is missing
+      when: ansible_swaptotal_mb is not defined or ansible_memtotal_mb is not defined
+      block:
+        - name: Read memtotal and swaptotal from /proc/meminfo
+          ansible.builtin.shell: |
+            awk '
+              /MemTotal:/ {mem=int($2/1024)}
+              /SwapTotal:/ {swap=int($2/1024)}
+              END {
+                if (swap == "") swap = 0
+                print mem, swap
+              }
+            ' /proc/meminfo
+          register: memswap
+          changed_when: false
+
+        - name: Set fallback memtotal and swaptotal facts
+          ansible.builtin.set_fact:
+            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] }}"
+            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] }}"
 
   roles:
     - { role: 0-init }


### PR DESCRIPTION
### Fixes bug:
Prevents breaking runrole mechanics due calling restricted commands like lspci via setup module on Android environments.

Companion PR to #4122 

### Description of changes proposed in this pull request:
Disable full ansible.builtin.setup to avoid the hardware subset and custom tailor vars gathered from it only if such variables are not defined.

### Smoke-tested on which OS or OS's:
Debian / Android 15

### Mention a team member @username e.g. to help with code review:
@holta  
should this one be part of #4122 or is it ok to split it here.