### PR TITLE
maps: handle search bar arrangement on very narrow phones

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1024,43 +1024,45 @@
                     const myStyles = new CSSStyleSheet()
                     myStyles.replace(stylesheetText)
                     .then(() => {
-                        /* If the screen gets narrow enough (such as with vertically oriented phones
-                           that are especially low resolution) setting max-width on the search bar isn't
-                           enough to stop it from overlapping the top-right controls. And anyway, we
-                           don't want it to get too small. Instead, we move the top-right controls down
-                           and let the search bar take up the whole top of the screen. */
-                        myStyles.insertRule(`
-                            @media screen and (max-width:349px) {
-                                .maplibregl-ctrl-top-right {
-                                    top: 60px !important;
-                                    transition: top 0.25s ease;
+                        if (geocoder) {
+                            /* If the screen gets narrow enough (such as with vertically oriented phones
+                               that are especially low resolution) setting max-width on the search bar isn't
+                               enough to stop it from overlapping the top-right controls. And anyway, we
+                               don't want it to get too small. Instead, we move the top-right controls down
+                               and let the search bar take up the whole top of the screen. */
+                            myStyles.insertRule(`
+                                @media screen and (max-width:349px) {
+                                    .maplibregl-ctrl-top-right {
+                                        top: 60px !important;
+                                        transition: top 0.25s ease;
+                                    }
+                                    /* Ensure the search bar stretches to hit the edge of the screen to make it look nice */
+                                    .maplibregl-ctrl-top-left {
+                                        width: calc(100% - 20px);
+                                    }
                                 }
-                                /* Ensure the search bar stretches to hit the edge of the screen to make it look nice */
-                                .maplibregl-ctrl-top-left {
-                                    width: calc(100% - 20px);
-                                }
-                            }
-                        `)
-                        /* If the screen gets narrow but not too narrow, we can simply set max-width to
-                           stop the search bar from overlapping the top-right controls. It won't get too
-                           small in this range.
+                            `)
+                            /* If the screen gets narrow but not too narrow, we can simply set max-width to
+                               stop the search bar from overlapping the top-right controls. It won't get too
+                               small in this range.
 
-                           This appears to be relevant for a very narrow range roughly (350px-400px screen
-                           width on the Chromium/Firefox dev tools for phone screens), but I am hoping
-                           that "modern" (circa 2025) smart phone will benefit from this. It looks nicer
-                           IMHO. */
-                        myStyles.insertRule(`
-                            @media screen and (min-width:350px) {
-                                /* Ensure the search bar doesn't stretch to hit the zoom buttons */
-                                .maplibregl-ctrl-top-left {
-                                    max-width: calc(100% - 60px);
+                               This appears to be relevant for a very narrow range roughly (350px-400px screen
+                               width on the Chromium/Firefox dev tools for phone screens), but I am hoping
+                               that "modern" (circa 2025) smart phone will benefit from this. It looks nicer
+                               IMHO. */
+                            myStyles.insertRule(`
+                                @media screen and (min-width:350px) {
+                                    /* Ensure the search bar doesn't stretch to hit the zoom buttons */
+                                    .maplibregl-ctrl-top-left {
+                                        max-width: calc(100% - 60px);
+                                    }
+                                    .maplibregl-ctrl-top-right {
+                                        top: 0px !important;
+                                        transition: top 0.25s ease;
+                                    }
                                 }
-                                .maplibregl-ctrl-top-right {
-                                    top: 0px !important;
-                                    transition: top 0.25s ease;
-                                }
-                            }
-                        `)
+                            `)
+                        }
                     })
                     mb.shadowRoot.adoptedStyleSheets = [...mb.shadowRoot.adoptedStyleSheets, myStyles]
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1032,7 +1032,7 @@
                         myStyles.insertRule(`
                             @media screen and (max-width:349px) {
                                 .maplibregl-ctrl-top-right {
-                                    top: 5em !important;
+                                    top: 60px !important;
                                     transition: top 0.2s ease;
                                 }
                                 /* Ensure the search bar stretches to hit the edge of the screen to make it look nice */
@@ -1054,6 +1054,10 @@
                                 /* Ensure the search bar doesn't stretch to hit the zoom buttons */
                                 .maplibregl-ctrl-top-left {
                                     max-width: calc(100% - 60px);
+                                }
+                                .maplibregl-ctrl-top-right {
+                                    top: 0px !important;
+                                    transition: top 0.2s ease;
                                 }
                             }
                         `)

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1024,10 +1024,37 @@
                     const myStyles = new CSSStyleSheet()
                     myStyles.replace(stylesheetText)
                     .then(() => {
+                        /* If the screen gets narrow enough (such as with vertically oriented phones
+                           that are especially low resolution) setting max-width on the search bar isn't
+                           enough to stop it from overlapping the top-right controls. And anyway, we
+                           don't want it to get too small. Instead, we move the top-right controls down
+                           and let the search bar take up the whole top of the screen. */
                         myStyles.insertRule(`
-                            /* Ensure the search bar doesn't stretch to hit the zoom buttons */
-                            .maplibregl-ctrl-top-left {
-                                max-width: calc(100% - 60px);
+                            @media screen and (max-width:349px) {
+                                .maplibregl-ctrl-top-right {
+                                    top: 5em !important;
+                                    transition: top 0.2s ease;
+                                }
+                                /* Ensure the search bar stretches to hit the edge of the screen to make it look nice */
+                                .maplibregl-ctrl-top-left {
+                                    width: calc(100% - 20px);
+                                }
+                            }
+                        `)
+                        /* If the screen gets narrow but not too narrow, we can simply set max-width to
+                           stop the search bar from overlapping the top-right controls. It won't get too
+                           small in this range.
+
+                           This appears to be relevant for a very narrow range roughly (350px-400px screen
+                           width on the Chromium/Firefox dev tools for phone screens), but I am hoping
+                           that "modern" (circa 2025) smart phone will benefit from this. It looks nicer
+                           IMHO. */
+                        myStyles.insertRule(`
+                            @media screen and (min-width:350px) {
+                                /* Ensure the search bar doesn't stretch to hit the zoom buttons */
+                                .maplibregl-ctrl-top-left {
+                                    max-width: calc(100% - 60px);
+                                }
                             }
                         `)
                     })

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1033,7 +1033,7 @@
                             @media screen and (max-width:349px) {
                                 .maplibregl-ctrl-top-right {
                                     top: 60px !important;
-                                    transition: top 0.2s ease;
+                                    transition: top 0.25s ease;
                                 }
                                 /* Ensure the search bar stretches to hit the edge of the screen to make it look nice */
                                 .maplibregl-ctrl-top-left {
@@ -1057,7 +1057,7 @@
                                 }
                                 .maplibregl-ctrl-top-right {
                                     top: 0px !important;
-                                    transition: top 0.2s ease;
+                                    transition: top 0.25s ease;
                                 }
                             }
                         `)


### PR DESCRIPTION
### Fixes bug:

On very narrow phones, the search bar overlaps the top-right controls. My previous fix #4266 was only good for larger phones.

### Description of changes proposed in this pull request:

This time, I implement @chapmanjacobd 's initial suggestion of sliding the top-right controls down to make room for the search bar, and I also make the search bar hug the right side of the screen to make it look cleaner. But I only do this for particularly narrow phones. For larger phones, I still think it looks nicer to squish the search bar.

I made the "larger phone" range rather small, but it applies to my phone. I think I could have made the transition closer to 300px-wide screens instead of 350px, but at that point the search bar is getting squished a fair amount and I'd rather give more room for people to type.

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
