### PR TITLE
[code] work around  non-interactive curl/ansible requests get 403

### DIFF
--- a/.github/workflows/tests/expected_state_medium.yml
+++ b/.github/workflows/tests/expected_state_medium.yml
@@ -24,4 +24,3 @@ awstats_installed: True
 matomo_installed: True
 captiveportal_installed: True
 calibreweb_installed: True
-code_installed: True

--- a/roles/code/defaults/main.yml
+++ b/roles/code/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # URL apk download urls
 adfa_code_download_url: https://appdevforall.org/apk_repo
-code_apk_release_name: "CodeOnTheGo-latest.apk"
+code_apk_release_name: ""
 
 ## Set arch for future releases
 #code_apk_release_arch64: ""
@@ -23,11 +23,9 @@ code_data_root_content: "{{ code_data_root_static }}/content"
 code_arm64_release_apk:
   - name: "{{ code_apk_release_name }}"
     filename: "{{ code_apk_release_name }}"
-    sha256sum: "28022d3ad8e288ab8d9a9b7067a278bacb4788cf41098fc580e5a94538bc75f8"
 
 ## future releases might include
 #code_arm32_release_apk:
 #  - name: "{{ code_apk_release_name }}"
 #    filename: "{{ code_apk_release_name }}"
-#    sha256sum: ""
 

--- a/roles/code/defaults/main.yml
+++ b/roles/code/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # URL apk download urls
 adfa_code_download_url: https://appdevforall.org/apk_repo
-code_apk_release_name: ""
+code_apk_pattern: "CodeOnTheGo-.*?armv8a\\.apk"
 
 ## Set arch for future releases
 #code_apk_release_arch64: ""

--- a/roles/code/defaults/main.yml
+++ b/roles/code/defaults/main.yml
@@ -1,15 +1,19 @@
-# Initial COTG role to setup distribution site
-# 64bits support, leaving room for future 32bits support.
+# Initial "Code on the Go" role to set up "offline" distribution.
+# 64-bit support for now, leaving room for future 32-bit support.
 
-# URL apk download urls
-adfa_code_download_url: https://appdevforall.org/apk_repo
-code_apk_pattern: "CodeOnTheGo-.*?armv8a\\.apk"
+# URL & Regular Expressions
+code_download_url: https://appdevforall.org/apk_repo
+code_apk_32bit_pattern: "CodeOnTheGo-.*?armv7a\\.apk"
+code_apk_64bit_pattern: "CodeOnTheGo-.*?armv8a\\.apk"
 
-## Set arch for future releases
-#code_apk_release_arch64: ""
-#code_apk_release_arch32: ""
+# 2025-12-13: Filename vars had been dynamically bound to non-existent
+# (undefined) vars, auto-populated after scraping above URL, but let's not!
+# Cleaner: install.yml now sets these 2 vars, after scraping the above URL...
+#
+# code_apk_32bit_filename:
+# code_apk_64bit_filename:
 
-# Last build site
+# Date Scraped
 code_play_build_date: "{{ lookup('pipe', 'date -R') }}"
 
 # Root folder path vars
@@ -19,13 +23,3 @@ code_data_root: "{{ content_base }}/code"        # /library/code
 code_data_root_static: "{{ code_serve_path }}/static"
 code_data_root_apk: "{{ code_data_root_static }}/apk"
 code_data_root_content: "{{ code_data_root_static }}/content"
-
-code_arm64_release_apk:
-  - name: "{{ code_apk_release_name }}"
-    filename: "{{ code_apk_release_name }}"
-
-## future releases might include
-#code_arm32_release_apk:
-#  - name: "{{ code_apk_release_name }}"
-#    filename: "{{ code_apk_release_name }}"
-

--- a/roles/code/tasks/enable-or-disable.yml
+++ b/roles/code/tasks/enable-or-disable.yml
@@ -1,12 +1,12 @@
 - name: Enable http://box/code via NGINX, by installing {{ nginx_conf_dir }}/code-nginx.conf
-  ansible.builtin.copy:
+  copy:
     src: code-nginx.conf
     dest: "{{ nginx_conf_dir }}/code-nginx.conf"    # /etc/nginx/conf.d
     mode: "0644"
   when: code_enabled
 
 - name: Disable http://box/code via NGINX, by removing {{ nginx_conf_dir }}/code-nginx.conf
-  ansible.builtin.file:
+  file:
     path: "{{ nginx_conf_dir }}/code-nginx.conf"    # /etc/nginx/conf.d
     state: absent
   when: not code_enabled

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -82,7 +82,7 @@
 - name: Get CodeOnTheGo version number
   ansible.builtin.set_fact:
     cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
