### PR TITLE
install warning routine only if user is created

### DIFF
--- a/roles/iiab-admin/README.rst
+++ b/roles/iiab-admin/README.rst
@@ -71,3 +71,4 @@ Admin Console
 -------------
 
 Has been moved to this separate git repo: https://github.com/iiab/iiab-admin-console
+

--- a/roles/iiab-admin/tasks/admin-user.yml
+++ b/roles/iiab-admin/tasks/admin-user.yml
@@ -54,3 +54,6 @@
 #    path: /etc/sudoers
 #    line: "{{ iiab_admin_user }} ALL=(ALL) NOPASSWD: ALL"
 ##    line: "%wheel ALL= NOPASSWD: ALL"
+
+- name: Install password warning(s)
+  include_tasks: pwd-warnings.yml

--- a/roles/iiab-admin/tasks/main.yml
+++ b/roles/iiab-admin/tasks/main.yml
@@ -34,8 +34,6 @@
 # ...and/or...
 # (7) by IIAB's Admin Console > Utilities > Change Password
 
-- name: Install password warning(s)
-  include_tasks: pwd-warnings.yml
 
 
 # RECORD iiab-admin AS INSTALLED


### PR DESCRIPTION
Less filesystem clutter when the user is not created