### PR TITLE
[proot] remove matomo from default apps to improve performance

### DIFF
--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -68,8 +68,8 @@ kolibri_enabled: True
 
 ##############################
 # Matomo - enable at will.
-matomo_install: True
-matomo_enabled: True
+matomo_install: False
+matomo_enabled: False
 ##############################
 
 ##############################


### PR DESCRIPTION
### Fixes bug:
Reduces installation time, resources and overhead on Android devices

### Description of changes proposed in this pull request:
Disable Matomo installation by default on Android devices

### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 