### PR TITLE
maps: don't create history every time you scroll

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -155,7 +155,7 @@
                 const zoom = Math.round(mb.zoom * 100) / 100
                 const globe = mb.globe ? 'g' : 'm' // [g]lobe : [m]ercator (i.e. like a paper map)
                 const terrain = mb.terrain ? 't' : 'f' // [t]errain : [f]lat (i.e. no mountains)
-                window.location.hash = `${lat}/${lon}/${pitch}/${bearing}/${zoom}/${globe}/${terrain}/${mapStyleChoice}/${activeFQRegionName}`
+                history.replaceState({}, "", `#${lat}/${lon}/${pitch}/${bearing}/${zoom}/${globe}/${terrain}/${mapStyleChoice}/${activeFQRegionName}`)
             }
 
             // Why two different functions for reading the URL hash?


### PR DESCRIPTION
### Fixes bug:

Right now every time you move the map, it updates the "hash" so that reloading or sharing the page will leave you where you left off. However the way it was implemented, it adds to the browser history each time.

### Description of changes proposed in this pull request:

Entering the 21st century and using something called `history.replaceState(...)` instead of `window.location.hash = ...`

I'd be curious if there are unseen downsides to this. Do people actually want this in their history sometimes?

@holta Whether the /home/ link points to `/maps` or `/maps/`, no matter how many times you move on the map, this change will make it a single "back button" click to take you back home from the map.

### Smoke-tested on which OS or OS's:

Raspi Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd