### PR TITLE
Add file sizes and log reading instructions to map downloads

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -68,7 +68,7 @@ maplibre_search_js_and_styles:
 
 maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
 
-# Mostly colors, topography, etc. 58M
+# Mostly colors, topography, etc.
 maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
 
 # Two different symlinks because the front end could requset openstreetmap or naturalearth
@@ -80,17 +80,17 @@ maps_dot_black_ne_symlink_name: naturalearth-openmaptiles.pmtiles
 # option and just have low zoom osm. So then it will be `maps_vector_zoom` and
 # just have numbers, like for satellite.
 maps_dot_black_vector_tiles:
-  # "high res" full osm, including 3d buildings. 78GiB as of Oct 2025
+  # "high res" full osm, including 3d buildings.
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-full"
   osm-full: "openstreetmap-openmaptiles.{{ maps_data_date }}.full.pmtiles"
 
-  # "medium res" osm, up to zoom level 9 (original file has 14). 1.9GiB as of Oct 2025
+  # "medium res" osm, up to zoom level 9 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
   osm-z9: "openstreetmap-openmaptiles.{{ maps_data_date }}.zoom_0-09.pmtiles"
 
-  # "low res" - mostly borders, rivers, country names, large roads. 85MB
+  # "low res" - mostly borders, rivers, country names, large roads.
   # maps_vector_quality = "ne"
   # (ne = "Natural Earth")
   ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.full.pmtiles"
@@ -98,19 +98,19 @@ maps_dot_black_vector_tiles:
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
 maps_dot_black_satellite_tiles:
-  # Low quality satellite, up to zoom level 7 (original file has 13), 85MiB
+  # Low quality satellite, up to zoom level 7 (original file has 13)
   # maps_sat_zoom = 7
   7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
 
-  # Moderately high quality satellite, up to zoom level 9 (original file has 13), 1.2GiB
+  # Moderately high quality satellite, up to zoom level 9 (original file has 13)
   # maps_sat_zoom = 9
   9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
 
-  # Pretty high quality satellite, up to zoom level 11 (original file has 13), 21GiB
+  # Pretty high quality satellite, up to zoom level 11 (original file has 13)
   # maps_sat_zoom = 11
   11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-11.pmtiles"
 
-  # Pretty high quality satellite, up to zoom level 12 (original file has 13), 80GiB
+  # Pretty high quality satellite, up to zoom level 12 (original file has 13)
   # maps_sat_zoom = 12
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -91,23 +91,23 @@
       args:
         executable: /bin/bash
         creates: "{{ dest_path }}"
-    vars:
-      # Where the file eventually goes
-      dest_path: "{{ dest_base_path }}/{{ item }}"
-      log_file: "{{ item }}.log"
-      working_dir: "/library/downloads/maps"
-    rescue:
-      # We output summaries to a log file for the user's benefit,
-      # but all of the errors necessarily show up there as well.
-      # Here, we parse out the error message, ignoring almost all of
-      # the summary lines, which could be a lot.
-      # Finally, we exit 1 so Ansible shows this error.
-      - name: "Error downloading {{ item }}"
-        shell: |
-          set -euo pipefail
+  vars:
+    # Where the file eventually goes
+    dest_path: "{{ dest_base_path }}/{{ item }}"
+    log_file: "{{ item }}.log"
+    working_dir: "/library/downloads/maps"
+  rescue:
+    # We output summaries to a log file for the user's benefit,
+    # but all of the errors necessarily show up there as well.
+    # Here, we parse out the error message, ignoring almost all of
+    # the summary lines, which could be a lot.
+    # Finally, we exit 1 so Ansible shows this error.
+    - name: "Error downloading {{ item }}"
+      shell: |
+        set -euo pipefail
 
-          cd {{ working_dir }}
+        cd {{ working_dir }}
 
-          echo "aria2c error:" 1>&2
-          tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
-          exit 1
+        echo "aria2c error:" 1>&2
+        tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
+        exit 1

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -56,38 +56,41 @@
         size_disp = str(round(size / MiB, 2)) + ' MiB'
       else:
         size_disp = str(round(size / GiB, 2)) + ' GiB'
-      print(' (' + size_disp + ')')
+      print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
     args:
       executable: /usr/bin/python3
     register: download_file_size
 
