### PR TITLE
default_vars.yml should always match local_vars_small.yml (so fix ancient osm typo!)

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -513,7 +513,7 @@ moodle_enabled: False
 # Regional OSM vector maps use far less disk space than bitmap/raster versions.
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
-osm_vector_maps_enabled: False
+osm_vector_maps_enabled: True
 # Set to "True" to download .mbtiles files from Archive.org (might be slow!)
 maps_from_internet_archive: False
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps

--- a/vars/local_vars_none.yml
+++ b/vars/local_vars_none.yml
@@ -6,6 +6,7 @@ kolibri_enabled: False
 kiwix_install: False
 kiwix_enabled: False
 osm_vector_maps_install: False
+osm_vector_maps_enabled: False
 maps_install: False
 awstats_install: False
 awstats_enabled: False


### PR DESCRIPTION
Looks like this insignificant typo's been kicking around for years.

Not that it matters much as all these osm_vector_maps_* variables will be going away in due course... but in any case let's enforce the social contract that default_vars.yml and local_vars_small.yml should always be functionally equivalent.