### PR TITLE
[kolibri] workaround for deprecated SHA-1 keys in Kolibri repository

### DIFF
--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -81,7 +81,7 @@
 # https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html
 - name: Add signed Kolibri PPA 'jammy'
   apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
+    repo: "deb [trusted=yes] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main" #TODO: update once SHA1 keys are replaced.
 #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
 #   #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
 


### PR DESCRIPTION
Update once the GPG keys are updated upstream

### Fixes bug:
Workaround Kolibri deprecated sha-1 keys breaking MEDIUM/Android size installations.
Related: #4253 

### Description of changes proposed in this pull request:
_Please note:_ This is a workaround, not a fix. As the only ones that can fix it are the Kolibri PPA maintainers by updating the key properly.
Instead of using the key we tell apt to trust the repo without checking keys.

### Smoke-tested on which OS or OS's:
Ubuntu 25.10 / Debian 13 (Android)

### Mention a team member @username e.g. to help with code review:
@holta @jvonau 