### PR TITLE
[code] update fetch page and download url for new codg hosting changes.

### DIFF
--- a/.github/workflows/tests/expected_state_medium.yml
+++ b/.github/workflows/tests/expected_state_medium.yml
@@ -24,3 +24,4 @@ awstats_installed: True
 matomo_installed: True
 captiveportal_installed: True
 calibreweb_installed: True
+code_installed: True

--- a/roles/code/defaults/main.yml
+++ b/roles/code/defaults/main.yml
@@ -2,7 +2,8 @@
 # 64-bit support for now, leaving room for future 32-bit support.
 
 # URL & Regular Expressions
-code_download_url: https://appdevforall.org/apk_repo
+code_fetch_apk_url: https://www.appdevforall.org/codeonthego
+code_download_url: https://download.appdevforall.org
 code_apk_32bit_pattern: "CodeOnTheGo-.*?armv7a\\.apk"
 code_apk_64bit_pattern: "CodeOnTheGo-.*?armv8a\\.apk"
 

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -92,7 +92,7 @@
 
 - name: Get CodeOnTheGo version number
   set_fact:
-    cotg_version: "{{ code_apk_64bit_filename | regex_search('CodeOnTheGo-release([0-9.]+)', '\\1') }}"
+    cotg_version: "{{ (code_apk_64bit_filename | regex_findall('CodeOnTheGo-release([0-9]+(?:\\.[0-9]+)*)') | first) }}"
   when: code_blocked_by_cdn is undefined
 
 - name: "Show resolved APK release name"

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -21,12 +21,12 @@
   when: code_apk_release_name is undefined
   block:
 
-    - name: Fetch APK index page from {{ code_download_url }}/
+    - name: Fetch APK index page from {{ code_fetch_apk_url }}/
       uri:
-        url: "{{ code_download_url }}/"
+        url: "{{ code_fetch_apk_url }}/"
         return_content: true
       register: apk_index
-      failed_when: apk_index.status != 200 and apk_index.status != 403
+      failed_when: apk_index.status not in [200, 403, 404]
 
     - name: Mark 'code' role as blocked by CDN
       set_fact:
@@ -68,6 +68,7 @@
             | regex_findall(code_apk_64bit_pattern)
             | sort
             | last
+            | default('')
           }}
       when: code_blocked_by_cdn is undefined
 
@@ -79,8 +80,14 @@
             | regex_findall(code_apk_32bit_pattern)
             | sort
             | last
+            | default('')
           }}
       when: code_blocked_by_cdn is undefined
+
+    - name: Fail if no apk is found on fetched page.
+      fail:
+        msg: Could not find expected APK link in page. (Status = {{ apk_index.status }})
+      when: code_apk_64bit_filename | length == 0
 
 - name: Get CodeOnTheGo version number
   set_fact:

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -88,6 +88,7 @@
       fail:
         msg: Could not find expected APK link in page. (Status = {{ apk_index.status }})
       when: code_apk_64bit_filename | length == 0
+      #ignore_errors: yes
 
 - name: Get CodeOnTheGo version number
   set_fact:

--- a/roles/code/templates/content/en.md.j2
+++ b/roles/code/templates/content/en.md.j2
@@ -49,8 +49,6 @@ If you want to get details about the latest release; please visit [https://www.a
 
 Find some useful resources online to interact with the community of users and developers behind Code on the Go.
 
-- [Online APK repo](https://appdevforall.org/apk_repo/)
-- [Repo archive](https://appdevforall.org/apk_repo/archive/)
 - [GitHub Issues page](https://github.com/appdevforall/CodeOnTheGo/issues)
 - [Telegram Official Channel](https://t.me/CodeOnTheGoOfficial)
 - [Telegram Discussion Group](https://t.me/CodeOnTheGoDiscussions)

--- a/roles/code/templates/content/en.md.j2
+++ b/roles/code/templates/content/en.md.j2
@@ -49,6 +49,7 @@ If you want to get details about the latest release; please visit [https://www.a
 
 Find some useful resources online to interact with the community of users and developers behind Code on the Go.
 
+- [Online Release Website](https://www.appdevforall.org/codeonthego/)
 - [GitHub Issues page](https://github.com/appdevforall/CodeOnTheGo/issues)
 - [Telegram Official Channel](https://t.me/CodeOnTheGoOfficial)
 - [Telegram Discussion Group](https://t.me/CodeOnTheGoDiscussions)

--- a/roles/code/templates/content/es.md.j2
+++ b/roles/code/templates/content/es.md.j2
@@ -48,6 +48,7 @@ Si desea conocer los detalles acerca de la versión mas reciente; por favor visi
 
 Encuentre algunos recursos útiles en línea para interactuar con la comunidad de usuarios y desarrolladores detrás de Code on the Go.
 
+- [Página en línea de Publicaciones](https://www.appdevforall.org/codeonthego/)
 - [Pagina de Incidencias de GitHub](https://github.com/appdevforall/CodeOnTheGo/issues)
 - [Canal Oficial de Telegram](https://t.me/CodeOnTheGoOfficial)
 - [Grupo de Discusión de Telegram](https://t.me/CodeOnTheGoDiscussions)

--- a/roles/code/templates/content/es.md.j2
+++ b/roles/code/templates/content/es.md.j2
@@ -48,8 +48,6 @@ Si desea conocer los detalles acerca de la versión mas reciente; por favor visi
 
 Encuentre algunos recursos útiles en línea para interactuar con la comunidad de usuarios y desarrolladores detrás de Code on the Go.
 
-- [Repositorio APK en línea](https://appdevforall.org/apk_repo/)
-- [Archivo del repositorio](https://appdevforall.org/apk_repo/archive/)
 - [Pagina de Incidencias de GitHub](https://github.com/appdevforall/CodeOnTheGo/issues)
 - [Canal Oficial de Telegram](https://t.me/CodeOnTheGoOfficial)
 - [Grupo de Discusión de Telegram](https://t.me/CodeOnTheGoDiscussions)


### PR DESCRIPTION
### Fixes bug:
Update download apk website from deprecated  [1] to new one [2].

[1] https://appdevforall.org/apk_repo
[2] https://download.appdevforall.org

To actual download the latest release apk release.

### Description of changes proposed in this pull request:
Add new var:
- code_fetch_apk_url: https://www.appdevforall.org/codeonthego/

By updating we pull from the new download sources. Along we update for a  new url to parse the apk release and deal with last remaining CloudFlare traffic sanitation issues like receiving 404 response even when serving the actual website:

```
$ curl -I https://www.appdevforall.org/codeonthego/
HTTP/2 404 
date: Thu, 18 Dec 2025 20:23:12 GMT
content-type: text/html; charset=UTF-8
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=wPIhEP4GuMr2O0gyTdQFS9OsfZkxqsUNyH8ZDnVxZY9WLyN%2BgdIQ3JkbnPKc8MhWQONV10fnpuzmc4OmHIi2oOi33ZXhQS%2BtkGiNdVB4Rgyj91NYgnoXqyJRCk56%2FP%2FR"}]}
x-powered-by: PHP/8.1.33
link: <https://www.appdevforall.org/wp-json/>; rel="https://api.w.org/"
link: <https://www.appdevforall.org/wp-json/wp/v2/pages/2223>; rel="alternate"; title="JSON"; type="application/json"
link: <https://www.appdevforall.org/?p=2223>; rel=shortlink
x-litespeed-cache: hit
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
vary: Accept-Encoding
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
alt-svc: h3=":443"; ma=86400
age: 33378
cache-control: max-age=86400
cf-cache-status: HIT
speculation-rules: "/cdn-cgi/speculation"
server: cloudflare
cf-ray: 9b01606e2c106b34-DFW

```

Browser console:

<img width="1051" height="120" alt="code_404" src="https://github.com/user-attachments/assets/e36fc01f-b6ba-4f3b-a0b8-cc1e1ddc1af3" />

On the good side of things, IP specific 403 restriction seems to be behind us, as they no longer fail.

Convert list variable output to string.
Old:
<img width="920" height="110" alt="list" src="https://github.com/user-attachments/assets/d73bf7bc-9a86-4333-9e5a-9c187f781566" />
New:
<img width="759" height="94" alt="string" src="https://github.com/user-attachments/assets/2e88b977-b5cb-443e-a12b-01c823eadb67" />



### Smoke-tested on which OS or OS's:

Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 