### PR TITLE
Let's try reverting to MediaWiki 1.44.3 for PHP 8.4+

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: "1.45"    # "1.40" quotes nec if trailing zero
-mediawiki_minor_version: 1
+mediawiki_major_version: "1.44"    # "1.40" quotes nec if trailing zero
+mediawiki_minor_version: 3
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
### Fixes bug:

Experimental workaround to deal with Wikimedia Foundation's current inability to support MediaWiki on 2025 OS's like Debian 13 Trixie, Raspberry Pi OS Trixie, Ubuntu 25.10, etc:

- PR #4169

### Description of changes proposed in this pull request:

Hopefully reverting to MediaWiki 1.44.3 (and subsequent versions of 1.44.x) will do the job, until upstream (Wikimedia Foundation) gets Parsoid working on modern OS's with PHP 8.4, 8.5 etc.

### Smoke-tested on which OS or OS's:

Ongoing!

### Mention a team member @username e.g. to help with code review:

@jvonau

### Tangentially related issue:

- #4168