### PR TITLE
Don't download map js/style assets over and over

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -45,32 +45,30 @@ maps_dot_black_js_and_styles:
 #  -    filename: maps.black.js
 #  -    sha256sum: 7b3843b5ded151d585ccf3a6db02093e3a95851be36dcffc5fa92030657b9c93
 
-  - name: maps.black-component.js
-    filename: maps.black-component.js
+  - filename: maps.black-component.js
     sha256sum: d8a6366065d5fd6840368e88a5b06467b2c5ac3e349a35420b4dee6cc070e542
 
-  - name: resourcetiles-minimal.pmtiles
-    filename: resourcetiles-minimal.pmtiles
+  - filename: resourcetiles-minimal.pmtiles
     sha256sum: 0037047ee0f87dbccd3fc7e6bfa99632d97c41cfd5977bff3b7f86665f3c4f51
 
 # Basic maplibre search javascript and styles
 # TODO get the minified versions of all these?
 maplibre_search_js_and_styles:
 
-  - name: maplibre-gl.css
-    filename: maplibre-gl@5.7.3/dist/maplibre-gl.css
+  - filename: maplibre-gl.css
+    url_subpath: maplibre-gl@5.7.3/dist/maplibre-gl.css
     sha256sum: 43c1d886b5fdf0aac4e7135bd6f84b823d9f48283a648012665f9be52c01389f
 
-  - name: maplibre-gl.js
-    filename: maplibre-gl@5.7.3/dist/maplibre-gl.js
+  - filename: maplibre-gl.js
+    url_subpath: maplibre-gl@5.7.3/dist/maplibre-gl.js
     sha256sum: 2986bbddce2c7a944775791201fad5108ec8768fc2e3243cac607b23826e4bc0
 
-  - name: maplibre-gl-geocoder.min.js
-    filename: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.min.js"
+  - filename: maplibre-gl-geocoder.min.js
+    url_subpath: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.min.js"
     sha256sum: 21aa5e1cadf31a4b40aeb3f6989f38b486172d6f6266f158431bbf3eefd256f5
 
-  - name: maplibre-gl-geocoder.css
-    filename: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.css"
+  - filename: maplibre-gl-geocoder.css
+    url_subpath: "@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.css"
     sha256sum: 9fc78e63cbec12058daefb460f630d203a23f209cac8e19a84d0b257e8325fc3
 
 maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -20,7 +20,7 @@
 - name: Download the remaining basic maps.black javascript and styles (0644)
   get_url:
     url: "{{ maps_dot_black_small_assets_url }}/{{ item.filename }}"
-    dest: "{{ maps_serve_path }}"
+    dest: "{{ maps_serve_path }}/{{ item.filename }}"
     checksum: "sha256:{{ item.sha256sum }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"
@@ -114,8 +114,8 @@
 
 - name: Download all the basic maplibre javascript and styles (0644)
   get_url:
-    url: "{{ unpkg_url }}/{{ item.filename }}"
-    dest: "{{ maps_serve_path }}"
+    url: "{{ unpkg_url }}/{{ item.url_subpath }}"
+    dest: "{{ maps_serve_path }}/{{ item.filename }}"
     checksum: "sha256:{{ item.sha256sum }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"


### PR DESCRIPTION
### Fixes bug:

maps.black and maplibre assets were downloading every time. `resourcetiles-minimal.pmtiles` in particular takes about 5 seconds.

I couldn't figure out why before and I gave up. It turns out the reason is that the `force` parameter is as-if true if the destination is a directory. I had no idea. (seems dumb to me but maybe there's a good reason I'm not thinking of).

### Description of changes proposed in this pull request:

Specify a file path for the `dest` of the `get_url`s in the maps role. @chapmanjacobd your PR #4210 does not update these with `get_curl`. If you plan to do so very soon I can hold off on this.

### Smoke-tested on which OS or OS's:

Trixie raspi

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 