### PR TITLE
[WIP] Obtain map data via meta links using aria2c

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -16,6 +16,22 @@ nominatim_home: /srv/nominatim
 nominatim_num_workers_procs: 1 # 4 seems to freeze it up if I make too many requests. But, maybe 1 is too few. Also, optimal on Pi Zero may be lower.
 nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 
+# `maps_data_date` is for data that changes all the time (osm vector data,
+#     search [eventually!])
+# `maps_slow_data_date` is for big data that changes rarely if ever (satellite,
+#     natural earth, terrain, search [for now!])
+#
+# It sucks to have up-to-date files with different dates, but the alternative
+# is to force the user to download the same satellite file over and over every
+# time the vector data changes. This is why we have the "slow" designation.
+# Some of it may never change. Some of it, like search, will probably start
+# changing much faster once we're ready for it. We can even decide on multiple
+# date designations down the line. I just want one "slow" date to set all of
+# these items *for now*.
+#
+maps_data_date: 2025-12-10
+maps_slow_data_date: 2025-12-10
+
 # TODO host our own assets and tiles? Because they may get updated which will break our checksums.
 # TODO s/filename/remotesubpath?
 
@@ -55,9 +71,7 @@ maplibre_search_js_and_styles:
 
 maps_dot_black_common_tiles:
   # Mostly colors, topography, etc. 58M
-  - name: naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles
-    filename: naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles
-    src_url: "{{ maps_dot_black_tiles_url }}/naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
+  - "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.pmtiles"
 
 maps_dot_black_vector_symlink_name: openstreetmap-openmaptiles.pmtiles
 
@@ -69,74 +83,48 @@ maps_dot_black_vector_tiles:
   # "high res" full osm, including 3d buildings. 78GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-full"
-  osm-full:
-    name: openstreetmap-openmaptiles-full.pmtiles
-    filename: openstreetmap-openmaptiles-full.pmtiles # NOTE - saves as different filename than the source URL to make room for the symlink
-    src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles.pmtiles"
+  osm-full: "openstreetmap-openmaptiles.{{ map_data_date }}.full.pmtiles"
 
   # "medium res" osm, up to zoom level 9 (original file has 14). 1.9GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
-  osm-z9:
-    name: openstreetmap-openmaptiles-zoom_0-09.pmtiles
-    filename: openstreetmap-openmaptiles-zoom_0-09.pmtiles
-    src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles-zoom_0-09.pmtiles"
+  osm-z9: "openstreetmap-openmaptiles.{{ map_data_date }}.zoom_0-09.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads. 85MB
   # maps_vector_quality = "ne"
-  ne: # for "Natural Earth"
-    name: naturalearth-openmaptiles.pmtiles
-    filename: naturalearth-openmaptiles.pmtiles
-    src_url: "{{ maps_dot_black_tiles_url }}/naturalearth-openmaptiles.pmtiles"
+  # (ne = "Natural Earth")
+  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.pmtiles"
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
 maps_dot_black_satellite_tiles:
   # Low quality satellite, up to zoom level 7 (original file has 13), 85MiB
   # maps_sat_zoom = 7
-  7:
-    name: s2maps-sentinel2-2023-zoom_0-07.pmtiles
-    filename: s2maps-sentinel2-2023-zoom_0-07.pmtiles
-    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-07.pmtiles"
+  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13), 1.2GiB
   # maps_sat_zoom = 9
-  9:
-    name: s2maps-sentinel2-2023-zoom_0-09.pmtiles
-    filename: s2maps-sentinel2-2023-zoom_0-09.pmtiles
-    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-09.pmtiles"
+  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13), 21GiB
   # maps_sat_zoom = 11
-  11:
-    name: s2maps-sentinel2-2023-zoom_0-11.pmtiles
-    filename: s2maps-sentinel2-2023-zoom_0-11.pmtiles
-    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-11.pmtiles"
+  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-11.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13), 80GiB
   # maps_sat_zoom = 12
