### PR TITLE
maps: search bar no overlap with buttons

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1023,6 +1023,14 @@
                     const stylesheetText = [...mapLibreGlGeocoderCSS.cssRules, ...mapLibreGlTerradrawCSS.cssRules].reduce((accumulator, rule) => accumulator + rule.cssText, '');
                     const myStyles = new CSSStyleSheet()
                     myStyles.replace(stylesheetText)
+                    .then(() => {
+                        myStyles.insertRule(`
+                            /* Ensure the search bar doesn't stretch to hit the zoom buttons */
+                            .maplibregl-ctrl-top-left {
+                                max-width: calc(100% - 60px);
+                            }
+                        `)
+                    })
                     mb.shadowRoot.adoptedStyleSheets = [...mb.shadowRoot.adoptedStyleSheets, myStyles]
 
                     if (geocoder) {


### PR DESCRIPTION
### Fixes bug:

Search bar, which is a maplibre control set on the "top-left", overlaps controls on the "top-right" when using on a small enough phone vertically.

### Description of changes proposed in this pull request:

Just set a max-width on the search bar.

<img width="512" alt="overlapping" src="https://github.com/user-attachments/assets/a97c1061-11f2-442a-aa5d-792004ab7dda" />
<img width="512" alt="fixed" src="https://github.com/user-attachments/assets/b163969f-1fb6-4d2b-b8c6-f15267a0a9eb" />

@chapmanjacobd suggested solving this by sliding down the controls on the top-right for thin screens to make room for the search bar. Just aesthetically I just prefer setting the max width to stop it from overlapping. On my own phone, and every test phone in Firefox's dev tools, it's really not that much of an overlap in the first place. It seems like shrinking the width loses 1-3 characters. I can still type more characters than on my desktop or on my phone in horizontal mode, where the search bar shrinks (maplibre's own responsive design choice).

Now, if there are phones that I'm not considering which are actually a lot smaller and that our users might use, then yeah I agree with setting a rule to move the controls down to make room for it. @holta what do you think?

### Smoke-tested on which OS or OS's:

RasPi Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 