### PR TITLE
Better map region download error message

### DIFF
--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -76,7 +76,8 @@ def create_extract(extract_name, extract_box):
         result = subprocess.run(
             [PMTILES, "extract", files["source"], files["tmp"], "--bbox=" + extract_box],
         )
-        assert result.returncode == 0, "pmtiles extract exited with returncode " + str(result.returncode)
+        if result.returncode != 0:
+            raise Exception(f"Region download failed. Double-check your Internet connection. (error code {result.returncode})")
 
     for files in extract_files.values():
         shutil.move(files["tmp"], files["extract"])
@@ -94,7 +95,8 @@ def approve_download_size(extract_name):
             capture_output=True,
             text=True,
         )
-        assert result.returncode == 0, "pmtiles extract --dry-run exited with returncode " + str(result.returncode)
+        if result.returncode != 0:
+            raise Exception(f"Download size check failed. Double-check your Internet connection. (error code {result.returncode})")
 
         # Parse transfer and archive sizes from the last line of --dry-run output.
         # (Though we'll check every line to make it a bit more robust)


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Suggests to the user to doublecheck their Internet connection if region downloader fails. I confused myself with this one a few times.

### Smoke-tested on which OS or OS's:

RPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 