-  12:
-    name: s2maps-sentinel2-2023-zoom_0-12.pmtiles
-    filename: s2maps-sentinel2-2023-zoom_0-12.pmtiles
-    src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-12.pmtiles"
+  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
-nominatim_db_symlink_name: mydb.sqlite
-nominatim_db_basic_name: mydb.basic.sqlite
-nominatim_db_full_name: mydb.full.sqlite
+nominatim_db_symlink_name: nominatim.sqlite
+nominatim_db_basic_name: "nominatim.{{ maps_slow_data_date }}.basic.sqlite"
+nominatim_db_full_name: "nominatim.{{ maps_slow_data_date }}.full.sqlite"
 
 nominatim_data:
   # Basic nominatim database
   # maps_search_full = False
-  False:
-    name: "{{ nominatim_db_basic_name }}"
-    filename: "{{ nominatim_db_basic_name }}"
-    src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_basic_name }}"
+  False: "{{ nominatim_db_basic_name }}"
     # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
     # TODO - Make a basic small whole-world map, at least as good as previous maps
 
   # Full nominatim database
   # maps_search_full = True
-  True:
-    name: "{{ nominatim_db_full_name }}"
-    filename: "{{ nominatim_db_full_name }}"
-    src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_full_name }}"
+  True: "{{ nominatim_db_full_name }}"

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -58,7 +58,6 @@ maps_dot_black_common_tiles:
   - name: naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles
     filename: naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles
     src_url: "{{ maps_dot_black_tiles_url }}/naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
-    sha256sum: 22b44759a3f4c7f6a6c7abdcc3dd48786ebbb96f9b3479e6692083e25021207b
 
 maps_dot_black_vector_symlink_name: openstreetmap-openmaptiles.pmtiles
 
@@ -74,7 +73,6 @@ maps_dot_black_vector_tiles:
     name: openstreetmap-openmaptiles-full.pmtiles
     filename: openstreetmap-openmaptiles-full.pmtiles # NOTE - saves as different filename than the source URL to make room for the symlink
     src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles.pmtiles"
-    sha256sum: 95b90ef180b15f6496d01f7437a9ed058d2a1b61ac5dba32f43790010acba77c
 
   # "medium res" osm, up to zoom level 9 (original file has 14). 1.9GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
@@ -83,7 +81,6 @@ maps_dot_black_vector_tiles:
     name: openstreetmap-openmaptiles-zoom_0-09.pmtiles
     filename: openstreetmap-openmaptiles-zoom_0-09.pmtiles
     src_url: "{{ iiab_map_host_url }}/openstreetmap-openmaptiles-zoom_0-09.pmtiles"
-    sha256sum: 32fc190bd9009c54b8fc826e215ea4a73ee34de4bbac500cf4fe56eee4f12bdc
 
   # "low res" - mostly borders, rivers, country names, large roads. 85MB
   # maps_vector_quality = "ne"
@@ -91,7 +88,6 @@ maps_dot_black_vector_tiles:
     name: naturalearth-openmaptiles.pmtiles
     filename: naturalearth-openmaptiles.pmtiles
     src_url: "{{ maps_dot_black_tiles_url }}/naturalearth-openmaptiles.pmtiles"
-    sha256sum: 5ff72ad4944fe64188802d45d5ee88c8c819c94d3b21eba8fae7b19a92a1cc3b
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
@@ -102,7 +98,6 @@ maps_dot_black_satellite_tiles:
     name: s2maps-sentinel2-2023-zoom_0-07.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-07.pmtiles
     src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-07.pmtiles"
-    sha256sum: a97e35ac88e7e99bf467eef921f5af9955844ecf74f399eec4bdb36f37108f4f
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13), 1.2GiB
   # maps_sat_zoom = 9
@@ -110,7 +105,6 @@ maps_dot_black_satellite_tiles:
     name: s2maps-sentinel2-2023-zoom_0-09.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-09.pmtiles
     src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-09.pmtiles"