-  - name: "Download {{ iiab_map_host_url }}/{{ item }}{{ download_file_size.stdout_lines.0 | default('')}} via .meta4 file"
+  - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
     # cd to the temp directory so that the aria2c file, data file, and (perhaps
     # eventually) torrent file all end up there.
     shell: |
       set -euo pipefail
 
-      cd /library/downloads/maps/
+      cd {{ working_dir }}
 
       aria2c \
           --connect-timeout="{{ download_timeout }}" \
           --log-level=warn \
           --console-log-level=warn \
-          --summary-interval=0 \
-          --show-console-readout=false \
+          --summary-interval=600 \
           --download-result=hide \
           --follow-metalink=mem \
           --max-connection-per-server=4 \
           --file-allocation=falloc \
           --enable-http-pipelining=true \
           --seed-time=0 \
-          "{{ iiab_map_host_url }}/{{ item }}.meta4"
+          "{{ iiab_map_host_url }}/{{ item }}.meta4" \
+          > "{{ log_file }}"
 
       chmod 644 "{{ item }}"
       mv "{{ item }}" "{{ dest_path }}"
+      rm "{{ log_file }}"
     args:
       executable: /bin/bash
       creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item }}"
+    log_file: "{{ item }}.log"
+    working_dir: "/library/downloads/maps"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -62,6 +62,7 @@
       vars:
         # Where the file eventually goes
         dest_path: "{{ dest_base_path }}/{{ item }}"
+
         log_file: "{{ item }}.log"
         working_dir: "/library/downloads/maps"
       register: download_file_size
@@ -99,6 +100,7 @@
       vars:
         # Where the file eventually goes
         dest_path: "{{ dest_base_path }}/{{ item }}"
+
         log_file: "{{ item }}.log"
         working_dir: "/library/downloads/maps"
   rescue:
@@ -116,3 +118,6 @@
         echo "aria2c error:" 1>&2
         tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
         exit 1
+      vars:
+        log_file: "{{ item }}.log"
+        working_dir: "/library/downloads/maps"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -102,7 +102,7 @@
     # Here, we parse out the error message, ignoring almost all of
     # the summary lines, which could be a lot.
     # Finally, we exit 1 so Ansible shows this error.
-    - name: "Output aria2 error without showing a ton of summary lines"
+    - name: "Error downloading {{ item }}"
       shell: |
         set -euo pipefail
 

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -69,11 +69,12 @@
 
       cd {{ working_dir }}
 
+      echo "Starting download..." > "{{ log_file }}"
       aria2c \
           --connect-timeout="{{ download_timeout }}" \
           --log-level=warn \
           --console-log-level=warn \
-          --summary-interval=600 \
+          --summary-interval=60 \
           --download-result=hide \
           --follow-metalink=mem \
           --max-connection-per-server=4 \
@@ -81,7 +82,7 @@
           --enable-http-pipelining=true \
           --seed-time=0 \
           "{{ iiab_map_host_url }}/{{ item }}.meta4" \
-          > "{{ log_file }}"
+          >> "{{ log_file }}"
 
       chmod 644 "{{ item }}"
       mv "{{ item }}" "{{ dest_path }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -36,11 +36,6 @@
 # TODO - files should be owned by www-data
 
 - block:
-    vars:
-      # Where the file eventually goes
-      dest_path: "{{ dest_base_path }}/{{ item }}"
-      log_file: "{{ item }}.log"
-      working_dir: "/library/downloads/maps"
     - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
       shell: |
         import sys, xmltodict, requests, os
@@ -96,6 +91,11 @@
       args:
         executable: /bin/bash
         creates: "{{ dest_path }}"
+    vars:
+      # Where the file eventually goes
+      dest_path: "{{ dest_base_path }}/{{ item }}"
+      log_file: "{{ item }}.log"
+      working_dir: "/library/downloads/maps"
     rescue:
       # We output summaries to a log file for the user's benefit,
       # but all of the errors necessarily show up there as well.

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -96,3 +96,18 @@
     dest_path: "{{ dest_base_path }}/{{ item }}"
     log_file: "{{ item }}.log"
     working_dir: "/library/downloads/maps"
+  rescue:
+    # We output summaries to a log file for the user's benefit,
+    # but all of the errors necessarily show up there as well.
+    # Here, we parse out the error message, ignoring almost all of
+    # the summary lines, which could be a lot.
+    # Finally, we exit 1 so Ansible shows this error.
+    - name: "Output aria2 error without showing a ton of summary lines"
+      shell: |
+        set -euo pipefail
+
+        cd {{ working_dir }}
+
+        echo "aria2c error:" 1>&2
+        tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
+        exit 1

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -35,66 +35,62 @@
 #
 # TODO - files should be owned by www-data
 
