### PR TITLE
let NM manage br0 also

### DIFF
--- a/roles/network/templates/network/60-iiab.yml.j2
+++ b/roles/network/templates/network/60-iiab.yml.j2
@@ -1,6 +1,4 @@
 network:
-  version: 2
-  renderer: networkd
   bridges:
     br0:
       dhcp4: no


### PR DESCRIPTION
### Fixes bug:
#4264
### Description of changes proposed in this pull request:
I've reproduced the root cause, when /etc/netplan is populated with 90-MN-uuid.yml files the supplied 60-iiab.yml file is deleted upon reboot. Omitting Renderer from the 60-iiab.yml file allows NM to handle the br0 device, but results in the control file becoming 90-NM-someuuid.yml instead of 60-iiab,yml but br0 works. 
### Smoke-tested on which OS or OS's:
RasPiOS
### Mention a team member @username e.g. to help with code review:
