### PR TITLE
[proot] fix calling wrong pdsm service name

### DIFF
--- a/roles/calibre-web/tasks/install.yml
+++ b/roles/calibre-web/tasks/install.yml
@@ -20,7 +20,7 @@
   when: not is_proot
 
 - name: Stop 'calibre-web' via pdsm (proot)
-  command: pdsm stop kolibri
+  command: pdsm stop calibre-web
   register: pdsm_stop
   changed_when: "'already stopped' not in pdsm_stop.stdout"
   when: is_proot


### PR DESCRIPTION
### Fixes bug:
Fix incorrect role stopping Kolibri.

### Description of changes proposed in this pull request:
While creating the service templates, the Kolibri service name was mistakenly added to the wrong role. This PR fixes the issue so the installation doesn't finish with Kolibri stopped.

### Smoke-tested on which OS or OS's:
Debian (proot)

### Mention a team member @username e.g. to help with code review:
@holta 