-- name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
-  shell: |
-    import sys, xmltodict, requests, os
+- block:
+  - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
+    shell: |
+      import sys, xmltodict, requests, os
 
-    if os.path.exists("{{ dest_path }}"):
-      sys.exit(0)
+      if os.path.exists("{{ dest_path }}"):
+        sys.exit(0)
 
-    size = int(xmltodict.parse(
-      requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
-    )['metalink']['file']['size'])
-    KiB = 1024
-    MiB = KiB * 1024
-    GiB = MiB * 1024
+      size = int(xmltodict.parse(
+        requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
+      )['metalink']['file']['size'])
+      KiB = 1024
+      MiB = KiB * 1024
+      GiB = MiB * 1024
 
-    if size < MiB:
-      size_disp = str(round(size / KiB, 2)) + ' KiB'
-    elif size < GiB:
-      size_disp = str(round(size / MiB, 2)) + ' MiB'
-    else:
-      size_disp = str(round(size / GiB, 2)) + ' GiB'
-    print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
-  args:
-    executable: /usr/bin/python3
-  vars:
-    # Where the file eventually goes
-    dest_path: "{{ dest_base_path }}/{{ item }}"
-    log_file: "{{ item }}.log"
-    working_dir: "/library/downloads/maps"
-  register: download_file_size
+      if size < MiB:
+        size_disp = str(round(size / KiB, 2)) + ' KiB'
+      elif size < GiB:
+        size_disp = str(round(size / MiB, 2)) + ' MiB'
+      else:
+        size_disp = str(round(size / GiB, 2)) + ' GiB'
+      print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
+    args:
+      executable: /usr/bin/python3
+    register: download_file_size
 
-- name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
-  # cd to the temp directory so that the aria2c file, data file, and (perhaps
-  # eventually) torrent file all end up there.
-  shell: |
-    set -euo pipefail
+  - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
+    # cd to the temp directory so that the aria2c file, data file, and (perhaps
+    # eventually) torrent file all end up there.
+    shell: |
+      set -euo pipefail
 
-    cd {{ working_dir }}
+      cd {{ working_dir }}
 
-    echo "Starting download..." > "{{ log_file }}"
-    aria2c \
-        --connect-timeout="{{ download_timeout }}" \
-        --log-level=warn \
-        --console-log-level=warn \
-        --summary-interval=60 \
-        --download-result=hide \
-        --follow-metalink=mem \
-        --max-connection-per-server=4 \
-        --file-allocation=falloc \
-        --show-console-readout=false \
-        --enable-http-pipelining=true \
-        --seed-time=0 \
-        "{{ iiab_map_host_url }}/{{ item }}.meta4" \
-        >> "{{ log_file }}"
+      echo "Starting download..." > "{{ log_file }}"
+      aria2c \
+          --connect-timeout="{{ download_timeout }}" \
+          --log-level=warn \
+          --console-log-level=warn \
+          --summary-interval=60 \
+          --download-result=hide \
+          --follow-metalink=mem \
+          --max-connection-per-server=4 \
+          --file-allocation=falloc \
+          --show-console-readout=false \
+          --enable-http-pipelining=true \
+          --seed-time=0 \
+          "{{ iiab_map_host_url }}/{{ item }}.meta4" \
+          >> "{{ log_file }}"
 
-    chmod 644 "{{ item }}"
-    mv "{{ item }}" "{{ dest_path }}"
-    rm "{{ log_file }}"
-  args:
-    executable: /bin/bash
-    creates: "{{ dest_path }}"
+      chmod 644 "{{ item }}"
+      mv "{{ item }}" "{{ dest_path }}"
+      rm "{{ log_file }}"
+    args:
+      executable: /bin/bash
+      creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -35,33 +35,59 @@
 #
 # TODO - files should be owned by www-data
 
-- name: "Download {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
-  # cd to the temp directory so that the aria2c file, data file, and (perhaps
-  # eventually) torrent file all end up there.
-  shell: |
-    set -euo pipefail
+- block:
+  - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
+    shell: |
+      import sys, xmltodict, requests, os
 
-    cd /library/downloads/maps/
+      if os.path.exists("{{ dest_path }}"):
+        sys.exit(0)
 
