### PR TITLE
Update nodesource: use /usr/share in place of /etc/apt for keyrings [let's consider new recommendation `/etc/apt/keyrings` for external repos]

### DIFF
--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -95,12 +95,12 @@
 # apt install ./nodejs_18.11.0-deb-1nodesource1_amd64.deb    # SMARTER + CLEANER THAN: dpkg -i nodejs_18...
 # echo 'nodejs_installed: True' >> /etc/iiab/iiab_state.yml
 
-- name: Try NEW (since August 2023) approach setting up /etc/apt/keyrings/nodesource.gpg and /etc/apt/sources.list.d/nodesource.list -- per https://github.com/nodesource/distributions#installation-instructions
+- name: Setting up /usr/share/keyrings/nodesource.gpg and /etc/apt/sources.list.d/nodesource.list -- per https://deb.nodesource.com/setup_24.x
   shell: |
-    mkdir -p /etc/apt/keyrings
+    rm -f /usr/share/keyrings/nodesource.gpg
     rm -f /etc/apt/keyrings/nodesource.gpg
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" > /etc/apt/sources.list.d/nodesource.list
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" > /etc/apt/sources.list.d/nodesource.list
   register: curl_nodesource
   ignore_errors: yes
 


### PR DESCRIPTION
### Fixes bug:
No bug, update to newest fad in where gpg keys are stored
### Description of changes proposed in this pull request:
Matches the rest of the apt repo setups in iiab and upstream use
### Smoke-tested on which OS or OS's:
CI https://github.com/jvonau/iiab/actions/runs/21154673377/job/60837167849 and below.

excepts from https://deb.nodesource.com/setup_24.x
```
    if ! mkdir -p /usr/share/keyrings; then
      handle_error "$?" "Makes sure the path /usr/share/keyrings exist or run ' mkdir -p /usr/share/keyrings' with sudo"
    fi

    rm -f /usr/share/keyrings/nodesource.gpg || true
    rm -f /etc/apt/sources.list.d/nodesource.list || true

    # Run 'curl' and 'gpg' to download and import the NodeSource signing key
    if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
      handle_error "$?" "Failed to download and import the NodeSource signing key"
    fi


echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
```