-  when: not code_blocked_by_cdn
+  when: not code_blocked_by_cdn | default(false)
 
 - name: Make index.html file
   ansible.builtin.template:
@@ -105,7 +105,7 @@
     - en
     - es
   when: not code_blocked_by_cdn
-  
+
 - name: Continue APK install tasks when no 403 blocking
   ansible.builtin.include_tasks: install_apkfile.yml
   when: not code_blocked_by_cdn | default(false)

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -17,12 +17,34 @@
     src: static/
     dest: "{{ code_data_root_static }}"
 
+- name: "Ensure code_apk_release_name is set (autodetect latest armv8a APK if empty)"
+  when: code_apk_release_name | length == 0
+  block:
+
+    - name: "Fetch APK index page from {{ adfa_code_download_url }}/"
+      ansible.builtin.uri:
+        url: "{{ adfa_code_download_url }}/"
+        return_content: true
+      register: apk_index
+
+    - name: "Extract latest armv8a APK filename from index"
+      ansible.builtin.set_fact:
+        code_apk_release_name: >-
+          {{
+            apk_index.content
+            | regex_findall(code_apk_pattern)
+            | unique
+            | sort
+            | last
+          }}
+
+    - name: "Show resolved APK release name"
+      ansible.builtin.debug:
+        var: code_apk_release_name
+
 - name: Get CodeOnTheGo version number
-  ansible.builtin.shell: >
-    curl -s https://appdevforall.org/apk_repo/ |
-    sed -nE 's/.*CodeOnTheGo-release([0-9.]+)\.apk.*/\1/p'
-  register: cotg_version_raw
-  changed_when: false
+  ansible.builtin.set_fact:
+    cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
 
 - name: Make index.html file
   ansible.builtin.template:

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -127,9 +127,11 @@
 - name: "Set 'code_installed: True'"
   set_fact:
     code_installed: True
+  when: not code_blocked_by_cdn | default(false)
 
 - name: "Add 'code_installed: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^code_installed'
     line: 'code_installed: True'
+  when: not code_blocked_by_cdn | default(false)

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -36,7 +36,7 @@
     - name: Warn about 403 APK index
       fail:
         msg: |
-          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs; see pause banner below.
+          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs.
 
           ================ CODE ROLE WARNING ================
           The 'code' role hit a CDN 403 (APK index query blocked).
@@ -87,12 +87,14 @@
     src: "index.html.j2"
     dest: "{{ code_serve_path }}/index.html"
     mode: "0644"
+  when: code_blocked_by_cdn is undefined
 
 - name: Make content directory
   file:
     path: "{{ code_data_root_content }}"
     state: directory
     mode: "0755"
+  when: code_blocked_by_cdn is undefined
 
 - name: Render localized Markdown content files
   template:
@@ -110,6 +112,7 @@
 
 - name: Setup 'code' nginx conf file
   include_tasks: nginx.yml
+  when: code_blocked_by_cdn is undefined
 
 
 # RECORD CODE AS INSTALLED

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -3,7 +3,7 @@
   register: df1
 
 
-- name: "Make code directories available"
+- name: Make code directories available
   file:
     path: "{{ item }}"
     state: directory
@@ -12,16 +12,16 @@
     - "{{ code_data_root }}"
     - "{{ code_serve_path }}"
 
-- name: "Copy static assets"
+- name: Copy static assets
   copy:
     src: static/
     dest: "{{ code_data_root_static }}"
 
-- name: "Ensure code_apk_release_name is set (autodetect latest armv8a APK if empty)"
+- name: Ensure code_apk_release_name is set (autodetect latest armv8a APK if empty)
   when: code_apk_release_name is undefined
   block:
 
-    - name: "Fetch APK index page from {{ adfa_code_download_url }}/"
+    - name: Fetch APK index page from {{ adfa_code_download_url }}/
       uri:
         url: "{{ adfa_code_download_url }}/"
         return_content: true
@@ -31,17 +31,18 @@
         and apk_index.status != 200
         and apk_index.status != 403
 
-    - name: "Warn about {{ apk_index.status }} APK index"
+    - name: Warn about 403 APK index
       fail:
         msg: |
-          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP {{ apk_index.status }}). CDN is likely blocking datacenter IPs; see pause banner below.
-          ================ CODE ROLE WARNING ================
-          The 'code' role hit a CDN {{ apk_index.status }} (APK index query blocked).
+          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs; see pause banner below.
 