-    aria2c \
-        --connect-timeout="{{ download_timeout }}" \
-        --log-level=warn \
-        --console-log-level=warn \
-        --summary-interval=0 \
-        --show-console-readout=false \
-        --download-result=hide \
-        --follow-metalink=mem \
-        --max-connection-per-server=4 \
-        --file-allocation=falloc \
-        --enable-http-pipelining=true \
-        --seed-time=0 \
-        "{{ iiab_map_host_url }}/{{ item }}.meta4"
+      size = int(xmltodict.parse(
+        requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
+      )['metalink']['file']['size'])
+      KiB = 1024
+      MiB = KiB * 1024
+      GiB = MiB * 1024
 
-    chmod 644 "{{ item }}"
-    mv "{{ item }}" "{{ dest_path }}"
-  args:
-    executable: /bin/bash
-    creates: "{{ dest_path }}"
+      if size < MiB:
+        size_disp = str(round(size / KiB, 2)) + ' KiB'
+      elif size < GiB:
+        size_disp = str(round(size / MiB, 2)) + ' MiB'
+      else:
+        size_disp = str(round(size / GiB, 2)) + ' GiB'
+      print(' (' + size_disp + ')')
+    args:
+      executable: /usr/bin/python3
+    register: download_file_size
+
+  - name: "Download {{ iiab_map_host_url }}/{{ item }}{{ download_file_size.stdout_lines.0 | default('')}} via .meta4 file"
+    # cd to the temp directory so that the aria2c file, data file, and (perhaps
+    # eventually) torrent file all end up there.
+    shell: |
+      set -euo pipefail
+
+      cd /library/downloads/maps/
+
+      aria2c \
+          --connect-timeout="{{ download_timeout }}" \
+          --log-level=warn \
+          --console-log-level=warn \
+          --summary-interval=0 \
+          --show-console-readout=false \
+          --download-result=hide \
+          --follow-metalink=mem \
+          --max-connection-per-server=4 \
+          --file-allocation=falloc \
+          --enable-http-pipelining=true \
+          --seed-time=0 \
+          "{{ iiab_map_host_url }}/{{ item }}.meta4"
+
+      chmod 644 "{{ item }}"
+      mv "{{ item }}" "{{ dest_path }}"
+    args:
+      executable: /bin/bash
+      creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item }}"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -59,6 +59,11 @@
         print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
       args:
         executable: /usr/bin/python3
+      vars:
+        # Where the file eventually goes
+        dest_path: "{{ dest_base_path }}/{{ item }}"
+        log_file: "{{ item }}.log"
+        working_dir: "/library/downloads/maps"
       register: download_file_size
 
     - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
@@ -91,11 +96,11 @@
       args:
         executable: /bin/bash
         creates: "{{ dest_path }}"
-  vars:
-    # Where the file eventually goes
-    dest_path: "{{ dest_base_path }}/{{ item }}"
-    log_file: "{{ item }}.log"
-    working_dir: "/library/downloads/maps"
+      vars:
+        # Where the file eventually goes
+        dest_path: "{{ dest_base_path }}/{{ item }}"
+        log_file: "{{ item }}.log"
+        working_dir: "/library/downloads/maps"
   rescue:
     # We output summaries to a log file for the user's benefit,
     # but all of the errors necessarily show up there as well.

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -79,6 +79,7 @@
           --follow-metalink=mem \
           --max-connection-per-server=4 \
           --file-allocation=falloc \
+          --show-console-readout=false \
           --enable-http-pipelining=true \
           --seed-time=0 \
           "{{ iiab_map_host_url }}/{{ item }}.meta4" \

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -36,78 +36,78 @@
 # TODO - files should be owned by www-data
 
 - block:
-  - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
-    shell: |
-      import sys, xmltodict, requests, os
+    vars:
+      # Where the file eventually goes
+      dest_path: "{{ dest_base_path }}/{{ item }}"
+      log_file: "{{ item }}.log"
+      working_dir: "/library/downloads/maps"
+    - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
+      shell: |
+        import sys, xmltodict, requests, os
 
-      if os.path.exists("{{ dest_path }}"):
-        sys.exit(0)
+        if os.path.exists("{{ dest_path }}"):
+          sys.exit(0)
 
-      size = int(xmltodict.parse(
-        requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
-      )['metalink']['file']['size'])
-      KiB = 1024
-      MiB = KiB * 1024
-      GiB = MiB * 1024
+        size = int(xmltodict.parse(
+          requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
+        )['metalink']['file']['size'])
+        KiB = 1024
+        MiB = KiB * 1024
+        GiB = MiB * 1024
 