-    sha256sum: 544cec6533aca91a504ee274ea3dc64c39cc401b464f6470dd3e7bf2e55a3943
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13), 21GiB
   # maps_sat_zoom = 11
@@ -118,7 +112,6 @@ maps_dot_black_satellite_tiles:
     name: s2maps-sentinel2-2023-zoom_0-11.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-11.pmtiles
     src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-11.pmtiles"
-    sha256sum: e7215559fcbfb48a0d45452931f6e258834eeb2d8a6acc927a7e4b49b8fb0116
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13), 80GiB
   # maps_sat_zoom = 12
@@ -126,7 +119,6 @@ maps_dot_black_satellite_tiles:
     name: s2maps-sentinel2-2023-zoom_0-12.pmtiles
     filename: s2maps-sentinel2-2023-zoom_0-12.pmtiles
     src_url: "{{ iiab_map_host_url }}/s2maps-sentinel2-2023-zoom_0-12.pmtiles"
-    sha256sum: 81aa6eb7ed64714e8bc58596bcb1e1c0cf345cb211a78ccf1fd3145466b97c83
 
 nominatim_db_symlink_name: mydb.sqlite
 nominatim_db_basic_name: mydb.basic.sqlite
@@ -141,7 +133,6 @@ nominatim_data:
     src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_basic_name }}"
     # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
     # TODO - Make a basic small whole-world map, at least as good as previous maps
-    sha256sum: 4c87584c9f8e58fdf9072257d7f25605132ef613a1aa1e922525d52b9be7a8e2
 
   # Full nominatim database
   # maps_search_full = True
@@ -149,4 +140,3 @@ nominatim_data:
     name: "{{ nominatim_db_full_name }}"
     filename: "{{ nominatim_db_full_name }}"
     src_url: "{{ iiab_map_host_url }}/{{ nominatim_db_full_name }}"
-    sha256sum: bb9e95c644298aca3154bf6436939bbb305511dde4563d2a1743916e819864fc

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -69,7 +69,7 @@ maplibre_search_js_and_styles:
 maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
 
 # Mostly colors, topography, etc. 58M
-maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.pmtiles"
+maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
 
 maps_dot_black_vector_symlink_name: openstreetmap-openmaptiles.pmtiles
 
@@ -91,7 +91,7 @@ maps_dot_black_vector_tiles:
   # "low res" - mostly borders, rivers, country names, large roads. 85MB
   # maps_vector_quality = "ne"
   # (ne = "Natural Earth")
-  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.pmtiles"
+  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.full.pmtiles"
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -71,7 +71,9 @@ maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pm
 # Mostly colors, topography, etc. 58M
 maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
 
-maps_dot_black_vector_symlink_name: openstreetmap-openmaptiles.pmtiles
+# Two different symlinks because the front end could requset openstreetmap or naturalearth
+maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
+maps_dot_black_ne_symlink_name: naturalearth-openmaptiles.pmtiles
 
 # File size circa Sept 2025
 # TODO - hopefully before this is merged, we'll get rid of "ne" (naturalearth)

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -66,11 +66,10 @@ maplibre_search_js_and_styles:
     filename: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.css"
     sha256sum: 9fc78e63cbec12058daefb460f630d203a23f209cac8e19a84d0b257e8325fc3
 
-# TODO symlink for maps_dot_black_common_tiles since I added the date
+maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
 
-maps_dot_black_common_tiles:
-  # Mostly colors, topography, etc. 58M
-  - "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.pmtiles"
+# Mostly colors, topography, etc. 58M
+maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.pmtiles"
 
 maps_dot_black_vector_symlink_name: openstreetmap-openmaptiles.pmtiles
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -4,7 +4,7 @@
 maps_dot_black_small_assets_url: https://v1.maps.black
 maps_dot_black_tiles_url: https://maps.black
 unpkg_url: https://unpkg.com
-iiab_map_host_url: https://iiab.switnet.org/maps/0
+iiab_map_host_url: https://iiab.switnet.org/maps/1
 
 # TODO I wonder if it should go under /library/maps/vector_tiles and symlink from the www directory.
 # That way it would be near the search data. It would be easier to find everything.

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -32,9 +32,6 @@ nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 maps_data_date: 2025-12-10
 maps_slow_data_date: 2025-12-10
 
-# TODO host our own assets and tiles? Because they may get updated which will break our checksums.
-# TODO s/filename/remotesubpath?
-
 # Basic maps.black javascript and styles
 maps_dot_black_js_and_styles:
   - name: maps.black.js
@@ -69,6 +66,8 @@ maplibre_search_js_and_styles:
     filename: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.css"
     sha256sum: 9fc78e63cbec12058daefb460f630d203a23f209cac8e19a84d0b257e8325fc3
 
+# TODO symlink for maps_dot_black_common_tiles since I added the date
+
 maps_dot_black_common_tiles:
   # Mostly colors, topography, etc. 58M
   - "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.pmtiles"
@@ -83,12 +82,12 @@ maps_dot_black_vector_tiles:
   # "high res" full osm, including 3d buildings. 78GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-full"
-  osm-full: "openstreetmap-openmaptiles.{{ map_data_date }}.full.pmtiles"
+  osm-full: "openstreetmap-openmaptiles.{{ maps_data_date }}.full.pmtiles"
 
   # "medium res" osm, up to zoom level 9 (original file has 14). 1.9GiB as of Oct 2025
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
-  osm-z9: "openstreetmap-openmaptiles.{{ map_data_date }}.zoom_0-09.pmtiles"
+  osm-z9: "openstreetmap-openmaptiles.{{ maps_data_date }}.zoom_0-09.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads. 85MB
   # maps_vector_quality = "ne"
@@ -115,16 +114,14 @@ maps_dot_black_satellite_tiles:
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
 nominatim_db_symlink_name: nominatim.sqlite
-nominatim_db_basic_name: "nominatim.{{ maps_slow_data_date }}.basic.sqlite"
-nominatim_db_full_name: "nominatim.{{ maps_slow_data_date }}.full.sqlite"
 
 nominatim_data:
   # Basic nominatim database
   # maps_search_full = False
-  False: "{{ nominatim_db_basic_name }}"
+  False: "nominatim.{{ maps_slow_data_date }}.basic.sqlite"
     # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
     # TODO - Make a basic small whole-world map, at least as good as previous maps
 
   # Full nominatim database
   # maps_search_full = True
-  True: "{{ nominatim_db_full_name }}"
+  True: "nominatim.{{ maps_slow_data_date }}.full.sqlite"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -17,9 +17,8 @@
 # Integrity: aria2 will perform a sha256 checksum on each downloaded chunk of
 # the file.
 #
-# Security: We will NOT commit sha256 checksums to the repository at this time,
-# but that option remains open if the concern comes up. The best option may be
-# to get the checksum of the meta4 file (and maybe the torrent file?)
+# Security: If there is a security concern down the line, we can provide PGP
+# signatures for the meta4 and/or torrent files.
 #
 # Consistent versions: Data file versions may correspond to each other (e.g.
 # vector map "extracts" should ideally match the low-res world map). This can
@@ -50,10 +49,7 @@
 
     rm -f {{ item }}*
 
-    wget "{{ iiab_map_host_url }}/{{ item }}.meta4"
-    wget "{{ iiab_map_host_url }}/{{ item }}.torrent"
     aria2c \
-        --metalink-file="{{ item }}.meta4" \
         --connect-timeout="{{ download_timeout }}" \
         --log-level=warn \
         --console-log-level=warn \
@@ -61,11 +57,10 @@
         --download-result=hide \
         --follow-metalink=mem \
         --max-connection-per-server=4 \
-        --continue=true \
         --file-allocation=falloc \
         --enable-http-pipelining=true \
-        --seed-time=0
-        -o "{{ dest_path }}"
+        --seed-time=0 \
+        "{{ iiab_map_host_url }}/{{ item }}.meta4"
 
     chmod 644 "{{ item }}"
     mv "{{ item }}" "{{ dest_path }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -1,57 +1,63 @@
-# This is an attempt at a "smart" downloader of large files. It behaves the way
-# I was hoping ansible's `get_url` would behave in the first place:
+# This will download large files using aria2c and meta4 files, and possibly
+# torrent files.
 #
-# * Download the file to a temp file
-# * Get the sha256sum of the temp file
-# * If the sha256sum is not what is expected, throw an error
-# * Rename the temp file to the destination path
-# * Save the sha256sum to a separate file (with extension .sha256)
+# There are a few concerns for downloading such files which we may or may not be
+# addressing at this time:
 #
-# On subsequent runs, the usual behavior will be that it sees the saved
-# sha256sum file, it matches the expected sha256sum, and it skips. (This is
-# the logical equivalent of calculating the sha256sum on the actual downloaded
-# file, but much faster for large files).
+# Efficiency for implementers:
 #
-# However, if we need to update the sha256sum for whatever reason, it will see
-# that the sha256sum does not match, and it runs the download process again.
+# * We will work toward supporting torrents, which may be faster than http.
+# * Aria2c will hopefully perform checksums in-memory (even if via disk cache)
+#   during download. This will be faster than a full checksum after download,
+#   which definitely requires disk read for large files.
+# * Once files are fully downloaded and moved out of the temp directory, they
+#   will not be downloaded on subsequent role runs. (This relates to "Updating
+#   data" below)
+#
+# Integrity: Aria2 will perform a sha256 checksum on each downloaded chunk of
+# the file.
+#
+# Security: We will NOT commit sha256 checksums to the repository at this time,
+# but that option remains open if the concern comes up. The best option may be
+# to get the checksum of the meta4 file (and maybe the torrent file?)
+#
+# Consistent versions: Data file versions may correspond to each other (e.g.
+# the "current" vector map should ideally match the search database). This can
+# be handled by putting a date in the file names of the data files, perhaps
+# committed to the repository. However, at this time this concern is handled
+# upstream of this file.
+#
+# Updating data: As of Dec 2025 this concern is out of scope. We assume that
+# users will either figure it out on their own, or reinstall IIAB from scratch.
+# That said, assuming we have dates in file names, this may be supported de
+# facto, but we will not go out of our way to free up room by deleting the
+# outdated files. (Perhaps adding automatic deletion will not be so hard once
+# the time comes)
 #
 # NOTE Already downloaded files show up as "skipped" instead of "ok".  I could
 # fix this but we'll move to the download manager in due time anyway.
 # TODO - files should be owned by www-data
 
-- name: "Check previous sha256sum, if any, for {{ item.src_url }})"
-  shell: |
-    set -euo pipefail
-
-    cat {{ dest_sha256_path }} || echo "nope"
-  args:
-    executable: /bin/bash
-  register: current_sha256sum
-  vars:
-    # Where the file's sha256sum is saved
-    dest_sha256_path: "{{ dest_base_path }}/{{ item.filename }}.sha256"
-
 - name: "Download {{ item.src_url }}"
-  # Do `wget -c` in hopes of continuing incomplete downloads on the temp file.
-  # However, if the hash doesn't match afterwards, delete the temp file.
-  # I'm not sure if the `echo` statements will do anything useful for debugging.
+  # cd to the temp directory so that the aria2c file, meta4 file, torrent file,
+  # and data file all end up there.
   shell: |
     set -euo pipefail
 
