### PR TITLE
Deb822 format for apt repos [for Kolibri, MongoDB, Node.js, Yarn — including interim Sequoia PGP SHA-1 workaround for Kolibri & MongoDB on Debian & RPiOS Trixie]

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -67,3 +67,5 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 
 # Set variables to patch kolibri on proot-distro environment
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
+
+kolibri_suite: jammy

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -68,4 +68,4 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 # Set variables to patch kolibri on proot-distro environment
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
 
-kolibri_suite: jammy
+kolibri_suite: noble

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -73,13 +73,26 @@
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
 - name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
   shell: |
-    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    #gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    #gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --export --armor DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81 --output /etc/apt/keyrings/learningequality-kolibri.gpg
 
 - name: Remove stale apt .list
   file:
     path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
     state: absent
+
+- name: Workaround https://github.com/iiab/iiab/issues/4253
+  shell: |
+    mkdir /etc/crypto-policies/back-ends/
+    cat << EOF > /etc/crypto-policies/back-ends/apt-sequoia.config
+    [hash_algorithms]
+    sha1.second_preimage_resistance = 2026-06-01
+    EOF
+  args:
+    creates: /etc/crypto-policies/back-ends/apt-sequoia.config
+  when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -73,10 +73,9 @@
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
 - name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
   shell: |
-    #gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    #gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --export --armor DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81 --output /etc/apt/keyrings/learningequality-kolibri.gpg
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+  when: not is_debian
 
 - name: Remove stale apt .list
   file:
@@ -85,13 +84,19 @@
 
 - name: Workaround https://github.com/iiab/iiab/issues/4253
   shell: |
-    mkdir /etc/crypto-policies/back-ends/
+    mkdir -p /etc/crypto-policies/back-ends/
     cat << EOF > /etc/crypto-policies/back-ends/apt-sequoia.config
     [hash_algorithms]
     sha1.second_preimage_resistance = 2026-06-01
     EOF
   args:
     creates: /etc/crypto-policies/back-ends/apt-sequoia.config
+  when: is_debian
+
+- name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
+  shell: |
+    gpg --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --export --armor DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81 > /etc/apt/keyrings/learningequality-kolibri.gpg
   when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,17 +71,25 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: Download Kolibri's apt key to /usr/share/keyrings/learningequality-kolibri.gpg
+- name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --yes --output /usr/share/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+
+- name: Remove stale apt .list
+  file:
+    path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
+    state: absent
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892
 # https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html
-- name: Add signed Kolibri PPA 'jammy'
-  apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
+- name: Add signed Kolibri PPA {{ kolibri_suite }}
+  template:
+    src: kolibri_ubuntu.sources.j2
+    dest: /etc/apt/sources.list.d/kolibri_ubuntu.sources
+#  apt_repository:
+#    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
 #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
 #   #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
 

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -149,6 +149,7 @@
 - name: apt install kolibri (using apt source specified above, if kolibri_deb_url ISN'T defined)
   apt:
     name: kolibri
+    update_cache: true
   when: kolibri_deb_url is undefined
   # environment:
   #   KOLIBRI_HOME: "{{ kolibri_home }}"    # 2023-03-27: These don't do a thing

--- a/roles/kolibri/templates/kolibri_ubuntu.sources.j2
+++ b/roles/kolibri/templates/kolibri_ubuntu.sources.j2
@@ -1,0 +1,5 @@
+Types: deb
+URIs: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
+Suites: {{ kolibri_suite }}
+Components: main
+Signed-By: /etc/apt/keyrings/learningequality-kolibri.gpg

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -125,7 +125,7 @@
   when: is_debian
 
 - name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }} for Debian
-  shell:
+  shell: |
     gpg --keyserver keyserver.ubuntu.com --recv-keys F5679A222C647C87527C2F8CB00A0BD1E2C63C11
     gpg --export --armor F5679A222C647C87527C2F8CB00A0BD1E2C63C11 > /etc/apt/keyrings/mongodb.gpg
   when: is_debian

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -161,7 +161,7 @@
 # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
 # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
 # So IIAB overlays MongoDB 5.0.5 64-bit RPi binaries for now (~141 LINES BELOW!)
-- name: Otherwise, install mongodb-org's Ubuntu jammy source/repo for MongoDB version {{ mongodb_version }}
+- name: Otherwise, install mongodb-org's Ubuntu source/repo for MongoDB version {{ mongodb_version }}
   #apt_repository:
   #  repo: deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
     #repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
@@ -175,10 +175,6 @@
     src: mongodb.sources.j2
     dest: /etc/apt/sources.list.d/mongodb_ubuntu.sources
   when: not (is_debian and os_ver is version('debian-12', '<'))
-
-- name: Update APT cache
-  apt:
-    update_cache: yes
 
 # 2022-10-23: Force-install MongoDB on Ubuntu 22.04+, Mint 21 & Debian 12;
 # as each includes libssl3 not libssl1.1 (#3190).  LATER REMOVE ALL 7 STANZAS
@@ -304,6 +300,9 @@
 #     filename: mongodb-org
 #   when: is_ubuntu and not is_linuxmint
 
+- name: Update APT cache
+  apt:
+    update_cache: yes
 
 - name: "Install packages: mongodb-org, mongodb-org-server"
   package:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -97,7 +97,7 @@
   # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
   # 2025-07-16 far clean option, that we should consider in future: (as they also publish ready-to-go ".pub" keys)
   #shell: curl https://pgp.mongodb.com/server-{{ mongodb_version }}.pub > /usr/share/keyrings/mongodb.gpg
-  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /usr/share/keyrings/mongodb.gpg
+  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /etc/apt/keyrings/mongodb.gpg
   #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | apt-key add -
   #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_version }}.asc | apt-key add -
   #args:
@@ -106,6 +106,11 @@
   # "Unsupported parameters for (ansible.legacy.command) module: warn.
   # Supported parameters include: removes, strip_empty_ends, _raw_params,
   # _uses_shell, stdin_add_newline, creates, chdir, executable, argv, stdin."
+
+- name: Remove stale apt .list
+  file:
+    path: /etc/apt/sources.list.d/repo_mongodb_org_apt_ubuntu.list
+    state: absent
 
 # 2023-01-19: MongoDB only offers x86_64 for Debian, AND IN ANY CASE all their
 # MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4,
@@ -118,16 +123,16 @@
     # 11 and Bookworm 12 (testing branch) revert to buster for now:
     # 2022-09-27: Changed from 'buster' to 'bullseye' (i.e. Debian 11) as
     # this was recently added to https://repo.mongodb.org/apt/debian/dists/
-    repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_version }} main
+    repo: deb [ arch=amd64 signed-by=/etc/apt/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_version }} main
     #repo: deb https://repo.mongodb.org/apt/debian bullseye/mongodb-org/{{ mongodb_version }} main
     #repo: deb https://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main
     #filename: mongodb-org
   when: is_debian and os_ver is version('debian-12', '<') and ansible_facts.architecture == "x86_64"
 
-- name: Install mongodb-org's Ubuntu jammy source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_version }}, if other x86_64 OS
-  apt_repository:
-    repo: deb [ arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_version }} multiverse
-  when: not (is_debian and os_ver is version('debian-12', '<')) and ansible_facts.architecture == "x86_64"
+#- name: Install mongodb-org's Ubuntu jammy source/repo [ arch=amd64 ] for MongoDB version {{ mongodb_version }}, if other x86_64 OS
+#  apt_repository:
+#    repo: deb [ arch=amd64 signed-by=/etc/apt/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{{ mongodb_version }} multiverse
+#  when: not (is_debian and os_ver is version('debian-12', '<')) and ansible_facts.architecture == "x86_64"
 
 # 2023-01-19: Tested on x86_64 VM's with Ubuntu 22.04 & Debian 12.  Based on
 # MongoDB 6.0.3 (released 2022-11-15) instructions here:
@@ -138,17 +143,20 @@
 # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
 # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
 # So IIAB overlays MongoDB 5.0.5 64-bit RPi binaries for now (~141 LINES BELOW!)
-- name: Otherwise, install mongodb-org's Ubuntu focal source/repo [ arch=arm64 ] for MongoDB version {{ mongodb_version }}
-  apt_repository:
-    repo: deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
+- name: Otherwise, install mongodb-org's Ubuntu focal source/repo for MongoDB version {{ mongodb_version }}
+  #apt_repository:
+  #  repo: deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
     #repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
     #repo: deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
     #filename: mongodb-org
-  when: not ansible_facts.architecture == "x86_64"
+  #when: not ansible_facts.architecture == "x86_64"
   #when: is_ubuntu or is_debian and os_ver is version('debian-12', '>=')
   #when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint and os_ver is version('linuxmint-12', '>=') or is_debian and os_ver is version('debian-12', '>=')
   #when: not (is_debian and ansible_architecture == "x86_64")
-
+  template:
+    src: mongodb.sources.j2
+    dest: /etc/apt/sources.list.d/mongodb_ubuntu.sources
+  when: not (is_debian and os_ver is version('debian-12', '<'))
 
 # 2022-10-23: Force-install MongoDB on Ubuntu 22.04+, Mint 21 & Debian 12;
 # as each includes libssl3 not libssl1.1 (#3190).  LATER REMOVE ALL 7 STANZAS

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -97,7 +97,7 @@
   # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
   # 2025-07-16 far clean option, that we should consider in future: (as they also publish ready-to-go ".pub" keys)
   #shell: curl https://pgp.mongodb.com/server-{{ mongodb_version }}.pub > /usr/share/keyrings/mongodb.gpg
-  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /etc/apt/keyrings/mongodb.gpg
+#  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /etc/apt/keyrings/mongodb.gpg
   #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | apt-key add -
   #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_version }}.asc | apt-key add -
   #args:
@@ -106,11 +106,25 @@
   # "Unsupported parameters for (ansible.legacy.command) module: warn.
   # Supported parameters include: removes, strip_empty_ends, _raw_params,
   # _uses_shell, stdin_add_newline, creates, chdir, executable, argv, stdin."
+  shell:
+    gpg --keyserver keyserver.ubuntu.com --recv-keys F5679A222C647C87527C2F8CB00A0BD1E2C63C11
+    gpg --export --armor F5679A222C647C87527C2F8CB00A0BD1E2C63C11 --output /etc/apt/keyrings/mongodb.gpg
 
 - name: Remove stale apt .list
   file:
     path: /etc/apt/sources.list.d/repo_mongodb_org_apt_ubuntu.list
     state: absent
+
+- name: Workaround https://github.com/iiab/iiab/issues/4253
+  shell: |
+    mkdir /etc/crypto-policies/back-ends/
+    cat << EOF > /etc/crypto-policies/back-ends/apt-sequoia.config
+    [hash_algorithms]
+    sha1.second_preimage_resistance = 2026-06-01
+    EOF
+  args:
+    creates: /etc/crypto-policies/back-ends/apt-sequoia.config
+  when: is_debian
 
 # 2023-01-19: MongoDB only offers x86_64 for Debian, AND IN ANY CASE all their
 # MongoDB 6.0's are ONLY COMPILED FOR ARM v8.2-A i.e. FAIL ON ARM v8-A RPi 4,

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -143,7 +143,7 @@
 # 64-bit Ubuntu on Raspberry Pi hardware (MIGHT) hypothetically be possible:
 # https://www.mongodb.com/developer/products/mongodb/mongodb-on-raspberry-pi/
 # So IIAB overlays MongoDB 5.0.5 64-bit RPi binaries for now (~141 LINES BELOW!)
-- name: Otherwise, install mongodb-org's Ubuntu focal source/repo for MongoDB version {{ mongodb_version }}
+- name: Otherwise, install mongodb-org's Ubuntu jammy source/repo for MongoDB version {{ mongodb_version }}
   #apt_repository:
   #  repo: deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
     #repo: deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{{ mongodb_version }} multiverse
@@ -214,7 +214,7 @@
         state: absent
       when: is_ubuntu
 
-  when: mongodb_version is version('6.0', '<') and (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_debian and os_ver is version('debian-12', '>='))
+  when: mongodb_version is version('6.0', '<')
 
 - debug:
     msg: 5-STANZA BLOCK ABOVE, RAN *IF* FORCED INSTALL OF libssl1.1 WAS NEEDED

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -93,11 +93,11 @@
 #     msg: 16-STANZA BLOCK BELOW, RUNS *IF* 64-BIT -- i.e. ansible_architecture == "aarch64" or ansible_architecture == "x86_64"
 
 # - block:
-- name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }}
+- name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }} for Ubuntu
   # https://www.mongodb.com/community/forums/t/installing-mongodb-over-ubuntu-22-04/159931/90
   # 2025-07-16 far clean option, that we should consider in future: (as they also publish ready-to-go ".pub" keys)
   #shell: curl https://pgp.mongodb.com/server-{{ mongodb_version }}.pub > /usr/share/keyrings/mongodb.gpg
-#  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /etc/apt/keyrings/mongodb.gpg
+  shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | gpg --dearmor > /etc/apt/keyrings/mongodb.gpg
   #shell: wget -qO - https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc | apt-key add -
   #shell: wget -qO - https://pgp.mongodb.com/server-{{ mongodb_version }}.asc | apt-key add -
   #args:
@@ -106,9 +106,7 @@
   # "Unsupported parameters for (ansible.legacy.command) module: warn.
   # Supported parameters include: removes, strip_empty_ends, _raw_params,
   # _uses_shell, stdin_add_newline, creates, chdir, executable, argv, stdin."
-  shell:
-    gpg --keyserver keyserver.ubuntu.com --recv-keys F5679A222C647C87527C2F8CB00A0BD1E2C63C11
-    gpg --export --armor F5679A222C647C87527C2F8CB00A0BD1E2C63C11 --output /etc/apt/keyrings/mongodb.gpg
+  when: not is_debian
 
 - name: Remove stale apt .list
   file:
@@ -117,13 +115,19 @@
 
 - name: Workaround https://github.com/iiab/iiab/issues/4253
   shell: |
-    mkdir /etc/crypto-policies/back-ends/
+    mkdir -p /etc/crypto-policies/back-ends/
     cat << EOF > /etc/crypto-policies/back-ends/apt-sequoia.config
     [hash_algorithms]
     sha1.second_preimage_resistance = 2026-06-01
     EOF
   args:
     creates: /etc/crypto-policies/back-ends/apt-sequoia.config
+  when: is_debian
+
+- name: Add mongodb.org signing key (only 64-bit available) for MongoDB version {{ mongodb_version }} for Debian
+  shell:
+    gpg --keyserver keyserver.ubuntu.com --recv-keys F5679A222C647C87527C2F8CB00A0BD1E2C63C11
+    gpg --export --armor F5679A222C647C87527C2F8CB00A0BD1E2C63C11 > /etc/apt/keyrings/mongodb.gpg
   when: is_debian
 
 # 2023-01-19: MongoDB only offers x86_64 for Debian, AND IN ANY CASE all their

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -158,6 +158,10 @@
     dest: /etc/apt/sources.list.d/mongodb_ubuntu.sources
   when: not (is_debian and os_ver is version('debian-12', '<'))
 
+- name: Update APT cache
+  apt:
+    update_cache: yes
+
 # 2022-10-23: Force-install MongoDB on Ubuntu 22.04+, Mint 21 & Debian 12;
 # as each includes libssl3 not libssl1.1 (#3190).  LATER REMOVE ALL 7 STANZAS
 # BELOW, IF/WHEN MongoDB ONE DAY FINALLY SUPPORTS libssl3 ?  (MongoDB 6.2 fix

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,11 +1,10 @@
 Types: deb
 Trusted: yes
 URIs: https://repo.mongodb.org/apt/ubuntu/
-#{% if rpi_model != "none" %} # rpi_image isn't in master yet
-{% if dpkg_arch.stdout == "arm64" %}
-Suites: focal/mongodb-org/{{ mongodb_version }}
-{% else %}
-Suites: jammy/mongodb-org/{{ mongodb_version }}
-{% endif %}
-Components: multiverse
+{% if dpkg_arch.stdout != "arm64" %} 
+Suites: jammy/mongodb-org/{{ mongodb_version }} 
+{% else %} 
+Suites: focal/mongodb-org/{{ mongodb_version }} 
+{% endif %} 
+Components: multiverse 
 Signed-By: /etc/apt/keyrings/mongodb.gpg

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,0 +1,5 @@
+Types: deb
+URIs: https://repo.mongodb.org/apt/ubuntu/
+Suites: focal/mongodb-org/{{ mongodb_version }}
+Components: multiverse
+Signed-By: /etc/apt/keyrings/mongodb.gpg

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,5 +1,9 @@
 Types: deb
 URIs: https://repo.mongodb.org/apt/ubuntu/
+{% if rpi_model != "none" %}
+Suites: focal/mongodb-org/{{ mongodb_version }}
+{% else %}
 Suites: jammy/mongodb-org/{{ mongodb_version }}
+{% endif %}
 Components: multiverse
 Signed-By: /etc/apt/keyrings/mongodb.gpg

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -2,7 +2,7 @@ Types: deb
 Trusted: yes
 URIs: https://repo.mongodb.org/apt/ubuntu/
 #{% if rpi_model != "none" %} # rpi_image isn't in master yet
-{% if dpkg_arch == "arm64" %}
+{% if dpkg_arch.stdout == "arm64" %}
 Suites: focal/mongodb-org/{{ mongodb_version }}
 {% else %}
 Suites: jammy/mongodb-org/{{ mongodb_version }}

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,6 +1,8 @@
 Types: deb
+Trusted: yes
 URIs: https://repo.mongodb.org/apt/ubuntu/
-{% if rpi_model != "none" %}
+#{% if rpi_model != "none" %} # rpi_image isn't in master yet
+{% if dpkg_arch == "arm64" %}
 Suites: focal/mongodb-org/{{ mongodb_version }}
 {% else %}
 Suites: jammy/mongodb-org/{{ mongodb_version }}

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,5 +1,5 @@
 Types: deb
 URIs: https://repo.mongodb.org/apt/ubuntu/
-Suites: focal/mongodb-org/{{ mongodb_version }}
+Suites: jammy/mongodb-org/{{ mongodb_version }}
 Components: multiverse
 Signed-By: /etc/apt/keyrings/mongodb.gpg

--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -100,7 +100,7 @@
     mkdir -p /etc/apt/keyrings
     rm -f /etc/apt/keyrings/nodesource.gpg
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" > /etc/apt/sources.list.d/nodesource.list
+    # echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" > /etc/apt/sources.list.d/nodesource.list
   register: curl_nodesource
   ignore_errors: yes
 
@@ -113,11 +113,17 @@
 #   #  warn: no
 #   #  creates: /etc/apt/sources.list.d/nodesource.list
 
-- name: Remove /etc/apt/sources.list.d/nodesource.list if above failed
+- name: Remove old /etc/apt/sources.list.d/nodesource.list
   file:
     path: /etc/apt/sources.list.d/nodesource.list
     state: absent
-  when: curl_nodesource.failed
+  # when: curl_nodesource.failed
+
+- name: Supply /etc/apt/sources.list.d/nodesource.sources from template
+  template:
+    src: nodesource.sources.j2
+    dest: /etc/apt/sources.list.d/nodesource.sources
+  when: not curl_nodesource.failed
 
 - name: Install Node.js -- also includes /usr/bin/npm if nodesource.list installed above
   apt:

--- a/roles/nodejs/templates/nodesource.sources.j2
+++ b/roles/nodejs/templates/nodesource.sources.j2
@@ -1,0 +1,5 @@
+Types: deb
+URIs: https://deb.nodesource.com/node_{{ nodejs_version }}/
+Suites: nodistro
+Components: main
+Signed-By: /etc/apt/keyrings/nodesource.gpg

--- a/roles/yarn/tasks/install.yml
+++ b/roles/yarn/tasks/install.yml
@@ -4,12 +4,20 @@
 
 
 - name: Yarn | Download apt key to /usr/share/keyrings/yarn.gpg
-  shell: curl https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn.gpg
+  shell: curl https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /etc/apt/keyrings/yarn.gpg
+
+- name: Remove stale apt .list
+  file:
+    path: /etc/apt/sources.list.d/dl_yarnpkg_com_debian.list
+    state: absent
 
 - name: Yarn | Add signed Yarn PPA to /etc/apt/sources.list.d/dl_yarnpkg_com_debian.list
-  apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main"
+  #apt_repository:
+  #  repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main"
     #filename: yarn    # If legacy filename yarn.list is preferred
+  template:
+    src: yarn.sources
+    dest: /etc/apt/sources.list.d/yarn.sources
 
 # 2023-04-01 above avoids DEPRECATED apt-key command & associated problems:
 # https://github.com/iiab/iiab/wiki/IIAB-Platforms#etcapttrustedgpg-legacy-keyring-warnings

--- a/roles/yarn/templates/yarn.sources
+++ b/roles/yarn/templates/yarn.sources
@@ -1,0 +1,5 @@
+Types: deb
+URIs: https://dl.yarnpkg.com/debian/
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/yarn.gpg


### PR DESCRIPTION
### Fixes bug:
#4253
### Description of changes proposed in this pull request:
change to deb822 format for apt repos - does the same as `apt modernize-sources` 
https://share.google/aimode/fzTIprU1NSpnTNyig
### Smoke-tested on which OS or OS's:
CI & RasPiOS pending
### Mention a team member @username e.g. to help with code review:
@Ark74 @chapmanjacobd