-      if size < MiB:
-        size_disp = str(round(size / KiB, 2)) + ' KiB'
-      elif size < GiB:
-        size_disp = str(round(size / MiB, 2)) + ' MiB'
-      else:
-        size_disp = str(round(size / GiB, 2)) + ' GiB'
-      print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
-    args:
-      executable: /usr/bin/python3
-    register: download_file_size
+        if size < MiB:
+          size_disp = str(round(size / KiB, 2)) + ' KiB'
+        elif size < GiB:
+          size_disp = str(round(size / MiB, 2)) + ' MiB'
+        else:
+          size_disp = str(round(size / GiB, 2)) + ' GiB'
+        print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
+      args:
+        executable: /usr/bin/python3
+      register: download_file_size
 
-  - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
-    # cd to the temp directory so that the aria2c file, data file, and (perhaps
-    # eventually) torrent file all end up there.
-    shell: |
-      set -euo pipefail
-
-      cd {{ working_dir }}
-
-      echo "Starting download..." > "{{ log_file }}"
-      aria2c \
-          --connect-timeout="{{ download_timeout }}" \
-          --log-level=warn \
-          --console-log-level=warn \
-          --summary-interval=60 \
-          --download-result=hide \
-          --follow-metalink=mem \
-          --max-connection-per-server=4 \
-          --file-allocation=falloc \
-          --show-console-readout=false \
-          --enable-http-pipelining=true \
-          --seed-time=0 \
-          "{{ iiab_map_host_url }}/{{ item }}.meta4" \
-          >> "{{ log_file }}"
-
-      chmod 644 "{{ item }}"
-      mv "{{ item }}" "{{ dest_path }}"
-      rm "{{ log_file }}"
-    args:
-      executable: /bin/bash
-      creates: "{{ dest_path }}"
-  vars:
-    # Where the file eventually goes
-    dest_path: "{{ dest_base_path }}/{{ item }}"
-    log_file: "{{ item }}.log"
-    working_dir: "/library/downloads/maps"
-  rescue:
-    # We output summaries to a log file for the user's benefit,
-    # but all of the errors necessarily show up there as well.
-    # Here, we parse out the error message, ignoring almost all of
-    # the summary lines, which could be a lot.
-    # Finally, we exit 1 so Ansible shows this error.
-    - name: "Error downloading {{ item }}"
+    - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
+      # cd to the temp directory so that the aria2c file, data file, and (perhaps
+      # eventually) torrent file all end up there.
       shell: |
         set -euo pipefail
 
         cd {{ working_dir }}
 
-        echo "aria2c error:" 1>&2
-        tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
-        exit 1
+        echo "Starting download..." > "{{ log_file }}"
+        aria2c \
+            --connect-timeout="{{ download_timeout }}" \
+            --log-level=warn \
+            --console-log-level=warn \
+            --summary-interval=60 \
+            --download-result=hide \
+            --follow-metalink=mem \
+            --max-connection-per-server=4 \
+            --file-allocation=falloc \
+            --show-console-readout=false \
+            --enable-http-pipelining=true \
+            --seed-time=0 \
+            "{{ iiab_map_host_url }}/{{ item }}.meta4" \
+            >> "{{ log_file }}"
+
+        chmod 644 "{{ item }}"
+        mv "{{ item }}" "{{ dest_path }}"
+        rm "{{ log_file }}"
+      args:
+        executable: /bin/bash
+        creates: "{{ dest_path }}"
+    rescue:
+      # We output summaries to a log file for the user's benefit,
+      # but all of the errors necessarily show up there as well.
+      # Here, we parse out the error message, ignoring almost all of
+      # the summary lines, which could be a lot.
+      # Finally, we exit 1 so Ansible shows this error.
+      - name: "Error downloading {{ item }}"
+        shell: |
+          set -euo pipefail
+
+          cd {{ working_dir }}
+
+          echo "aria2c error:" 1>&2
+          tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
+          exit 1

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -35,62 +35,66 @@
 #
 # TODO - files should be owned by www-data
 
-- block:
-  - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
-    shell: |
-      import sys, xmltodict, requests, os
+- name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
+  shell: |
+    import sys, xmltodict, requests, os
 
-      if os.path.exists("{{ dest_path }}"):
-        sys.exit(0)
+    if os.path.exists("{{ dest_path }}"):
+      sys.exit(0)
 
