### PR TITLE
Install tiny map regions during CI/CD

### DIFF
--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -11,10 +11,10 @@
       - python3-xmltodict
       - python3-requests
 
-- include_tasks: install_frontend.yml
-
 - include_tasks: install_tile_extract.yml
   when: maps_region_downloader
+
+- include_tasks: install_frontend.yml
 
 - include_tasks: install_nominatim.yml
   when: maps_search_engine == "nominatim"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -99,6 +99,20 @@
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
         state: link
 
+- name: Initiate the extracts json
+  copy:
+    content: '{"regions": {}}'
+    dest: "{{ maps_serve_path }}/{{ tile_extract.info_file }}"
+    mode: "0644"
+    force: false
+
+- name: "Download preset full quality regions"
+  # TODO - Is there a safer way to pass in item.name and item.bbox?
+  shell: |
+    set -euo pipefail
+    {{ tile_extract.working_dir }}/tile-extract.py extract {{item.name}} {{item.bbox}} noninteractive
+  with_items: "{{ maps_preset_full_quality_regions }}"
+
 # If the user goes back to "none", we want to delete the symlink that gives them terrain.
 # However, it will not delete the pmtiles file that it points to.
 - name: Unselect terrain tiles

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -110,7 +110,7 @@
   # TODO - Is there a safer way to pass in item.name and item.bbox?
   shell: |
     set -euo pipefail
-    {{ tile_extract.working_dir }}/tile-extract.py extract {{item.name}} {{item.bbox}} noninteractive
+    {{ tile_extract.working_dir }}/tile-extract.py extract {{ item.name }} {{ item.bbox }} noninteractive
   with_items: "{{ maps_preset_full_quality_regions }}"
 
 # If the user goes back to "none", we want to delete the symlink that gives them terrain.

--- a/roles/maps/tasks/install_tile_extract.yml
+++ b/roles/maps/tasks/install_tile_extract.yml
@@ -47,10 +47,3 @@
     src: "tile-extract.py.j2"
     dest: "{{ tile_extract.working_dir }}/tile-extract.py"
     mode: "0755"
-
-- name: Initiate the extracts json
-  copy:
-    content: '{"regions": {}}'
-    dest: "{{ maps_serve_path }}/{{ tile_extract.info_file }}"
-    mode: "0644"
-    force: false

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -25,6 +25,9 @@ def validate_extract_box(extract_box):
     except Exception:
         raise ValueError("extract_box is malformed: ", extract_box)
 
+def validate_noninteractive(noninteractive):
+    assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
+
 def get_extract_files(extract_name):
     MAPS_DATA_DATE = "{{ maps_data_date }}"
     MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
@@ -46,7 +49,9 @@ def get_extract_files(extract_name):
         "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}"),
     }
 
-def yes_no(prompt):
+def yes_no(prompt, noninteractive, noninteractive_response):
+    if noninteractive:
+        return noninteractive_response
     while True:
         response = input(f'{prompt} y/n ')
         if response == "y":
@@ -110,7 +115,7 @@ def approve_download_size(extract_name):
                 break
 
         if re_match is None:
-            return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?")
+            return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?", False, None)
 
         (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
 
@@ -143,13 +148,15 @@ def approve_download_size(extract_name):
     # Ask the user if they're okay with the size.
     return yes_no(
         f'\nNew regions will be {display(transfer_total)} downloaded, {display(archive_total)} on disk. This will'
-        f'\nleave about {display(free_b - archive_total)} free space on this partition. Continue?')
+        f'\nleave about {display(free_b - archive_total)} free space on this partition. Continue?',
+        noninteractive, True,
+    )
 
 
-def check_for_existing_name(extract_name):
+def check_for_existing_name(extract_name, noninteractive):
     existing_extracts = json.loads(open(EXTRACTS_JSON).read())
     if extract_name in existing_extracts["regions"].keys():
-        return yes_no(f'Already have a full quality region called \"{extract_name}\". Overwrite it?')
+        return yes_no(f'Already have a full quality region called \"{extract_name}\". Overwrite it?', noninteractive, False)
     else:
         return True
 
@@ -219,21 +226,34 @@ if __name__ == "__main__":
 
         case "extract":
             # Get and validate arguments
-            assert len(sys.argv) == 4, "extract takes two arguments: extract_name, extract_box"
-            extract_box = sys.argv[3]
+            assert len(sys.argv) in (4, 5), (
+                "extract arguments are: `extract_name`, `extract_box`, and (optional) `noninteractive`"
+            )
+
             extract_name = sys.argv[2]
+            extract_box = sys.argv[3]
+            noninteractive = sys.argv[4] if len(sys.argv) > 4 else ""
+
             validate_extract_name(extract_name)
             validate_extract_box(extract_box)
+            validate_noninteractive(noninteractive)
+            noninteractive = bool(noninteractive)
 
             # Check arguments against existing data
             update_extracts_json() # Make sure we have updated data before we check for overlaps
             if not check_for_overlaps(extract_box):
-                sys.exit("error: you cannot download overlapping full quality regions")
-            if not check_for_existing_name(extract_name):
-                sys.exit(1)
+                if noninteractive:
+                    sys.exit(0)
+                else:
+                    sys.exit("error: you cannot download overlapping full quality regions")
+            if not check_for_existing_name(extract_name, noninteractive):
+                if noninteractive:
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
 
             # Get a download estimate and give users a chance to back out
-            if not approve_download_size(extract_name):
+            if not noninteractive and not approve_download_size(extract_name):
                 sys.exit(1)
 
             # Do the extracts

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -525,6 +525,7 @@ maps_search_engine: static              # See https://github.com/iiab/iiab/blob/
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
+maps_preset_full_quality_regions: []    # Full-quality regions to install during installation. Intended for CI/CD, not end users.
 
 # MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.
 # This role was formerly installed by roles/sugarizer/meta/main.yml

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -317,6 +317,11 @@ maps_search_engine: static              # See https://github.com/iiab/iiab/blob/
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
+maps_preset_full_quality_regions:
+  - name: london
+    bbox: -0.172187453,51.477245915,-0.143235226,51.493348151
+  - name: nepal-mountains
+    bbox: 83.680824998,28.401673033,84.055999541,28.724927625
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Add to my new `local_vars_maps_test.yml` (which so far downloads the lowest zoom-level map that a user can pick): Download a small part of London and a small part of the mountains of Nepal at full quality, each I think less than 5MB.

This requires that I be able to run the region downloader as part of ansible. And that required me to add a noninteractive mode to the region downloader. So this does a few things in the end.

London gives testers buildings. Nepal gives testers interesting satellite imagery and terrain. And while we're at it, we can test the region downloader.

### Smoke-tested on which OS or OS's:

RasPi Trixie. I made sure that the region downloader still works in interactive mode.

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 