### PR TITLE
[proot] enable php-fpm via nginx role.

### DIFF
--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -71,8 +71,7 @@
   when: not is_proot
 
 - name: Enable & Restart recently installed 'php-fpm' via pdsm (proot)
-  when:
-    - is_proot
+  when: is_proot
   block:
     - name: Enable 'php-fpm' via pdsm (proot)
       command: pdsm enable php-fpm

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -70,9 +70,15 @@
     state: restarted
   when: not is_proot
 
-- name: Restart 'php-fpm' via pdsm (proot)
-  command: pdsm restart php-fpm
-  when: is_proot
+- name: Enable & Restart recently installed 'php-fpm' via pdsm (proot)
+  when:
+    - is_proot
+  block:
+    - name: Enable 'php-fpm' via pdsm (proot)
+      command: pdsm enable php-fpm
+
+    - name: Restart 'php-fpm' via pdsm (proot)
+      command: pdsm restart php-fpm
 
 
 # RECORD NGINX AS INSTALLED


### PR DESCRIPTION
### Fixes bug:
php-fpm is not explicitly enabled in the nginx role. In proot-distro, this leaves php-fpm disabled by default.

### Description of changes proposed in this pull request:
This PR explicitly enables php-fpm after core packages are installed.

On systemd-based environments this isn't needed because services are enabled automatically on install. In proot, that doesn't happen. Since the nginx role lacks a php-fpm entry in enable-or-disable.yml, php-fpm remained disabled and was only running on the initial run due to a restart.

The fix adds an enable step alongside the service restart, ensuring php-fpm stays enabled by default, so roles like Matomo work correctly after a "reboot".

### Smoke-tested on which OS or OS's:
Debian 13 (Android)

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 