### PR TITLE
Revert PR #4215, fix #4218 + do likewise in run-one-role.yml

### DIFF
--- a/iiab-stages.yml
+++ b/iiab-stages.yml
@@ -12,12 +12,17 @@
     - /etc/iiab/iiab_state.yml
 
   pre_tasks:
-    - name: Gather minimal facts default
+    - name: Gather facts -- when not is_proot (not Android)
+      setup:
+      when: not is_proot
+
+    - name: Gather minimal facts -- when is_proot (Android)
       setup:
         gather_subset:
           - 'all'
           - '!hardware'
           - '!network'
+      when: is_proot
 
     - name: Compute memory and swap facts when hardware subset is missing
       when: ansible_swaptotal_mb is not defined or ansible_memtotal_mb is not defined
@@ -37,8 +42,8 @@
 
         - name: Set fallback memtotal and swaptotal facts
           set_fact:
-            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] }}"
-            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] }}"
+            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] | int }}"
+            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] | int }}"
 
   tasks:
     - name: 0-init

--- a/run-one-role.yml
+++ b/run-one-role.yml
@@ -11,12 +11,17 @@
     - /etc/iiab/iiab_state.yml
 
   pre_tasks:
-    - name: Gather minimal facts default
+    - name: Gather facts -- when not is_proot (not Android)
+      setup:
+      when: not is_proot
+
+    - name: Gather minimal facts -- when is_proot (Android)
       setup:
         gather_subset:
           - 'all'
           - '!hardware'
           - '!network'
+      when: is_proot
 
     - name: Compute memory and swap facts when hardware subset is missing
       when: ansible_swaptotal_mb is not defined or ansible_memtotal_mb is not defined
@@ -36,8 +41,8 @@
 
         - name: Set fallback memtotal and swaptotal facts
           set_fact:
-            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] }}"
-            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] }}"
+            ansible_memtotal_mb: "{{ memswap.stdout.split()[0] | int }}"
+            ansible_swaptotal_mb: "{{ memswap.stdout.split()[1] | int }}"
 
   roles:
     - { role: 0-init }


### PR DESCRIPTION
### Fixes bug:

Several people have asked me to urgently revert PR #4215.  So this PR takes care of that in a more complete way, also resolving #4218, as well as making the same fixes for the `runrole` command too.

Allowing for a clean baseline, that we can then build upon.  e.g. to permit larger capabilities and cleanups present in PRs like #4217, #4219, #4221 and beyond.

### Smoke-tested on which OS or OS's:

LARGE-sized IIAB install on the latest Ubuntu Server 26.04: https://paste.centos.org/view/31e4d63b

### Mention a team member @username e.g. to help with code review:

@Ark74 @jvonau @chapmanjacobd