### PR TITLE
use iiab/iiab/releases/download URL

### DIFF
--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -248,6 +248,7 @@ jobs:
           extract_sha256 = sha256_hash.hexdigest()
 
           manifest_name = f"{img_name}.rpi-imager-manifest"
+          release_name = os.environ.get('RELEASE_NAME')
 
           manifest = {
               "imager": {
@@ -302,7 +303,7 @@ jobs:
                       "name": f"Internet in a Box - {os.environ.get('EDITION', 'Custom')} (64-bit)",
                       "description": f"IIAB {os.environ.get('IIAB_BASE_VERSION', '')} {os.environ.get('EDITION', '')} edition",
                       "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-                      "url": f"file:///home/YOUR_USERNAME/Downloads/{zst_name}",
+                      "url": f"https://github.com/iiab/iiab/releases/download/{release_name}/{zst_name}",
                       "image_download_size": compressed_size,
                       "extract_size": image_size,
                       "extract_sha256": extract_sha256,

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -244,6 +244,7 @@ jobs:
           extract_sha256 = sha256_hash.hexdigest()
 
           manifest_name = f"{img_name}.rpi-imager-manifest"
+          release_name = os.environ.get('RELEASE_NAME')
 
           manifest = {
               "imager": {
@@ -298,7 +299,7 @@ jobs:
                       "name": f"Internet in a Box - {os.environ.get('EDITION', 'Custom')} (64-bit)",
                       "description": f"IIAB {os.environ.get('IIAB_BASE_VERSION', '')} {os.environ.get('EDITION', '')} edition",
                       "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-                      "url": f"file:///home/YOUR_USERNAME/Downloads/{zst_name}",
+                      "url": f"https://github.com/iiab/iiab/releases/download/{release_name}/{zst_name}",
                       "image_download_size": compressed_size,
                       "extract_size": image_size,
                       "extract_sha256": extract_sha256,

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -244,6 +244,7 @@ jobs:
           extract_sha256 = sha256_hash.hexdigest()
 
           manifest_name = f"{img_name}.rpi-imager-manifest"
+          release_name = os.environ.get('RELEASE_NAME')
 
           manifest = {
               "imager": {
@@ -298,7 +299,7 @@ jobs:
                       "name": f"Internet in a Box - {os.environ.get('EDITION', 'Custom')} (64-bit)",
                       "description": f"IIAB {os.environ.get('IIAB_BASE_VERSION', '')} {os.environ.get('EDITION', '')} edition",
                       "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-                      "url": f"file:///home/YOUR_USERNAME/Downloads/{zst_name}",
+                      "url": f"https://github.com/iiab/iiab/releases/download/{release_name}/{zst_name}",
                       "image_download_size": compressed_size,
                       "extract_size": image_size,
                       "extract_sha256": extract_sha256,


### PR DESCRIPTION
### Fixes bug:

Should allow people to use the rpi-imager-manifest file directly without downloading the zst image file

@jvonau