### PR TITLE
Index html cleanup

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -385,595 +385,595 @@
                     }
                 })
 
-                function setStyle() {
-                    // The first level key is the `mapStyleChoice`, i.e. "natural", "political", etc, from the dropdown menu. (These are names specific to
-                    // IIAB maps.)
-                    //
-                    // The second level key is a boolean indicating whether the currently visible map is using OSM or Natural Earth data for vector data.
-                    //
-                    // Both of these together point to a maps.black "mapstyle" which implies a maplibre style and data sources.
-                    mb.mapstyle = {
-                        // Has nicely colored regions, and buildings
-                        natural: {
-                            true:  "openstreetmap-openmaptiles/openfreemap/liberty",
-                            false: "naturalearth-openmaptiles/openfreemap/liberty",
-                        },
-                        // Has more clearly defined political boundaries
-                        // TODO - find something like this with buildings too?
-                        political:  {
-                            true:  "openstreetmap-openmaptiles/qwant/basic",
-                            false: undefined, // We will hide this option for naturalearth since it's not great for political maps - TODO Extract a low res osm for political map.
-                        },
-                        hybrid:  {
-                            true:  "openstreetmap-openmaptiles/maps.black/hybrid-2023",
-                            false: "naturalearth-openmaptiles/maps.black/hybrid-2023", // we'll have a smaller satellite file with the same name in this case
-                        },
-                        satellite:  {
-                            true:  "raster/s2maps/2023",
-                            false: "raster/s2maps/2023", // we'll have a smaller satellite file with the same name in this case
-                        },
-                    }[mapStyleChoice][MAPS_VECTOR_IS_OSM || !!activeFQRegionName]
-                    console.log("setting to", mapStyleChoice, "i.e.", mb.mapstyle)
-
-                    setUpMap() // The above will reset the map so we have to add controls and other things again. This also covers initial page load.
-                }
-
-                class MapsDotBlackStyleControl {
-                    onAdd(map) {
-                        this._map = map;
-                        this._container = document.createElement('div');
-                        this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
-
-                        const naturalSelected = mapStyleChoice === "natural" ? `selected="selected"` : ""
-                        const politicalSelected = mapStyleChoice === "political" ? `selected="selected"` : ""
-                        const satelliteSelected = mapStyleChoice === "satellite" ? `selected="selected"` : ""
-                        const hybridSelected = mapStyleChoice === "hybrid" ? `selected="selected"` : ""
-
-                        // For now don't include political for naturalearth because it doesn't have great political options zoomed out
-                        const maybePolitical = (MAPS_VECTOR_IS_OSM || !!activeFQRegionName) ? `<option title="Political Map" value="political" ${politicalSelected}>&#x1F3F3;</option>` : "";
-
-                        // Keep in mind that maps.black destroys and creates this every time we change the map style or features.
-                        // This makes it a little complicated to add handlers. So for now, I inline it.
-                        //
-                        // appearance: none - get rid of the little arrow from the dropdown
-                        // border: none - get rid of the standard select tag border
-                        // outline: none - don't highlight it after using (noticed on Chromium)
-                        // border-radius is done here, but border as such is done by maplibregl-ctrl-group
-                        // height and width experimentally match the Globe control
-                        // padding and font size are a balance:
-                        // * Make icons big enough (I'd like to make them a little bigger)
-                        // * Make icons nicely centered
-                        // * Make room for the "+" I'm cramming into the Hybrid option
-                        // * TODO - Just get some images for this part and make it consistent
-
-                        this._container.innerHTML = `
-                            <select
-                              class="styleswitch"
-                              id="styleswitch"
-                              onchange="mapStyleChoice = this.value; setStyle()"
-                              title="Select Map Style"
-                              style="background: white; padding-top:2px; padding-left:5px; border: none; outline: none; appearance: none; font-size: 13px; border-radius: 5px; height: 29px; width: 29px;"
-                            >
-                                <option title="Natural Map" value="natural" ${naturalSelected}>&#x1F33F;</option>
-                                ${maybePolitical}
-                                <option title="Satellite" value="satellite" ${satelliteSelected}>&#x1F4E1;</option>
-                                <option title="Satellite + Map" value="hybrid" ${hybridSelected}>&#x1F4E1;+</option>
-                            </select>
-                        `
-                        return this._container;
-                    }
-
-                    onRemove() {
-                        this._container.parentNode.removeChild(this._container);
-                        this._map = undefined;
-                    }
-                }
-
-                // This button brings us back from a Full Quality Region to the full world map
-                class ReturnFromRegionControl {
-                    onAdd(map) {
-                        this._map = map;
-                        this._container = document.createElement('div');
-                        const button = document.createElement('button');
-                        button.type = "button"
-                        button.title = "Return to world map"
-                        button.innerHTML = "&#8617;&#65039;" // curved arrow
-                        this._container.appendChild(button)
-                        this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
-                        this._container.style = 'cursor: pointer;'
-                        this._container.onclick = () => {
-                            const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
-
-                            // First we kick off a zoom animation to a view focusing on the region, zoomed out a bit more than when we entered it.
-                            mb.map.setMaxBounds() // untether us from the bounds first so we can zoom out further
-                            mb.map.fitBounds(
-                                [[min_lon - 0.5, min_lat - 0.5], [max_lon + 0.5, max_lat + 0.5]],
-                                {speed: 1.75}, // a little slower than the Delete button, but a little faster than the default
-                            )
-
-                            // Then we create a handler that gets called once the zoom animation is complete.
-                            // (We don't have to worry about removing this handler. setStyle will refresh
-                            // the map and wipe everthing.)
-                            mb.map.on('moveend', () => {
-                                // Unset the Full Quality Region, i.e. go back to the full-sized map
-                                activeFQRegionName = ""
-
-                                // As we exit from a Full Quality Region, we have to disable things that may not be available in the full-sized map.
-                                // (This sucks and a better organization of the code would prevent this.)
-                                mb.terrain = mb.hillshade = mb.terrain && (MAPS_TERRAIN_ZOOM || !!activeFQRegionName)
-                                if (mapStyleChoice === "political" && !(MAPS_VECTOR_IS_OSM || !!activeFQRegionName)) {
-                                  mapStyleChoice = "hybrid"
-                                }
-
-                                setStyle()
-                            })
-                        }
-                        return this._container
-                    }
-
-                    onRemove() {
-                        this._container.parentNode.removeChild(this._container);
-                        this._map = undefined;
-                    }
-                }
-
-                class DeleteFQRegionControl {
-                    onAdd(map) {
-
-                        this._map = map;
-                        this._container = document.createElement('div');
-                        const button = document.createElement('button');
-                        button.type = "button"
-                        button.title = "Delete this region"
-                        button.innerHTML = "&#128465;&#65039;" // wastebasket
-                        this._container.appendChild(button)
-                        this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
-                        this._container.style = 'cursor: pointer;'
-                        this._container.onclick = () => {
-                            const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
-
-                            // Zoom out to view the region so that the delete popup is well placed
-                            mb.map.fitBounds([[min_lon, min_lat], [max_lon, max_lat]], {maxDuration: 2000, speed: 5})
-                            const center = [
-                                min_lon + (max_lon - min_lon) / 2,
-                                min_lat + (max_lat - min_lat) / 2,
-                            ]
-
-                            const deleteCommand = document.createElement('div');
-                            const deleteCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py delete ${activeFQRegionName}`
-                            deleteCommand.innerHTML = `<pre
-                                  style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
-                                  onclick="window.getSelection().selectAllChildren(this)"
-                              >${deleteCommandString}</pre>`
-
-                            const popupContainer = document.createElement('div');
-                            popupContainer.innerHTML = `
-                                <h1>Delete this region</h1>
-                                <ul>
-                                  <li>Click below to select text</li>
-                                  <li>Copy text</li>
-                                  <li>Paste and run in a terminal logged into your Internet in a Box</li>
-                                  <li>When it is done deleting, reload this page</li>
-                                </ul>
-                            `
-                            popupContainer.appendChild(deleteCommand)
-
-                            const deletePopup = new maplibregl.Popup()
-                                .setLngLat(center)
-                                .setDOMContent(popupContainer)
-                                .addTo(mb.map);
-                            }
-                        return this._container
-                    }
-
-                    onRemove() {
-                        this._container.parentNode.removeChild(this._container);
-                        this._map = undefined;
-                    }
-                }
-
-                class MapsDotBlackGlobeControl extends maplibregl.GlobeControl {
-                    onAdd(map) {
-                        // Depends on GlobeControl using `_toggleProjection` internally in this
-                        // way, which might change in a different version of maplibregl:
-                        // https://github.com/maplibre/maplibre-gl-js/blob/93634b011a147666a62887bc61bffd351fa9971d/src/ui/control/globe_control.ts
-                        //
-                        // The reason we are doing this is that maps.black has its own wrapper for
-                        // projection, among other aspects of the map. Rather than directly accessing the
-                        // underlying map object to change the projection (as maplibregl.GlobeControl
-                        // does), we will overload this method to use maps.black's wrapper.
-                        //
-                        // TODO implement this in a less hacky way, maybe. like maybe from scratch?
-                        this._toggleProjection = () => {
-                            // Not ideal to use the global `mb` but the alternative would be contrived and probably more error prone
-                            mb.globe = !mb.globe
-
-                            // Changing "features" of mb such as globe, or "mapstyle", seems to cause maps.black to
-                            //  rebuild the map, and in the process dumping all of the controls we added. So, we have
-                            // to add them again. (On the bright side, it means we don't need to toggle the highlighted
-                            // state of the button since that's set on control creation.)
-                            setUpMap()
-                        }
-
-                        return super.onAdd(map)
-                    }
-                }
-
-                class MapsDotBlackTerrainControl extends maplibregl.TerrainControl {
-                    onAdd(map) {
-                        // Depends on TerrainControl using `_toggleTerrain` internally in this
-                        // way, which might change in a different version of maplibregl:
-                        // https://github.com/maplibre/maplibre-gl-js/blob/b457ca945cf746a75ecb5412a2165142faa159c0/src/ui/control/terrain_control.ts
-                        //
-                        // The reason we are doing this is that maps.black has its own wrapper for
-                        // terrain, among other aspects of the map. Rather than directly accessing the
-                        // underlying map object to change the terrain (as maplibregl.TerrainControl
-                        // does), we will overload this method to use maps.black's wrapper.
-                        //
-                        // TODO implement this in a less hacky way, maybe. like maybe from scratch?
-                        this._toggleTerrain = () => {
-                            // Not ideal to use the global `mb` but the alternative would be contrived and probably more error prone
-                            mb.terrain = mb.hillshade = !mb.terrain
-
-                            // Changing "features" of mb such as terrain, or "mapstyle", seems to cause maps.black to
-                            //  rebuild the map, and in the process dumping all of the controls we added. So, we have
-                            // to add them again. (On the bright side, it means we don't need to toggle the highlighted
-                            // state of the button since that's set on control creation.)
-                            setUpMap()
-                        }
-
-                        return super.onAdd(map)
-                    }
-                }
-
-                // https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/
-                const nominatimGeocoderApi = {
-                    // TODO reverse geocode
-                    forwardGeocode: async (config) => {
-                        const features = [];
-                        try {
-                            const request = `/nominatim/search?q=${
-                                config.query
-                            }&format=geojson&polygon_geojson=1&addressdetails=1&extratags=1`;
-                            const response = await fetch(request);
-                            const geojson = await response.json();
-                            for (const feature of geojson.features) {
-                                const center = [
-                                    feature.bbox[0] + (feature.bbox[2] - feature.bbox[0]) / 2,
-                                    feature.bbox[1] + (feature.bbox[3] - feature.bbox[1]) / 2,
-                                ];
-                                const point = {
-                                    type: 'Feature',
-                                    geometry: {
-                                        type: 'Point',
-                                        coordinates: center
-                                    },
-                                    place_name: feature.properties.display_name,
-                                    properties: feature.properties,
-                                    text: feature.properties.display_name,
-                                    place_type: ['place'],
-                                    extratags: feature.properties.extratags,
-                                    center,
-
-                                    // TODO When you click on a search result in the list, it sets the view around that *specific* result's *bbox* specified here.
-                                    // On the other hand, hitting Enter in the search input sets the view around *all* of the result *markers* (with maximum zoom of 10).
-                                    // Ideally, it would set the view around *all* of the result *bboxes*, I think. So let's figure that out.
-                                    bbox: feature.bbox,
-                                };
-                                features.push(point);
-                            }
-                            // Just show borders for all results, for demo purposes for now.
-                            // Cut off at 5 because that's the number of markers that get shown.
-                            // TODO - have it only show the border when you actually click on a search result.
-                            showSearchResultBorder(geojson.features.slice(0, 5))
-                        } catch (e) {
-                            console.error(`Failed to forwardGeocode with error: ${e}`);
-                        }
-
-                        return {
-                            features
-                        };
-                    }
-                };
-
-                function showSearchResultBorder(searchResult) {
-                    const source = mb.map.getSource('search-result')
-                    if (source) {
-                        // TODO - can we do source.updateData(searchResult) instead ???
-                        mb.map.removeLayer('search-result-polygons')
-                        mb.map.removeLayer('search-result-outline')
-                        mb.map.removeSource('search-result')
-                    }
-                    mb.map.addSource('search-result', {
-                      type: 'geojson',
-                      data: {type: 'FeatureCollection', features: searchResult}
-                    });
-                    mb.map.addLayer({id: "search-result-polygons", type: "fill", source: 'search-result', layout:{}, paint: {'fill-color': '#FF4444', 'fill-opacity': 0.2}})
-                    mb.map.addLayer({id: "search-result-outline", type: "line", source: 'search-result', layout:{}, paint: {'line-color': '#FF4444', 'line-width': 2}})
-                }
-
-                // have to use MAX_ZOOM in a couple different places to cover a couple different scenarios, it seems
-                const MAX_ZOOM = 10;
-                const geocoder = new MaplibreGeocoder(nominatimGeocoderApi, {
-                    maplibregl,
-                    zoom: MAX_ZOOM,
-                    flyTo: {
-                        maxZoom: MAX_ZOOM,
+            function setStyle() {
+                // The first level key is the `mapStyleChoice`, i.e. "natural", "political", etc, from the dropdown menu. (These are names specific to
+                // IIAB maps.)
+                //
+                // The second level key is a boolean indicating whether the currently visible map is using OSM or Natural Earth data for vector data.
+                //
+                // Both of these together point to a maps.black "mapstyle" which implies a maplibre style and data sources.
+                mb.mapstyle = {
+                    // Has nicely colored regions, and buildings
+                    natural: {
+                        true:  "openstreetmap-openmaptiles/openfreemap/liberty",
+                        false: "naturalearth-openmaptiles/openfreemap/liberty",
                     },
-                    popup: true,
-                })
-                const scaleControl = new maplibregl.ScaleControl()
-                drawControl = new MaplibreTerradrawControl.MaplibreTerradrawControl({
-                    modes: [
-                        'rectangle',
-                    ],
-                    open: true,
-                });
+                    // Has more clearly defined political boundaries
+                    // TODO - find something like this with buildings too?
+                    political:  {
+                        true:  "openstreetmap-openmaptiles/qwant/basic",
+                        false: undefined, // We will hide this option for naturalearth since it's not great for political maps - TODO Extract a low res osm for political map.
+                    },
+                    hybrid:  {
+                        true:  "openstreetmap-openmaptiles/maps.black/hybrid-2023",
+                        false: "naturalearth-openmaptiles/maps.black/hybrid-2023", // we'll have a smaller satellite file with the same name in this case
+                    },
+                    satellite:  {
+                        true:  "raster/s2maps/2023",
+                        false: "raster/s2maps/2023", // we'll have a smaller satellite file with the same name in this case
+                    },
+                }[mapStyleChoice][MAPS_VECTOR_IS_OSM || !!activeFQRegionName]
+                console.log("setting to", mapStyleChoice, "i.e.", mb.mapstyle)
 
-                // separating this because it's just so much
-                function setUpFQRegionDownloader() {
-                    if (downloadedFQRegions !== null && !!activeFQRegionName && (activeFQRegionName in downloadedFQRegions)) {
-                        mb.map.addControl(new DeleteFQRegionControl(), 'top-left');
-                        return
-                    }
+                setUpMap() // The above will reset the map so we have to add controls and other things again. This also covers initial page load.
+            }
 
-                    mb.map.addControl(drawControl, 'top-left');
+            class MapsDotBlackStyleControl {
+                onAdd(map) {
+                    this._map = map;
+                    this._container = document.createElement('div');
+                    this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
 
-                    terraDrawInstance = drawControl.getTerraDrawInstance()
-                    const drawControlButton = drawControl
-                        .controlContainer
-                        .getElementsByClassName("maplibregl-terradraw-add-rectangle-button")[0]
+                    const naturalSelected = mapStyleChoice === "natural" ? `selected="selected"` : ""
+                    const politicalSelected = mapStyleChoice === "political" ? `selected="selected"` : ""
+                    const satelliteSelected = mapStyleChoice === "satellite" ? `selected="selected"` : ""
+                    const hybridSelected = mapStyleChoice === "hybrid" ? `selected="selected"` : ""
 
-                    // Keep the rectangle functionality but change it to the download button.
-                    // From the perspective of a user of this app, this is a download tool.
-                    drawControlButton.classList.remove("maplibregl-terradraw-add-rectangle-button");
-                    drawControlButton.classList.add("maplibregl-terradraw-download-button");
-                    drawControlButton.title = "Select region for download"
+                    // For now don't include political for naturalearth because it doesn't have great political options zoomed out
+                    const maybePolitical = (MAPS_VECTOR_IS_OSM || !!activeFQRegionName) ? `<option title="Political Map" value="political" ${politicalSelected}>&#x1F3F3;</option>` : "";
 
-                    let downloadPopup = null
-                    function removePopup() {
-                        if (downloadPopup) {
-                            downloadPopup.remove()
-                            downloadPopup = null
-                        }
-                    }
-                    function removeOtherRectangles(id) {
-                        for (feature of drawControl.getFeatures().features) {
-                            if (feature.id !== id) {
-                                terraDrawInstance.removeFeatures([feature.id])
+                    // Keep in mind that maps.black destroys and creates this every time we change the map style or features.
+                    // This makes it a little complicated to add handlers. So for now, I inline it.
+                    //
+                    // appearance: none - get rid of the little arrow from the dropdown
+                    // border: none - get rid of the standard select tag border
+                    // outline: none - don't highlight it after using (noticed on Chromium)
+                    // border-radius is done here, but border as such is done by maplibregl-ctrl-group
+                    // height and width experimentally match the Globe control
+                    // padding and font size are a balance:
+                    // * Make icons big enough (I'd like to make them a little bigger)
+                    // * Make icons nicely centered
+                    // * Make room for the "+" I'm cramming into the Hybrid option
+                    // * TODO - Just get some images for this part and make it consistent
+
+                    this._container.innerHTML = `
+                        <select
+                          class="styleswitch"
+                          id="styleswitch"
+                          onchange="mapStyleChoice = this.value; setStyle()"
+                          title="Select Map Style"
+                          style="background: white; padding-top:2px; padding-left:5px; border: none; outline: none; appearance: none; font-size: 13px; border-radius: 5px; height: 29px; width: 29px;"
+                        >
+                            <option title="Natural Map" value="natural" ${naturalSelected}>&#x1F33F;</option>
+                            ${maybePolitical}
+                            <option title="Satellite" value="satellite" ${satelliteSelected}>&#x1F4E1;</option>
+                            <option title="Satellite + Map" value="hybrid" ${hybridSelected}>&#x1F4E1;+</option>
+                        </select>
+                    `
+                    return this._container;
+                }
+
+                onRemove() {
+                    this._container.parentNode.removeChild(this._container);
+                    this._map = undefined;
+                }
+            }
+
+            // This button brings us back from a Full Quality Region to the full world map
+            class ReturnFromRegionControl {
+                onAdd(map) {
+                    this._map = map;
+                    this._container = document.createElement('div');
+                    const button = document.createElement('button');
+                    button.type = "button"
+                    button.title = "Return to world map"
+                    button.innerHTML = "&#8617;&#65039;" // curved arrow
+                    this._container.appendChild(button)
+                    this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+                    this._container.style = 'cursor: pointer;'
+                    this._container.onclick = () => {
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
+
+                        // First we kick off a zoom animation to a view focusing on the region, zoomed out a bit more than when we entered it.
+                        mb.map.setMaxBounds() // untether us from the bounds first so we can zoom out further
+                        mb.map.fitBounds(
+                            [[min_lon - 0.5, min_lat - 0.5], [max_lon + 0.5, max_lat + 0.5]],
+                            {speed: 1.75}, // a little slower than the Delete button, but a little faster than the default
+                        )
+
+                        // Then we create a handler that gets called once the zoom animation is complete.
+                        // (We don't have to worry about removing this handler. setStyle will refresh
+                        // the map and wipe everthing.)
+                        mb.map.on('moveend', () => {
+                            // Unset the Full Quality Region, i.e. go back to the full-sized map
+                            activeFQRegionName = ""
+
+                            // As we exit from a Full Quality Region, we have to disable things that may not be available in the full-sized map.
+                            // (This sucks and a better organization of the code would prevent this.)
+                            mb.terrain = mb.hillshade = mb.terrain && (MAPS_TERRAIN_ZOOM || !!activeFQRegionName)
+                            if (mapStyleChoice === "political" && !(MAPS_VECTOR_IS_OSM || !!activeFQRegionName)) {
+                              mapStyleChoice = "hybrid"
                             }
-                        }
+
+                            setStyle()
+                        })
                     }
-                    terraDrawInstance.on("change", (ids, type) => {
-                        if (type === "create") {
-                            // We're starting to create a new rectangle. Delete other rectangles on the map.
-                            // Not sure why ids would contain more than one, but at worst we'll
-                            // delete whatever extra stuff that might be there.
-                            removeOtherRectangles(ids[0])
-                            removePopup()
-                        }
-                    })
-                    terraDrawInstance.on("finish", (id, context) => {
-                        if (context.mode !== "rectangle" || context.action !== "draw") {
-                          // Confirm expected values. I don't know why it would be anything else
-                          // but I'm not totally familiar with terraDraw.
-                          return
-                        }
+                    return this._container
+                }
 
-                        // Remove any other rectangles. They *shouldn't* be here in the first place,
-                        // but again this system is unfamiliar so just in case I make sure we're in
-                        // a familiar state. And then, we select the remaining one which by
-                        // elimination should be the one we just finished.
-                        removeOtherRectangles(id)
-                        removePopup()
+                onRemove() {
+                    this._container.parentNode.removeChild(this._container);
+                    this._map = undefined;
+                }
+            }
 
-                        // We assume that the library is doing its job and it's a rectangle
-                        const rectangle = drawControl.getFeatures().features[0]
-                        const shape = rectangle.geometry.coordinates[0]
+            class DeleteFQRegionControl {
+                onAdd(map) {
 
-                        // A small note about the 180/-180 longitude border:
-                        //
-                        // I was initially afraid that this approach would lead to a bug if the selected region crossed
-                        // longitude of 180 (which is the same as -180). Let's say 170 on the west to -175 on the east.
-                        // Usually the western edge of the bounding box has the smallest longitude, but not when we are
-                        // crossing 180/-180.
-                        //
-                        // However, it seems as though this plugin accounts for that. If the current center of the
-                        // map *view* is to the west of 180/-180, then the longitudes of this bounding box would be
-                        // expressed as 170, 185. If the map view center is moved east of 180/-180, then longitudes of the
-                        // the bounding box would be expressed as -190, -175.
-                        //
-                        // Therefore, the min/max sorting should work as intended even if the bounding box straddles the
-                        // 180/-180 line. Furthermore, a lot of the downstream headaches with displaying regions go away.
-                        const lats = shape.map( ([lon, lat]) => lat)
-                        const lons = shape.map( ([lon, lat]) => lon)
+                    this._map = map;
+                    this._container = document.createElement('div');
+                    const button = document.createElement('button');
+                    button.type = "button"
+                    button.title = "Delete this region"
+                    button.innerHTML = "&#128465;&#65039;" // wastebasket
+                    this._container.appendChild(button)
+                    this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+                    this._container.style = 'cursor: pointer;'
+                    this._container.onclick = () => {
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
 
-                        const min_lon = Math.min.apply(null, lons)
-                        const min_lat = Math.min.apply(null, lats)
-                        const max_lon = Math.max.apply(null, lons)
-                        const max_lat = Math.max.apply(null, lats)
-
+                        // Zoom out to view the region so that the delete popup is well placed
+                        mb.map.fitBounds([[min_lon, min_lat], [max_lon, max_lat]], {maxDuration: 2000, speed: 5})
                         const center = [
                             min_lon + (max_lon - min_lon) / 2,
                             min_lat + (max_lat - min_lat) / 2,
                         ]
 
-                        function popupButton(textContent, onclick) {
-                            const button = document.createElement('button')
-                            button.textContent = textContent
-                            button.onclick = onclick
-                            button.className = "maplibregl-ctrl maplibregl-ctrl-group" // happens to look good
-                            button.style = "padding-left: 5px;padding-right: 5px; margin: 5px; text-align: center; cursor: pointer;"
-                            return button
-                        }
+                        const deleteCommand = document.createElement('div');
+                        const deleteCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py delete ${activeFQRegionName}`
+                        deleteCommand.innerHTML = `<pre
+                              style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
+                              onclick="window.getSelection().selectAllChildren(this)"
+                          >${deleteCommandString}</pre>`
 
-                        const backButton = popupButton("Back", () => {
-                            // show popupStart, hide popupFinish
-                            popupStart.style = ""
-                            popupFinish.style = "display: none;"
-                        })
-
-                        const doneButton = popupButton("Done", () => {
-                            terraDrawInstance.clear();
-                            removePopup();
-                        })
-                        const cancelButton = popupButton("Cancel", () => {
-                            terraDrawInstance.clear();
-                            removePopup();
-                        })
-
-                        const downloadCommand = document.createElement('div');
-                        downloadCommand.set = function(downloadName) {
-                            const downloadCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py extract ${downloadName} ${min_lon},${min_lat},${max_lon},${max_lat}`
-                            this.innerHTML = `<pre
-                                style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
-                                onclick="window.getSelection().selectAllChildren(this)"
-                            >${downloadCommandString}</pre>`
-                        }
-
-                        const downloadNameInput = document.createElement('input');
-                        downloadNameInput.style = "display: block; margin-bottom: 1em;"
-
-                        function updateName () {
-                            const cleanedName = downloadNameInput.value.slice(0, 35).toLowerCase().replace(/[^a-z0-9]+/g, "_")
-                            downloadNameInput.value = cleanedName
-                            downloadCommand.set(cleanedName)
-                            nextButton.set()
-                        }
-                        // be as annoying and cover as many bases as I can
-                        downloadNameInput.onkeydown = downloadNameInput.onpaste = downloadNameInput.onchange = updateName
-
-                        downloadNameInput.onkeyup = e => {
-                            updateName() // because onkeydown happens before the new value is actually set
-                            if (e.key === "Enter") {
-                                tryGoToNext()
-                            }
-                        }
-
-                        const popupStart = document.createElement('div');
-                        popupStart.innerHTML = `
-                            <h1>Download region</h1>
-                            <p>Choose a name for this <b>Full Quality Region</b> <i>(lower case letters, numbers, and _ only)</i>
-                            </p>
-                        `
-                        function tryGoToNext() {
-                            if (downloadNameInput.value.length > 0) {
-                                popupFinish.style = "" // show popupFinish
-                                popupStart.style = "display: none;"
-                                updateName() // for good measure. we want to avoid them inputting a destructive command!
-                            }
-                        }
-                        const nextButton = popupButton("", tryGoToNext)
-                        nextButton.set = function() {
-                            if (downloadNameInput.value.length > 0) {
-                                this.innerHTML = "Next"
-                            } else {
-                                this.innerHTML = "<span style='color: #888'>Next</span>"
-                            }
-                        }
-                        nextButton.set()
-
-                        popupStart.appendChild(downloadNameInput)
-                        popupStart.appendChild(nextButton)
-                        popupStart.appendChild(cancelButton)
-
-                        const popupFinish = document.createElement('div');
-                        popupFinish.style = "display: none;"
-                        popupFinish.innerHTML = `
-                            <h1>Download region</h1>
+                        const popupContainer = document.createElement('div');
+                        popupContainer.innerHTML = `
+                            <h1>Delete this region</h1>
                             <ul>
                               <li>Click below to select text</li>
                               <li>Copy text</li>
                               <li>Paste and run in a terminal logged into your Internet in a Box</li>
-                              <li>When it is done downloading, reload this page</li>
+                              <li>When it is done deleting, reload this page</li>
                             </ul>
                         `
-                        popupFinish.appendChild(downloadCommand)
-                        popupFinish.appendChild(backButton)
-                        popupFinish.appendChild(doneButton)
+                        popupContainer.appendChild(deleteCommand)
 
-                        const popupContainer = document.createElement('div');
-                        popupContainer.appendChild(popupStart)
-                        popupContainer.appendChild(popupFinish)
-
-                        downloadPopup = new maplibregl.Popup({closeOnClick: false, closeButton: false})
+                        const deletePopup = new maplibregl.Popup()
                             .setLngLat(center)
                             .setDOMContent(popupContainer)
                             .addTo(mb.map);
-                    })
+                        }
+                    return this._container
                 }
 
-                // We need a timeout to wait for mb.map.style to be set
-                let setUpMapTimeout = null
-                function setUpMap() {
-                    // Whether we're setting a new timeout, actually setting up all this
-                    // stuff, or neither, make sure no further timeouts are looming.
-                    clearTimeout(setUpMapTimeout)
+                onRemove() {
+                    this._container.parentNode.removeChild(this._container);
+                    this._map = undefined;
+                }
+            }
 
-                    if (scaleControl._map) {
-                      // We are already set up. Neither set up again, nor set a timer
+            class MapsDotBlackGlobeControl extends maplibregl.GlobeControl {
+                onAdd(map) {
+                    // Depends on GlobeControl using `_toggleProjection` internally in this
+                    // way, which might change in a different version of maplibregl:
+                    // https://github.com/maplibre/maplibre-gl-js/blob/93634b011a147666a62887bc61bffd351fa9971d/src/ui/control/globe_control.ts
+                    //
+                    // The reason we are doing this is that maps.black has its own wrapper for
+                    // projection, among other aspects of the map. Rather than directly accessing the
+                    // underlying map object to change the projection (as maplibregl.GlobeControl
+                    // does), we will overload this method to use maps.black's wrapper.
+                    //
+                    // TODO implement this in a less hacky way, maybe. like maybe from scratch?
+                    this._toggleProjection = () => {
+                        // Not ideal to use the global `mb` but the alternative would be contrived and probably more error prone
+                        mb.globe = !mb.globe
+
+                        // Changing "features" of mb such as globe, or "mapstyle", seems to cause maps.black to
+                        //  rebuild the map, and in the process dumping all of the controls we added. So, we have
+                        // to add them again. (On the bright side, it means we don't need to toggle the highlighted
+                        // state of the button since that's set on control creation.)
+                        setUpMap()
+                    }
+
+                    return super.onAdd(map)
+                }
+            }
+
+            class MapsDotBlackTerrainControl extends maplibregl.TerrainControl {
+                onAdd(map) {
+                    // Depends on TerrainControl using `_toggleTerrain` internally in this
+                    // way, which might change in a different version of maplibregl:
+                    // https://github.com/maplibre/maplibre-gl-js/blob/b457ca945cf746a75ecb5412a2165142faa159c0/src/ui/control/terrain_control.ts
+                    //
+                    // The reason we are doing this is that maps.black has its own wrapper for
+                    // terrain, among other aspects of the map. Rather than directly accessing the
+                    // underlying map object to change the terrain (as maplibregl.TerrainControl
+                    // does), we will overload this method to use maps.black's wrapper.
+                    //
+                    // TODO implement this in a less hacky way, maybe. like maybe from scratch?
+                    this._toggleTerrain = () => {
+                        // Not ideal to use the global `mb` but the alternative would be contrived and probably more error prone
+                        mb.terrain = mb.hillshade = !mb.terrain
+
+                        // Changing "features" of mb such as terrain, or "mapstyle", seems to cause maps.black to
+                        //  rebuild the map, and in the process dumping all of the controls we added. So, we have
+                        // to add them again. (On the bright side, it means we don't need to toggle the highlighted
+                        // state of the button since that's set on control creation.)
+                        setUpMap()
+                    }
+
+                    return super.onAdd(map)
+                }
+            }
+
+            // https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/
+            const nominatimGeocoderApi = {
+                // TODO reverse geocode
+                forwardGeocode: async (config) => {
+                    const features = [];
+                    try {
+                        const request = `/nominatim/search?q=${
+                            config.query
+                        }&format=geojson&polygon_geojson=1&addressdetails=1&extratags=1`;
+                        const response = await fetch(request);
+                        const geojson = await response.json();
+                        for (const feature of geojson.features) {
+                            const center = [
+                                feature.bbox[0] + (feature.bbox[2] - feature.bbox[0]) / 2,
+                                feature.bbox[1] + (feature.bbox[3] - feature.bbox[1]) / 2,
+                            ];
+                            const point = {
+                                type: 'Feature',
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: center
+                                },
+                                place_name: feature.properties.display_name,
+                                properties: feature.properties,
+                                text: feature.properties.display_name,
+                                place_type: ['place'],
+                                extratags: feature.properties.extratags,
+                                center,
+
+                                // TODO When you click on a search result in the list, it sets the view around that *specific* result's *bbox* specified here.
+                                // On the other hand, hitting Enter in the search input sets the view around *all* of the result *markers* (with maximum zoom of 10).
+                                // Ideally, it would set the view around *all* of the result *bboxes*, I think. So let's figure that out.
+                                bbox: feature.bbox,
+                            };
+                            features.push(point);
+                        }
+                        // Just show borders for all results, for demo purposes for now.
+                        // Cut off at 5 because that's the number of markers that get shown.
+                        // TODO - have it only show the border when you actually click on a search result.
+                        showSearchResultBorder(geojson.features.slice(0, 5))
+                    } catch (e) {
+                        console.error(`Failed to forwardGeocode with error: ${e}`);
+                    }
+
+                    return {
+                        features
+                    };
+                }
+            };
+
+            function showSearchResultBorder(searchResult) {
+                const source = mb.map.getSource('search-result')
+                if (source) {
+                    // TODO - can we do source.updateData(searchResult) instead ???
+                    mb.map.removeLayer('search-result-polygons')
+                    mb.map.removeLayer('search-result-outline')
+                    mb.map.removeSource('search-result')
+                }
+                mb.map.addSource('search-result', {
+                  type: 'geojson',
+                  data: {type: 'FeatureCollection', features: searchResult}
+                });
+                mb.map.addLayer({id: "search-result-polygons", type: "fill", source: 'search-result', layout:{}, paint: {'fill-color': '#FF4444', 'fill-opacity': 0.2}})
+                mb.map.addLayer({id: "search-result-outline", type: "line", source: 'search-result', layout:{}, paint: {'line-color': '#FF4444', 'line-width': 2}})
+            }
+
+            // have to use MAX_ZOOM in a couple different places to cover a couple different scenarios, it seems
+            const MAX_ZOOM = 10;
+            const geocoder = new MaplibreGeocoder(nominatimGeocoderApi, {
+                maplibregl,
+                zoom: MAX_ZOOM,
+                flyTo: {
+                    maxZoom: MAX_ZOOM,
+                },
+                popup: true,
+            })
+            const scaleControl = new maplibregl.ScaleControl()
+            drawControl = new MaplibreTerradrawControl.MaplibreTerradrawControl({
+                modes: [
+                    'rectangle',
+                ],
+                open: true,
+            });
+
+            // separating this because it's just so much
+            function setUpFQRegionDownloader() {
+                if (downloadedFQRegions !== null && !!activeFQRegionName && (activeFQRegionName in downloadedFQRegions)) {
+                    mb.map.addControl(new DeleteFQRegionControl(), 'top-left');
+                    return
+                }
+
+                mb.map.addControl(drawControl, 'top-left');
+
+                terraDrawInstance = drawControl.getTerraDrawInstance()
+                const drawControlButton = drawControl
+                    .controlContainer
+                    .getElementsByClassName("maplibregl-terradraw-add-rectangle-button")[0]
+
+                // Keep the rectangle functionality but change it to the download button.
+                // From the perspective of a user of this app, this is a download tool.
+                drawControlButton.classList.remove("maplibregl-terradraw-add-rectangle-button");
+                drawControlButton.classList.add("maplibregl-terradraw-download-button");
+                drawControlButton.title = "Select region for download"
+
+                let downloadPopup = null
+                function removePopup() {
+                    if (downloadPopup) {
+                        downloadPopup.remove()
+                        downloadPopup = null
+                    }
+                }
+                function removeOtherRectangles(id) {
+                    for (feature of drawControl.getFeatures().features) {
+                        if (feature.id !== id) {
+                            terraDrawInstance.removeFeatures([feature.id])
+                        }
+                    }
+                }
+                terraDrawInstance.on("change", (ids, type) => {
+                    if (type === "create") {
+                        // We're starting to create a new rectangle. Delete other rectangles on the map.
+                        // Not sure why ids would contain more than one, but at worst we'll
+                        // delete whatever extra stuff that might be there.
+                        removeOtherRectangles(ids[0])
+                        removePopup()
+                    }
+                })
+                terraDrawInstance.on("finish", (id, context) => {
+                    if (context.mode !== "rectangle" || context.action !== "draw") {
+                      // Confirm expected values. I don't know why it would be anything else
+                      // but I'm not totally familiar with terraDraw.
                       return
                     }
 
-                    // TODO use a maps-dot-black "on add map" callback instead, if such a thing exists.
-                    // The problem is that at on creation, mb doesn't immediately contain a map.
-                    if (mb.map && mb.map.style) { // NOTE mb.map.loaded() becomes true much later than mb.map.style. mb.map.style seems to be sufficient.
-                        // sigh. deal with sneaking the style sheets into a "Shadow DOM" here. Thankfully this somehow isn't an issue with javascript.
-                        // https://stackoverflow.com/questions/79736280/importing-a-css-stylesheet-into-a-webcomponent-with-shadow-dom-in-firefox/79744809#79744809
-                        // TODO - See if I can do this in a more direct way. I only need the geocoder css as part of this shadow DOM. Also I probably don't need the
-                        // other maplibre css, that's probably already included in maps.black.
+                    // Remove any other rectangles. They *shouldn't* be here in the first place,
+                    // but again this system is unfamiliar so just in case I make sure we're in
+                    // a familiar state. And then, we select the remaining one which by
+                    // elimination should be the one we just finished.
+                    removeOtherRectangles(id)
+                    removePopup()
 
-                        const mapLibreGlGeocoderCSS = [...document.styleSheets].find((styleSheet) => (styleSheet.href || "").split('/').pop() === 'maplibre-gl-geocoder.css');
-                        const mapLibreGlTerradrawCSS = [...document.styleSheets].find((styleSheet) => (styleSheet.href || "").split('/').pop() === 'maplibre-gl-terradraw.css');
-                        const stylesheetText = [...mapLibreGlGeocoderCSS.cssRules, ...mapLibreGlTerradrawCSS.cssRules].reduce((accumulator, rule) => accumulator + rule.cssText, '');
-                        const myStyles = new CSSStyleSheet()
-                        myStyles.replace(stylesheetText)
-                        mb.shadowRoot.adoptedStyleSheets = [...mb.shadowRoot.adoptedStyleSheets, myStyles]
+                    // We assume that the library is doing its job and it's a rectangle
+                    const rectangle = drawControl.getFeatures().features[0]
+                    const shape = rectangle.geometry.coordinates[0]
 
-                        if (MAPS_SEARCH_ENGINE === "nominatim") {
-                            mb.map.addControl(geocoder, 'top-left');
-                        }
-                        mb.map.addControl(scaleControl);
+                    // A small note about the 180/-180 longitude border:
+                    //
+                    // I was initially afraid that this approach would lead to a bug if the selected region crossed
+                    // longitude of 180 (which is the same as -180). Let's say 170 on the west to -175 on the east.
+                    // Usually the western edge of the bounding box has the smallest longitude, but not when we are
+                    // crossing 180/-180.
+                    //
+                    // However, it seems as though this plugin accounts for that. If the current center of the
+                    // map *view* is to the west of 180/-180, then the longitudes of this bounding box would be
+                    // expressed as 170, 185. If the map view center is moved east of 180/-180, then longitudes of the
+                    // the bounding box would be expressed as -190, -175.
+                    //
+                    // Therefore, the min/max sorting should work as intended even if the bounding box straddles the
+                    // 180/-180 line. Furthermore, a lot of the downstream headaches with displaying regions go away.
+                    const lats = shape.map( ([lon, lat]) => lat)
+                    const lons = shape.map( ([lon, lat]) => lon)
 
-                        if (MAPS_REGION_DOWNLOADER) {
-                          setUpFQRegionDownloader()
-                        }
+                    const min_lon = Math.min.apply(null, lons)
+                    const min_lat = Math.min.apply(null, lats)
+                    const max_lon = Math.max.apply(null, lons)
+                    const max_lat = Math.max.apply(null, lats)
 
-                        if (downloadedFQRegions !== null && !!activeFQRegionName && (activeFQRegionName in downloadedFQRegions)) {
-                            mb.map.addControl(new ReturnFromRegionControl(), 'top-left');
+                    const center = [
+                        min_lon + (max_lon - min_lon) / 2,
+                        min_lat + (max_lat - min_lat) / 2,
+                    ]
 
-                            // We are looking at a full quality region. Let's prevent
-                            // the user from straying far from it so they don't get lost.
-                            const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
-                            mb.map.setMaxBounds([[min_lon - 0.5, min_lat - 0.5], [max_lon + 0.5, max_lat + 0.5]], {})
-                        }
-
-                        mb.map.addControl(new MapsDotBlackGlobeControl(), 'top-right');
-                        if (MAPS_TERRAIN_ZOOM || !!activeFQRegionName) {
-                            mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
-                        }
-                        mb.map.addControl(new MapsDotBlackStyleControl(), 'top-right');
-                        // NOTE Navigation control is added via `navigationcontrol` attribute on the maps-black tag
-
-                        // The call to this function (`setUpMap`) may have been triggered by a globe, terrain, or style change.
-                        // That should be reflected in the hash:
-                        setHash()
-
-                        // Future changes in orientation should also be reflected in the hash:
-                        mb.map.off('moveend', setHash) // unsetting first, in case it's already there from a previous refresh
-                        mb.map.on('moveend', setHash)
-
-                        // Any time we set up the map, we should make a point to show the full quality region outlines as well.
-                        // This depends both on mb.map.style.loaded() and also for the fetch to have returned.
-                        // Thus, it'll be on its own timer loop. We just need to make sure to kick it off here.
-                        showFQRegionOutlines()
-
-                        setDefaultView()
-                    } else {
-                        // For now try periodically until it's ready.
-                        setUpMapTimeout = setTimeout(setUpMap, 100)
+                    function popupButton(textContent, onclick) {
+                        const button = document.createElement('button')
+                        button.textContent = textContent
+                        button.onclick = onclick
+                        button.className = "maplibregl-ctrl maplibregl-ctrl-group" // happens to look good
+                        button.style = "padding-left: 5px;padding-right: 5px; margin: 5px; text-align: center; cursor: pointer;"
+                        return button
                     }
+
+                    const backButton = popupButton("Back", () => {
+                        // show popupStart, hide popupFinish
+                        popupStart.style = ""
+                        popupFinish.style = "display: none;"
+                    })
+
+                    const doneButton = popupButton("Done", () => {
+                        terraDrawInstance.clear();
+                        removePopup();
+                    })
+                    const cancelButton = popupButton("Cancel", () => {
+                        terraDrawInstance.clear();
+                        removePopup();
+                    })
+
+                    const downloadCommand = document.createElement('div');
+                    downloadCommand.set = function(downloadName) {
+                        const downloadCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py extract ${downloadName} ${min_lon},${min_lat},${max_lon},${max_lat}`
+                        this.innerHTML = `<pre
+                            style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
+                            onclick="window.getSelection().selectAllChildren(this)"
+                        >${downloadCommandString}</pre>`
+                    }
+
+                    const downloadNameInput = document.createElement('input');
+                    downloadNameInput.style = "display: block; margin-bottom: 1em;"
+
+                    function updateName () {
+                        const cleanedName = downloadNameInput.value.slice(0, 35).toLowerCase().replace(/[^a-z0-9]+/g, "_")
+                        downloadNameInput.value = cleanedName
+                        downloadCommand.set(cleanedName)
+                        nextButton.set()
+                    }
+                    // be as annoying and cover as many bases as I can
+                    downloadNameInput.onkeydown = downloadNameInput.onpaste = downloadNameInput.onchange = updateName
+
+                    downloadNameInput.onkeyup = e => {
+                        updateName() // because onkeydown happens before the new value is actually set
+                        if (e.key === "Enter") {
+                            tryGoToNext()
+                        }
+                    }
+
+                    const popupStart = document.createElement('div');
+                    popupStart.innerHTML = `
+                        <h1>Download region</h1>
+                        <p>Choose a name for this <b>Full Quality Region</b> <i>(lower case letters, numbers, and _ only)</i>
+                        </p>
+                    `
+                    function tryGoToNext() {
+                        if (downloadNameInput.value.length > 0) {
+                            popupFinish.style = "" // show popupFinish
+                            popupStart.style = "display: none;"
+                            updateName() // for good measure. we want to avoid them inputting a destructive command!
+                        }
+                    }
+                    const nextButton = popupButton("", tryGoToNext)
+                    nextButton.set = function() {
+                        if (downloadNameInput.value.length > 0) {
+                            this.innerHTML = "Next"
+                        } else {
+                            this.innerHTML = "<span style='color: #888'>Next</span>"
+                        }
+                    }
+                    nextButton.set()
+
+                    popupStart.appendChild(downloadNameInput)
+                    popupStart.appendChild(nextButton)
+                    popupStart.appendChild(cancelButton)
+
+                    const popupFinish = document.createElement('div');
+                    popupFinish.style = "display: none;"
+                    popupFinish.innerHTML = `
+                        <h1>Download region</h1>
+                        <ul>
+                          <li>Click below to select text</li>
+                          <li>Copy text</li>
+                          <li>Paste and run in a terminal logged into your Internet in a Box</li>
+                          <li>When it is done downloading, reload this page</li>
+                        </ul>
+                    `
+                    popupFinish.appendChild(downloadCommand)
+                    popupFinish.appendChild(backButton)
+                    popupFinish.appendChild(doneButton)
+
+                    const popupContainer = document.createElement('div');
+                    popupContainer.appendChild(popupStart)
+                    popupContainer.appendChild(popupFinish)
+
+                    downloadPopup = new maplibregl.Popup({closeOnClick: false, closeButton: false})
+                        .setLngLat(center)
+                        .setDOMContent(popupContainer)
+                        .addTo(mb.map);
+                })
+            }
+
+            // We need a timeout to wait for mb.map.style to be set
+            let setUpMapTimeout = null
+            function setUpMap() {
+                // Whether we're setting a new timeout, actually setting up all this
+                // stuff, or neither, make sure no further timeouts are looming.
+                clearTimeout(setUpMapTimeout)
+
+                if (scaleControl._map) {
+                  // We are already set up. Neither set up again, nor set a timer
+                  return
                 }
+
+                // TODO use a maps-dot-black "on add map" callback instead, if such a thing exists.
+                // The problem is that at on creation, mb doesn't immediately contain a map.
+                if (mb.map && mb.map.style) { // NOTE mb.map.loaded() becomes true much later than mb.map.style. mb.map.style seems to be sufficient.
+                    // sigh. deal with sneaking the style sheets into a "Shadow DOM" here. Thankfully this somehow isn't an issue with javascript.
+                    // https://stackoverflow.com/questions/79736280/importing-a-css-stylesheet-into-a-webcomponent-with-shadow-dom-in-firefox/79744809#79744809
+                    // TODO - See if I can do this in a more direct way. I only need the geocoder css as part of this shadow DOM. Also I probably don't need the
+                    // other maplibre css, that's probably already included in maps.black.
+
+                    const mapLibreGlGeocoderCSS = [...document.styleSheets].find((styleSheet) => (styleSheet.href || "").split('/').pop() === 'maplibre-gl-geocoder.css');
+                    const mapLibreGlTerradrawCSS = [...document.styleSheets].find((styleSheet) => (styleSheet.href || "").split('/').pop() === 'maplibre-gl-terradraw.css');
+                    const stylesheetText = [...mapLibreGlGeocoderCSS.cssRules, ...mapLibreGlTerradrawCSS.cssRules].reduce((accumulator, rule) => accumulator + rule.cssText, '');
+                    const myStyles = new CSSStyleSheet()
+                    myStyles.replace(stylesheetText)
+                    mb.shadowRoot.adoptedStyleSheets = [...mb.shadowRoot.adoptedStyleSheets, myStyles]
+
+                    if (MAPS_SEARCH_ENGINE === "nominatim") {
+                        mb.map.addControl(geocoder, 'top-left');
+                    }
+                    mb.map.addControl(scaleControl);
+
+                    if (MAPS_REGION_DOWNLOADER) {
+                      setUpFQRegionDownloader()
+                    }
+
+                    if (downloadedFQRegions !== null && !!activeFQRegionName && (activeFQRegionName in downloadedFQRegions)) {
+                        mb.map.addControl(new ReturnFromRegionControl(), 'top-left');
+
+                        // We are looking at a full quality region. Let's prevent
+                        // the user from straying far from it so they don't get lost.
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
+                        mb.map.setMaxBounds([[min_lon - 0.5, min_lat - 0.5], [max_lon + 0.5, max_lat + 0.5]], {})
+                    }
+
+                    mb.map.addControl(new MapsDotBlackGlobeControl(), 'top-right');
+                    if (MAPS_TERRAIN_ZOOM || !!activeFQRegionName) {
+                        mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
+                    }
+                    mb.map.addControl(new MapsDotBlackStyleControl(), 'top-right');
+                    // NOTE Navigation control is added via `navigationcontrol` attribute on the maps-black tag
+
+                    // The call to this function (`setUpMap`) may have been triggered by a globe, terrain, or style change.
+                    // That should be reflected in the hash:
+                    setHash()
+
+                    // Future changes in orientation should also be reflected in the hash:
+                    mb.map.off('moveend', setHash) // unsetting first, in case it's already there from a previous refresh
+                    mb.map.on('moveend', setHash)
+
+                    // Any time we set up the map, we should make a point to show the full quality region outlines as well.
+                    // This depends both on mb.map.style.loaded() and also for the fetch to have returned.
+                    // Thus, it'll be on its own timer loop. We just need to make sure to kick it off here.
+                    showFQRegionOutlines()
+
+                    setDefaultView()
+                } else {
+                    // For now try periodically until it's ready.
+                    setUpMapTimeout = setTimeout(setUpMap, 100)
+                }
+            }
 
             window.addEventListener("load", () => {
                 readHashGlobeAndTerrain()

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -377,7 +377,7 @@
                         // Real hack with `setTimeout`; I need to refactor `setStyle` and `setUpMap`.
                         // Setting it to a whole 1000 ms to avoid an intermittent console error.
                         // This is handling a somewhat uncommon case so I will just go with this non-ideal but easy approach.
-                        setUpMapTimeout = setTimeout(() => {
+                        setTimeout(() => {
                             // The currently active Full Quality Region seems to be nonexistent.
                             // One very likely scenario for this is that the user deleted a region by this name and reloaded the page.
                             // Another hypothetical is that someone is looking at an old link, or maybe a link copied from another IIAB?

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -51,10 +51,6 @@
             const MAPS_SEARCH_ENGINE = "{{ maps_search_engine }}"
             const MAPS_REGION_DOWNLOADER = "{{ maps_region_downloader }}" === "True"
 
-            // globally scoped function, for access from select tag's onchange handler.
-            // TODO This code layout sucks, should clean it.
-            let setStyle = null
-
             // we want style choice to survive the map reset that happens when a maps.black
             // feature or style changes, so we rely on this instead of the select tag value
             let mapStyleChoice
@@ -388,8 +384,8 @@
                         }, 1000)
                     }
                 })
-            window.addEventListener("load", () => {
-                function _setStyle() {
+
+                function setStyle() {
                     // The first level key is the `mapStyleChoice`, i.e. "natural", "political", etc, from the dropdown menu. (These are names specific to
                     // IIAB maps.)
                     //
@@ -421,10 +417,6 @@
 
                     setUpMap() // The above will reset the map so we have to add controls and other things again. This also covers initial page load.
                 }
-                setStyle = _setStyle
-
-                readHashGlobeAndTerrain()
-                setTimeout(setStyle) // TODO run this without the timeout. it requires rearranging a bunch of code so I don't want to do it now.
 
                 class MapsDotBlackStyleControl {
                     onAdd(map) {
@@ -982,7 +974,12 @@
                         setUpMapTimeout = setTimeout(setUpMap, 100)
                     }
                 }
+
+            window.addEventListener("load", () => {
+                readHashGlobeAndTerrain()
+                setStyle()
             });
+
         </script>
     </head>
     <body>


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Clean up a bit of my tangled frontend code and fix one probably inconsequential mistake. It looks complicated but it's actually quite simple if you look at all three commits separately:

* 543778b955e9c5a396e0147e678900653115e1fd Due to a bad copy/paste or something, I assigned the wrong timeout to `setUpMapTimeout`. I'm guessing it didn't create any actual bugs. I think it would have been in a different scope.
* 0e83293707c71b5070c2e437d55c614451b3f061 Move almost everything out of the window load handler. I had accumulated a dependency of things inside of it that referred to other things defined inside of it. I thought it would be complicated to take it out. Turns out if I just take them all out at once it's fine. I just have two functions calls in there now.
* 7ba8cc46876fcdbc2d02fb10ea8ea246179b2dfc Strictly indentation. If you add ?w=1 to the end of the URL it'll tell you it's whitespace only changes.

The benefit of this is that now I can organize my code a little better. Hopefully make it easier for others to follow. Perhaps it'll simplify some future feature implementations.

My next step in cleanup was going to be to add a map.on('load'...) handler for maps.black to get rid of some timeout loops I have, but that's looking to be a lot more of a mess than I expected so I may put that off.

### Smoke-tested on which OS or OS's:

RasPi Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 