-    wget -c "{{ item.src_url }}" -O "{{ dest_tmp_path }}" -T "{{ download_timeout }}" || (echo "download failed"; exit 1)
-    sha256sum "{{ dest_tmp_path }}" | grep "{{ item.sha256sum }}" || (echo "sha256sum mismatch!"; rm "{{ dest_tmp_path }}"; exit 1)
-    chmod 644 "{{ dest_tmp_path }}"
-    mv "{{ dest_tmp_path }}" "{{ dest_path }}"
-    echo {{ item.sha256sum }} > {{ dest_sha256_path }}
+    cd /library/downloads/maps/
+    wget "{{ item.src_url }}.meta4"
+    wget "{{ item.src_url }}.torrent"
+
+    aria2c --metalink-file="{{ item.filename }}".meta4" --connect-timeout="{{ download_timeout }}"
+    chmod 644 "{{ item.filename }}"
+    mv "{{ item.filename }}" "{{ dest_path }}"
+
+    rm "{{ item.filename }}".meta4
+    rm "{{ item.filename }}".torrent
+    rm "{{ item.filename }}".aria2
   args:
     executable: /bin/bash
-  when: current_sha256sum.stdout_lines.0 != item.sha256sum
+  creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item.filename }}"
-
-    # Where the file goes as it's being downloaded
-    dest_tmp_path: "/library/downloads/maps/{{ item.filename }}"
-
-    # Where the file's sha256sum goes, which indicates the contents of the current file
-    dest_sha256_path: "{{ dest_base_path }}/{{ item.filename }}.sha256"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -7,14 +7,14 @@
 # Efficiency for implementers:
 #
 # * We will work toward supporting torrents, which may be faster than http.
-# * Aria2c will hopefully perform checksums in-memory (even if via disk cache)
+# * aria2c will hopefully perform checksums in-memory (even if via disk cache)
 #   during download. This will be faster than a full checksum after download,
 #   which definitely requires disk read for large files.
 # * Once files are fully downloaded and moved out of the temp directory, they
 #   will not be downloaded on subsequent role runs. (This relates to "Updating
 #   data" below)
 #
-# Integrity: Aria2 will perform a sha256 checksum on each downloaded chunk of
+# Integrity: aria2 will perform a sha256 checksum on each downloaded chunk of
 # the file.
 #
 # Security: We will NOT commit sha256 checksums to the repository at this time,
@@ -22,10 +22,10 @@
 # to get the checksum of the meta4 file (and maybe the torrent file?)
 #
 # Consistent versions: Data file versions may correspond to each other (e.g.
-# the "current" vector map should ideally match the search database). This can
-# be handled by putting a date in the file names of the data files, perhaps
-# committed to the repository. However, at this time this concern is handled
-# upstream of this file.
+# vector map "extracts" should ideally match the low-res world map). This can
+# be handled by putting a date in the file names of the data files. The date
+# can be committed to the repository. However, at this time this concern is
+# handled upstream of this file.
 #
 # Updating data: As of Dec 2025 this concern is out of scope. We assume that
 # users will either figure it out on their own, or reinstall IIAB from scratch.

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -47,8 +47,6 @@
 
     cd /library/downloads/maps/
 
-    rm -f {{ item }}*
-
     aria2c \
         --connect-timeout="{{ download_timeout }}" \
         --log-level=warn \
@@ -64,8 +62,6 @@
 
     chmod 644 "{{ item }}"
     mv "{{ item }}" "{{ dest_path }}"
-
-    rm -f {{ item }}*
   args:
     executable: /bin/bash
     creates: "{{ dest_path }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -48,6 +48,7 @@
         --log-level=warn \
         --console-log-level=warn \
         --summary-interval=0 \
+        --show-console-readout=false \
         --download-result=hide \
         --follow-metalink=mem \
         --max-connection-per-server=4 \

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -33,15 +33,11 @@
 # outdated files. (Perhaps adding automatic deletion will not be so hard once
 # the time comes)
 #
-# NOTE Already downloaded files show up as "skipped" instead of "ok".  I could
-# fix this but we'll move to the download manager in due time anyway.
 # TODO - files should be owned by www-data
 
 - name: "Download {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
