### PR TITLE
Remove libcamera*

### DIFF
--- a/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
@@ -118,6 +118,7 @@ jobs:
           apt update
           mkdir -p /etc/initramfs-tools/conf.d
           echo 'MODULES=most' > /etc/initramfs-tools/conf.d/nspawn.conf
+          apt -y remove libcamera*
           apt -y full-upgrade
 
           apt install curl

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -130,6 +130,7 @@ jobs:
           apt update
           mkdir -p /etc/initramfs-tools/conf.d
           echo 'MODULES=most' > /etc/initramfs-tools/conf.d/nspawn.conf
+          apt -y remove libcamera*
           apt -y full-upgrade
 
           apt install curl

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -132,7 +132,9 @@ jobs:
 
           expect -re {#\s?$} { send "apt update\r" }
           expect -re {#\s?$} { send "mkdir -p /etc/initramfs-tools/conf.d && echo 'MODULES=most' > /etc/initramfs-tools/conf.d/nspawn.conf\r" }
-          expect -re {#\s?$} { send "DEBIAN_FRONTEND=noninteractive apt -y full-upgrade\r" }
+          expect -re {#\s?$} { send "export DEBIAN_FRONTEND=noninteractive\r" }
+          expect -re {#\s?$} { send "apt -y remove libcamera*\r" }
+          expect -re {#\s?$} { send "apt -y full-upgrade\r" }
 
           expect -re {#\s?$} { send "curl -fLo /usr/sbin/iiab https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab\r" }
           expect -re {#\s?$} { send "chmod 0755 /usr/sbin/iiab\r" }

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -132,7 +132,9 @@ jobs:
 
           expect -re {#\s?$} { send "apt update\r" }
           expect -re {#\s?$} { send "mkdir -p /etc/initramfs-tools/conf.d && echo 'MODULES=most' > /etc/initramfs-tools/conf.d/nspawn.conf\r" }
-          expect -re {#\s?$} { send "DEBIAN_FRONTEND=noninteractive apt -y full-upgrade\r" }
+          expect -re {#\s?$} { send "export DEBIAN_FRONTEND=noninteractive\r" }
+          expect -re {#\s?$} { send "apt -y remove libcamera*\r" }
+          expect -re {#\s?$} { send "apt -y full-upgrade\r" }
 
           expect -re {#\s?$} { send "curl -fLo /usr/sbin/iiab https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab\r" }
           expect -re {#\s?$} { send "chmod 0755 /usr/sbin/iiab\r" }


### PR DESCRIPTION
### Fixes bug:

libcamera starts pulling in some desktop packages via depends and it might be better to remove it as most users probably aren't going to use it

### Description of changes proposed in this pull request:

Based on: https://github.com/iiab/iiab/pull/4291/changes/ccc9d0fc97b15f8aca8911e9a02d262dbf159ff9

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
