### PR TITLE
[proot] install openssh on termux by default

### DIFF
--- a/roles/proot_services/0_termux-setup.sh
+++ b/roles/proot_services/0_termux-setup.sh
@@ -174,6 +174,7 @@ step_termux_base() {
     coreutils \
     grep \
     sed \
+    openssh \
     proot \
     proot-distro || true
 


### PR DESCRIPTION
### Fixes bug:
Align OpenSSH installation with the final `proot_services` README.md.

### Description of changes proposed in this pull request:
While working on PR #4122, I was reluctant to install SSH by default because it could increase the security risk on people’s phones. The pragmatic rationale for installing it by default now is:

- In Termux, services are not started automatically by default unless the user explicitly sets them up.
- In practice, even when SSH is installed, `sshd` will not be running, which helps mitigate the risk of having it installed.
- We also mentioned:
  > "The `sshd` service can be automated to start when Termux launches (see Termux-services). We recommend doing this only after improving login security using SSH keys."

Given the above, I believe the cost of not having ssh available by default (extra friction, mismatches with the README, and harder debugging) outweighs the relatively small security impact of installing it.

So, to simplify the setup process and match the README, this PR now installs openssh by default in Termux. That way, users can expect `sshd` to be available if they need it for debugging or simply to work more comfortably on their device.

### Smoke-tested on which OS or OS's:
Debian (proot)

### Mention a team member @username e.g. to help with code review:
@holta 