-          HTTP status: {{ apk_index.status }}
+          ================ CODE ROLE WARNING ================
+          The 'code' role hit a CDN 403 (APK index query blocked).
+
+          HTTP status: 403
           This likely means the APK store is behind some CDN and
           blocking datacenter IP ranges, so non-interactive curl/Ansible
-          requests get a {{ apk_index.status }} "Just a moment..." page.
+          requests get a 403 "Just a moment..." page.
 
           GitHub issues/PRs related:
           - https://github.com/iiab/iiab/issues/4174
@@ -52,17 +53,17 @@
       when: apk_index.status == 403
       ignore_errors: yes
 
-    - name: "Warn about APK index 403 blocking"
+    - name: Warn about APK index 403 blocking
       pause:
         seconds: 20
       when: apk_index.status == 403
 
-    - name: "Mark 'code' role as blocked by CDN"
+    - name: Mark 'code' role as blocked by CDN
       set_fact:
         code_blocked_by_cdn: true
       when: apk_index.status == 403
 
-    - name: "Extract latest armv8a APK filename from index"
+    - name: Extract latest armv8a APK filename from index
       set_fact:
         code_apk_release_name: >-
           {{
@@ -79,24 +80,24 @@
         var: code_apk_release_name
       when: not code_blocked_by_cdn
 
-- name: "Get CodeOnTheGo version number"
+- name: Get CodeOnTheGo version number
   set_fact:
     cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
   when: code_blocked_by_cdn is undefined
 
-- name: "Make index.html file"
+- name: Make index.html file
   template:
     src: "index.html.j2"
     dest: "{{ code_serve_path }}/index.html"
     mode: "0644"
 
-- name: "Make content directory"
+- name: Make content directory
   file:
     path: "{{ code_data_root_content }}"
     state: directory
     mode: "0755"
 
-- name: "Render localized Markdown content files"
+- name: Render localized Markdown content files
   template:
     src: "content/{{ item }}.md.j2"
     dest: "{{ code_data_root_content }}/{{ item }}.md"
@@ -106,32 +107,32 @@
     - es
   when: code_blocked_by_cdn is undefined
 
-- name: "Continue APK install tasks when no 403 blocking"
+- name: Continue APK install tasks when no 403 blocking
   include_tasks: install_apkfile.yml
   when: code_blocked_by_cdn is undefined
 
-- name: "Setup 'code' nginx conf file"
+- name: Setup 'code' nginx conf file
   include_tasks: nginx.yml
 
 # RECORD CODE AS INSTALLED
 
-- name: "Record (final) disk space used"
+- name: Record (final) disk space used
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: "Add 'code_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}"
+- name: Add 'code_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: code
     option: code_disk_usage
     value: "{{ df2.stdout | int - df1.stdout | int }}"
 
-- name: "Set 'code_installed: True'"
+- name: Set 'code_installed: True'
   set_fact:
     code_installed: True
   when: code_blocked_by_cdn is undefined
 
-- name: "Add 'code_installed: True' to {{ iiab_state_file }}"
+- name: Add 'code_installed: True' to {{ iiab_state_file }}
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^code_installed'

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -71,11 +71,6 @@
           }}
       when: code_blocked_by_cdn is undefined
 
-    - name: "Show resolved APK release name"
-      debug:
-        var: code_apk_release_name
-      when: code_blocked_by_cdn is undefined
-
     - name: Extract latest armv7a APK filename from index
       set_fact:
         code_apk_32bit_filename: >-
@@ -89,7 +84,12 @@
 
 - name: Get CodeOnTheGo version number
   set_fact:
-    cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
+    cotg_version: "{{ code_apk_64bit_filename | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
+  when: code_blocked_by_cdn is undefined
+
+- name: "Show resolved APK release name"
+  debug:
+    var: cotg_version
   when: code_blocked_by_cdn is undefined
 
 - name: Make index.html file

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -21,9 +21,9 @@
   when: code_apk_release_name is undefined
   block:
 
-    - name: Fetch APK index page from {{ adfa_code_download_url }}/
+    - name: Fetch APK index page from {{ code_download_url }}/
       uri:
-        url: "{{ adfa_code_download_url }}/"
+        url: "{{ code_download_url }}/"
         return_content: true
       register: apk_index
       failed_when: apk_index.status != 200 and apk_index.status != 403
@@ -36,7 +36,7 @@
     - name: Warn about 403 APK index
       fail:
         msg: |
