### PR TITLE
use is_container instead of rpi_image for container specific exclusions

### DIFF
--- a/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/10min-unittest-IMAGE-on-rpios-lite.yml
@@ -91,6 +91,7 @@ jobs:
           cp --preserve=mode,timestamps ../iiab/vars/local_vars_unittest.yml "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo "rpi_image: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          echo "is_VM: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
           sed -i "s/^iiab_admin_user_install: True/iiab_admin_user_install: False/" "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           if ! command -v systemd-nspawn &> /dev/null; then
@@ -182,6 +183,7 @@ jobs:
           # Remove image-specific configuration
           rm -f "$MOUNT_DIR/etc/initramfs-tools/conf.d/nspawn.conf"
           sed -i '/rpi_image: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          sed -i '/is_VM: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo uninitialized > "$MOUNT_DIR/etc/machine-id"
           rm -f "$MOUNT_DIR/etc/iiab/uuid"

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -103,6 +103,7 @@ jobs:
           cp --preserve=mode,timestamps ../iiab/vars/local_vars_tiny.yml "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo "rpi_image: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          echo "is_VM: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
           sed -i "s/^iiab_admin_user_install: True/iiab_admin_user_install: False/" "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           if ! command -v systemd-nspawn &> /dev/null; then
@@ -196,6 +197,7 @@ jobs:
           # Remove image-specific configuration
           rm -f "$MOUNT_DIR/etc/initramfs-tools/conf.d/nspawn.conf"
           sed -i '/rpi_image: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          sed -i '/is_VM: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo uninitialized > "$MOUNT_DIR/etc/machine-id"
           rm -f "$MOUNT_DIR/etc/iiab/uuid"

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -103,6 +103,7 @@ jobs:
           cp --preserve=mode,timestamps ../iiab/vars/local_vars_small.yml "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo "rpi_image: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          echo "is_VM: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
           sed -i "s/^iiab_admin_user_install: True/iiab_admin_user_install: False/" "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           if ! command -v expect &>/dev/null; then
@@ -193,6 +194,7 @@ jobs:
           # Remove image-specific configuration
           rm -f "$MOUNT_DIR/etc/initramfs-tools/conf.d/nspawn.conf"
           sed -i '/rpi_image: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          sed -i '/is_VM: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo uninitialized > "$MOUNT_DIR/etc/machine-id"
           rm -f "$MOUNT_DIR/etc/iiab/uuid"

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -103,6 +103,7 @@ jobs:
           cp --preserve=mode,timestamps ../iiab/vars/local_vars_medium.yml "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo "rpi_image: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          echo "is_VM: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
           sed -i "s/^iiab_admin_user_install: True/iiab_admin_user_install: False/" "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           if ! command -v expect &>/dev/null; then
@@ -193,6 +194,7 @@ jobs:
           # Remove image-specific configuration
           rm -f "$MOUNT_DIR/etc/initramfs-tools/conf.d/nspawn.conf"
           sed -i '/rpi_image: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          sed -i '/is_VM: True/d' "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo uninitialized > "$MOUNT_DIR/etc/machine-id"
           rm -f "$MOUNT_DIR/etc/iiab/uuid"

--- a/.github/workflows/35min-large-on-rpios-lite.yml
+++ b/.github/workflows/35min-large-on-rpios-lite.yml
@@ -82,6 +82,7 @@ jobs:
           cp --preserve=mode,timestamps ../iiab/vars/local_vars_large.yml "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           echo "rpi_image: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
+          echo "is_VM: True" >> "$MOUNT_DIR/etc/iiab/local_vars.yml"
           sed -i "s/^iiab_admin_user_install: True/iiab_admin_user_install: False/" "$MOUNT_DIR/etc/iiab/local_vars.yml"
 
           if ! command -v expect &>/dev/null; then

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -13,7 +13,7 @@
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     state: present
-    reload: "{{ rpi_image is undefined }}"
+    reload: "{{ is_VM is undefined }}"
   with_items:
     #- { name: 'kernel.sysrq', value: '1' }             # OS values differ, Ok?
     - { name: 'kernel.core_uses_pid', value: '1' }

--- a/roles/munin/tasks/install.yml
+++ b/roles/munin/tasks/install.yml
@@ -8,7 +8,7 @@
   sysctl:
     name: net.ipv6.conf.all.disable_ipv6
     value: 0
-  when: rpi_image is undefined
+  when: is_VM is undefined
 
 - name: "Install 4 packages: libcgi-fast-perl, munin, munin-node, munin-plugins-extra"
   package:
@@ -32,7 +32,7 @@
   sysctl:
     name: net.ipv6.conf.all.disable_ipv6
     value: 1
-  when: rpi_image is undefined
+  when: is_VM is undefined
 
 - name: Establish username/password Admin/changeme in /etc/munin/munin-htpasswd
   htpasswd:

--- a/roles/network/tasks/NM-debian.yml
+++ b/roles/network/tasks/NM-debian.yml
@@ -18,7 +18,7 @@
 # hostapd will overrule cmdline.txt
 - name: Run "nmcli radio wifi on" to unblock WiFi when RasPiOS
   command: nmcli radio wifi on
-  when: is_raspbian and not discovered_wireless_iface == "none" and rpi_image is undefined
+  when: is_raspbian and not discovered_wireless_iface == "none" and is_VM is undefined
 
 # The running variable(s) in NM are rewritten to this file upon stopping the service.
 # The above toggles the WirelessEnabled= to true in NetworkManager.state

--- a/roles/network/tasks/install.yml
+++ b/roles/network/tasks/install.yml
@@ -85,7 +85,7 @@
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     state: present
-    reload: "{{ rpi_image is undefined }}"
+    reload: "{{ is_VM is undefined }}"
   with_items:
     - { name: 'net.ipv4.ip_forward', value: '1' }                          # Default: 0.  Masquerading LAN->Internet
     - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }              # Default: 2.  Enable Spoof protection (reverse-path filter)

--- a/roles/transmission/tasks/enable-or-disable.yml
+++ b/roles/transmission/tasks/enable-or-disable.yml
@@ -3,7 +3,7 @@
     daemon_reload: yes
     name: transmission-daemon
     enabled: yes
-    state: "{{ 'restarted' if rpi_image is undefined else 'stopped' }}"
+    state: "{{ 'restarted' if is_VM is undefined else 'started' }}"
   when: transmission_enabled
 
 - debug:

--- a/roles/transmission/tasks/enable-or-disable.yml
+++ b/roles/transmission/tasks/enable-or-disable.yml
@@ -3,7 +3,7 @@
     daemon_reload: yes
     name: transmission-daemon
     enabled: yes
-    state: "{{ 'restarted' if is_VM is undefined else 'started' }}"
+    state: "{{ 'restarted' if is_VM is undefined else 'stopped' }}"
   when: transmission_enabled
 
 - debug:


### PR DESCRIPTION
### Fixes bug:

Right now it's difficult to exclude things which fail in containers. Moving these away from rpi_image allows for greater flexibility and control.

### Description of changes proposed in this pull request:

Container/VM detection - set to True when running inside systemd-nspawn, LXC, etc.

Used to skip kernel-level sysctl and systemd service operations that fail in containers.

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
@holta