### PR TITLE
Map download touchups

### DIFF
--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -35,7 +35,20 @@
 #
 # TODO - files should be owned by www-data
 
-- block:
+
+- vars:
+    # Where the file eventually goes
+    dest_path: "{{ dest_base_path }}/{{ item }}"
+
+    # Use md5sum to generate the log file name:
+    # * Name has short, consistent length. The "to check progress..." message
+    #   fits within 80 characters on terminal (at least in the current
+    #   ansible version) in case users have small screens.
+    # * If the user mis-copies, it's less likely to do anything destructive.
+    log_file: "{{ item | hash('md5') }}.log"
+    working_dir: "/library/downloads/maps"
+
+  block:
     - name: "Fetching file size for {{ iiab_map_host_url }}/{{ item }} via .meta4 file"
       shell: |
         import sys, xmltodict, requests, os
@@ -59,17 +72,6 @@
         print('(' + size_disp + ') To check download progress see above.')
       args:
         executable: /usr/bin/python3
-      vars:
-        # Where the file eventually goes
-        dest_path: "{{ dest_base_path }}/{{ item }}"
-
-        # Use md5sum to generate the log file name:
-        # * Name has short, consistent length. The "to check progress..." message
-        #   fits within 80 characters on terminal (at least in the current
-        #   ansible version) in case users have small screens.
-        # * If the user mis-copies, it's less likely to do anything destructive.
-        log_file: "{{ item | hash('md5') }}.log"
-        working_dir: "/library/downloads/maps"
 
       # The existence of console output in download_file_details
       # implies that the download should happen.
@@ -85,9 +87,6 @@
           - "   tail {{ working_dir }}/{{ log_file }}  "
           - ""
           - ""
-      vars:
-        log_file: "{{ item | hash('md5') }}.log"
-        working_dir: "/library/downloads/maps"
       # If the file already exists (and thus no download will happen) the above
       # task should exit before any console output.
       when: download_file_details.stdout_lines|length != 0
@@ -124,12 +123,7 @@
       args:
         executable: /bin/bash
         creates: "{{ dest_path }}"
-      vars:
-        # Where the file eventually goes
-        dest_path: "{{ dest_base_path }}/{{ item }}"
 
-        log_file: "{{ item | hash('md5') }}.log"
-        working_dir: "/library/downloads/maps"
   rescue:
     # We output summaries to a log file for the user's benefit,
     # but all of the errors necessarily show up there as well.
@@ -145,6 +139,3 @@
         echo "aria2c error:" 1>&2
         tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
         exit 1
-      vars:
-        log_file: "{{ item | hash('md5') }}.log"
-        working_dir: "/library/downloads/maps"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -56,18 +56,42 @@
           size_disp = str(round(size / MiB, 2)) + ' MiB'
         else:
           size_disp = str(round(size / GiB, 2)) + ' GiB'
-        print(' (' + size_disp + ') To check progress, run: "tail {{ working_dir }}/{{ log_file }}"')
+        print('(' + size_disp + ') To check download progress see above.')
       args:
         executable: /usr/bin/python3
       vars:
         # Where the file eventually goes
         dest_path: "{{ dest_base_path }}/{{ item }}"
 
-        log_file: "{{ item }}.log"
+        # Use md5sum to generate the log file name:
+        # * Name has short, consistent length. The "to check progress..." message
+        #   fits within 80 characters on terminal (at least in the current
+        #   ansible version) in case users have small screens.
+        # * If the user mis-copies, it's less likely to do anything destructive.
+        log_file: "{{ item|hash('md5') }}.log"
+
         working_dir: "/library/downloads/maps"
+
       register: download_file_size
 
-    - name: "Download {{ item }}{{ download_file_size.stdout_lines.0 | default(' (done)')}}"
+    # Put in some space to make it easier to read by implementers.
+    - debug:
+        msg:
+            - ""
+            - ""
+            - "   To check download progress, run:       "
+            - ""
+            - "   tail {{ working_dir }}/{{ log_file }}  "
+            - ""
+            - ""
+      vars:
+        log_file: "{{ item|hash('md5') }}.log"
+        working_dir: "/library/downloads/maps"
+      # If the file already exists (and thus no download will happen) the above
+      # task should exit before any console output.
+      when: download_file_size.stdout_lines|length != 0
+
+    - name: "Download {{ item }} {{ download_file_size.stdout_lines.0 | default('(done)')}}"
       # cd to the temp directory so that the aria2c file, data file, and (perhaps
       # eventually) torrent file all end up there.
       shell: |
@@ -101,7 +125,7 @@
         # Where the file eventually goes
         dest_path: "{{ dest_base_path }}/{{ item }}"
 
-        log_file: "{{ item }}.log"
+        log_file: "{{ item|hash('md5') }}.log"
         working_dir: "/library/downloads/maps"
   rescue:
     # We output summaries to a log file for the user's benefit,
@@ -119,5 +143,5 @@
         tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
         exit 1
       vars:
-        log_file: "{{ item }}.log"
+        log_file: "{{ item|hash('md5') }}.log"
         working_dir: "/library/downloads/maps"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -78,13 +78,13 @@
     # Put in some space to make it easier to read by implementers.
     - debug:
         msg:
-            - ""
-            - ""
-            - "   To check download progress, run:       "
-            - ""
-            - "   tail {{ working_dir }}/{{ log_file }}  "
-            - ""
-            - ""
+          - ""
+          - ""
+          - "   To check download progress, run:       "
+          - ""
+          - "   tail {{ working_dir }}/{{ log_file }}  "
+          - ""
+          - ""
       vars:
         log_file: "{{ item | hash('md5') }}.log"
         working_dir: "/library/downloads/maps"

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -69,10 +69,11 @@
         #   ansible version) in case users have small screens.
         # * If the user mis-copies, it's less likely to do anything destructive.
         log_file: "{{ item|hash('md5') }}.log"
-
         working_dir: "/library/downloads/maps"
 
-      register: download_file_size
+      # The existence of console output in download_file_details
+      # implies that the download should happen.
+      register: download_file_details
 
     # Put in some space to make it easier to read by implementers.
     - debug:
@@ -89,9 +90,9 @@
         working_dir: "/library/downloads/maps"
       # If the file already exists (and thus no download will happen) the above
       # task should exit before any console output.
-      when: download_file_size.stdout_lines|length != 0
+      when: download_file_details.stdout_lines|length != 0
 
-    - name: "Download {{ item }} {{ download_file_size.stdout_lines.0 | default('(done)')}}"
+    - name: "Download {{ item }} {{ download_file_details.stdout_lines.0 | default('(done)')}}"
       # cd to the temp directory so that the aria2c file, data file, and (perhaps
       # eventually) torrent file all end up there.
       shell: |
@@ -99,7 +100,9 @@
 
         cd {{ working_dir }}
 
-        echo "Starting download..." > "{{ log_file }}"
+        date > "{{ log_file }}"
+        echo "Starting (or continuing) download for {{ item }}..." >> "{{ log_file }}"
+        echo >> "{{ log_file }}"
         aria2c \
             --connect-timeout="{{ download_timeout }}" \
             --log-level=warn \

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -101,7 +101,7 @@
         cd {{ working_dir }}
 
         date > "{{ log_file }}"
-        echo "Starting (or continuing) download for {{ item }}..." >> "{{ log_file }}"
+        echo "Downloading {{ item }}..." >> "{{ log_file }}"
         echo >> "{{ log_file }}"
         aria2c \
             --connect-timeout="{{ download_timeout }}" \

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -69,7 +69,7 @@
           size_disp = str(round(size / MiB, 2)) + ' MiB'
         else:
           size_disp = str(round(size / GiB, 2)) + ' GiB'
-        print('(' + size_disp + ') To check download progress see above.')
+        print('(' + size_disp + ') To check download progress, see previous step (above).')
       args:
         executable: /usr/bin/python3
 

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -68,7 +68,7 @@
         #   fits within 80 characters on terminal (at least in the current
         #   ansible version) in case users have small screens.
         # * If the user mis-copies, it's less likely to do anything destructive.
-        log_file: "{{ item|hash('md5') }}.log"
+        log_file: "{{ item | hash('md5') }}.log"
         working_dir: "/library/downloads/maps"
 
       # The existence of console output in download_file_details
@@ -86,7 +86,7 @@
             - ""
             - ""
       vars:
-        log_file: "{{ item|hash('md5') }}.log"
+        log_file: "{{ item | hash('md5') }}.log"
         working_dir: "/library/downloads/maps"
       # If the file already exists (and thus no download will happen) the above
       # task should exit before any console output.
@@ -128,7 +128,7 @@
         # Where the file eventually goes
         dest_path: "{{ dest_base_path }}/{{ item }}"
 
-        log_file: "{{ item|hash('md5') }}.log"
+        log_file: "{{ item | hash('md5') }}.log"
         working_dir: "/library/downloads/maps"
   rescue:
     # We output summaries to a log file for the user's benefit,
@@ -146,5 +146,5 @@
         tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
         exit 1
       vars:
-        log_file: "{{ item|hash('md5') }}.log"
+        log_file: "{{ item | hash('md5') }}.log"
         working_dir: "/library/downloads/maps"


### PR DESCRIPTION
### Fixes bug:

For map data downloading in ansible, I was concerned that the "to view progress" line did a line wrap in the ansible task name.

Also the log didn't have a starting timestamp.

### Description of changes proposed in this pull request:

* Output the "to view progress" instructions in a debug task right before the download task.
* Rename the log file to use the md5sum of the file name. That way the file is of shorter, consistent length.
* Output the date in the log, as well as the file name since the log file name no longer matches it due to the md5sum.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 