### PR TITLE
Specify bash for a couple shell directives

### DIFF
--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -155,3 +155,5 @@
         echo "aria2c error:" 1>&2
         tac "{{ log_file }}" | sed '/'"Download Progress Summary as of"'/q' | tac 1>&2
         exit 1
+      args:
+        executable: /bin/bash

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -111,6 +111,8 @@
   shell: |
     set -euo pipefail
     {{ tile_extract.working_dir }}/tile-extract.py extract {{ item.name }} {{ item.bbox }} noninteractive
+  args:
+    executable: /bin/bash
   with_items: "{{ maps_preset_full_quality_regions }}"
 
 # If the user goes back to "none", we want to delete the symlink that gives them terrain.


### PR DESCRIPTION
### Fixes bug:

On certain configurations, it seems that bash is not assumed for ansible `shell:` directives. @Akatama ran into this when downloading regions in CI. Hopefully he can confirm that this will fix it.

### Smoke-tested on which OS or OS's:
RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta