### PR TITLE
[code] add working role available by default

### DIFF
--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -7,12 +7,13 @@
 is_proot: True
 
 ##############################
-# Currently it targets 5 main apps
+# Currently it targets 6 main apps
 # 1 Kiwix          localhost:8085/kiwix
 # 2 New Maps       localhost:8085/maps
 # 3 Calibre-Web    localhost:8085/books
 # 4 Kolibri        localhost:8085/kolibri
 # 5 Matomo         localhost:8085/matomo
+# 6 Code on the Go localhost;8085/code
 ##############################
 
 ##############################
@@ -70,6 +71,12 @@ kolibri_enabled: True
 # Matomo - enable at will.
 matomo_install: True
 matomo_enabled: True
+##############################
+
+##############################
+# Code on the Go 
+code_install: True
+code_enabled: True
 ##############################
 
 ##############################


### PR DESCRIPTION
### Fixes bug:
Enabled Code on the Go APK 

### Description of changes proposed in this pull request:
Add working `code` role on the Android flavor by default.

### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 