-          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs.
+          The 'code' role could not access: {{ code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs.
 
           ================ CODE ROLE WARNING ================
           The 'code' role hit a CDN 403 (APK index query blocked).
@@ -62,11 +62,10 @@
 
     - name: Extract latest armv8a APK filename from index
       set_fact:
-        code_apk_release_name: >-
+        code_apk_64bit_filename: >-
           {{
             apk_index.content
-            | regex_findall(code_apk_pattern)
-            | unique
+            | regex_findall(code_apk_64bit_pattern)
             | sort
             | last
           }}
@@ -75,6 +74,17 @@
     - name: "Show resolved APK release name"
       debug:
         var: code_apk_release_name
+      when: code_blocked_by_cdn is undefined
+
+    - name: Extract latest armv7a APK filename from index
+      set_fact:
+        code_apk_32bit_filename: >-
+          {{
+            apk_index.content
+            | regex_findall(code_apk_32bit_pattern)
+            | sort
+            | last
+          }}
       when: code_blocked_by_cdn is undefined
 
 - name: Get CodeOnTheGo version number

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -4,7 +4,7 @@
 
 
 - name: "Make code directories available"
-  ansible.builtin.file:
+  file:
     path: "{{ item }}"
     state: directory
     mode: "0755"
@@ -13,7 +13,7 @@
     - "{{ code_serve_path }}"
 
 - name: "Copy static assets"
-  ansible.builtin.copy:
+  copy:
     src: static/
     dest: "{{ code_data_root_static }}"
 
@@ -22,7 +22,7 @@
   block:
 
     - name: "Fetch APK index page from {{ adfa_code_download_url }}/"
-      ansible.builtin.uri:
+      uri:
         url: "{{ adfa_code_download_url }}/"
         return_content: true
       register: apk_index
@@ -53,17 +53,17 @@
       ignore_errors: yes
 
     - name: "Warn about APK index 403 blocking"
-      ansible.builtin.pause:
+      pause:
         seconds: 20
       when: apk_index.status == 403
 
     - name: "Mark 'code' role as blocked by CDN"
-      ansible.builtin.set_fact:
+      set_fact:
         code_blocked_by_cdn: true
       when: apk_index.status == 403
 
     - name: "Extract latest armv8a APK filename from index"
-      ansible.builtin.set_fact:
+      set_fact:
         code_apk_release_name: >-
           {{
             apk_index.content
@@ -75,17 +75,17 @@
       when: code_blocked_by_cdn is undefined
 
     - name: "Show resolved APK release name"
-      ansible.builtin.debug:
+      debug:
         var: code_apk_release_name
       when: not code_blocked_by_cdn
 
 - name: "Get CodeOnTheGo version number"
-  ansible.builtin.set_fact:
+  set_fact:
     cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
   when: code_blocked_by_cdn is undefined
 
 - name: "Make index.html file"
-  ansible.builtin.template:
+  template:
     src: "index.html.j2"
     dest: "{{ code_serve_path }}/index.html"
     mode: "0644"
@@ -97,7 +97,7 @@
     mode: "0755"
 
 - name: "Render localized Markdown content files"
-  ansible.builtin.template:
+  template:
     src: "content/{{ item }}.md.j2"
     dest: "{{ code_data_root_content }}/{{ item }}.md"
     mode: "0644"
@@ -107,9 +107,11 @@
   when: code_blocked_by_cdn is undefined
 
 - name: "Continue APK install tasks when no 403 blocking"
-  ansible.builtin.include_tasks: install_apkfile.yml
+  include_tasks: install_apkfile.yml
   when: code_blocked_by_cdn is undefined
 
+- name: "Setup 'code' nginx conf file"
+  include_tasks: nginx.yml
 
 # RECORD CODE AS INSTALLED
 

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -26,6 +26,41 @@
         url: "{{ adfa_code_download_url }}/"
         return_content: true
       register: apk_index
+      failed_when: >
+        apk_index.status is defined
+        and apk_index.status != 200
+        and apk_index.status != 403
+
+    - name: "Warn about APK index 403 blocking"
+      fail:
+        msg: |
+          The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP {{ apk_index.status }}). CDN is likely blocking datacenter IPs; see pause banner below.
+          ================ CODE ROLE WARNING ================
+          The 'code' role hit a CDN 403 (APK index query blocked).
+
+          HTTP status: {{ apk_index.status }}
+          This likely means the APK store is behind some CDN and
+          blocking datacenter IP ranges, so non-interactive curl/Ansible
+          requests get a 403 "Just a moment..." page.
+
+          GitHub issues/PRs related:
+          - https://github.com/iiab/iiab/issues/4174
+          - https://github.com/iiab/iiab/pull/4176
+
+          Continuing IIAB without CodeOnTheGo APK content...
+          ===================================================
+      when: apk_index.status | default(0) == 403
+      ignore_errors: yes
+
+    - name: "Warn about APK index 403 blocking"
+      ansible.builtin.pause:
+        seconds: 20
+      when: apk_index.status | default(0) == 403
+
+    - name: "Mark 'code' role as blocked by CDN"
+      ansible.builtin.set_fact:
+        code_blocked_by_cdn: true
+      when: apk_index.status | default(0) == 403
 
     - name: "Extract latest armv8a APK filename from index"
       ansible.builtin.set_fact:
@@ -37,14 +72,17 @@
             | sort
             | last
           }}
+      when: not code_blocked_by_cdn
 
     - name: "Show resolved APK release name"
       ansible.builtin.debug:
         var: code_apk_release_name
+      when: not code_blocked_by_cdn
 
 - name: Get CodeOnTheGo version number
   ansible.builtin.set_fact:
     cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
+  when: not code_blocked_by_cdn
 
 - name: Make index.html file
   ansible.builtin.template:
@@ -66,8 +104,11 @@
   loop:
     - en
     - es
-
-- include_tasks: install_apkfile.yml
+  when: not code_blocked_by_cdn
+  
+- name: Continue APK install tasks when no 403 blocking
+  ansible.builtin.include_tasks: install_apkfile.yml
+  when: not code_blocked_by_cdn | default(false)
 
 
 # RECORD CODE AS INSTALLED

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -52,7 +52,7 @@
 
           Continuing IIAB without CodeOnTheGo APK content...
           ===================================================
-      when: code_blocked_by_cdn
+      when: code_blocked_by_cdn is defined
       ignore_errors: yes
 
     - name: Warn about APK index 403 blocking
@@ -70,12 +70,12 @@
             | sort
             | last
           }}
