### PR TITLE
Add terrain to maps [and standardize around "none" (string) or none (NoneType) instead of "", for null values]

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -29,6 +29,30 @@ To configure your map, set the following variables (for the option your choose!)
    maps_sat_zoom: 12
    ```
 
+## What about terrain? (which is still experimental)?
+
+To add terrain files, you can set this optional setting. You may find that when looking at mountains, high quality satellite imagery may compensate for low quality terrain, and vice versa.
+
+1. If you want **~980MB** terrain maps (up to zoom 7), include:
+   ```
+   maps_ter_zoom: 7
+   ```
+
+2. If you want **~6.4GB** terrain maps (up to zoom 8), include:
+   ```
+   maps_ter_zoom: 8
+   ```
+
+3. If you want **~29GB** terrain maps (up to zoom 9), include:
+   ```
+   maps_ter_zoom: 9
+   ```
+
+4. If you want **~106GB** terrain maps (up to zoom 10), include:
+   ```
+   maps_ter_zoom: 10
+   ```
+
 ## Can I try out search (which is still experimental)?
 
 This is not recommended for very low power devices such as Pi Zero 2 W at this time, though this might change.

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -35,22 +35,22 @@ To add terrain files, you can set this optional setting. You may find that when 
 
 1. If you want **~980MB** terrain maps (up to zoom 7), include:
    ```
-   maps_ter_zoom: 7
+   maps_terrain_zoom: 7
    ```
 
 2. If you want **~6.4GB** terrain maps (up to zoom 8), include:
    ```
-   maps_ter_zoom: 8
+   maps_terrain_zoom: 8
    ```
 
 3. If you want **~29GB** terrain maps (up to zoom 9), include:
    ```
-   maps_ter_zoom: 9
+   maps_terrain_zoom: 9
    ```
 
 4. If you want **~106GB** terrain maps (up to zoom 10), include:
    ```
-   maps_ter_zoom: 10
+   maps_terrain_zoom: 10
    ```
 
 ## Can I try out search (which is still experimental)?

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -115,9 +115,10 @@ maps_dot_black_satellite_tiles:
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
-# However this is not ideal as it may point to an extract that we made
-# ourselves that only goes to a lower zoom level. In the near future, we may be
-# able to change what maps.black queries for, and we should change this.
+# However the fact that it includes "z0-z10" is not ideal, as it may point to an
+# extract that we made ourselves that only goes to a lower zoom level. In the
+# near future, we may be able to change what maps.black queries for, and we
+# should change this.
 maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 
 maps_dot_black_terrain_tiles:

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -134,7 +134,7 @@ maps_dot_black_terrain_tiles:
   # maps_ter_zoom = 10
   # (This is the highest quality that maps.black offers in pmtiles format. They
   # offer 11, 12, and 13 in squashfs format, but they are massive files.)
-  10: "terrarium.{{ maps_slow_data_date }}.zoom_0-10.pmtiles"
+  10: "terrarium.{{ maps_slow_data_date }}.full.pmtiles"
 
 nominatim_db_symlink_name: nominatim.sqlite
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -136,6 +136,12 @@ maps_dot_black_terrain_tiles:
   # offer 11, 12, and 13 in squashfs format, but they are massive files.)
   10: "terrarium.{{ maps_slow_data_date }}.full.pmtiles"
 
+  # NOT RECOMMENDED. VERY LOW QUALITY terrain, up to zoom level 5 or 6.
+  # We will probably end up getting rid of these, but we would like to test
+  # them out to be sure.
+  5: "terrarium.{{ maps_slow_data_date }}.zoom_0-05.pmtiles"
+  6: "terrarium.{{ maps_slow_data_date }}.zoom_0-06.pmtiles"
+
 nominatim_db_symlink_name: nominatim.sqlite
 
 nominatim_data:

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -114,6 +114,28 @@ maps_dot_black_satellite_tiles:
   # maps_sat_zoom = 12
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
+# NOTE: This symlink's name matches what maps.black is explicitly querying for.
+# However this is not ideal as it may point to an extract that we made
+# ourselves that only goes to a lower zoom level. In the near future, we may be
+# able to change what maps.black queries for, and we should change this.
+maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
+
+maps_dot_black_terrain_tiles:
+  # Low quality terrain, up to zoom level 7 (original file has 10)
+  # maps_ter_zoom = 7
+  7: "terrarium.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
+
+  # maps_ter_zoom = 8
+  8: "terrarium.{{ maps_slow_data_date }}.zoom_0-08.pmtiles"
+
+  # maps_ter_zoom = 9
+  9: "terrarium.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
+
+  # maps_ter_zoom = 10
+  # (This is the highest quality that maps.black offers in pmtiles format. They
+  # offer 11, 12, and 13 in squashfs format, but they are massive files.)
+  10: "terrarium.{{ maps_slow_data_date }}.zoom_0-10.pmtiles"
+
 nominatim_db_symlink_name: nominatim.sqlite
 
 nominatim_data:

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -29,8 +29,8 @@ nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 # date designations down the line. I just want one "slow" date to set all of
 # these items *for now*.
 #
-maps_data_date: 2025-12-10
-maps_slow_data_date: 2025-12-10
+maps_data_date: "2025-12-10"
+maps_slow_data_date: "2025-12-10"
 
 # Basic maps.black javascript and styles
 maps_dot_black_js_and_styles:

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -122,16 +122,16 @@ maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 
 maps_dot_black_terrain_tiles:
   # Low quality terrain, up to zoom level 7 (original file has 10)
-  # maps_ter_zoom = 7
+  # maps_terrain_zoom = 7
   7: "terrarium.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
 
-  # maps_ter_zoom = 8
+  # maps_terrain_zoom = 8
   8: "terrarium.{{ maps_slow_data_date }}.zoom_0-08.pmtiles"
 
-  # maps_ter_zoom = 9
+  # maps_terrain_zoom = 9
   9: "terrarium.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
 
-  # maps_ter_zoom = 10
+  # maps_terrain_zoom = 10
   # (This is the highest quality that maps.black offers in pmtiles format. They
   # offer 11, 12, and 13 in squashfs format, but they are massive files.)
   10: "terrarium.{{ maps_slow_data_date }}.full.pmtiles"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -76,23 +76,25 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 
-- name: "Make sure maps_ter_zoom has a valid value"
-  assert:
-    that: maps_dot_black_terrain_tiles[maps_ter_zoom] is defined
-    fail_msg: "Error: maps_ter_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
-    quiet: yes
+- block
+    - name: "Make sure maps_ter_zoom has a valid value"
+      assert:
+        that: maps_dot_black_terrain_tiles[maps_ter_zoom] is defined
+        fail_msg: "Error: maps_ter_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+        quiet: yes
 
-- name: Download terrain tiles
-  include_tasks: download_large_file.yml
-  vars:
-    dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+    - name: Download terrain tiles
+      include_tasks: download_large_file.yml
+      vars:
+        dest_base_path: "{{ maps_serve_path }}"
+        item: "{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
 
-- name: Select terrain tiles
-  file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
-    state: link
+    - name: Select terrain tiles
+      file:
+        src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+        dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
+        state: link
+  when: maps_ter_zoom != ""
 
 ### maplibre search ###
 

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -76,6 +76,24 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 
+- name: "Make sure maps_ter_zoom has a valid value"
+  assert:
+    that: maps_dot_black_terrain_tiles[maps_ter_zoom] is defined
+    fail_msg: "Error: maps_ter_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    quiet: yes
+
+- name: Download terrain tiles
+  include_tasks: download_large_file.yml
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
+    item: "{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+
+- name: Select terrain tiles
+  file:
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+    dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
+    state: link
+
 ### maplibre search ###
 
 - name: Download all the basic maplibre javascript and styles (0644)

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -76,7 +76,7 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 
-- block
+- block:
     - name: "Make sure maps_terrain_zoom has a valid value"
       assert:
         that: maps_dot_black_terrain_tiles[maps_terrain_zoom] is defined

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -77,24 +77,24 @@
     state: link
 
 - block
-    - name: "Make sure maps_ter_zoom has a valid value"
+    - name: "Make sure maps_terrain_zoom has a valid value"
       assert:
-        that: maps_dot_black_terrain_tiles[maps_ter_zoom] is defined
-        fail_msg: "Error: maps_ter_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+        that: maps_dot_black_terrain_tiles[maps_terrain_zoom] is defined
+        fail_msg: "Error: maps_terrain_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
         quiet: yes
 
     - name: Download terrain tiles
       include_tasks: download_large_file.yml
       vars:
         dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+        item: "{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
 
     - name: Select terrain tiles
       file:
-        src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_ter_zoom] }}"
+        src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
         state: link
-  when: maps_ter_zoom != ""
+  when: maps_terrain_zoom != "none"
 
 ### maplibre search ###
 

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -76,7 +76,8 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 
-- block:
+- when: maps_terrain_zoom != "none"
+  block:
     - name: "Make sure maps_terrain_zoom has a valid value"
       assert:
         that: maps_dot_black_terrain_tiles[maps_terrain_zoom] is defined
@@ -94,7 +95,6 @@
         src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
         state: link
-  when: maps_terrain_zoom != "none"
 
 ### maplibre search ###
 

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -96,6 +96,14 @@
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
         state: link
 
+# If the user goes back to "none", we want to delete the symlink that gives them terrain.
+# However, it will not delete the pmtiles file that it points to.
+- name: Unselect terrain tiles
+  file:
+    path: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
+    state: absent
+- when: maps_terrain_zoom == "none"
+
 ### maplibre search ###
 
 - name: Download all the basic maplibre javascript and styles (0644)

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -102,7 +102,7 @@
   file:
     path: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
     state: absent
-- when: maps_terrain_zoom == "none"
+  when: maps_terrain_zoom == "none"
 
 ### maplibre search ###
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -55,8 +55,9 @@
                 const pitch = Math.round(mb.pitch * 1000) / 1000
                 const bearing = Math.round(mb.bearing * 1000) / 1000
                 const zoom = Math.round(mb.zoom * 100) / 100
-                const globe = mb.globe ? 'g' : 'm' // [g]lobe : [m]ercator (i.e. flat)
-                window.location.hash = `${lat}/${lon}/${pitch}/${bearing}/${zoom}/${globe}/${mapStyleChoice}`
+                const globe = mb.globe ? 'g' : 'm' // [g]lobe : [m]ercator (i.e. like a paper map)
+                const terrain = mb.terrain ? 't' : 'f' // [t]errain : [f]lat (i.e. no mountains)
+                window.location.hash = `${lat}/${lon}/${pitch}/${bearing}/${zoom}/${globe}/${terrain}/${mapStyleChoice}`
             }
 
             // Why two different functions for reading the URL hash?
@@ -69,12 +70,12 @@
             //
             // Strangely, if we set the `globe` parameter here, it seems to make `mb.globe = ...`
             // not work later on, which makes the `GlobeControl` no longer work. So, we call
-            // `readHashGlobe()` after window load.
+            // `readHashGlobe()` after window load. We'll do the same for terrain for uniformity.
             //
             // We already handle `mapStyleChoice` in our own funny way so it doesn't really matter
             // when it's set.
             function readHash() {
-                const [lat, lon, pitch, bearing, zoom, globe, _mapStyleChoice] = window.location.hash.slice(1).split('/')
+                const [lat, lon, pitch, bearing, zoom, globe, terrain, _mapStyleChoice] = window.location.hash.slice(1).split('/')
 
                 // Set this whether or not we have the hash, unlike the other parameters.
                 // We still need to set a default here.
@@ -91,9 +92,10 @@
                     shouldSetDefaultView = true
                 }
             }
-            function readHashGlobe() {
-                const [lat, lon, pitch, bearing, zoom, globe, _mapStyleChoice] = window.location.hash.slice(1).split('/')
+            function readHashGlobeAndTerrain() {
+                const [lat, lon, pitch, bearing, zoom, globe, terrain, _mapStyleChoice] = window.location.hash.slice(1).split('/')
                 mb.globe = globe === 'g'
+                mb.terrain = mb.hillshade = terrain === 't' // contour lines is another thing that uses terrain maps, which we can consider
             }
 
             function setDefaultView() {
@@ -136,7 +138,7 @@
                 }
                 setStyle = _setStyle
 
-                readHashGlobe()
+                readHashGlobeAndTerrain()
                 setTimeout(setStyle) // TODO run this without the timeout. it requires rearranging a bunch of code so I don't want to do it now.
 
                 class MapsDotBlackStyleControl {
@@ -207,8 +209,35 @@
                             mb.globe = !mb.globe
 
                             // Changing "features" of mb such as globe, or "mapstyle", seems to cause maps.black to
-                            //  rebuild the map, and inthe process dumping all of the controls we added. So, we have
+                            //  rebuild the map, and in the process dumping all of the controls we added. So, we have
                             // to add them again.
+                            setUpMap()
+                        }
+
+                        return super.onAdd(map)
+                    }
+                }
+
+                class MapsDotBlackTerrainControl extends maplibregl.TerrainControl {
+                    onAdd(map) {
+                        // Depends on TerrainControl using `_toggleTerrain` internally in this
+                        // way, which might change in a different version of maplibregl:
+                        // https://github.com/maplibre/maplibre-gl-js/blob/b457ca945cf746a75ecb5412a2165142faa159c0/src/ui/control/terrain_control.ts
+                        //
+                        // The reason we are doing this is that maps.black has its own wrapper for
+                        // terrain, among other aspects of the map. Rather than directly accessing the
+                        // underlying map object to change the terrain (as maplibregl.TerrainControl
+                        // does), we will overload this method to use maps.black's wrapper.
+                        //
+                        // TODO implement this in a less hacky way, maybe. like maybe from scratch?
+                        this._toggleTerrain = () => {
+                            // Not ideal to use the global `mb` but the alternative would be contrived and probably more error prone
+                            mb.terrain = mb.hillshade = !mb.terrain
+
+                            // Changing "features" of mb such as terrain, or "mapstyle", seems to cause maps.black to
+                            //  rebuild the map, and in the process dumping all of the controls we added. So, we have
+                            // to add them again. (On the bright side, it means we don't need to toggle the highlighted
+                            // state of the button since that's set on control creation.)
                             setUpMap()
                         }
 
@@ -366,12 +395,13 @@
                         // TODO - instantiate these above along with the geocoder and ScaleControl. Though it
                         // may require some reworking of the code that assumes it gets torn down and rebuilt.
                         mb.map.addControl(new MapsDotBlackGlobeControl(), 'top-right');
+                        mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
                         mb.map.addControl(new MapsDotBlackStyleControl(), 'top-right');
                         // NOTE Navigation control is added via `navigationcontrol` attribute on the maps-black tag
 
                         setMaxZoom()
 
-                        // The call to this function (`setUpMap`) may have been triggered by a globe or style change.
+                        // The call to this function (`setUpMap`) may have been triggered by a globe, terrain, or style change.
                         // That should be reflected in the hash:
                         setHash()
 
@@ -390,8 +420,7 @@
     </head>
     <body>
         {# `cooperativegestures=false` provides familiar zoom/scroll/tilt controls for fullscreen #}
-        {# TODO - Don't set terrain on all the time. Create a terrain button like the globe button. Add it to the URL hash. #}
-        <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false" terrain="true" hillshade="true"></maps-black>
+        <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false"></maps-black>
         <script>
           mb = document.getElementsByTagName("maps-black")[0];
           readHash()

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -396,7 +396,9 @@
                         // TODO - instantiate these above along with the geocoder and ScaleControl. Though it
                         // may require some reworking of the code that assumes it gets torn down and rebuilt.
                         mb.map.addControl(new MapsDotBlackGlobeControl(), 'top-right');
-                        mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
+                        if ("{{ maps_terrain_zoom  }}" !== "none") {
+                            mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
+                        }
                         mb.map.addControl(new MapsDotBlackStyleControl(), 'top-right');
                         // NOTE Navigation control is added via `navigationcontrol` attribute on the maps-black tag
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -390,7 +390,8 @@
     </head>
     <body>
         {# `cooperativegestures=false` provides familiar zoom/scroll/tilt controls for fullscreen #}
-        <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false"></maps-black>
+        {# TODO - Don't set terrain on all the time. Create a terrain button like the globe button. Add it to the URL hash. #}
+        <maps-black loader="pmtiles" navigationcontrol="true" cooperativegestures="false" terrain="true" hillshade="true"></maps-black>
         <script>
           mb = document.getElementsByTagName("maps-black")[0];
           readHash()

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -210,7 +210,8 @@
 
                             // Changing "features" of mb such as globe, or "mapstyle", seems to cause maps.black to
                             //  rebuild the map, and in the process dumping all of the controls we added. So, we have
-                            // to add them again.
+                            // to add them again. (On the bright side, it means we don't need to toggle the highlighted
+                            // state of the button since that's set on control creation.)
                             setUpMap()
                         }
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -513,7 +513,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -513,6 +513,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -38,6 +38,7 @@ maps_install: True
 maps_enabled: True
 maps_vector_quality: ne
 maps_sat_zoom: 7
+maps_ter_zoom: ""
 ##############################
 
 ##############################

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -38,7 +38,7 @@ maps_install: True
 maps_enabled: True
 maps_vector_quality: ne
 maps_sat_zoom: 7
-maps_ter_zoom: ""
+maps_terrain_zoom: none
 ##############################
 
 ##############################

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -309,7 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -309,6 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -309,7 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -309,6 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -309,7 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -309,6 +309,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -315,6 +315,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -315,7 +315,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_ter_zoom: "" # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database
 


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

This will download maps.black's terrain files. Before merging I'll add a button like the globe button to turn it on. For now in this PR I have it always on to remind myself to do it.

However, this requires the files to be uploaded to our host first. Before I do that I wanted some quick feedback on something. So this is WIP.

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd @holta 