### PR TITLE
Fix OS vars (is_debian was erroneously being set on Mint & Trisquel)

### DIFF
--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -19,8 +19,8 @@
 - name: "Set OS vars -- is_raspbian, is_debian, is_ubuntu, is_linuxmint, is_trisquel"
   set_fact:
     is_raspbian: "{{ 'raspbian' in os_ver }}"      # Subset of is_debian
-    is_debian: "{{ 'debian' in os_ver or is_raspbian }}"    # OPPOSITE of is_ubuntu
-    is_ubuntu: "{{ not is_ubuntu }}"                        # OPPOSITE of is_debian
+    is_debian: "{{ 'debian' in os_ver or 'raspbian' in os_ver }}"    # OPPOSITE of is_ubuntu
+    is_ubuntu: "{{ not is_debian }}"                                 # OPPOSITE of is_debian
     is_linuxmint: "{{ 'linuxmint' in os_ver }}"    # Subset of is_ubuntu
     is_trisquel: "{{ 'trisquel' in os_ver }}"      # Subset of is_ubuntu
 

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -19,8 +19,8 @@
 - name: "Set OS vars -- is_raspbian, is_debian, is_ubuntu, is_linuxmint, is_trisquel"
   set_fact:
     is_raspbian: "{{ 'raspbian' in os_ver }}"      # Subset of is_debian
-    is_debian: "{{ 'debian' in os_ver or 'raspbian' in os_ver }}"    # OPPOSITE of is_ubuntu
-    is_ubuntu: "{{ not is_debian }}"                                 # OPPOSITE of is_debian
+    is_debian: "{{ 'debian' in os_ver or 'raspbian' in os_ver }}"             # OPPOSITE of is_ubuntu
+    is_ubuntu: "{{ not 'debian' in os_ver and not 'raspbian' in os_ver }}"    # OPPOSITE of is_debian
     is_linuxmint: "{{ 'linuxmint' in os_ver }}"    # Subset of is_ubuntu
     is_trisquel: "{{ 'trisquel' in os_ver }}"      # Subset of is_ubuntu
 

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -16,13 +16,13 @@
     python_version: "{{ ansible_facts.ansible_local.local_facts.python_version }}"
     php_version: "{{ ansible_facts.ansible_local.local_facts.php_version }}"
 
-- name: "Set OS vars -- is_debian: {{ not 'ubuntu' in os_ver }}, is_trisquel: {{ 'trisquel' in os_ver }}, is_ubuntu: {{ 'ubuntu' in os_ver }}, is_linuxmint: {{ 'linuxmint' in os_ver }}, is_raspbian: {{ 'raspbian' in os_ver }}"
+- name: "Set OS vars -- is_raspbian, is_debian, is_ubuntu, is_linuxmint, is_trisquel"
   set_fact:
-    is_debian: "{{ not 'ubuntu' in os_ver }}"      # OPPOSITE of is_ubuntu
-    is_trisquel: "{{ 'trisquel' in os_ver }}"      # Subset of is_ubuntu
-    is_ubuntu: "{{ 'ubuntu' in os_ver }}"          # OPPOSITE of is_debian
-    is_linuxmint: "{{ 'linuxmint' in os_ver }}"    # Subset of is_ubuntu
     is_raspbian: "{{ 'raspbian' in os_ver }}"      # Subset of is_debian
+    is_debian: "{{ 'debian' in os_ver or is_raspbian }}"    # OPPOSITE of is_ubuntu
+    is_ubuntu: "{{ not is_ubuntu }}"                        # OPPOSITE of is_debian
+    is_linuxmint: "{{ 'linuxmint' in os_ver }}"    # Subset of is_ubuntu
+    is_trisquel: "{{ 'trisquel' in os_ver }}"      # Subset of is_ubuntu
 
 - name: Run command 'dpkg --print-architecture' to identify OS architecture (CPU arch as revealed by ansible_architecture ~= ansible_machine is NOT enough!)
   command: dpkg --print-architecture

--- a/roles/0-init/tasks/main.yml
+++ b/roles/0-init/tasks/main.yml
@@ -114,16 +114,16 @@
       value: "{{ devicetree_model }}"
     - option: os_ver
       value: "{{ os_ver }}"
+    - option: is_raspbian
+      value: "{{ is_raspbian }}"
     - option: is_debian
       value: "{{ is_debian }}"
-    - option: is_trisquel
-      value: "{{ is_trisquel }}"
     - option: is_ubuntu
       value: "{{ is_ubuntu }}"
     - option: is_linuxmint
       value: "{{ is_linuxmint }}"
-    - option: is_raspbian
-      value: "{{ is_raspbian }}"
+    - option: is_trisquel
+      value: "{{ is_trisquel }}"
     - option: python_version
       value: "{{ python_version }}"
     - option: php_version


### PR DESCRIPTION
### Fixes bug:

Fix OS detection logic, so that it parses var `os_ver` correctly, when setting our 5 `is_distro` vars.  In summary:

- is_debian should be set on Pure Debian and RPiOS.

- is_ubuntu should be set on Ubuntu, Linux Mint and Trisquel.

### Description of changes proposed in this pull request:

Rework the parsing of var `os_ver` to do the job correctly.

### Smoke-tested on which OS or OS's:

CI tests confirm the most common 2 distros (RPiOS and Ubuntu).  And further testing (i.e. on all 5 distros) can't hurt, ideally with LARGE-sized IIAB installs.

### Mention a team member @username e.g. to help with code review:

@chapmanjacobd @Ark74