-      size = int(xmltodict.parse(
-        requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
-      )['metalink']['file']['size'])
-      KiB = 1024
-      MiB = KiB * 1024
-      GiB = MiB * 1024
+    size = int(xmltodict.parse(
+      requests.get("{{ iiab_map_host_url }}/{{ item }}.meta4").content
+    )['metalink']['file']['size'])
+    KiB = 1024
+    MiB = KiB * 1024
+    GiB = MiB * 1024
 
-      if size < MiB:
-        size_disp = str(round(size / KiB, 2)) + ' KiB'
-      elif size < GiB:
-        size_disp = str(round(size / MiB, 2)) + ' MiB'
-      else:
-        size_disp = str(round(size / GiB, 2)) + ' GiB'
-      print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
-    args:
-      executable: /usr/bin/python3
-    register: download_file_size
+    if size < MiB:
+      size_disp = str(round(size / KiB, 2)) + ' KiB'
+    elif size < GiB:
+      size_disp = str(round(size / MiB, 2)) + ' MiB'
+    else:
+      size_disp = str(round(size / GiB, 2)) + ' GiB'
+    print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
+  args:
+    executable: /usr/bin/python3
+  vars:
+    # Where the file eventually goes
+    dest_path: "{{ dest_base_path }}/{{ item }}"
+    log_file: "{{ item }}.log"
+    working_dir: "/library/downloads/maps"
+  register: download_file_size
 
-  - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
-    # cd to the temp directory so that the aria2c file, data file, and (perhaps
-    # eventually) torrent file all end up there.
-    shell: |
-      set -euo pipefail
+- name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
+  # cd to the temp directory so that the aria2c file, data file, and (perhaps
+  # eventually) torrent file all end up there.
+  shell: |
+    set -euo pipefail
 
-      cd {{ working_dir }}
+    cd {{ working_dir }}
 
-      echo "Starting download..." > "{{ log_file }}"
-      aria2c \
-          --connect-timeout="{{ download_timeout }}" \
-          --log-level=warn \
-          --console-log-level=warn \
-          --summary-interval=60 \
-          --download-result=hide \
-          --follow-metalink=mem \
-          --max-connection-per-server=4 \
-          --file-allocation=falloc \
-          --show-console-readout=false \
-          --enable-http-pipelining=true \
-          --seed-time=0 \
-          "{{ iiab_map_host_url }}/{{ item }}.meta4" \
-          >> "{{ log_file }}"
+    echo "Starting download..." > "{{ log_file }}"
+    aria2c \
+        --connect-timeout="{{ download_timeout }}" \
+        --log-level=warn \
+        --console-log-level=warn \
+        --summary-interval=60 \
+        --download-result=hide \
+        --follow-metalink=mem \
+        --max-connection-per-server=4 \
+        --file-allocation=falloc \
+        --show-console-readout=false \
+        --enable-http-pipelining=true \
+        --seed-time=0 \
+        "{{ iiab_map_host_url }}/{{ item }}.meta4" \
+        >> "{{ log_file }}"
 
-      chmod 644 "{{ item }}"
-      mv "{{ item }}" "{{ dest_path }}"
-      rm "{{ log_file }}"
-    args:
-      executable: /bin/bash
-      creates: "{{ dest_path }}"
+    chmod 644 "{{ item }}"
+    mv "{{ item }}" "{{ dest_path }}"
+    rm "{{ log_file }}"
+  args:
+    executable: /bin/bash
+    creates: "{{ dest_path }}"
   vars:
     # Where the file eventually goes
     dest_path: "{{ dest_base_path }}/{{ item }}"

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -4,9 +4,11 @@
     state: directory
     # mode: 0755
 
-- name: Install aria2
+- name: Install downloading tools
   apt:
-    name: aria2
+    name:
+      - aria2
+      - python3-xmltodict
 
 - include_tasks: install_frontend.yml
 


### PR DESCRIPTION
### Fixes bug:

Users don't know how big the file is that they're downloading, nor how far along they are.

### Description of changes proposed in this pull request:

Firstly, run a python script that does a request for the meta4 file (this is skipped if the file is already downloaded) and pulls out the file size. That size is then injected into the name of the downloading task for the implementer's benefit.

Secondly, I output aria2c updates to a log file and give users instructions on how to read it.

### Smoke-tested on which OS or OS's:

Ras Pi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 