### PR TITLE
[calibre-web] fix service name on proot condition.

### DIFF
--- a/roles/calibre-web/tasks/enable-or-disable.yml
+++ b/roles/calibre-web/tasks/enable-or-disable.yml
@@ -8,7 +8,7 @@
 
 - name: Enable & Restart 'calibre-web' via pdsm (proot)
   when:
-    - calibre_enabled
+    - calibreweb_enabled
     - is_proot
   block:
     - name: Enable 'calibre-web' via pdsm (proot)


### PR DESCRIPTION
### Fixes bug:
Fix service name on proot condition preventing from enabling and starting role on android by default.

### Description of changes proposed in this pull request:
Currently checking proot-distro roles, I found out that calibre-web is not being enabled/started due to wrong naming the service.

### Smoke-tested on which OS or OS's:
Debian (Android)

### Mention a team member @username e.g. to help with code review:
@holta 