### PR TITLE
[android] explicit declare enabled roles on android (64bits)

### DIFF
--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -29,6 +29,12 @@ admin_console_enabled: False
 ##############################
 
 ##############################
+# Kiwix
+kiwix_install: True
+kiwix_enabled: True
+##############################
+
+##############################
 # New maps
 # Size ~170 MB = 85 MB vector + 85 MB satellite
 
@@ -46,6 +52,24 @@ maps_region_downloader: True
 ##############################
 
 ##############################
+# Calibre-web
+calibreweb_install: True
+calibreweb_enabled: True
+##############################
+
+##############################
+# Kolibri
+kolibri_install: True
+kolibri_enabled: True
+##############################
+
+##############################
+# Matomo - enable at will.
+matomo_install: True
+matomo_enabled: True
+##############################
+
+##############################
 # Disable sshd as it is not directly used on proot-distro
 sshd_install: False
 sshd_enabled: False
@@ -59,12 +83,6 @@ tailscale_enabled: False    # Stub var, doesn't yet do anything!
 # No stats planned on IIAB on Android
 awstats_install: False
 awstats_enabled: False
-##############################
-
-##############################
-# Matomo - enable at will.
-matomo_install: True
-matomo_enabled: True
 ##############################
 
 ##############################


### PR DESCRIPTION
### Fixes bug:
Related to: https://github.com/iiab/iiab-android/pull/31

### Description of changes proposed in this pull request:
Explicitly declare all the known supported roles (on 64bits), as 32bits will need them to be tweaked accordingly.

### Smoke-tested on which OS or OS's:
None, just verbose definition.

### Mention a team member @username e.g. to help with code review:
@holta 