-      when: not code_blocked_by_cdn
+      when: code_blocked_by_cdn is undefined
 
     - name: "Show resolved APK release name"
       debug:
         var: code_apk_release_name
-      when: not code_blocked_by_cdn
+      when: code_blocked_by_cdn is undefined
 
 - name: Get CodeOnTheGo version number
   set_fact:
@@ -111,6 +111,7 @@
 - name: Setup 'code' nginx conf file
   include_tasks: nginx.yml
 
+
 # RECORD CODE AS INSTALLED
 
 - name: Record (final) disk space used
@@ -124,12 +125,12 @@
     option: code_disk_usage
     value: "{{ df2.stdout | int - df1.stdout | int }}"
 
-- name: Set 'code_installed: True'
+- name: "Set 'code_installed: True'"
   set_fact:
     code_installed: True
   when: code_blocked_by_cdn is undefined
 
-- name: Add 'code_installed: True' to {{ iiab_state_file }}
+- name: "Add 'code_installed: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^code_installed'

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -3,7 +3,7 @@
   register: df1
 
 
-- name: Make code directories available
+- name: "Make code directories available"
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -12,13 +12,13 @@
     - "{{ code_data_root }}"
     - "{{ code_serve_path }}"
 
-- name: Copy static assets
+- name: "Copy static assets"
   ansible.builtin.copy:
     src: static/
     dest: "{{ code_data_root_static }}"
 
 - name: "Ensure code_apk_release_name is set (autodetect latest armv8a APK if empty)"
-  when: code_apk_release_name | length == 0
+  when: code_apk_release_name is undefined
   block:
 
     - name: "Fetch APK index page from {{ adfa_code_download_url }}/"
@@ -31,17 +31,17 @@
         and apk_index.status != 200
         and apk_index.status != 403
 
-    - name: "Warn about APK index 403 blocking"
+    - name: "Warn about {{ apk_index.status }} APK index"
       fail:
         msg: |
           The 'code' role could not access: {{ adfa_code_download_url }}/ (HTTP {{ apk_index.status }}). CDN is likely blocking datacenter IPs; see pause banner below.
           ================ CODE ROLE WARNING ================
-          The 'code' role hit a CDN 403 (APK index query blocked).
+          The 'code' role hit a CDN {{ apk_index.status }} (APK index query blocked).
 
           HTTP status: {{ apk_index.status }}
           This likely means the APK store is behind some CDN and
           blocking datacenter IP ranges, so non-interactive curl/Ansible
