### PR TITLE
[maps] enable pmtiles for arm-32bits support

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -36,6 +36,9 @@ maps_slow_data_date: "2025-12-10"
 
 tile_extract:
   pmtiles:
+    armhf:
+      src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.30.1_Linux_armv7.tar.gz
+      sha256sum: 9948f518efa87163d0587ce7b95dd1a98d1ddecdf11131e4286cd331fd63b04a
     arm64:
       src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_arm64.tar.gz
       sha256sum: e44823cff328c2ea354096ccbfd7e7ef6c8f05b11553ad28fcaa33989123a57f

--- a/roles/maps/tasks/install_tile_extract.yml
+++ b/roles/maps/tasks/install_tile_extract.yml
@@ -8,9 +8,17 @@
     state: directory
     path: "{{ tile_extract.pmtiles_archive_tmp_dir }}"
 
+- name: Define detected arch
+  set_fact:
+    normalized_arch: >-
+      {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
+      {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
+      {% elif dpkg_arch.stdout is regex('^armv[6-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
+      {% else %}unsupported{% endif %}
+
 - name: "Make sure we have a supported arch for pmtiles"
   assert:
-    that: dpkg_arch.stdout == "amd64" or dpkg_arch.stdout == "arm64"
+    that: normalized_arch != "unsupported"
     fail_msg: "Error: unsupported architecture for pmtiles: "
     quiet: yes
 

--- a/roles/maps/tasks/install_tile_extract.yml
+++ b/roles/maps/tasks/install_tile_extract.yml
@@ -10,15 +10,15 @@
 
 - name: Define detected arch
   set_fact:
-    normalized_arch: >-
+    maps_normalized_arch: |
       {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
       {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
-      {% elif dpkg_arch.stdout is regex('^armv[6-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
+      {% elif dpkg_arch.stdout is regex('^armv[7-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
       {% else %}unsupported{% endif %}
 
 - name: "Make sure we have a supported arch for pmtiles"
   assert:
-    that: normalized_arch != "unsupported"
+    that: maps_normalized_arch != "unsupported"
     fail_msg: "Error: unsupported architecture for pmtiles: "
     quiet: yes
 


### PR DESCRIPTION
### Fixes bug:
Related to: https://github.com/iiab/iiab-android/issues/35

### Description of changes proposed in this pull request:
Add pmtile support for maps on 32bits.

### Smoke-tested on which OS or OS's:
Debian 13

### Mention a team member @username e.g. to help with code review:
@orblivion @holta @jvonau