### PR TITLE
[Lokole] use {{ apache_user }} as a group instead of {{ lokole_user }}

### DIFF
--- a/roles/lokole/tasks/install.yml
+++ b/roles/lokole/tasks/install.yml
@@ -77,23 +77,16 @@
   ansible.builtin.user:
     state: present
     name: "{{ lokole_user }}"
-    #group: "{{ lokole_user }}"
+    group: "{{ apache_user }}"
     groups: dialout, dip
     system: yes
     #uid: "{{ lokole_uid }}"
     home: "{{ lokole_home_dir }}"
 
-- name: "Add user '{{ apache_user }}' to group '{{ lokole_user }}' for socket access via NGINX"
-  ansible.builtin.user:
-    name: "{{ apache_user }}"
-    groups: "{{ lokole_user }}"
-    append: yes
-
 - name: mkdir {{ lokole_run_dir }}
   file:
     state: directory
     path: "{{ lokole_run_dir }}/lokole_restarter"
-    group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
     mode: g+rw
 
@@ -101,7 +94,6 @@
   file:
     state: directory
     path: "{{ lokole_log_dir }}"
-    group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
     mode: g+rw
 
@@ -114,7 +106,6 @@
   template:
     src: settings.env.j2
     dest: "{{ lokole_settings }}"
-    group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
     mode: g+rw
 
@@ -129,7 +120,6 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ lokole_confd }}/{{ item.dest }}"
-    group: "{{ lokole_user }}"
     owner: "{{ lokole_user }}"
     mode: "0644"
   with_items:

--- a/roles/lokole/tasks/setup.yml
+++ b/roles/lokole/tasks/setup.yml
@@ -16,7 +16,7 @@
     path: "{{ item.path }}"
     state: file
     owner: "{{ lokole_user }}"
-    group: "{{ lokole_user }}"
+    group: "{{ apache_user }}"
     mode: u=rw
   loop:
     - { path: "{{ lokole_run_dir }}/users.sqlite3" }


### PR DESCRIPTION
### Fixes bug:
When installing Lokole along with IIAB Admin Console, the `lokole` user gets removed from `www-data` group making nginx unable to acccess Lokole's gunicorn socket.

### Description of changes proposed in this pull request:
Add `{{ lokole_user }}` to `{{ apache_user }}` group to allow nginx to access Lokole's services/

### Smoke-tested on which OS or OS's:
- Ubuntu 24.04
### Mention a team member @username e.g. to help with code review:
@holta @nzola