### PR TITLE
Reduce maps CI size

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -192,7 +192,7 @@ maps_region_downloader: false
 
 If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "ultra-small" maps that you can install. These are too small[*] for useful map browsing, but still usable enough for QA testers.
 
-[*] Grand total disk usage is [~63 MB instead of the ~297 MB delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
+[*] Grand total disk usage is [~66 MB instead of the ~312 MB delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
 
    ```
    maps_ne6_zoom: ci

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -190,7 +190,9 @@ maps_region_downloader: false
 
 ## Testing
 
-If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "ultra-small" maps that you can install. These are too small for useful map browsing, but usable enough for QA testers.
+If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "ultra-small" maps that you can install. These are too small[*] for useful map browsing, but still usable enough for QA testers.
+
+[*] Grand total disk usage is [~63M instead of the ~297M delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
 
    ```
    maps_ne6_zoom: ci
@@ -201,7 +203,6 @@ If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "u
    maps_search_engine: static
    maps_search_static_db: pop-100k-cities
    ```
-
 
 ## Installation Tips
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -192,7 +192,7 @@ maps_region_downloader: false
 
 If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "ultra-small" maps that you can install. These are too small[*] for useful map browsing, but still usable enough for QA testers.
 
-[*] Grand total disk usage is [~63M instead of the ~297M delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
+[*] Grand total disk usage is [~63 MB instead of the ~297 MB delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
 
    ```
    maps_ne6_zoom: ci

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -13,7 +13,7 @@ NEW: Need more detail in specific areas, in addition to the above global maps? I
 
 To configure your map, set the following variables (for the options you choose!) in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) before installing IIAB software:
 
-1. If you want **~170 MB** = 85 MB vector (Lower detail, up to zoom 8, from Natural Earth) + 85 MB satellite (up to zoom 7), 
+1. If you want **~170 MB** = 85 MB vector (Lower detail, up to zoom 8, from Natural Earth) + 85 MB satellite (up to zoom 7):
 
    ```
    osm_vector_maps_install: False
@@ -187,6 +187,21 @@ maps_region_downloader: false
 ```
 
 ...and run the `maps` role again. At this point, you will be able to view your Full Quality Regions, but the Download and Delete buttons will be gone.
+
+## Testing
+
+If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "ultra-small" maps that you can install. These are too small for useful map browsing, but usable enough for QA testers.
+
+   ```
+   maps_ne6_zoom: ci
+
+   maps_vector_quality: osm-z1
+   maps_satellite_zoom: 4
+
+   maps_search_engine: static
+   maps_search_static_db: pop-100k-cities
+   ```
+
 
 ## Installation Tips
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -97,7 +97,12 @@ maplibre_js_and_styles:
 maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
 
 # Mostly colors, topography, etc.
-maps_dot_black_naturalearth6_tiles: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
+maps_dot_black_naturalearth6_tiles:
+  # For actual users
+  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
+
+  # FOR TESTING ONLY
+  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.zoom_0-04.pmtiles"
 
 # Two different symlinks because the front end could requset openstreetmap or naturalearth
 maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
@@ -123,6 +128,11 @@ maps_dot_black_vector_tiles:
   # (ne = "Natural Earth")
   ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.full.pmtiles"
 
+  # FOR TESTING ONLY
+  # "medium res" osm, up to zoom level 1 (original file has 14).
+  # maps_vector_quality = "osm-z1"
+  osm-z1: "openstreetmap-openmaptiles.{{ maps_data_date }}.zoom_0-01.pmtiles"
+
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
 maps_dot_black_satellite_tiles:
@@ -145,6 +155,11 @@ maps_dot_black_satellite_tiles:
   # Highest available quality satellite, up to zoom level 13
   # maps_satellite_zoom = full
   full: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.full.pmtiles"
+
+  # FOR TESTING ONLY
+  # Super-low quality satellite, up to zoom level 4 (original file has 13)
+  # maps_satellite_zoom = 4
+  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-04.pmtiles"
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
 # However the fact that it includes "z0-z10" is not ideal, as it may point to an

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -221,3 +221,8 @@ static_search_data:
   # Cities-only static database
   # maps_search_static_db = "pop-1k-cities"
   pop-1k-cities: "static-search.{{ maps_data_date }}.pop-1k-cities"
+
+  # Large cities-only static database
+  # maps_search_static_db = "pop-100k-cities"
+  # FOR TESTING ONLY
+  pop-100k-cities: "static-search.{{ maps_data_date }}.pop-100k-cities"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -27,11 +27,11 @@
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_naturalearth6_tiles }}"
+    item: "{{ maps_dot_black_naturalearth6_tiles[maps_ne6_zoom] }}"
 
 - name: Select naturalearth6 tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_tiles }}"
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_tiles[maps_ne6_zoom] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
     state: link
 

