### PR TITLE
[proot] don't manually enable by default apps services.

### DIFF
--- a/roles/proot_services/defaults/main.yml
+++ b/roles/proot_services/defaults/main.yml
@@ -13,6 +13,6 @@ pdsm_installed_services:
 # users can enable any of the installed services in their own setup.
 pdsm_enabled_services:
   - nginx # maps only requirement.
-  - kiwix
+#  - kiwix
 #  - kolibri
 #  - calibre-web

--- a/roles/proot_services/defaults/main.yml
+++ b/roles/proot_services/defaults/main.yml
@@ -13,6 +13,3 @@ pdsm_installed_services:
 # users can enable any of the installed services in their own setup.
 pdsm_enabled_services:
   - nginx # maps only requirement.
-#  - kiwix
-#  - kolibri
-#  - calibre-web


### PR DESCRIPTION
### Fixes bug:
Curtom local_vars.yml in android could not require kiwx or other apps to be enabled.

### Description of changes proposed in this pull request:
This is a quick change to disable manually services enabled. A follow up PR should improve current handling of start / enable of installed services.

### Smoke-tested on which OS or OS's:
None required.

### Mention a team member @username e.g. to help with code review:
@holta 