### PR TITLE
Maps test CI needs region downloader tool

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -136,7 +136,7 @@ PREREQ: Confirm [IIAB Maps]((#how-do-i-try-iiabs-new-maps-as-of-march-2026)) (wi
 In order to turn it on, add the following setting: (e.g. in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?))
 
 ```
-maps_region_downloader: true
+maps_region_downloader: True
 ```
 
 Reinstall the new IIAB Maps, if already installed:
@@ -183,7 +183,7 @@ At the moment, overlapping regions are not allowed. However, if you find that yo
 Finally, once your Full Quality Regions are in place and you are ready to let others use your map, you can turn off the setting:
 
 ```
-maps_region_downloader: false
+maps_region_downloader: False
 ```
 
 ...and run the `maps` role again. At this point, you will be able to view your Full Quality Regions, but the Download and Delete buttons will be gone.
@@ -203,7 +203,7 @@ If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "u
    maps_search_engine: static
    maps_search_static_db: pop-100k-cities
 
-   maps_region_downloader: true
+   maps_region_downloader: True
    ```
 
 ## Installation Tips

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -202,6 +202,8 @@ If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "u
 
    maps_search_engine: static
    maps_search_static_db: pop-100k-cities
+
+   maps_region_downloader: true
    ```
 
 ## Installation Tips

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -106,6 +106,12 @@
     mode: "0644"
     force: false
 
+- name: "Make sure maps_region_downloader is true if maps_preset_full_quality_regions has items"
+  assert:
+    that: maps_region_downloader or (maps_preset_full_quality_regions | length <= 0)
+    fail_msg: "Error: you have maps_preset_full_quality_regions. Either set maps_region_downloader to true or unset maps_preset_full_quality_regions (this will not delete any already downloaded regions)."
+    quiet: yes
+
 - name: "Download preset full quality regions"
   # TODO - Is there a safer way to pass in item.name and item.bbox?
   shell: |

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -326,7 +326,7 @@ maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in 
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-100k-cities  # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_region_downloader: False           # Tool to select regions for full-quality download
+maps_region_downloader: True            # Tool to select regions for full-quality download. Needed for maps_preset_full_quality_regions.
 maps_preset_full_quality_regions:       # Small portion of london and Nepal mountains
   - name: london
     bbox: -0.172187453,51.477245915,-0.143235226,51.493348151


### PR DESCRIPTION
### Fixes bug:

`local_vars_maps_test.yml` fails because it doesn't install the map region downloader utility. I never caught this before because I develop on a machine with it already installed. (And, because we have not started using it for actual CI yet.)

### Notes:

`maps_region_downloader` has two functions: install the downloader tool, and show the downloader button on the map. This fix is annoying for the hypothetical user who wants to install regions via ansible vars but does not want the downloader tool button on their map. They would need to set both variables for the first run and then comment them out both out after.

However, this hypothetical user likely does not exist. The regions-via-ansible feature is intended for CI. If this proves wrong LMK.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@Akatama @holta 