### PR TITLE
Switch to iiab.switnet.org for satellite imagery

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -29,6 +29,8 @@ To configure your map, set the following variables (for the option your choose!)
    maps_satellite_zoom: 12
    ```
 
+See `maps_dot_black_vector_tiles` and `maps_dot_black_satellite_tiles` [here](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) for all valid values.
+
 ## What about terrain?
 
 To add terrain files, you can set this optional setting. You may find that when looking at mountains, high quality satellite imagery may compensate for low quality terrain, and vice versa.
@@ -52,6 +54,8 @@ To add terrain files, you can set this optional setting. You may find that when 
    ```
    maps_terrain_zoom: 10
    ```
+
+See `maps_dot_black_terrain_tiles` [here](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) for all valid values.
 
 ## Can I try out search (which is still experimental)?
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -143,6 +143,10 @@ maps_dot_black_satellite_tiles:
   # maps_satellite_zoom = 12
   12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
 
+  # Highest available quality satellite, up to zoom level 13
+  # maps_satellite_zoom = full
+  full: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.full.pmtiles"
+
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
 # However the fact that it includes "z0-z10" is not ideal, as it may point to an
 # extract that we made ourselves that only goes to a lower zoom level. In the

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -28,27 +28,22 @@ def validate_extract_box(extract_box):
 def get_extract_files(extract_name):
     MAPS_DATA_DATE = "{{ maps_data_date }}"
     MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
+    IIAB_MAP_HOST_URL = "{{ iiab_map_host_url }}"
 
-    tmp_file = lambda base: os.path.join(TMP_DIR, f"{base}.full-region.{extract_name}.pmtiles")
-    extract_file = lambda base: os.path.join(HOSTING_DIR, f"{base}.full-region.{extract_name}.pmtiles")
+    def get_paths(base):
+        return {
+            "source":
+                f"{IIAB_MAP_HOST_URL}/{base}.full.pmtiles",
+            "extract":
+                os.path.join(HOSTING_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
+            "tmp":
+                os.path.join(TMP_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
+        }
 
     return {
-        "vector": {
-            "source": f"https://iiab.switnet.org/maps/1/openstreetmap-openmaptiles.{MAPS_DATA_DATE}.full.pmtiles",
-            "extract": extract_file(f"openstreetmap-openmaptiles.{MAPS_DATA_DATE}"),
-            "tmp": tmp_file(f"openstreetmap-openmaptiles.{MAPS_DATA_DATE}"),
-        },
-        "satellite": {
-            # TODO - point to https://iiab.switnet.org/maps/1 once we have z13 maps on there (which I should do soon! in case of data change? which won't happen.)
-            "source": "https://maps.black/s2maps-sentinel2-2023.pmtiles",
-            "extract": extract_file(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}"),
-            "tmp": tmp_file(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}"),
-        },
-        "terrain": {
-            "source": f"https://iiab.switnet.org/maps/1/terrarium.{MAPS_SLOW_DATA_DATE}.full.pmtiles",
-            "extract": extract_file(f"terrarium.{MAPS_SLOW_DATA_DATE}"),
-            "tmp": tmp_file(f"terrarium.{MAPS_SLOW_DATA_DATE}"),
-        },
+        "vector": get_paths(f"openstreetmap-openmaptiles.{MAPS_DATA_DATE}"),
+        "satellite": get_paths(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}"),
+        "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}"),
     }
 
 def yes_no(prompt):


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Download satellite imagery from switnet.org instead of maps.black, as we do for other tile data.

### Smoke-tested on which OS or OS's:

RasPi Trixie (Though I only full tested the regional download. For downloading the full new region I got as far as running out of space on my SD card.)

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd @holta 