### PR TITLE
Static search: add to marker popup

### DIFF
--- a/roles/maps/files/static_search.js
+++ b/roles/maps/files/static_search.js
@@ -36,7 +36,7 @@ var AddressTextualIndex = class {
         results.push(candidate);
       }
     }
-    results.sort((x, y) => y.pop - x.pop)
+    results.sort((x, y) => Number(y.pop) - Number(x.pop))
     return results;
   }
   async search(query) {

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -707,7 +707,7 @@
                                 },
                                 place_name: result.name,
                                 properties: {
-                                    population: result.pop,
+                                    population: Number(result.pop),
                                 },
                                 text: result.name,
                                 place_type: ['place'],
@@ -760,7 +760,7 @@
                                     ${state_and_country_name}
                                 </div>
                                 <div>
-                                    Population: ${feature.properties.population}
+                                    Population: ${feature.properties.population.toLocaleString()}
                                 </div>
                             </div>
                           `

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -706,7 +706,9 @@
                                     coordinates: center
                                 },
                                 place_name: result.name,
-                                properties: [],
+                                properties: {
+                                    population: result.pop,
+                                },
                                 text: result.name,
                                 place_type: ['place'],
                                 extratags: [],
@@ -743,6 +745,26 @@
                 static: {
                     api: staticGeocoderApi,
                     options: {
+                        popupRender: feature => {
+                          // Hopefully similar enough to the default popup for search results
+
+                          // Not ideal to assume that comma means this but I suspect maplibre does this too
+                          const [city_name, ...rest] = feature.place_name.split(',')
+                          const state_and_country_name = rest.join(',')
+                          return `
+                            <div class="mapboxgl-ctrl-geocoder--suggestion maplibre-ctrl-geocoder--suggestion popup-suggestion">
+                                <div class="mapboxgl-ctrl-geocoder--suggestion-title maplibre-ctrl-geocoder--suggestion-title popup-suggestion-title">
+                                    <b>${city_name}</b>
+                                </div>
+                                <div class="mapboxgl-ctrl-geocoder--suggestion-address maplibre-ctrl-geocoder--suggestion-address popup-suggestion-address">
+                                    ${state_and_country_name}
+                                </div>
+                                <div>
+                                    Population: ${feature.properties.population}
+                                </div>
+                            </div>
+                          `
+                        },
                         showResultsWhileTyping: true,
 
                         // In case we want to alter the time from stopping typing to searching:

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -746,8 +746,6 @@
                     api: staticGeocoderApi,
                     options: {
                         popupRender: feature => {
-                          // Hopefully similar enough to the default popup for search results
-
                           // Not ideal to assume that comma means this but I suspect maplibre does this too
                           const [city_name, ...rest] = feature.place_name.split(',')
                           const state_and_country_name = rest.join(',')


### PR DESCRIPTION
A couple small items to keep PRs small.

### Description of changes proposed in this pull request:

* Add the population to the search result marker popup. Right now it just shows the city name and state and country.
* Embolden the city name, since there's a few items there now.
* Make sorting by population more proper by actually subtracting numbers, instead of strings (which Javascript treats as numbers anyway, but come on).

### Smoke-tested on which OS or OS's:

RasPi Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 