### PR TITLE
[kolibri] add upstream custom debian repo fixing sha1 key issues.

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -79,6 +79,6 @@ os_repo:
     keyring: "/etc/apt/keyrings/learningequality-kolibri.gpg"
     suite: "noble"
 
-repo_uris:     "{{ os_repo[is_debian | string].repo }}"
-keyring_file:  "{{ os_repo[is_debian | string].keyring }}"
+repo_uris: "{{ os_repo[is_debian | string].repo }}"
+keyring_file: "{{ os_repo[is_debian | string].keyring }}"
 kolibri_suite: "{{ os_repo[is_debian | string].suite }}"

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -68,16 +68,16 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 # Set variables to patch kolibri on proot-distro environment
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
 
-# Custom repo data by OS
+# Custom repo data by OS (PR #4300)
 kolibri_repo_dict:
-  True: # when is_debian
-    repo: "https://learningequality.github.io/kolibri-installer-debian/"
-    keyring: "/etc/apt/keyrings/learningequality-kolibri.asc"
-    suite: "stable"
-  False: # when not is_debian
-    repo: "http://ppa.launchpad.net/learningequality/kolibri/ubuntu/"
-    keyring: "/etc/apt/keyrings/learningequality-kolibri.gpg"
-    suite: "noble"
+  True:    # when is_debian
+    repo: https://learningequality.github.io/kolibri-installer-debian/
+    keyring: /etc/apt/keyrings/learningequality-kolibri.asc
+    suite: stable
+  False:    # when not is_debian
+    repo: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
+    keyring: /etc/apt/keyrings/learningequality-kolibri.gpg
+    suite: noble
 
 kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian].repo }}"
 kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian].keyring }}"

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -69,16 +69,16 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
 
 # Custom repo data by OS
-os_repo:
-  true: # when is_debian
+kolibri_repo_dict:
+  True: # when is_debian
     repo: "https://learningequality.github.io/kolibri-installer-debian/"
     keyring: "/etc/apt/keyrings/learningequality-kolibri.asc"
     suite: "stable"
-  false: # when not is_debian
+  False: # when not is_debian
     repo: "http://ppa.launchpad.net/learningequality/kolibri/ubuntu/"
     keyring: "/etc/apt/keyrings/learningequality-kolibri.gpg"
     suite: "noble"
 
-repo_uris: "{{ os_repo[is_debian | string].repo }}"
-keyring_file: "{{ os_repo[is_debian | string].keyring }}"
-kolibri_suite: "{{ os_repo[is_debian | string].suite }}"
+kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian | string].repo }}"
+kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian | string].keyring }}"
+kolibri_suite: "{{ kolibri_repo_dict[is_debian | string].suite }}"

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -79,6 +79,6 @@ kolibri_repo_dict:
     keyring: "/etc/apt/keyrings/learningequality-kolibri.gpg"
     suite: "noble"
 
-kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian | string].repo }}"
-kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian | string].keyring }}"
-kolibri_suite: "{{ kolibri_repo_dict[is_debian | string].suite }}"
+kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian].repo }}"
+kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian].keyring }}"
+kolibri_suite: "{{ kolibri_repo_dict[is_debian].suite }}"

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -68,4 +68,17 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 # Set variables to patch kolibri on proot-distro environment
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
 
-kolibri_suite: noble
+# Custom repo data by OS
+os_repo:
+  true: # when is_debian
+    repo: "https://learningequality.github.io/kolibri-installer-debian/"
+    keyring: "/etc/apt/keyrings/learningequality-kolibri.asc"
+    suite: "stable"
+  false: # when not is_debian
+    repo: "http://ppa.launchpad.net/learningequality/kolibri/ubuntu/"
+    keyring: "/etc/apt/keyrings/learningequality-kolibri.gpg"
+    suite: "noble"
+
+repo_uris:     "{{ os_repo[is_debian | string].repo }}"
+keyring_file:  "{{ os_repo[is_debian | string].keyring }}"
+kolibri_suite: "{{ os_repo[is_debian | string].suite }}"

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -77,10 +77,11 @@
     gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
   when: not is_debian
 
-# - name: Remove stale apt .list
-#   file:
-#     path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
-#     state: absent
+# 2026-03-11: LET'S DELETE THESE 4 LINES LATER IN 2026
+- name: "Remove Kolibri PPA's legacy apt .list"
+  file:
+    path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
+    state: absent
 
 - name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if is_debian"
   shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,10 +71,10 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: "Download Kolibri's apt key to {{ keyring_file }}"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --yes --output "{{ keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
   when: not is_debian
 
 - name: Remove stale apt .list
@@ -82,10 +82,10 @@
     path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
     state: absent
 
-- name: "Download Kolibri's apt key to {{ keyring_file }}"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
   shell: |
     curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc | \
-    tee "{{ keyring_file }}" > /dev/null
+    tee "{{ kolibri_keyring_file }}" > /dev/null
   when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -84,8 +84,8 @@
 
 - name: "Download Kolibri's apt key to {{ keyring_file }}"
   shell: |
-  curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc | \
-  tee "{{ keyring_file }}" > /dev/null
+    curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc | \
+    tee "{{ keyring_file }}" > /dev/null
   when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,21 +71,19 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if not is_debian"
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
     gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
   when: not is_debian
 
-- name: Remove stale apt .list
-  file:
-    path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
-    state: absent
+# - name: Remove stale apt .list
+#   file:
+#     path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
+#     state: absent
 
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
-  shell: |
-    curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc | \
-    tee "{{ kolibri_keyring_file }}" > /dev/null
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if is_debian"
+  shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"
   when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,10 +71,10 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
+- name: "Download Kolibri's apt key to {{ keyring_file }}"
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --yes --output /etc/apt/keyrings/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    gpg --yes --output "{{ keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
   when: not is_debian
 
 - name: Remove stale apt .list
@@ -82,21 +82,10 @@
     path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
     state: absent
 
-- name: Workaround https://github.com/iiab/iiab/issues/4253
+- name: "Download Kolibri's apt key to {{ keyring_file }}"
   shell: |
-    mkdir -p /etc/crypto-policies/back-ends/
-    cat << EOF > /etc/crypto-policies/back-ends/apt-sequoia.config
-    [hash_algorithms]
-    sha1.second_preimage_resistance = 2026-06-01
-    EOF
-  args:
-    creates: /etc/crypto-policies/back-ends/apt-sequoia.config
-  when: is_debian
-
-- name: Download Kolibri's apt key to /etc/apt/keyrings/learningequality-kolibri.gpg
-  shell: |
-    gpg --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --export --armor DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81 > /etc/apt/keyrings/learningequality-kolibri.gpg
+  curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc | \
+  tee "{{ keyring_file }}" > /dev/null
   when: is_debian
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...

--- a/roles/kolibri/templates/kolibri.sources.j2
+++ b/roles/kolibri/templates/kolibri.sources.j2
@@ -1,5 +1,5 @@
 Types: deb
-URIs: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
+URIs: {{ repo_uris }}
 Suites: {{ kolibri_suite }}
 Components: main
-Signed-By: /etc/apt/keyrings/learningequality-kolibri.gpg
+Signed-By: {{ keyring_file }}

--- a/roles/kolibri/templates/kolibri.sources.j2
+++ b/roles/kolibri/templates/kolibri.sources.j2
@@ -1,5 +1,5 @@
 Types: deb
-URIs: {{ repo_uris }}
+URIs: {{ kolibri_repo_uris }}
 Suites: {{ kolibri_suite }}
 Components: main
-Signed-By: {{ keyring_file }}
+Signed-By: {{ kolibri_keyring_file }}


### PR DESCRIPTION
### Fixes bug:
#4253

### Description of changes proposed in this pull request:
Add a dictionary to build repos according to OS (Debian/Ubuntu) using the latest upstream Debian repo.

### Smoke-tested on which OS or OS's:
Debian 13 | Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:
@holta 