-          requests get a 403 "Just a moment..." page.
+          requests get a {{ apk_index.status }} "Just a moment..." page.
 
           GitHub issues/PRs related:
           - https://github.com/iiab/iiab/issues/4174
@@ -49,18 +49,18 @@
 
           Continuing IIAB without CodeOnTheGo APK content...
           ===================================================
-      when: apk_index.status | default(0) == 403
+      when: apk_index.status == 403
       ignore_errors: yes
 
     - name: "Warn about APK index 403 blocking"
       ansible.builtin.pause:
         seconds: 20
-      when: apk_index.status | default(0) == 403
+      when: apk_index.status == 403
 
     - name: "Mark 'code' role as blocked by CDN"
       ansible.builtin.set_fact:
         code_blocked_by_cdn: true
-      when: apk_index.status | default(0) == 403
+      when: apk_index.status == 403
 
     - name: "Extract latest armv8a APK filename from index"
       ansible.builtin.set_fact:
@@ -72,31 +72,31 @@
             | sort
             | last
           }}
-      when: not code_blocked_by_cdn
+      when: code_blocked_by_cdn is undefined
 
     - name: "Show resolved APK release name"
       ansible.builtin.debug:
         var: code_apk_release_name
       when: not code_blocked_by_cdn
 
-- name: Get CodeOnTheGo version number
+- name: "Get CodeOnTheGo version number"
   ansible.builtin.set_fact:
     cotg_version: "{{ code_apk_release_name | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
-  when: not code_blocked_by_cdn | default(false)
+  when: code_blocked_by_cdn is undefined
 
-- name: Make index.html file
+- name: "Make index.html file"
   ansible.builtin.template:
     src: "index.html.j2"
     dest: "{{ code_serve_path }}/index.html"
     mode: "0644"
 
-- name: Make content directory
+- name: "Make content directory"
   file:
     path: "{{ code_data_root_content }}"
     state: directory
     mode: "0755"
 
-- name: Render localized Markdown content files
+- name: "Render localized Markdown content files"
   ansible.builtin.template:
     src: "content/{{ item }}.md.j2"
     dest: "{{ code_data_root_content }}/{{ item }}.md"
@@ -104,20 +104,20 @@
   loop:
     - en
     - es
-  when: not code_blocked_by_cdn
+  when: code_blocked_by_cdn is undefined
 
-- name: Continue APK install tasks when no 403 blocking
+- name: "Continue APK install tasks when no 403 blocking"
   ansible.builtin.include_tasks: install_apkfile.yml
-  when: not code_blocked_by_cdn | default(false)
+  when: code_blocked_by_cdn is undefined
 
 
 # RECORD CODE AS INSTALLED
 
-- name: Record (final) disk space used
+- name: "Record (final) disk space used"
   shell: df -B1 --output=used / | tail -1
   register: df2
 
-- name: Add 'code_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}
+- name: "Add 'code_disk_usage = {{ df2.stdout | int - df1.stdout | int }}' to {{ iiab_ini_file }}"
   ini_file:
     path: "{{ iiab_ini_file }}"    # /etc/iiab/iiab.ini
     section: code
@@ -127,11 +127,11 @@
 - name: "Set 'code_installed: True'"
   set_fact:
     code_installed: True
-  when: not code_blocked_by_cdn | default(false)
+  when: code_blocked_by_cdn is undefined
 
 - name: "Add 'code_installed: True' to {{ iiab_state_file }}"
   lineinfile:
     path: "{{ iiab_state_file }}"    # /etc/iiab/iiab_state.yml
     regexp: '^code_installed'
     line: 'code_installed: True'
-  when: not code_blocked_by_cdn | default(false)
+  when: code_blocked_by_cdn is undefined

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -26,10 +26,12 @@
         url: "{{ adfa_code_download_url }}/"
         return_content: true
       register: apk_index
-      failed_when: >
-        apk_index.status is defined
-        and apk_index.status != 200
-        and apk_index.status != 403
+      failed_when: apk_index.status != 200 and apk_index.status != 403
+
+    - name: Mark 'code' role as blocked by CDN
+      set_fact:
+        code_blocked_by_cdn: true
+      when: apk_index.status == 403
 
     - name: Warn about 403 APK index
       fail:
@@ -50,18 +52,13 @@
 
           Continuing IIAB without CodeOnTheGo APK content...
           ===================================================
-      when: apk_index.status == 403
+      when: code_blocked_by_cdn
       ignore_errors: yes
 
     - name: Warn about APK index 403 blocking
       pause:
         seconds: 20
-      when: apk_index.status == 403
-
-    - name: Mark 'code' role as blocked by CDN
-      set_fact:
-        code_blocked_by_cdn: true
-      when: apk_index.status == 403
+      when: code_blocked_by_cdn
 
     - name: Extract latest armv8a APK filename from index
       set_fact:
@@ -73,7 +70,7 @@
             | sort
             | last
           }}
-      when: code_blocked_by_cdn is undefined
+      when: not code_blocked_by_cdn
 
     - name: "Show resolved APK release name"
       debug:

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -58,7 +58,7 @@
     - name: Warn about APK index 403 blocking
       pause:
         seconds: 20
-      when: code_blocked_by_cdn
+      when: code_blocked_by_cdn is defined
 
     - name: Extract latest armv8a APK filename from index
       set_fact:

--- a/roles/code/tasks/install_apkfile.yml
+++ b/roles/code/tasks/install_apkfile.yml
@@ -7,17 +7,17 @@
 ### Current release - arm64 ###
 - name: Download arch arm64 APK
   get_url:
-    url: "{{ code_download_url }}/{{ item.filename }}"
-    dest: "{{ code_data_root_apk }}/{{ item.filename }}"
+    url: "{{ code_download_url }}/{{ code_apk_64bit_filename }}"
+    dest: "{{ code_data_root_apk }}/{{ code_apk_64bit_filename }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"
-  loop: "{{ code_apk_64bit_filename }}"
+  when: code_apk_64bit_filename
 
 ### Future release - arm32 ###
-#- name: Download arch arm32 apk (0644)
+#- name: Download arch arm64 APK
 #  get_url:
-#    url: "{{ code_download_url }}/{{ item.filename }}"
-#    dest: "{{ code_data_root_apk }}/{{ item.filename }}"
+#    url: "{{ code_download_url }}/{{ code_apk_64bit_filename }}"
+#    dest: "{{ code_data_root_apk }}/{{ code_apk_64bit_filename }}"
 #    mode: "0644"
 #    timeout: "{{ download_timeout }}"
-#  loop: "{{ code_apk_32bit_filename }}"
+#  when: code_apk_64bit_filename

--- a/roles/code/tasks/install_apkfile.yml
+++ b/roles/code/tasks/install_apkfile.yml
@@ -6,20 +6,18 @@
 
 ### Current release - arm64 ###
 - name: Download arch arm64 APK
-  ansible.builtin.get_url:
-    url: "{{ adfa_code_download_url }}/{{ item.filename }}"
+  get_url:
+    url: "{{ code_download_url }}/{{ item.filename }}"
     dest: "{{ code_data_root_apk }}/{{ item.filename }}"
-    #checksum: "sha256:{{ item.sha256sum }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"
-  loop: "{{ code_arm64_release_apk }}"
-  
+  loop: "{{ code_apk_64bit_filename }}"
+
 ### Future release - arm32 ###
 #- name: Download arch arm32 apk (0644)
-#  ansible.builtin.get_url:
-#    url: "{{ adfa_code_download_url }}/{{ item.filename }}"
+#  get_url:
+#    url: "{{ code_download_url }}/{{ item.filename }}"
 #    dest: "{{ code_data_root_apk }}/{{ item.filename }}"
-#    checksum: "sha256:{{ item.sha256sum }}"
 #    mode: "0644"
 #    timeout: "{{ download_timeout }}"
-#  loop: "{{ code_arm32_release_apk }}"
+#  loop: "{{ code_apk_32bit_filename }}"

--- a/roles/code/tasks/install_apkfile.yml
+++ b/roles/code/tasks/install_apkfile.yml
@@ -5,19 +5,17 @@
     # mode: 0755
 
 ### Current release - arm64 ###
-- name: Download arch arm64 APK
+- name: Download arch arm 64-bits APK
   get_url:
     url: "{{ code_download_url }}/{{ code_apk_64bit_filename }}"
     dest: "{{ code_data_root_apk }}/{{ code_apk_64bit_filename }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"
-  when: code_apk_64bit_filename
 
 ### Future release - arm32 ###
-#- name: Download arch arm64 APK
+#- name: Download arch arm 32-bits APK
 #  get_url:
-#    url: "{{ code_download_url }}/{{ code_apk_64bit_filename }}"
-#    dest: "{{ code_data_root_apk }}/{{ code_apk_64bit_filename }}"
+#    url: "{{ code_download_url }}/{{ code_apk_32bit_filename }}"
+#    dest: "{{ code_data_root_apk }}/{{ code_apk_32bit_filename }}"
 #    mode: "0644"
 #    timeout: "{{ download_timeout }}"
-#  when: code_apk_64bit_filename

--- a/roles/code/tasks/main.yml
+++ b/roles/code/tasks/main.yml
@@ -17,8 +17,8 @@
       include_tasks: install.yml
       when: code_installed is undefined
 
-    - name: Enable/Disable/Reload NGINX for code, if nginx_enabled
-      include_tasks: nginx.yml
+    - name: Enable/Disable/Reload NGINX for COTG
+      include_tasks: enable-or-disable.yml
 
     - name: Add 'code' variable values to {{ iiab_ini_file }}
       ini_file:

--- a/roles/code/templates/content/en.md.j2
+++ b/roles/code/templates/content/en.md.j2
@@ -34,7 +34,7 @@ To get help at any time, long-press anything to display a brief tooltip with lin
 
 ## Download
 
-Code on the Go is updated weekly, the version being hosted on this site is: **{{ cotg_version_raw.stdout }}**  
+Code on the Go is updated weekly, the version being hosted on this site is: **{{ cotg_version }}**  
 If you want to get details about the latest release; please visit [https://www.appdevforall.org/codeonthego/](https://www.appdevforall.org/codeonthego/)
 
 <div class="download-button-wrapper">

--- a/roles/code/templates/content/en.md.j2
+++ b/roles/code/templates/content/en.md.j2
@@ -38,8 +38,12 @@ Code on the Go is updated weekly, the version being hosted on this site is: **{{
 If you want to get details about the latest release; please visit [https://www.appdevforall.org/codeonthego/](https://www.appdevforall.org/codeonthego/)
 
 <div class="download-button-wrapper">
-  <a href="static/apk/{{ code_arm64_release_apk[0].filename }}" class="download-button">Download Code on the Go (64-bit ARM devices)</a>
+  <a href="static/apk/{{ code_apk_64bit_filename }}" class="download-button">Download Code on the Go (64-bit ARM devices)</a>
 </div>
+
+<!-- <div class="download-button-wrapper">
+  <a href="static/apk/{{ code_apk_32bit_filename }}" class="download-button">Download Code on the Go (32-bit ARM devices)</a>
+</div> -->
 
 ## Online resources
 

--- a/roles/code/templates/content/es.md.j2
+++ b/roles/code/templates/content/es.md.j2
@@ -37,8 +37,12 @@ Code on the Go es actualizado semanalmente, la versión siendo alojada por esta 
 Si desea conocer los detalles acerca de la versión mas reciente; por favor visite [https://www.appdevforall.org/codeonthego/](https://www.appdevforall.org/codeonthego/)
 
 <div class="download-button-wrapper">
-  <a href="static/apk/{{ code_arm64_release_apk[0].filename }}" class="download-button">Descargue Code on the Go (dispositivos ARM de 64 bits)</a>
+  <a href="static/apk/{{ code_apk_64bit_filename }}" class="download-button">Descargue Code on the Go (dispositivos ARM de 64 bits)</a>
 </div>
+
+<!-- <div class="download-button-wrapper">
+  <a href="static/apk/{{ code_apk_32bit_filename }}" class="download-button">Descargue Code on the Go (dispositivos ARM de 32 bits)</a>
+</div> -->
 
 ## Recursos en línea
 

--- a/roles/code/templates/content/es.md.j2
+++ b/roles/code/templates/content/es.md.j2
@@ -33,7 +33,7 @@ Para obtener ayuda en cualquier momento, mantén pulsado cualquier elemento para
 
 ## Descargar
 
-Code on the Go es actualizado semanalmente, la versión siendo alojada por esta página es: **{{ cotg_version_raw.stdout }}**   
+Code on the Go es actualizado semanalmente, la versión siendo alojada por esta página es: **{{ cotg_version }}**   
 Si desea conocer los detalles acerca de la versión mas reciente; por favor visite [https://www.appdevforall.org/codeonthego/](https://www.appdevforall.org/codeonthego/)
 
 <div class="download-button-wrapper">


### PR DESCRIPTION
### Fixes bug:
#4174 

### Description of changes proposed in this pull request:
~~Replace "latest" apk url with latest existing one on download page.~~

Workaround the CDN restriction until ADFA normalize it's service. A follow up PR should address new changes when settled. 

### Smoke-tested on which OS or OS's:
Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 