-  # cd to the temp directory so that the aria2c file, meta4 file, torrent file,
-  # and data file all end up there. Delete any possible remnants of previous
-  # attempts to download the file before, to avoid errors due to renaming
-  # (appending .1, etc)
+  # cd to the temp directory so that the aria2c file, data file, and (perhaps
+  # eventually) torrent file all end up there.
   shell: |
     set -euo pipefail
 

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -40,24 +40,27 @@
 
 - name: "Download {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
   # cd to the temp directory so that the aria2c file, meta4 file, torrent file,
-  # and data file all end up there.
+  # and data file all end up there. Delete any possible remnants of previous
+  # attempts to download the file before, to avoid errors due to renaming
+  # (appending .1, etc)
   shell: |
     set -euo pipefail
 
     cd /library/downloads/maps/
+
+    rm -f {{ item }}*
+
     wget "{{ iiab_map_host_url }}/{{ item }}.meta4"
     wget "{{ iiab_map_host_url }}/{{ item }}.torrent"
 
-    aria2c --metalink-file="{{ item }}".meta4" --connect-timeout="{{ download_timeout }}"
+    aria2c --metalink-file="{{ item }}.meta4" --connect-timeout="{{ download_timeout }}"
     chmod 644 "{{ item }}"
     mv "{{ item }}" "{{ dest_path }}"
 
-    rm "{{ item }}".meta4
-    rm "{{ item }}".torrent
-    rm "{{ item }}".aria2
+    rm -f {{ item }}*
   args:
     executable: /bin/bash
-  creates: "{{ dest_path }}"
+    creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -38,26 +38,26 @@
 # fix this but we'll move to the download manager in due time anyway.
 # TODO - files should be owned by www-data
 
-- name: "Download {{ item.src_url }}"
+- name: "Download {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
   # cd to the temp directory so that the aria2c file, meta4 file, torrent file,
   # and data file all end up there.
   shell: |
     set -euo pipefail
 
     cd /library/downloads/maps/
-    wget "{{ item.src_url }}.meta4"
-    wget "{{ item.src_url }}.torrent"
+    wget "{{ iiab_map_host_url }}/{{ item }}.meta4"
+    wget "{{ iiab_map_host_url }}/{{ item }}.torrent"
 
-    aria2c --metalink-file="{{ item.filename }}".meta4" --connect-timeout="{{ download_timeout }}"
-    chmod 644 "{{ item.filename }}"
-    mv "{{ item.filename }}" "{{ dest_path }}"
+    aria2c --metalink-file="{{ item }}".meta4" --connect-timeout="{{ download_timeout }}"
+    chmod 644 "{{ item }}"
+    mv "{{ item }}" "{{ dest_path }}"
 
-    rm "{{ item.filename }}".meta4
-    rm "{{ item.filename }}".torrent
-    rm "{{ item.filename }}".aria2
+    rm "{{ item }}".meta4
+    rm "{{ item }}".torrent
+    rm "{{ item }}".aria2
   args:
     executable: /bin/bash
   creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
-    dest_path: "{{ dest_base_path }}/{{ item.filename }}"
+    dest_path: "{{ dest_base_path }}/{{ item }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -52,8 +52,21 @@
 
     wget "{{ iiab_map_host_url }}/{{ item }}.meta4"
     wget "{{ iiab_map_host_url }}/{{ item }}.torrent"
+    aria2c \
+        --metalink-file="{{ item }}.meta4" \
+        --connect-timeout="{{ download_timeout }}" \
+        --log-level=warn \
+        --console-log-level=warn \
+        --summary-interval=0 \
+        --download-result=hide \
+        --follow-metalink=mem \
+        --max-connection-per-server=4 \
+        --continue=true \
+        --file-allocation=falloc \
+        --enable-http-pipelining=true \
+        --seed-time=0
+        -o "{{ dest_path }}"
 
