### PR TITLE
Add attribution for search data to UI

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1100,6 +1100,9 @@
 
                     if (geocoder) {
                         mb.map.addControl(geocoder, 'top-left');
+
+                        // Initialize the same way as maps.black
+                        // https://github.com/maps-black/maps.black/blob/12205728ceb0672682381088c6c1e7ad05fdc4f5/client/maps.black.js#L120
                         mb.licenses = mb.licenses || { data: {}, styles: {}, fonts: {} }
                         mb.licenses.search = geocoderAlternatives[MAPS_SEARCH_ENGINE].licenses
                     }

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -765,8 +765,16 @@
                 nominatim: {
                     api: nominatimGeocoderApi,
                     options: geocoderCommonOptions,
+                    licenses: {
+                        "openstreetmap": "Search database is based on data from OpenStreetMap.\n\nhttps://www.openstreetmap.org/copyright",
+                        "wikipedia": "Wikipedia is used to determine importance of search results.\n\nhttps://en.wikipedia.org/wiki/Wikipedia:Copyrights",
+                        "wikidata": "Wikidata is used to determine importance of search results.\n\nhttps://www.wikidata.org/wiki/Wikidata:Licensing",
+                    },
                 },
                 static: {
+                    licenses: {
+                        "geonames": "Search database is based on data from GeoNames which is available under CC BY 4.0.\n\nhttps://www.geonames.org/\nhttps://creativecommons.org/licenses/by/4.0/",
+                    },
                     api: staticGeocoderApi,
                     options: {
                         minLength: 3, // Until and unless we add a "short names" json file
@@ -1092,6 +1100,8 @@
 
                     if (geocoder) {
                         mb.map.addControl(geocoder, 'top-left');
+                        mb.licenses = mb.licenses || { data: {}, styles: {}, fonts: {} }
+                        mb.licenses.search = geocoderAlternatives[MAPS_SEARCH_ENGINE].licenses
                     }
                     mb.map.addControl(scaleControl);
 


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Adds attribution for our search engines to the map interface. Maps.black already has a system for it. You click on "Attributions" on the bottom right and you get a list of attributions for everything on the map.

I'm actually not even totally sure this is everything for Nominatim but I don't even see openstreetmap.org attributing anything more than openstreetmap data, so we're probably fine here. But since we use GeoNames for now for search, I'd like to make sure to attribute that project.

This is when you click on "Attributions" (on the bottom right of the map):

<img width="870" height="498" alt="1" src="https://github.com/user-attachments/assets/77528ce4-63c5-4aea-9dbd-622b5029a578" />

This is when you expand the Geonames dropdown:

<img width="870" height="498" alt="2" src="https://github.com/user-attachments/assets/c152c6ee-d512-4ac9-96d1-e9995cd40949" />

This is when you expand the openstreetmap-openmaptiles dropdown. You can see that Maps.black decided to include the whole license instead of a link. That seems like a hassle and I don't see why it's necessary so I didn't bother doing the same:

<img width="870" height="498" alt="3" src="https://github.com/user-attachments/assets/122ea49b-513a-4fe3-9bac-7a9763c9dd76" />

BTW I do still hope to eventually switch to OSM for static search for better quality data, but I don't think that's imminent so I wanted to take care of this.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 