### PR TITLE
Update MediaWiki version to new 1.45.1 [fails on recent OS's with PHP 8.4+ due to Parsoid]

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: "1.44"    # "1.40" quotes nec if trailing zero
-mediawiki_minor_version: 2
+mediawiki_major_version: "1.45"    # "1.40" quotes nec if trailing zero
+mediawiki_minor_version: 0
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"

--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -5,7 +5,7 @@
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
 mediawiki_major_version: "1.45"    # "1.40" quotes nec if trailing zero
-mediawiki_minor_version: 0
+mediawiki_minor_version: 1
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
Pre-announcement:

https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/IKP5247UU7EZZEM2U4R5AHNULP2YFKDF/

Related:

- #4168

Building on:

- PR #4034