### PR TITLE
[proot] fix missing minimal default facts for Android 16

### DIFF
--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -12,19 +12,12 @@
     - /etc/iiab/iiab_state.yml
 
   pre_tasks:
-    - name: Gather facts (normal)
-      setup:
-        gather_subset:
-          - 'all'
-      when: not is_proot
-
-    - name: Gather minimal facts (proot)
+    - name: Gather minimal facts default
       setup:
         gather_subset:
           - 'all'
           - '!hardware'
           - '!network'
-      when: is_proot
 
     - name: Compute memory and swap facts when hardware subset is missing
       when: ansible_swaptotal_mb is not defined or ansible_memtotal_mb is not defined


### PR DESCRIPTION
### Fixes bug:
Android 16 is more prone to trigger security restrictions when gathering all subsets.
Since the first step is to gather facts: is_proot or not is_proot are not yet available.

### Description of changes proposed in this pull request:
This change fix missing gather files routine not patched for Android 16, so it defaults to minimal and grow from there if required. Matching working run-one-role.yml.

### Smoke-tested on which OS or OS's:
Debian 13 - Android 16 (Samsung - A165MUBS6CYL1)

### Mention a team member @username e.g. to help with code review:
@holta 