### PR TITLE
www_options: Restore browser autostart on RPiOS w/ desktop, by renaming chromium-browser to chromium

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -37,9 +37,10 @@
     path: /home/{{ iiab_admin_user }}/.config/labwc/
   register: labwc_dir
 
-- name: Does /usr/bin/chromium-browser exist?
+# 2025-12-14: RasPiOS 13 "Trixie" recently renamed chromium-browser to chromium
+- name: Does /usr/bin/chromium exist?
   stat:
-    path: /usr/bin/chromium-browser
+    path: /usr/bin/chromium
   register: chromium_browser
 
 # - name: Does /usr/bin/chromium exist? (check for browser filename change)
@@ -48,12 +49,12 @@
 #   register: chromium_present
 
 # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
-- name: If both above exist, add '/usr/bin/chromium-browser --disable-restore-session-state http://box/home &' to /home/{{ iiab_admin_user }}/.config/labwc/autostart
+- name: If both above exist, add '/usr/bin/chromium --disable-restore-session-state http://box/home &' to /home/{{ iiab_admin_user }}/.config/labwc/autostart
   lineinfile:
     path: /home/{{ iiab_admin_user }}/.config/labwc/autostart    # iiab-admin
     create: yes
     regexp: '^/usr/bin/chromium'
-    line: '/usr/bin/chromium-browser --disable-restore-session-state http://box/home &'
+    line: '/usr/bin/chromium --disable-restore-session-state http://box/home &'
   when: labwc_dir.stat.exists and labwc_dir.stat.isdir and chromium_browser.stat.exists
 
 # - name: Add chromium to /etc/xdg/lxsession/LXDE-pi/autostart


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Auto-detect chromium browser correctly on the latest RPiOS with desktop, so as to set up `/home/iiab-admin/.config/labwc/autostart` properly for browser auto-launch on boot (e.g. if {{ iiab_admin_user }} is iiab-admin).

### Smoke-tested on which OS or OS's:

RPiOS 13 "Trixie" 2025-12-04 with desktop

### Mention a team member @username e.g. to help with code review:

@avni

### Related PRs

- PR #3685
- PR #3859