### PR TITLE
MongoDB - remove debian workaround once installed

### DIFF
--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -346,9 +346,18 @@
 # https://andyfelong.com/downloads/raspbian_mongodb_5.0.5.gz
 # https://andyfelong.com/2021/08/mongodb-4-4-under-raspberry-pi-os-64-bit-raspbian64/
 
-- name: If hardware is Raspberry Pi and mongodb_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
-  command: apt-mark hold mongodb-org mongodb-org-server
-  when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
+#- name: If hardware is Raspberry Pi and mongodb_version >= 5.0, run 'apt-mark hold mongodb-org mongodb-org-server' -- so MongoDB 5.0.5 binaries {mongo, mongod, mongos} can be installed without apt interfering in future
+#  command: apt-mark hold mongodb-org mongodb-org-server
+#  when: rpi_model != "none" and mongodb_version is version('5.0', '>=')
+
+- name: Remove above workarounds https://github.com/iiab/iiab/pull/4260#issuecomment-3860830930 if is_debian
+  shell: |
+    rm -rf /root/.gnupg
+    rm -rf /etc/crypto-policies/back-ends
+    rm -rf /etc/apt/keyrings/mongodb.gpg
+    rm -rf /etc/apt/sources.list.d/mongodb_ubuntu.sources
+    apt update
+  when: is_debian
 
 - name: If hardware is Raspberry Pi and mongodb_version >= 5.0, unarchive 76MB {{ iiab_download_url }}//packages/raspbian_mongodb_5.0.5.gz OVERWRITING 5.0.9+ {mongo, mongod, mongos} in /usr/bin
   get_curl:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -352,7 +352,6 @@
 
 - name: Remove above workarounds https://github.com/iiab/iiab/pull/4260#issuecomment-3860830930 if is_debian
   shell: |
-    rm -rf /root/.gnupg
     rm -rf /etc/crypto-policies/back-ends
     rm -rf /etc/apt/keyrings/mongodb.gpg
     rm -rf /etc/apt/sources.list.d/mongodb_ubuntu.sources


### PR DESCRIPTION
### Fixes bug:
Future proofing, removes the relaxed apt security. 
### Description of changes proposed in this pull request:
Disable mongodb apt repo and reverse workaround found in 4697de1f4cceac45969aa7442757fcadf8a0d041 once mongodb is installed on is_debian.
### Smoke-tested on which OS or OS's:
CI
### Mention a team member @username e.g. to help with code review:
