### PR TITLE
static search: don't show "No results found" if we're not even searching yet

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -745,6 +745,7 @@
                 static: {
                     api: staticGeocoderApi,
                     options: {
+                        minLength: 3, // Until and unless we add a "short names" json file
                         popupRender: feature => {
                           // Not ideal to assume that comma means this but I suspect maplibre does this too
                           const [city_name, ...rest] = feature.place_name.split(',')


### PR DESCRIPTION
### Fixes bug:

For search bar, there is a misleading "No results found" if the user types two letters.

### Description of changes proposed in this pull request:

Conveniently, there's a built-in setting for the search widget that only searches if the minimum number of letters is typed. The default is 2. I've set it to 3.

### Smoke-tested on which OS or OS's:

RasPi Trixie

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 