### PR TITLE
Host all remaining maps.black assets ourselves

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -55,8 +55,9 @@ maps_dot_black_js_and_styles:
 #    NOTE: We are now building `maps.black.js` ourselves because we want to
 #    make changes to it. See the `build-maps.black-assets/` directory.
 #
-#    The other two files are from the same "version" of maps.black; if we update
-#    one, we should update the rest.
+#    This sha256sum represents the original version before any changes we've
+#    made. The other two files are from the same "version" of maps.black; if we
+#    update one, we should update the rest.
 #
 #  - name: maps.black.js
 #  -    filename: maps.black.js

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -1,7 +1,6 @@
 # NOTE: I'm more than happy to change the variable or directory names to
 # something more in line with IIAB expectations.
 
-maps_dot_black_small_assets_url: https://v1.maps.black
 unpkg_url: https://unpkg.com
 iiab_map_host_url: https://iiab.switnet.org/maps/1
 
@@ -56,19 +55,15 @@ maps_dot_black_js_and_styles:
 #    NOTE: We are now building `maps.black.js` ourselves because we want to
 #    make changes to it. See the `build-maps.black-assets/` directory.
 #
-#    This sha256sum represents the original version before any changes we've
-#    made. The other two files are from the same "version" of maps.black; if we
-#    update one, we should update the rest.
+#    The other two files are from the same "version" of maps.black; if we update
+#    one, we should update the rest.
 #
 #  - name: maps.black.js
 #  -    filename: maps.black.js
 #  -    sha256sum: 7b3843b5ded151d585ccf3a6db02093e3a95851be36dcffc5fa92030657b9c93
 
-  - filename: maps.black-component.js
-    sha256sum: d8a6366065d5fd6840368e88a5b06467b2c5ac3e349a35420b4dee6cc070e542
-
-  - filename: resourcetiles-minimal.pmtiles
-    sha256sum: 0037047ee0f87dbccd3fc7e6bfa99632d97c41cfd5977bff3b7f86665f3c4f51
+  - maps.black-component.js
+  - resourcetiles-minimal.pmtiles
 
 # MapLibre and plugins, javascript and css
 # TODO get the minified versions of all these?

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -18,12 +18,9 @@
     mode: "0644"
 
 - name: Download the remaining basic maps.black javascript and styles (0644)
-  get_url:
-    url: "{{ maps_dot_black_small_assets_url }}/{{ item.filename }}"
-    dest: "{{ maps_serve_path }}/{{ item.filename }}"
-    checksum: "sha256:{{ item.sha256sum }}"
-    mode: "0644"
-    timeout: "{{ download_timeout }}"
+  include_tasks: download_large_file.yml
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
   with_items: "{{ maps_dot_black_js_and_styles }}"
 
 - name: Download naturalearth6 tiles


### PR DESCRIPTION
### Fixes bug:

New Maps installation broken due to maps.black being down. (Even if it comes back, it seems we should be more resilient)

### Description of changes proposed in this pull request:

Host the remaining 2 maps.black assets ourselves and use meta4 downloader.

### Smoke-tested on which OS or OS's:

RasPi Trixie

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 