### PR TITLE
Rename ansible var: maps_sat_zoom -> maps_satellite_zoom

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -12,21 +12,21 @@ To configure your map, set the following variables (for the option your choose!)
    maps_enabled: True
 
    maps_vector_quality: ne
-   maps_sat_zoom: 7
+   maps_satellite_zoom: 7
    ```
 
 2. Or if you want **~3.1 GB** = 1.9 GB vector (Higher detail, up to zoom 9, from OpenStreetMap) + 1.2 GB satellite (up to zoom 9), include:
 
    ```
    maps_vector_quality: osm-z9
-   maps_sat_zoom: 9
+   maps_satellite_zoom: 9
    ```
 
 3. Or if you want **~168 GB** = 78 GB vector (Higher detail, up to zoom 14, including 3D buildings, from OpenStreetMap) + 80 GB satellite (up to zoom 12), include:
 
    ```
    maps_vector_quality: osm-full
-   maps_sat_zoom: 12
+   maps_satellite_zoom: 12
    ```
 
 ## What about terrain? (which is still experimental)?

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -99,19 +99,19 @@ maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
 maps_dot_black_satellite_tiles:
   # Low quality satellite, up to zoom level 7 (original file has 13)
-  # maps_sat_zoom = 7
+  # maps_satellite_zoom = 7
   7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13)
-  # maps_sat_zoom = 9
+  # maps_satellite_zoom = 9
   9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13)
-  # maps_sat_zoom = 11
+  # maps_satellite_zoom = 11
   11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-11.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13)
-  # maps_sat_zoom = 12
+  # maps_satellite_zoom = 12
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -58,21 +58,21 @@
     state: link
   when: maps_vector_quality == "ne"
 
-- name: "Make sure maps_sat_zoom has a valid value"
+- name: "Make sure maps_satellite_zoom has a valid value"
   assert:
-    that: maps_dot_black_satellite_tiles[maps_sat_zoom] is defined
-    fail_msg: "Error: maps_sat_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
+    fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
     quiet: yes
 
 - name: Download satellite tiles
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_satellite_tiles[maps_sat_zoom] }}"
+    item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
 
 - name: Select satellite tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_sat_zoom] }}"
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: link
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -349,22 +349,22 @@
                         //   this, it won't show up at all until the user zooms out to this level.
                         // * If we're zoomed in this far and start scrolling around, eventually we'll find
                         //   areas where the satellite won't show up.
-                        mb.map.setMaxZoom({{ maps_sat_zoom }} - 0.6)
-                        mb.zoom = Math.min(mb.zoom, {{ maps_sat_zoom }} - 0.6)
+                        mb.map.setMaxZoom({{ maps_satellite_zoom }} - 0.6)
+                        mb.zoom = Math.min(mb.zoom, {{ maps_satellite_zoom }} - 0.6)
                     }
                     if (["hybrid"].includes(mapStyleChoice)) {
                         if ("{{ maps_vector_quality }}" === "osm-z9" ) {
                             // I could do Math.min, but I think that so long as there's something to look
                             // at, let the user try to look at it, even if it's a little glitchy.
-                            mb.map.setMaxZoom(Math.max(9.9, {{ maps_sat_zoom }} + 0.9))
+                            mb.map.setMaxZoom(Math.max(9.9, {{ maps_satellite_zoom }} + 0.9))
                         } else {
-                            mb.map.setMaxZoom({{ maps_sat_zoom }} + 0.9)
+                            mb.map.setMaxZoom({{ maps_satellite_zoom }} + 0.9)
                         }
                         // However, as with the "satellite" stile, for the satellite to show up on map load
                         // (including switching from another style), it needs to be bound by the satellite's
                         // maximum zoom. (Though, if the satellite has higher zoom available than the vector,
                         // this is overly cautious. But this is not worth complicating for a minor inconvenience).
-                        mb.zoom = Math.min(mb.zoom, {{ maps_sat_zoom }} - 0.6)
+                        mb.zoom = Math.min(mb.zoom, {{ maps_satellite_zoom }} - 0.6)
                     }
                 }
                 function setUpMap() {

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -512,7 +512,7 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -37,7 +37,7 @@ osm_vector_maps_enabled: False
 maps_install: True
 maps_enabled: True
 maps_vector_quality: ne
-maps_sat_zoom: 7
+maps_satellite_zoom: 7
 maps_terrain_zoom: none
 ##############################
 

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -308,7 +308,7 @@ maps_from_internet_archive: False
 maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -308,7 +308,7 @@ maps_from_internet_archive: False
 maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -308,7 +308,7 @@ maps_from_internet_archive: False
 maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -314,7 +314,7 @@ maps_from_internet_archive: False
 maps_install: False
 maps_enabled: False
 maps_vector_quality: "ne" # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_sat_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 7 # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: "" # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_full: False # Full search database


### PR DESCRIPTION
*UPDATE YOUR `local_vars.yml` accordingly!*

### Fixes bug:

Confusing variable name

### Description of changes proposed in this pull request:

Rename ansible var: maps_sat_zoom -> maps_satellite_zoom

### Smoke-tested on which OS or OS's:

Raspi Trixie

### Mention a team member @username e.g. to help with code review:

@holta 