### PR TITLE
[proot] speed installation by dropping captive portal setup

### DIFF
--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -104,3 +104,9 @@ usb_lib_enabled: False
 network_install: False
 network_enabled: False
 ##############################
+
+##############################
+# Disable captiveportal
+captiveportal_install: False
+captiveportal_enabled: False
+##############################


### PR DESCRIPTION
### Fixes bug:
Reduce install time dropping: captiveportal

### Description of changes proposed in this pull request:
Quick disable captiveportal from the installation queue

### Smoke-tested on which OS or OS's:
Debian 13 (proot-distro)

### Mention a team member @username e.g. to help with code review:
@holta 