### PR TITLE
code: use WP JSON fallback endpoint for APK discovery; improve CDN-block handling [Code on the Go; WordPress]

### DIFF
--- a/roles/code/defaults/main.yml
+++ b/roles/code/defaults/main.yml
@@ -3,6 +3,8 @@
 
 # URL & Regular Expressions
 code_fetch_apk_url: https://www.appdevforall.org/codeonthego
+# Fallback JSON endpoint for the CodeOnTheGo page, update if/when the WP page ID changes.
+code_fetch_apk_url_json: https://www.appdevforall.org/wp-json/wp/v2/pages/2223
 code_download_url: https://download.appdevforall.org
 code_apk_32bit_pattern: "CodeOnTheGo-.*?armv7a\\.apk"
 code_apk_64bit_pattern: "CodeOnTheGo-.*?armv8a\\.apk"

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -28,23 +28,50 @@
       register: apk_index
       failed_when: apk_index.status not in [200, 403, 404]
 
+    - name: Initialize APK index body
+      set_fact:
+        apk_index_body: "{{ apk_index.content | default('') }}"
+
+    - name: Detect whether APK links exist in index body
+      set_fact:
+        apk_index_has_apk: "{{ apk_index_body is search(code_apk_64bit_pattern) }}"
+
+    - name: Fetch APK index via WP JSON endpoint (fallback if no APK links found)
+      uri:
+        url: "{{ code_fetch_apk_url_json }}"
+        method: GET
+        return_content: true
+        headers:
+          Accept: "application/json"
+      register: apk_index_json
+      failed_when: false
+      changed_when: false
+      when: apk_index.status in [200, 404] and (not apk_index_has_apk)
+
+    - name: Update APK index body from JSON fallback (if used)
+      set_fact:
+        apk_index_body: "{{ apk_index_json.content | default(apk_index_body, true) }}"
+        apk_index_has_apk: "{{ apk_index_json.content | default('') is search(code_apk_64bit_pattern) }}"
+      when: apk_index_json is defined
+
     - name: Mark 'code' role as blocked by CDN
       set_fact:
         code_blocked_by_cdn: true
-      when: apk_index.status == 403
+      when: apk_index.status == 403 or (apk_index_has_apk is defined and (not apk_index_has_apk))
 
     - name: Warn about 403 APK index
       fail:
         msg: |
-          The 'code' role could not access: {{ code_download_url }}/ (HTTP 403). CDN is likely blocking datacenter IPs.
+          The 'code' role could not parse expected APK links from: {{ code_fetch_apk_url }}/ (HTTP {{ apk_index.status }}).
+          CDN/WAF is likely blocking or challenging datacenter IPs (sometimes with HTTP 200).
 
           ================ CODE ROLE WARNING ================
-          The 'code' role hit a CDN 403 (APK index query blocked).
+          The 'code' role hit CDN/WAF blocking (APK index query blocked/challenged).
 
-          HTTP status: 403
+          HTTP status: {{ apk_index.status }}
           This likely means the APK store is behind some CDN and
           blocking datacenter IP ranges, so non-interactive curl/Ansible
-          requests get a 403 "Just a moment..." page.
+          requests can get a 403 or even a 200 "challenge" / non-content page.
 
           GitHub issues/PRs related:
           - https://github.com/iiab/iiab/issues/4174
@@ -64,7 +91,7 @@
       set_fact:
         code_apk_64bit_filename: >-
           {{
-            apk_index.content
+            apk_index_body
             | regex_findall(code_apk_64bit_pattern)
             | sort
             | last
@@ -76,7 +103,7 @@
       set_fact:
         code_apk_32bit_filename: >-
           {{
-            apk_index.content
+            apk_index_body
             | regex_findall(code_apk_32bit_pattern)
             | sort
             | last
@@ -87,7 +114,7 @@
     - name: Fail if no apk is found on fetched page.
       fail:
         msg: Could not find expected APK link in page. (Status = {{ apk_index.status }})
-      when: code_apk_64bit_filename | length == 0
+      when: code_blocked_by_cdn is undefined and (code_apk_64bit_filename | length == 0)
       #ignore_errors: yes
 
 - name: Get CodeOnTheGo version number

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -120,7 +120,6 @@
       fail:
         msg: Could not find expected APK link in page. (Status = {{ apk_index.status }})
       when: code_blocked_by_cdn is undefined and (code_apk_64bit_filename | length == 0)
-      #ignore_errors: yes
 
 - name: Get CodeOnTheGo version number
   set_fact:

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -2,6 +2,7 @@
   shell: df -B1 --output=used / | tail -1
   register: df1
 
+
 - name: Make code directories available
   file:
     path: "{{ item }}"

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -2,7 +2,6 @@
   shell: df -B1 --output=used / | tail -1
   register: df1
 
-
 - name: Make code directories available
   file:
     path: "{{ item }}"

--- a/roles/code/tasks/install.yml
+++ b/roles/code/tasks/install.yml
@@ -46,13 +46,19 @@
       register: apk_index_json
       failed_when: false
       changed_when: false
-      when: apk_index.status in [200, 404] and (not apk_index_has_apk)
+      when: not apk_index_has_apk
 
     - name: Update APK index body from JSON fallback (if used)
       set_fact:
-        apk_index_body: "{{ apk_index_json.content | default(apk_index_body, true) }}"
-        apk_index_has_apk: "{{ apk_index_json.content | default('') is search(code_apk_64bit_pattern) }}"
-      when: apk_index_json is defined
+        apk_index_body: "{{ (apk_index_json.json.content.rendered | default(apk_index_body, true)) }}"
+      when:
+        - apk_index_json is defined
+        - (apk_index_json.status | default(0)) == 200
+        - apk_index_json.json.content.rendered is defined
+
+    - name: Re-check whether APK links exist in (final) index body
+      set_fact:
+        apk_index_has_apk: "{{ apk_index_body is search(code_apk_64bit_pattern) }}"
 
     - name: Mark 'code' role as blocked by CDN
       set_fact:


### PR DESCRIPTION
### Fixes bug:
- Fix #4190
- Fix  #4174

### Description of changes proposed in this pull request:
Add WP json as fallback endpoint to overcome the 404 / 200-empty content issues when discovering the APK link / version.

### Smoke-tested on which OS or OS's:
#Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 