-    aria2c --metalink-file="{{ item }}.meta4" --connect-timeout="{{ download_timeout }}"
     chmod 644 "{{ item }}"
     mv "{{ item }}" "{{ dest_path }}"
 

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -4,6 +4,13 @@
     state: directory
     # mode: 0755
 
+- name: Install aria2
+  apt:
+    name:
+      - aria2c
+
+    state: present
+
 - include_tasks: install_frontend.yml
 
 - include_tasks: install_nominatim.yml

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -6,10 +6,7 @@
 
 - name: Install aria2
   apt:
-    name:
-      - aria2c
-
-    state: present
+    name: aria2c
 
 - include_tasks: install_frontend.yml
 

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -6,7 +6,7 @@
 
 - name: Install aria2
   apt:
-    name: aria2c
+    name: aria2
 
 - include_tasks: install_frontend.yml
 

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -20,11 +20,17 @@
     timeout: "{{ download_timeout }}"
   with_items: "{{ maps_dot_black_js_and_styles }}"
 
-- name: Download common tiles
+- name: Download naturalearth6 tiles
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-  with_items: "{{ maps_dot_black_common_tiles }}"
+    item: "{{ maps_dot_black_naturalearth6_tiles }}"
+
+- name: Select naturalearth6 tiles
+  file:
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_tiles }}"
+    dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
+    state: link
 
 - name: "Make sure maps_vector_quality has a valid value"
   assert:

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -44,11 +44,19 @@
     dest_base_path: "{{ maps_serve_path }}"
     item: "{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
 
-- name: Select vector tiles
+- name: Select vector tiles (if openstreetmap)
   file:
     src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_vector_symlink_name }}"
+    dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
+  when: maps_vector_quality != "ne"
+
+- name: Select vector tiles (if naturalearth)
+  file:
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
+    dest: "{{ maps_serve_path }}/{{ maps_dot_black_ne_symlink_name }}"
+    state: link
+  when: maps_vector_quality == "ne"
 
 - name: "Make sure maps_sat_zoom has a valid value"
   assert:

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -46,7 +46,7 @@
 
 - name: Select vector tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality].filename }}"
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_vector_symlink_name }}"
     state: link
 
@@ -64,7 +64,7 @@
 
 - name: Select satellite tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_sat_zoom].filename }}"
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_sat_zoom] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 

--- a/roles/maps/tasks/install_nominatim.yml
+++ b/roles/maps/tasks/install_nominatim.yml
@@ -42,7 +42,7 @@
 
 - name: Select nominatim database
   file:
-    src: "{{ maps_data_root }}/{{ nominatim_data[maps_search_full].filename }}"
+    src: "{{ maps_data_root }}/{{ nominatim_data[maps_search_full] }}"
     dest: "{{ maps_data_root }}/{{ nominatim_db_symlink_name }}"
     state: link
 


### PR DESCRIPTION
### Fixes bug:

Slowness from doing sha256sum after download

### Description of changes proposed in this pull request:

Download map data files via `.meta4` file and optionally `.torrent` file using `aria2c` instead of `wget`. This will handle checksums faster. We however will lose the "security" benefit of having the sha256sums "pinned" in the repository, for whatever it's worth. This also opens up torrents for us (I'm not sure if this change fully implements them or if it's just the first step in that direction). More details in comments.

I'd still like to "pin" a version to the repo, at least for now, so I'm adding dates to the file names. Dates in file names is something that we decided would be useful in the long run anyway when people share these files.

This depends on the meta4 and torrent files being uploaded to our data server, which we haven't done yet. I wanted to review this first because it might affect the upload. We might decide to change some file names, or maybe I wasn't using `aria2c` the best way.

### Smoke-tested on which OS or OS's:

TODO - I have to upload the files first.

I did partially test an earlier commit. It successfully installed the downloader yml file via ansible, and downloaded one data file.

### Mention a team member @username e.g. to help with code review:

@holta @chapmanjacobd 