### PR TITLE
zstd --long=27 -T0 -9 [and experiment with "light speed" -1 compression, when generating .img artifact for unit testing]

### DIFF
--- a/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
@@ -168,7 +168,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
@@ -168,7 +168,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -1 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-desktop.yml.paused
@@ -177,7 +177,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -180,7 +180,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -177,7 +177,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/20min-unittest-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/20min-unittest-IMAGE-on-rpios-desktop.yml.paused
@@ -184,7 +184,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -177,7 +177,7 @@ jobs:
           mv "$IMG_FILE" "${IMG_NAME}.img"
 
           # Compress image with zstd
-          zstd -T0 -6 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
+          zstd --long=27 -T0 -9 --stdout "${IMG_NAME}.img" > "${IMG_NAME}.img.zst"
           EOF
 
       - name: Generate rpi-imager manifest


### PR DESCRIPTION
### Fixes bug:

CI/CD glitch from https://github.com/iiab/iiab/actions/runs/23124647056/job/67165222771 suggests we might actually need a bit tighter/slower compression in the end, as GitHub Actions requires such files size be < 2GB = 2^31 bytes = 2,147,483,,648 bytes):

(Scrolling up and clicking, one can see that "Compressed size: 2195610658 bytes" just spillled over the limit...)

Hopefully this gets us under 2GB with a little bit of headroom