### PR TITLE
FIX code/tasks/install.yml: Don't run enable-or-disable.yml (was nginx.yml) until later!

### DIFF
--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -120,10 +120,6 @@
   include_tasks: install_apkfile.yml
   when: code_blocked_by_cdn is undefined
 
-- name: Setup 'code' nginx conf file
-  include_tasks: nginx.yml
-  when: code_blocked_by_cdn is undefined
-
 
 # RECORD CODE AS INSTALLED
 


### PR DESCRIPTION
### Fixes bug:

MEDIUM-sized and larger IIAB installs were broken, due to my oversight / misunderstanding of @Ark76's code within...

- PR #4176

### Description of changes proposed in this pull request:

Just run enable-or-disable.yml when needed (after install.yml has completed).

### Smoke-tested on which OS or OS's:

Ongoing.

### Mention a team member @username e.g. to help with code review:

@Ark74