### PR TITLE
[code] final restart nginx service via pdsm

### DIFF
--- a/roles/code/tasks/enable-or-disable.yml
+++ b/roles/code/tasks/enable-or-disable.yml
@@ -15,3 +15,8 @@
   systemd:
     name: nginx
     state: reloaded
+  when: not is_proot
+
+- name: Restart 'nginx' via pdsm (proot)
+  command: pdsm restart nginx
+  when: is_proot


### PR DESCRIPTION
### Fixes bug:
Missing  nginx service restart, not showing role when finished installation on proot

### Description of changes proposed in this pull request:
Added the required step to restart nginx in order to correctly finish the installation on proot-distro

### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 