### PR TITLE
Cleanup: Remove no longer used `phpmyadmin_name_zip`

### DIFF
--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -7,4 +7,3 @@
 phpmyadmin_version: 5.2.3
 phpmyadmin_name: "phpMyAdmin-{{ phpmyadmin_version }}-all-languages"
 phpmyadmin_dl_url: "https://files.phpmyadmin.net/phpMyAdmin/{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"
-phpmyadmin_name_zip: "{{ phpmyadmin_version }}/{{ phpmyadmin_name }}.tar.xz"

--- a/roles/phpmyadmin/tasks/install.yml
+++ b/roles/phpmyadmin/tasks/install.yml
@@ -39,7 +39,7 @@
 # - name: Change the owner of the PHP tree to Apache
 #   shell: "chown -R {{ apache_user }} /opt/phpmyadmin"
 #   #file:
-#   #  path: "/opt/{{ phpmyadmin_name_zip }}"
+#   #  path: "/opt/{{ phpmyadmin_name }}"
 #   #  owner: "{{ apache_user }}"
 #   #  recurse: yes
 #   #  state: directory


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

This variable is no longer used as of the `get_curl` PR: https://github.com/iiab/iiab/pull/4210/files#diff-d1a1702f3dc7f2318ff77da03bbab7e0f786b7c8e11312430242a9727467e00fL7

I didn't want to add more nitpicks to hold it up the review, but I thought it might be worth cleaning this up to avoid future confusion. The only uses of `phpmyadmin_name_zip` were the definition and a comment, and I think the comment was a typo based on looking at other code.

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
@holta 