### PR TITLE
maps large pmtiles download: allow-overwriting file when control file corrupted

### DIFF
--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -115,6 +115,7 @@
             --show-console-readout=false \
             --enable-http-pipelining=true \
             --seed-time=0 \
+            --allow-overwrite=true \
             "{{ iiab_map_host_url }}/{{ item }}.meta4" \
             >> "{{ log_file }}"
 


### PR DESCRIPTION
### Fixes bug:

Sometimes the aria2c control file won't be successfully written to disk. Thankfully this operation seems to be atomic so the file shows up as a `.aria2__temp` file instead of `.aria2` file.

The default behavior of aria2c does not handle this situation very well because it doesn't recognize this failure state: it writes to a new file with a `.1.ext` extension; but you can use the `--allow-overwrite=true` flag to force overwrite the file and start over which is the safest option in this case.

### Description of changes proposed in this pull request:

`--allow-overwrite=true` does not disable resume logic. If a valid .aria2 control file exists, aria2 will still use it and resume/continue as usual.

Alternatively, we could use `--continue --check-integrity=true` which is still safe because aria2c will recheck the chunks that have been downloaded against the meta4 file... but there's no option to only do it when the control file exists so that will slow down other cases where the control file was correctly written. Given that this situation is itself an edge case let's keep things simple and reliable by just starting over.

### Smoke-tested on which OS or OS's:

I tested it out on Ed's PC and it fixed the problem

### Mention a team member @username e.g. to help with code review:

@orblivion @holta