### PR TITLE
[proot] disable sudo's use_pty for tty consistency

### DIFF
--- a/roles/proot_services/tasks/install.yml
+++ b/roles/proot_services/tasks/install.yml
@@ -48,6 +48,9 @@
       shell: "pdsm enable {{ item }}" # initially only nginx
       loop: "{{ pdsm_enabled_services }}" # leave loop if anything other than nginx gets by default
 
+    - name: Disable sudo use_pty in proot (fix interactive prompts)
+      include_tasks: no_use_pty_sudo.yml
+
 
     # RECORD PROOT_SERVICES AS INSTALLED
 

--- a/roles/proot_services/tasks/main.yml
+++ b/roles/proot_services/tasks/main.yml
@@ -18,9 +18,6 @@
       include_tasks: install.yml
       when: proot_services_installed is undefined
 
-    - name: Disable sudo use_pty in proot (fix interactive prompts)
-      include_tasks: no_use_pty_sudo.yml
-
     - name: Enable/Disable/Reload NGINX for proot_services, if nginx_enabled
       include_tasks: nginx.yml
 

--- a/roles/proot_services/tasks/main.yml
+++ b/roles/proot_services/tasks/main.yml
@@ -16,7 +16,10 @@
 
     - name: Install proot_services (pdsm) if 'proot_services_installed' not defined, e.g. in {{ iiab_state_file }}    # /etc/iiab/iiab_state.yml
       include_tasks: install.yml
-      when: proot_services_installed is undefined and is_proot
+      when: proot_services_installed is undefined
+
+    - name: Disable sudo use_pty in proot (fix interactive prompts)
+      include_tasks: no_use_pty_sudo.yml
 
     - name: Enable/Disable/Reload NGINX for proot_services, if nginx_enabled
       include_tasks: nginx.yml

--- a/roles/proot_services/tasks/no_use_pty_sudo.yml
+++ b/roles/proot_services/tasks/no_use_pty_sudo.yml
@@ -21,5 +21,5 @@
     content: |
       # IIAB on Android / proot: avoid sudo PTY allocation, it breaks interactive prompts
       Defaults !use_pty
-  # Validate if visudo exists; otherwise skip validation safely.
-  validate: "/bin/sh -c 'command -v visudo >/dev/null 2>&1 && visudo -cf %s || true'"
+    # Validate if visudo exists; otherwise skip validation safely.
+    validate: "/bin/sh -c 'command -v visudo >/dev/null 2>&1 && visudo -cf %s || true'"

--- a/roles/proot_services/tasks/no_use_pty_sudo.yml
+++ b/roles/proot_services/tasks/no_use_pty_sudo.yml
@@ -1,0 +1,25 @@
+---
+# proot-distro: sudo's defaults use_pty breaks interactive stdin (/dev/tty mismatch) which
+# makes scripts hang at prompts waiting for a "y/n" answer. Disable PTY allocation for sudo.
+
+- name: Make sure /etc/sudoers.d exists
+  become: true
+  file:
+    path: /etc/sudoers.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+
+- name: Install /etc/sudoers.d/iiab-no-pty (proot only)
+  become: true
+  copy:
+    dest: /etc/sudoers.d/iiab-no-pty
+    owner: root
+    group: root
+    mode: '0440'
+    content: |
+      # IIAB on Android / proot: avoid sudo PTY allocation, it breaks interactive prompts
+      Defaults !use_pty
+  # Validate if visudo exists; otherwise skip validation safely.
+  validate: "/bin/sh -c 'command -v visudo >/dev/null 2>&1 && visudo -cf %s || true'"

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -42,6 +42,7 @@ maps_enabled: True
 maps_vector_quality: ne
 maps_satellite_zoom: 7
 maps_terrain_zoom: none
+maps_region_downloader: True
 ##############################
 
 ##############################


### PR DESCRIPTION
### Fixes bug:
Fixes interactive prompts inside proot-distro ran with "sudo" (root non-sudo commands are not affected).

### Description of changes proposed in this pull request:
Disable sudo calling pseudo tty, preventing tty mismatch which breaks interactive prompts like the use of:

```
/opt/iiab/maps/tile-extract/tile-extract.py

New regions will be XX MB downloaded, YY MB on disk. This will
leave about ZZ GB free space on this partition. Continue? y/n
```

### Smoke-tested on which OS or OS's:
Debian (proot)

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 