### PR TITLE
Fix frontend for full satellite download

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -37,7 +37,7 @@
             const MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
             const MAPS_VECTOR_QUALITY = "{{ maps_vector_quality }}"
             const MAPS_VECTOR_IS_OSM = MAPS_VECTOR_QUALITY.includes("osm")
-            const MAPS_SATELLITE_ZOOM = {{ maps_satellite_zoom }} // so far just a number
+            const MAPS_SATELLITE_ZOOM = "{{ maps_satellite_zoom }}" === "full" ? 13 : {{ maps_satellite_zoom }}
             const MAPS_TERRAIN_ZOOM = "{{ maps_terrain_zoom }}" === "none" ? null : {{ maps_terrain_zoom }} // a number if not null
             const MAPS_SEARCH_ENGINE = "{{ maps_search_engine }}"
             const MAPS_REGION_DOWNLOADER = "{{ maps_region_downloader }}" === "True"

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -37,8 +37,30 @@
             const MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
             const MAPS_VECTOR_QUALITY = "{{ maps_vector_quality }}"
             const MAPS_VECTOR_IS_OSM = MAPS_VECTOR_QUALITY.includes("osm")
-            const MAPS_SATELLITE_ZOOM = "{{ maps_satellite_zoom }}" === "full" ? 13 : {{ maps_satellite_zoom }}
-            const MAPS_TERRAIN_ZOOM = "{{ maps_terrain_zoom }}" === "none" ? null : {{ maps_terrain_zoom }} // a number if not null
+
+            let MAPS_SATELLITE_ZOOM = Number("{{ maps_satellite_zoom }}")
+            if (Number.isNaN(MAPS_SATELLITE_ZOOM)) {
+                if ("{{ maps_satellite_zoom }}" === "full") {
+                    // Full quality is 13
+                    MAPS_SATELLITE_ZOOM = 13
+                } else {
+                    // ERROR
+                    // Use a default that is hopefully always available. We hope they notice and report the bug if it ever comes here!
+                    MAPS_SATELLITE_ZOOM = 7
+                }
+            }
+
+            let MAPS_TERRAIN_ZOOM = Number("{{ maps_terrain_zoom }}")
+            if (Number.isNaN(MAPS_TERRAIN_ZOOM)) {
+                if ("{{ maps_terrain_zoom }}" === "none") {
+                    MAPS_TERRAIN_ZOOM = null
+                } else {
+                    // ERROR (same result as "none" but putting it separately)
+                    // Use a default that we can live with. We hope they notice and report the bug if it ever comes here!
+                    MAPS_TERRAIN_ZOOM = null
+                }
+            }
+
             const MAPS_SEARCH_ENGINE = "{{ maps_search_engine }}"
             const MAPS_REGION_DOWNLOADER = "{{ maps_region_downloader }}" === "True"
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -44,8 +44,9 @@
                     // Full quality is 13
                     MAPS_SATELLITE_ZOOM = 13
                 } else {
-                    // Use a default that is hopefully always available. We hope they notice and report the bug if it ever comes here!
-                    console.warning("Unexpected value for maps_satellite_zoom")
+                    // Use a default that is hopefully always available.
+                    // We hope they notice and report the bug if it ever comes here!
+                    console.warn("Unexpected value for maps_satellite_zoom")
                     MAPS_SATELLITE_ZOOM = 7
                 }
             }
@@ -55,8 +56,9 @@
                 if ("{{ maps_terrain_zoom }}" === "none") {
                     MAPS_TERRAIN_ZOOM = null
                 } else {
-                    // Use a default that we can live with. We hope they notice and report the bug if it ever comes here!
-                    console.warning("Unexpected value for maps_terrain_zoom")
+                    // Use a default that we can live with. We hope they notice and
+                    // report the bug if it ever comes here!
+                    console.warn("Unexpected value for maps_terrain_zoom")
                     MAPS_TERRAIN_ZOOM = null
                 }
             }

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -44,8 +44,8 @@
                     // Full quality is 13
                     MAPS_SATELLITE_ZOOM = 13
                 } else {
-                    // ERROR
                     // Use a default that is hopefully always available. We hope they notice and report the bug if it ever comes here!
+                    console.warning("Unexpected value for maps_satellite_zoom")
                     MAPS_SATELLITE_ZOOM = 7
                 }
             }
@@ -55,8 +55,8 @@
                 if ("{{ maps_terrain_zoom }}" === "none") {
                     MAPS_TERRAIN_ZOOM = null
                 } else {
-                    // ERROR (same result as "none" but putting it separately)
                     // Use a default that we can live with. We hope they notice and report the bug if it ever comes here!
+                    console.warning("Unexpected value for maps_terrain_zoom")
                     MAPS_TERRAIN_ZOOM = null
                 }
             }


### PR DESCRIPTION
### Fixes bug:

If satellite was set to "full" the front end wouldn't work. I was still assuming the value would be a number.

### Smoke-tested on which OS or OS's:

RPiOS 13 Trixie

### Mention a team member @username e.g. to help with code review:
@holta 