--- a/roles/maps/tasks/main.yml
+++ b/roles/maps/tasks/main.yml
@@ -49,6 +49,10 @@
           value: "{{ maps_search_nominatim_db }}"
         - option: maps_search_static_db
           value: "{{ maps_search_static_db }}"
+        - option: maps_preset_full_quality_regions
+          value: "{{ maps_preset_full_quality_regions }}"
+        - option: maps_ne6_zoom
+          value: "{{ maps_ne6_zoom }}"
 
   rescue:
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -105,9 +105,9 @@ def approve_download_size(extract_name):
         # can control and will likely look into for optimizing user experience.
         pattern = (
             r'\d+/\d+/\d+ \d+:\d+:\d+ extract.go:\d*: '
-            r'Extract transferred (\d*\.?\d*) (KB|MB|GB|TB) '
+            r'Extract transferred (\d*\.?\d*) (kB|MB|GB|TB) '
             r'\(overfetch \d*\.?\d*\) '
-            r'for an archive size of (\d*\.?\d*) (KB|MB|GB|TB)'
+            r'for an archive size of (\d*\.?\d*) (kB|MB|GB|TB)'
         )
         for line in result.stdout.split('\n'):
             re_match = re.match(pattern, line)
@@ -121,7 +121,7 @@ def approve_download_size(extract_name):
 
         # Determine the sizes of all of the pmtiles files in bytes
         unit_mult = {
-            'KB': 1_000,
+            'kB': 1_000,
             'MB': 1_000_000,
             'GB': 1_000_000_000,
             'TB': 1_000_000_000_000,

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -526,7 +526,7 @@ maps_search_nominatim_db: basic         # Nominatim search database quality (wor
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
 
-# The following are intended for CI/CD. The defaults here should be kept for end users:
+# The following are intended for CI/CD. The defaults here should be kept for implementers:
 maps_preset_full_quality_regions: []    # Full-quality regions to install during installation.
 maps_ne6_zoom: full                     # Quality for naturalearth6 files.
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -525,7 +525,10 @@ maps_search_engine: static              # See https://github.com/iiab/iiab/blob/
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
-maps_preset_full_quality_regions: []    # Full-quality regions to install during installation. Intended for CI/CD, not end users.
+
+# The following are intended for CI/CD. The defaults here should be kept for end users:
+maps_preset_full_quality_regions: []    # Full-quality regions to install during installation.
+maps_ne6_zoom: full                     # Quality for naturalearth6 files.
 
 # MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.
 # This role was formerly installed by roles/sugarizer/meta/main.yml

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -309,7 +309,7 @@ maps_from_internet_archive: False
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 
-# This will run on CI so we want to be careful how much it downloads. As of now, maps will download (slightly different from on-disk size) roughly:
+# 2026-03-24: This will run on CI so we want to be careful how much it downloads. As of now, maps will download (slightly different from on-disk size) roughly:
 #
 # 1M   various js/css
 # 7M   naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.zoom_0-04.pmtiles

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -309,32 +309,34 @@ maps_from_internet_archive: False
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 
-# This will run on CI so we want to be careful how much it downloads. As of now, maps will download:
+# This will run on CI so we want to be careful how much it downloads. As of now, maps will download roughly:
 #
-# 1M    various js/css
-# 58M   naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.full.pmtiles
-# 86M   naturalearth-openmaptiles.2025-12-10.full.pmtiles
-# 36M   resourcetiles-minimal.pmtiles
-# 85M   s2maps-sentinel2-2023.2025-12-10.zoom_0-07.pmtiles
-# 16M   static-search.2025-12-10.pop-1k-cities.tar.gz
-# 15M   full quality regions
+# 1M   various js/css
+# 7M   naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.zoom_0-04.pmtiles
+# 1M   openstreetmap-openmaptiles.2025-12-10.zoom_0-01.pmtiles
+# 36M  resourcetiles-minimal.pmtiles
+# 2M   s2maps-sentinel2-2023.2025-12-10.zoom_0-04.pmtiles
+# 16M  static-search.2025-12-10.pop-1k-cities.tar.gz
+# 15M  full quality regions
+#
 # ---------------------------------------------------------------
-# 297M  Total (with possible rounding errors)
+# 78M  Total (with possible rounding errors)
 
 maps_install: True
 maps_enabled: True
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: "osm-z1"           # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
-maps_preset_full_quality_regions:
+maps_preset_full_quality_regions:       # Small portion of london and Nepal mountains
   - name: london
     bbox: -0.172187453,51.477245915,-0.143235226,51.493348151
   - name: nepal-mountains
     bbox: 83.680824998,28.401673033,84.055999541,28.724927625
+maps_ne6_zoom: ci                       # Limited naturalearth6 for testing
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -324,7 +324,7 @@ maps_from_internet_archive: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_quality: "osm-z1"           # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: osm-z1             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -309,18 +309,18 @@ maps_from_internet_archive: False
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 
-# This will run on CI so we want to be careful how much it downloads. As of now, maps will download roughly:
+# This will run on CI so we want to be careful how much it downloads. As of now, maps will download (slightly different from on-disk size) roughly:
 #
 # 1M   various js/css
 # 7M   naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.zoom_0-04.pmtiles
 # 1M   openstreetmap-openmaptiles.2025-12-10.zoom_0-01.pmtiles
 # 36M  resourcetiles-minimal.pmtiles
 # 2M   s2maps-sentinel2-2023.2025-12-10.zoom_0-04.pmtiles
-# 16M  static-search.2025-12-10.pop-1k-cities.tar.gz
+# 1M   static-search.2025-12-10.pop-100k-cities.tar.gz
 # 15M  full quality regions
 #
 # ---------------------------------------------------------------
-# 78M  Total (with possible rounding errors)
+# 63M  Total (with possible rounding errors)
 
 maps_install: True
 maps_enabled: True
@@ -329,7 +329,7 @@ maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` i
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_search_static_db: pop-100k-cities  # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: False           # Tool to select regions for full-quality download
 maps_preset_full_quality_regions:       # Small portion of london and Nepal mountains
   - name: london

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -308,6 +308,19 @@ osm_vector_maps_enabled: False
 maps_from_internet_archive: False
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
+
+# This will run on CI so we want to be careful how much it downloads. As of now, maps will download:
+#
+# 1M    various js/css
+# 58M   naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.full.pmtiles
+# 86M   naturalearth-openmaptiles.2025-12-10.full.pmtiles
+# 36M   resourcetiles-minimal.pmtiles
+# 85M   s2maps-sentinel2-2023.2025-12-10.zoom_0-07.pmtiles
+# 16M   static-search.2025-12-10.pop-1k-cities.tar.gz
+# 15M   full quality regions
+# ---------------------------------------------------------------
+# 297M  Total (with possible rounding errors)
+
 maps_install: True
 maps_enabled: True
 maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.


### PR DESCRIPTION
### Description of changes proposed in this pull request:

For CI, use data files that are much smaller than even the default installation for users:

* `naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.zoom_0-04.pmtiles` which gives the "natural" style its "natural" look (zoom 0-4, down from of 0-6. I could make it smaller but it would look more broken for QA testers.)
* `openstreetmap-openmaptiles.2025-12-10.zoom_0-01.pmtiles` - vector maps (OSM zoom 0-1, down from Natural Earth 0-8)
* `s2maps-sentinel2-2023.2025-12-10.zoom_0-04.pmtiles` - satellite (zoom 0-4, down from 0-7)
* `static-search.2025-12-10.pop-100k-cities.tar.gz` - city search (all 100k+ population towns, down from all 1k+ population towns)

This brings the total down from ~297M to ~63M.

Thanks again to @Ark74 for helping with the hosting side.

### Smoke-tested on which OS or OS's:

RPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 