### PR TITLE
Update vector data to April 2026

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -48,7 +48,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
 3. Or if you want **~168 GB** = 78 GB vector (Higher detail, up to zoom 14 [users can overzoom to zoom 18], including 3D buildings, from OpenStreetMap) + 80 GB satellite (up to zoom 12), include:
 
    ```
-   maps_vector_quality: osm-full
+   maps_vector_quality: osm-z14
    maps_satellite_zoom: 12
    ```
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -117,10 +117,15 @@ maps_dot_black_vector_tiles:
   # maps_vector_quality = "osm-z14"
   osm-z14: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z14.pmtiles"
 
-  # "medium res" osm, up to zoom level 9 (original file has 14).
+  # (old) "medium res" osm, up to zoom level 9 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
   osm-z9: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-09.pmtiles"
+
+  # (new) "medium res" osm, up to zoom level 11 (original file has 14).
+  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
+  # maps_vector_quality = "osm-z11"
+  osm-z11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-11.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads.
   # maps_vector_quality = "ne"

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -98,10 +98,10 @@ maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pm
 # Mostly colors, topography, etc.
 maps_dot_black_naturalearth6_tiles:
   # For actual users
-  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-06.pmtiles"
+  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-z06.pmtiles"
 
   # FOR TESTING ONLY
-  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-04.pmtiles"
+  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-z04.pmtiles"
 
 # Two different symlinks because the front end could requset openstreetmap or naturalearth
 maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
@@ -120,12 +120,12 @@ maps_dot_black_vector_tiles:
   # (old) "medium res" osm, up to zoom level 9 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
-  osm-z9: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-09.pmtiles"
+  osm-z9: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z09.pmtiles"
 
   # (new) "medium res" osm, up to zoom level 11 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z11"
-  osm-z11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-11.pmtiles"
+  osm-z11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z11.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads.
   # maps_vector_quality = "ne"
@@ -135,7 +135,7 @@ maps_dot_black_vector_tiles:
   # FOR TESTING ONLY
   # "medium res" osm, up to zoom level 1 (original file has 14).
   # maps_vector_quality = "osm-z1"
-  osm-z1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-01.pmtiles"
+  osm-z1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z01.pmtiles"
 
 maps_vector_max_zoom: 14
 
@@ -144,19 +144,19 @@ maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 maps_dot_black_satellite_tiles:
   # Low quality satellite, up to zoom level 7 (original file has 13)
   # maps_satellite_zoom = 7
-  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-07.pmtiles"
+  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z07.pmtiles"
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13)
   # maps_satellite_zoom = 9
-  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-09.pmtiles"
+  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z09.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13)
   # maps_satellite_zoom = 11
-  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-11.pmtiles"
+  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z11.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13)
   # maps_satellite_zoom = 12
-  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-12.pmtiles"
+  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z12.pmtiles"
 
   # Highest available quality satellite, up to zoom level 13
   # maps_satellite_zoom = 13
@@ -165,7 +165,7 @@ maps_dot_black_satellite_tiles:
   # FOR TESTING ONLY
   # Super-low quality satellite, up to zoom level 4 (original file has 13)
   # maps_satellite_zoom = 4
-  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-04.pmtiles"
+  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z04.pmtiles"
 
 maps_satellite_max_zoom: 13
 
@@ -179,13 +179,13 @@ maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 maps_dot_black_terrain_tiles:
   # Low quality terrain, up to zoom level 7 (original file has 10)
   # maps_terrain_zoom = 7
-  7: "terrarium.{{ maps_slow_data_date }}.z00-07.pmtiles"
+  7: "terrarium.{{ maps_slow_data_date }}.z00-z07.pmtiles"
 
   # maps_terrain_zoom = 8
-  8: "terrarium.{{ maps_slow_data_date }}.z00-08.pmtiles"
+  8: "terrarium.{{ maps_slow_data_date }}.z00-z08.pmtiles"
 
   # maps_terrain_zoom = 9
-  9: "terrarium.{{ maps_slow_data_date }}.z00-09.pmtiles"
+  9: "terrarium.{{ maps_slow_data_date }}.z00-z09.pmtiles"
 
   # maps_terrain_zoom = 10
   # (This is the highest quality that maps.black offers in pmtiles format. They
@@ -195,8 +195,8 @@ maps_dot_black_terrain_tiles:
   # NOT RECOMMENDED. VERY LOW QUALITY terrain, up to zoom level 5 or 6.
   # We will probably end up getting rid of these, but we would like to test
   # them out to be sure.
-  5: "terrarium.{{ maps_slow_data_date }}.z00-05.pmtiles"
-  6: "terrarium.{{ maps_slow_data_date }}.z00-06.pmtiles"
+  5: "terrarium.{{ maps_slow_data_date }}.z00-z05.pmtiles"
+  6: "terrarium.{{ maps_slow_data_date }}.z00-z06.pmtiles"
 
 maps_terrain_max_zoom: 10
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -17,8 +17,7 @@ nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 maps_static_search_dir: "static-search"
 maps_static_search_root: "{{ maps_serve_path }}/{{ maps_static_search_dir }}"
 
-# `maps_data_date` is for data that changes all the time (osm vector data,
-#     search [eventually!])
+# `maps_vector_data_date` is for vector tiles
 # `maps_slow_data_date` is for big data that changes rarely if ever (satellite,
 #     natural earth, terrain, search [for now!])
 #
@@ -30,7 +29,7 @@ maps_static_search_root: "{{ maps_serve_path }}/{{ maps_static_search_dir }}"
 # date designations down the line. I just want one "slow" date to set all of
 # these items *for now*.
 #
-maps_data_date: "2025-12-10"
+maps_vector_data_date: "2026-04-01"
 maps_slow_data_date: "2025-12-10"
 
 tile_extract:
@@ -99,10 +98,10 @@ maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pm
 # Mostly colors, topography, etc.
 maps_dot_black_naturalearth6_tiles:
   # For actual users
-  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.full.pmtiles"
+  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-06.pmtiles"
 
   # FOR TESTING ONLY
-  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.zoom_0-04.pmtiles"
+  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-04.pmtiles"
 
 # Two different symlinks because the front end could requset openstreetmap or naturalearth
 maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
@@ -115,51 +114,55 @@ maps_dot_black_ne_symlink_name: naturalearth-openmaptiles.pmtiles
 maps_dot_black_vector_tiles:
   # "high res" full osm, including 3d buildings.
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
-  # maps_vector_quality = "osm-full"
-  osm-full: "openstreetmap-openmaptiles.{{ maps_data_date }}.full.pmtiles"
+  # maps_vector_quality = "osm-z14"
+  osm-z14: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z14.pmtiles"
 
   # "medium res" osm, up to zoom level 9 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_quality = "osm-z9"
-  osm-z9: "openstreetmap-openmaptiles.{{ maps_data_date }}.zoom_0-09.pmtiles"
+  osm-z9: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-09.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads.
   # maps_vector_quality = "ne"
   # (ne = "Natural Earth")
-  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.full.pmtiles"
+  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.z00-z08.pmtiles"
 
   # FOR TESTING ONLY
   # "medium res" osm, up to zoom level 1 (original file has 14).
   # maps_vector_quality = "osm-z1"
-  osm-z1: "openstreetmap-openmaptiles.{{ maps_data_date }}.zoom_0-01.pmtiles"
+  osm-z1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-01.pmtiles"
+
+maps_vector_max_zoom: 14
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 
 maps_dot_black_satellite_tiles:
   # Low quality satellite, up to zoom level 7 (original file has 13)
   # maps_satellite_zoom = 7
-  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
+  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-07.pmtiles"
 
   # Moderately high quality satellite, up to zoom level 9 (original file has 13)
   # maps_satellite_zoom = 9
-  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
+  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-09.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 11 (original file has 13)
   # maps_satellite_zoom = 11
-  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-11.pmtiles"
+  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-11.pmtiles"
 
   # Pretty high quality satellite, up to zoom level 12 (original file has 13)
   # maps_satellite_zoom = 12
-  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-12.pmtiles"
+  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-12.pmtiles"
 
   # Highest available quality satellite, up to zoom level 13
-  # maps_satellite_zoom = full
-  full: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.full.pmtiles"
+  # maps_satellite_zoom = 13
+  13: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z13.pmtiles"
 
   # FOR TESTING ONLY
   # Super-low quality satellite, up to zoom level 4 (original file has 13)
   # maps_satellite_zoom = 4
-  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.zoom_0-04.pmtiles"
+  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-04.pmtiles"
+
+maps_satellite_max_zoom: 13
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
 # However the fact that it includes "z0-z10" is not ideal, as it may point to an
@@ -171,30 +174,32 @@ maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 maps_dot_black_terrain_tiles:
   # Low quality terrain, up to zoom level 7 (original file has 10)
   # maps_terrain_zoom = 7
-  7: "terrarium.{{ maps_slow_data_date }}.zoom_0-07.pmtiles"
+  7: "terrarium.{{ maps_slow_data_date }}.z00-07.pmtiles"
 
   # maps_terrain_zoom = 8
-  8: "terrarium.{{ maps_slow_data_date }}.zoom_0-08.pmtiles"
+  8: "terrarium.{{ maps_slow_data_date }}.z00-08.pmtiles"
 
   # maps_terrain_zoom = 9
-  9: "terrarium.{{ maps_slow_data_date }}.zoom_0-09.pmtiles"
+  9: "terrarium.{{ maps_slow_data_date }}.z00-09.pmtiles"
 
   # maps_terrain_zoom = 10
   # (This is the highest quality that maps.black offers in pmtiles format. They
   # offer 11, 12, and 13 in squashfs format, but they are massive files.)
-  10: "terrarium.{{ maps_slow_data_date }}.full.pmtiles"
+  10: "terrarium.{{ maps_slow_data_date }}.z00-z10.pmtiles"
 
   # NOT RECOMMENDED. VERY LOW QUALITY terrain, up to zoom level 5 or 6.
   # We will probably end up getting rid of these, but we would like to test
   # them out to be sure.
-  5: "terrarium.{{ maps_slow_data_date }}.zoom_0-05.pmtiles"
-  6: "terrarium.{{ maps_slow_data_date }}.zoom_0-06.pmtiles"
+  5: "terrarium.{{ maps_slow_data_date }}.z00-05.pmtiles"
+  6: "terrarium.{{ maps_slow_data_date }}.z00-06.pmtiles"
+
+maps_terrain_max_zoom: 10
 
 # Similar to pmtiles, search databases should follow this convention:
 #
-#   {search-engine}.{maps_data_date}.full
-#   {search-engine}.{maps_data_date}.{subset}
-#   {search-engine}.{maps_data_date}.full-region.region-name
+#   {search-engine}.{maps_slow_data_date}.full
+#   {search-engine}.{maps_slow_data_date}.{subset}
+#   {search-engine}.{maps_slow_data_date}.full-region.region-name
 #
 # Though:
 #
@@ -220,9 +225,9 @@ static_search_symlink_name: world-map
 static_search_data:
   # Cities-only static database
   # maps_search_static_db = "pop-1k-cities"
-  pop-1k-cities: "static-search.{{ maps_data_date }}.pop-1k-cities"
+  pop-1k-cities: "static-search.{{ maps_slow_data_date }}.pop-1k-cities"
 
   # Large cities-only static database
   # maps_search_static_db = "pop-100k-cities"
   # FOR TESTING ONLY
-  pop-100k-cities: "static-search.{{ maps_data_date }}.pop-100k-cities"
+  pop-100k-cities: "static-search.{{ maps_slow_data_date }}.pop-100k-cities"

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -2,7 +2,7 @@
 # something more in line with IIAB expectations.
 
 unpkg_url: https://unpkg.com
-iiab_map_host_url: https://iiab.switnet.org/maps/1
+iiab_map_host_url: https://iiab.switnet.org/maps/2
 
 # TODO I wonder if it should go under /library/maps/vector_tiles and symlink from the www directory.
 # That way it would be near the search data. It would be easier to find everything.

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -130,6 +130,8 @@
                             return 1
                         case 'osm-z9':
                             return 9
+                        case 'osm-z11':
+                            return 11
                         case 'osm-z14':
                             return 14
                         default:

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -143,13 +143,16 @@
                 },
 
                 getPmtilesName: (baseName) => {
+                    // baseName and fname won't include ".pmtiles". ".pmtiles" gets added by the calling function.
+
+                    if (!activeFQRegionName) {
+                        console.log("not currently viewing a Full Quality Region; pmtiles file name unchanged", baseName)
+                        return baseName
+                    }
+
                     const pmtilesDates = downloadedFQRegions[activeFQRegionName].dates
 
-                    // baseName and fname won't include ".pmtiles". ".pmtiles" gets added by the calling function.
-                    if (!activeFQRegionName) {
-                        fname = baseName
-                        console.log("not currently viewing a Full Quality Region; pmtiles file name unchanged", fname)
-                    } else if (baseName.startsWith("terrarium")) {
+                    if (baseName.startsWith("terrarium")) {
                         // terrarium actually starts with "terrarium-z0-z10".
                         // We chop off the z0-z10 to avoid confusing since we
                         // make lower zoom versions.

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -40,15 +40,10 @@
 
             let MAPS_SATELLITE_ZOOM = Number("{{ maps_satellite_zoom }}")
             if (Number.isNaN(MAPS_SATELLITE_ZOOM)) {
-                if ("{{ maps_satellite_zoom }}" === "full") {
-                    // Full quality is 13
-                    MAPS_SATELLITE_ZOOM = 13
-                } else {
-                    // Use a default that is hopefully always available.
-                    // We hope they notice and report the bug if it ever comes here!
-                    console.warn("Unexpected value for maps_satellite_zoom")
-                    MAPS_SATELLITE_ZOOM = 7
-                }
+                // Use a default that is hopefully always available.
+                // We hope they notice and report the bug if it ever comes here!
+                console.warn("Unexpected value for maps_satellite_zoom")
+                MAPS_SATELLITE_ZOOM = 7
             }
 
             let MAPS_TERRAIN_ZOOM = Number("{{ maps_terrain_zoom }}")
@@ -131,9 +126,11 @@
                     }
 
                     switch (MAPS_VECTOR_QUALITY) {
+                        case 'osm-z1':
+                            return 1
                         case 'osm-z9':
                             return 9
-                        case 'osm-full':
+                        case 'osm-z14':
                             return 14
                         default:
                             // It seems that maps.black sets this up whether or not "ne"

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -143,6 +143,8 @@
                 },
 
                 getPmtilesName: (baseName) => {
+                    const pmtilesDates = downloadedFQRegions[activeFQRegionName].dates
+
                     // baseName and fname won't include ".pmtiles". ".pmtiles" gets added by the calling function.
                     if (!activeFQRegionName) {
                         fname = baseName
@@ -151,13 +153,13 @@
                         // terrarium actually starts with "terrarium-z0-z10".
                         // We chop off the z0-z10 to avoid confusing since we
                         // make lower zoom versions.
-                        fname = `terrarium.${MAPS_SLOW_DATA_DATE}.full-region.` + activeFQRegionName
+                        fname = `terrarium.${pmtilesDates.terrain}.full-region.` + activeFQRegionName
                         console.log("pmtiles file name for full quality region", fname)
                     } else if (baseName.startsWith("openstreetmap")) {
-                        fname = baseName + `.${MAPS_VECTOR_DATA_DATE}.full-region.` + activeFQRegionName
+                        fname = baseName + `.${pmtilesDates.vector}.full-region.` + activeFQRegionName
                         console.log("pmtiles file name for full quality region", fname)
                     } else if (baseName.startsWith("s2maps")) {
-                        fname = baseName + `.${MAPS_SLOW_DATA_DATE}.full-region.` + activeFQRegionName
+                        fname = baseName + `.${pmtilesDates.satellite}.full-region.` + activeFQRegionName
                         console.log("pmtiles file name for full quality region", fname)
                     } else {
                         fname = baseName
@@ -248,7 +250,7 @@
                 for (regionName_ in downloadedFQRegions) {
                     const regionName = regionName_ // fix variable capturing in callbacks below
                     const regionId = "region-" + regionName
-                    const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[regionName]
+                    const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[regionName].bbox
 
                     if (mb.map.getSource(regionId)) {
                         // Looks like we already ran this. Quit without setting a timeout.
@@ -354,7 +356,7 @@
                         if (regionName === activeFQRegionName) {
                             return
                         }
-                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[regionName]
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[regionName].bbox
 
                         // First we kick off a zoom animation to a view focusing on the region.
                         mb.map.fitBounds([[min_lon, min_lat], [max_lon, max_lat]], {})
@@ -520,7 +522,7 @@
                     this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
                     this._container.style = 'cursor: pointer;'
                     this._container.onclick = () => {
-                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName].bbox
 
                         // First we kick off a zoom animation to a view focusing on the region, zoomed out a bit more than when we entered it.
                         mb.map.setMaxBounds() // untether us from the bounds first so we can zoom out further
@@ -568,7 +570,7 @@
                     this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
                     this._container.style = 'cursor: pointer;'
                     this._container.onclick = () => {
-                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName].bbox
 
                         // Zoom out to view the region so that the delete popup is well placed
                         mb.map.fitBounds([[min_lon, min_lat], [max_lon, max_lat]], {maxDuration: 2000, speed: 5})
@@ -1116,7 +1118,7 @@
 
                         // We are looking at a full quality region. Let's prevent
                         // the user from straying far from it so they don't get lost.
-                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName]
+                        const [min_lon, min_lat, max_lon, max_lat] = downloadedFQRegions[activeFQRegionName].bbox
                         mb.map.setMaxBounds([[min_lon - 0.5, min_lat - 0.5], [max_lon + 0.5, max_lat + 0.5]], {})
                     }
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -33,7 +33,7 @@
              *    configs   *
              ****************/
 
-            const MAPS_DATA_DATE = "{{ maps_data_date }}"
+            const MAPS_VECTOR_DATA_DATE = "{{ maps_vector_data_date }}"
             const MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
             const MAPS_VECTOR_QUALITY = "{{ maps_vector_quality }}"
             const MAPS_VECTOR_IS_OSM = MAPS_VECTOR_QUALITY.includes("osm")
@@ -154,7 +154,7 @@
                         fname = `terrarium.${MAPS_SLOW_DATA_DATE}.full-region.` + activeFQRegionName
                         console.log("pmtiles file name for full quality region", fname)
                     } else if (baseName.startsWith("openstreetmap")) {
-                        fname = baseName + `.${MAPS_DATA_DATE}.full-region.` + activeFQRegionName
+                        fname = baseName + `.${MAPS_VECTOR_DATA_DATE}.full-region.` + activeFQRegionName
                         console.log("pmtiles file name for full quality region", fname)
                     } else if (baseName.startsWith("s2maps")) {
                         fname = baseName + `.${MAPS_SLOW_DATA_DATE}.full-region.` + activeFQRegionName

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -224,8 +224,8 @@ def update_extracts_json():
         region_extracts[name]["bbox"] = coordinates
         region_type_for_date = {
             's2maps-sentinel2-2023': 'satellite',
-            'terrain': 'terrarium',
-            'vector': 'openstreetmap-openmaptiles',
+            'terrarium': 'terrain',
+            'openstreetmap-openmaptiles': 'vector',
         }[region_extract_type]
         region_extracts[name]["dates"][region_type_for_date] = date
         region_extract_types[name].add(region_extract_type)

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -219,7 +219,7 @@ def update_extracts_json():
         # Add coordinates unless it's for some reason inconsistent between satellite, vector, terrain.
         if name in region_extracts and region_extracts[name]['bbox'] != coordinates:
             raise Exception("Inconsistent coordinates between different region extracts for", name)
-        if not re.match('\d{4}-\d{2}-\d{2}', date):
+        if not re.match(r'\d{4}-\d{2}-\d{2}', date):
             raise Exception(f"Invalid date for {name}: {date}")
         region_extracts[name]["bbox"] = coordinates
         region_type_for_date = {

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -85,17 +85,21 @@ def delete_extract(extract_name):
     (with different dates), confirm with the user before deleting.
     """
 
-    region_extract_types_for_name = defaultdict(set)
+    region_extract_types_for_name = defaultdict(list)
     all_paths = []
     for full_path, region_extract_type, date, name in iter_region_files():
         if name != extract_name:
             continue
         all_paths.append(full_path)
-        region_extract_types_for_name[region_extract_type].add(date)
+        region_extract_types_for_name[region_extract_type].append(date)
+
+    if len(all_paths) == 0:
+        print (f"Found no Full Quality Regions with the name '{extract_name}'")
+        return
 
     # Something weird happened, maybe a mixture of dates or something.
-    if len(all_paths) != 3 or not all(len(dates) == 1 for dates in region_extract_types_for_name):
-        print ("There are an unexpected set of files for this region")
+    if [len(dates) for dates in region_extract_types_for_name.values()] != [1, 1, 1]:
+        print (f"There are an unexpected set of files for the region '{extract_name}'")
         print ("(expected exactly one 'openstreetmap', one 's2maps', and one 'terranium'):")
         print ()
         for path in all_paths:

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -30,6 +30,11 @@ def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
 
 def get_new_extract_paths(extract_name):
+    """
+    Get the paths for *new* FQRs. I.e. what we expect to be able to download
+    from the server. Existing FQRs on the file system may have different dates,
+    so we can't rely on this function for getting an inventory or deletion.
+    """
     MAPS_VECTOR_DATA_DATE = "{{ maps_vector_data_date }}"
     MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
     IIAB_MAP_HOST_URL = "{{ iiab_map_host_url }}"
@@ -55,6 +60,9 @@ def get_new_extract_paths(extract_name):
     }
 
 def iter_region_files():
+    """
+    Get an inventory of exsting FQRs on the file system.
+    """
     for full_path in glob.glob(os.path.join(HOSTING_DIR, "*.full-region.*.pmtiles")):
         match (os.path.basename(full_path).split('.')):
             case [region_extract_type, date, "full-region", name, "pmtiles"]:
@@ -84,6 +92,10 @@ def delete_extract(extract_name):
     satellite). If we are missing one, or if we have multiple of a given type
     (with different dates), confirm with the user before deleting.
     """
+
+    # We could have used the extracts json for this. However, that one might
+    # skip over duplicates. So long as we're deleting, let's show everything we
+    # have so the user can really clean things up.
 
     region_extract_types_for_name = defaultdict(list)
     all_paths = []

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -29,7 +29,7 @@ def validate_extract_box(extract_box):
 def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
 
-def get_extract_files(extract_name):
+def get_new_extract_paths(extract_name):
     MAPS_VECTOR_DATA_DATE = "{{ maps_vector_data_date }}"
     MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
     IIAB_MAP_HOST_URL = "{{ iiab_map_host_url }}"
@@ -54,7 +54,16 @@ def get_extract_files(extract_name):
         "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}", TERRAIN_ZOOM_RANGE),
     }
 
-def yes_no(prompt, noninteractive, noninteractive_response):
+def iter_region_files():
+    for full_path in glob.glob(os.path.join(HOSTING_DIR, "*.full-region.*.pmtiles")):
+        match (os.path.basename(full_path).split('.')):
+            case [region_extract_type, date, "full-region", name, "pmtiles"]:
+                pass
+            case _:
+                raise Exception("Oops can't parse pmtiles file name:", full_path)
+        yield full_path, region_extract_type, date, name
+
+def yes_no(prompt, noninteractive=False, noninteractive_response=None):
     if noninteractive:
         return noninteractive_response
     while True:
@@ -68,35 +77,63 @@ def yes_no(prompt, noninteractive, noninteractive_response):
 # Main functions
 
 def delete_extract(extract_name):
-    extract_files = get_extract_files(extract_name)
-    for files in extract_files.values():
-        if os.path.exists(files["extract"]):
-            os.remove(files["extract"])
+    """
+    Delete all full-region files whose name matches `extract_name`.
+
+    In the normal case, we will have one of each type (vector, terrain,
+    satellite). If we are missing one, or if we have multiple of a given type
+    (with different dates), confirm with the user before deleting.
+    """
+
+    region_extract_types_for_name = defaultdict(set)
+    all_paths = []
+    for full_path, region_extract_type, date, name in iter_region_files():
+        if name != extract_name:
+            continue
+        all_paths.append(full_path)
+        region_extract_types_for_name[region_extract_type].add(date)
+
+    # Something weird happened, maybe a mixture of dates or something.
+    if len(all_paths) != 3 or not all(len(dates) == 1 for dates in region_extract_types_for_name):
+        print ("There are an unexpected set of files for this region")
+        print ("(expected exactly one 'openstreetmap', one 's2maps', and one 'terranium'):")
+        print ()
+        for path in all_paths:
+            print("*", path)
+        print ()
+        yes_no("Confirm delete?")
+
+    for path in all_paths:
+        if os.path.dirname(path) != HOSTING_DIR or f".{extract_name}." not in path:
+            # Last-minute sanity check before deleting files in case some other
+            # error is introduced before we get to this point.
+            raise Exception(f"Unknown error. Stopping before we delete the wrong file!", path)
+        os.remove(path)
 
 def create_extract(extract_name, extract_box):
-    extract_files = get_extract_files(extract_name)
+    extract_paths = get_new_extract_paths(extract_name)
 
     # Extract them all successfully before moving them.
-    for files in extract_files.values():
+    for paths in extract_paths.values():
         result = subprocess.run(
-            [PMTILES, "extract", files["source"], files["tmp"], "--bbox=" + extract_box],
+            [PMTILES, "extract", paths["source"], paths["tmp"], "--bbox=" + extract_box],
         )
         if result.returncode != 0:
             raise Exception(f"Region download failed. Double-check your Internet connection. (error code {result.returncode})")
 
-    for files in extract_files.values():
-        shutil.move(files["tmp"], files["extract"])
+    for paths in extract_paths.values():
+        shutil.move(paths["tmp"], paths["extract"])
 
 
 def approve_download_size(extract_name):
-    extract_files = get_extract_files(extract_name)
+    extract_paths = get_new_extract_paths(extract_name)
     extract_sizes = {}
 
     print("Determining download size...")
 
-    for files in extract_files.values():
+    for paths in extract_paths.values():
         result = subprocess.run(
-            [PMTILES, "extract", files["source"], files["tmp"], "--bbox=" + extract_box, "--dry-run"],
+            [PMTILES, "extract", paths["source"], paths["tmp"], "--bbox=" + extract_box, "--dry-run"],
             capture_output=True,
             text=True,
         )
@@ -122,7 +159,7 @@ def approve_download_size(extract_name):
                 break
 
         if re_match is None:
-            return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?", False, None)
+            return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?")
 
         (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
 
@@ -133,7 +170,7 @@ def approve_download_size(extract_name):
             'GB': 1_000_000_000,
             'TB': 1_000_000_000_000,
         }
-        extract_sizes[files['source']] = {
+        extract_sizes[paths['source']] = {
             "transfer": float(transfer_num) * unit_mult[transfer_unit],
             "archive":  float(archive_num)   * unit_mult[archive_unit],
         }
@@ -205,15 +242,8 @@ def update_extracts_json():
     # region_extract_types[name] = {extract_type_1, extract_type_2, etc}
     region_extract_types = defaultdict(set)
 
-    for region_extract in glob.glob(os.path.join(HOSTING_DIR, "*.full-region.*.pmtiles")):
-
-        match (os.path.basename(region_extract).split('.')):
-            case [region_extract_type, date, "full-region", name, "pmtiles"]:
-                pass
-            case _:
-                raise Exception("Oops can't parse pmtiles file name:", region_extract)
-
-        output = subprocess.getoutput(PMTILES + " show " + region_extract + " --header-json")
+    for full_path, region_extract_type, date, name in iter_region_files():
+        output = subprocess.getoutput(PMTILES + " show " + full_path + " --header-json")
         coordinates = [float(coord) for coord in json.loads(output)["bounds"]]
 
         # Add coordinates unless it's for some reason inconsistent between satellite, vector, terrain.

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -29,14 +29,18 @@ def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
 
 def get_extract_files(extract_name):
-    MAPS_DATA_DATE = "{{ maps_data_date }}"
+    MAPS_VECTOR_DATA_DATE = "{{ maps_vector_data_date }}"
     MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
     IIAB_MAP_HOST_URL = "{{ iiab_map_host_url }}"
 
-    def get_paths(base):
+    VECTOR_ZOOM_RANGE = "z00-z{{ '%02d' % maps_vector_max_zoom }}"
+    SATELLITE_ZOOM_RANGE = "z00-z{{ '%02d' % maps_satellite_max_zoom }}"
+    TERRAIN_ZOOM_RANGE = "z00-z{{ '%02d' % maps_terrain_max_zoom }}"
+
+    def get_paths(base, max_zoom):
         return {
             "source":
-                f"{IIAB_MAP_HOST_URL}/{base}.full.pmtiles",
+                f"{IIAB_MAP_HOST_URL}/{base}.{max_zoom}.pmtiles",
             "extract":
                 os.path.join(HOSTING_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
             "tmp":
@@ -44,9 +48,9 @@ def get_extract_files(extract_name):
         }
 
     return {
-        "vector": get_paths(f"openstreetmap-openmaptiles.{MAPS_DATA_DATE}"),
-        "satellite": get_paths(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}"),
-        "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}"),
+        "vector": get_paths(f"openstreetmap-openmaptiles.{MAPS_VECTOR_DATA_DATE}", VECTOR_ZOOM_RANGE),
+        "satellite": get_paths(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}", SATELLITE_ZOOM_RANGE),
+        "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}", TERRAIN_ZOOM_RANGE),
     }
 
 def yes_no(prompt, noninteractive, noninteractive_response):

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -101,7 +101,8 @@ def delete_extract(extract_name):
         for path in all_paths:
             print("*", path)
         print ()
-        yes_no("Confirm delete?")
+        if not yes_no("Confirm delete?"):
+            return
 
     for path in all_paths:
         if os.path.dirname(path) != HOSTING_DIR or f".{extract_name}." not in path:

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -174,7 +174,7 @@ def check_for_overlaps(new_box):
 
     existing_region_extracts = json.loads(open(EXTRACTS_JSON).read())["regions"]
     for existing in existing_region_extracts.values():
-        [long_1, lat_1, long_2, lat_2] = existing
+        [long_1, lat_1, long_2, lat_2] = existing['bbox']
         existing_min_long = min([long_1, long_2])
         existing_max_long = max([long_1, long_2])
         existing_min_lat = min([lat_1, lat_2])

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-import collections, json, glob, os, re, shutil, string, subprocess, sys
+import json, glob, os, re, shutil, string, subprocess, sys
+from collections import defaultdict
 
 HOSTING_DIR = "{{ maps_serve_path }}"
 EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ tile_extract.info_file }}")
@@ -190,13 +191,24 @@ def check_for_overlaps(new_box):
     return True
 
 def update_extracts_json():
-    region_extracts = {}
-    region_extract_types = collections.defaultdict(set)
+    # region_extracts[name] = {
+    #   "bbox": coordinates,
+    #   "dates": {
+    #     "terrain": terrain_date,
+    #     "vector": vector_date,
+    #     "satellite": satellite_date,
+    #   },
+    # }
+    region_extracts = defaultdict(
+        lambda: dict(dates=defaultdict(dict)),
+    )
+    # region_extract_types[name] = {extract_type_1, extract_type_2, etc}
+    region_extract_types = defaultdict(set)
 
     for region_extract in glob.glob(os.path.join(HOSTING_DIR, "*.full-region.*.pmtiles")):
 
         match (os.path.basename(region_extract).split('.')):
-            case [region_extract_type, _date, "full-region", name, "pmtiles"]:
+            case [region_extract_type, date, "full-region", name, "pmtiles"]:
                 pass
             case _:
                 raise Exception("Oops can't parse pmtiles file name:", region_extract)
@@ -205,9 +217,17 @@ def update_extracts_json():
         coordinates = [float(coord) for coord in json.loads(output)["bounds"]]
 
         # Add coordinates unless it's for some reason inconsistent between satellite, vector, terrain.
-        if name in region_extracts and region_extracts[name] != coordinates:
+        if name in region_extracts and region_extracts[name]['bbox'] != coordinates:
             raise Exception("Inconsistent coordinates between different region extracts for", name)
-        region_extracts[name] = coordinates
+        if not re.match('\d{4}-\d{2}-\d{2}', date):
+            raise Exception(f"Invalid date for {name}: {date}")
+        region_extracts[name]["bbox"] = coordinates
+        region_type_for_date = {
+            's2maps-sentinel2-2023': 'satellite',
+            'terrain': 'terrarium',
+            'vector': 'openstreetmap-openmaptiles',
+        }[region_extract_type]
+        region_extracts[name]["dates"][region_type_for_date] = date
         region_extract_types[name].add(region_extract_type)
 
     for name in region_extract_types:

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -43,10 +43,10 @@ def get_new_extract_paths(extract_name):
     SATELLITE_ZOOM_RANGE = "z00-z{{ '%02d' % maps_satellite_max_zoom }}"
     TERRAIN_ZOOM_RANGE = "z00-z{{ '%02d' % maps_terrain_max_zoom }}"
 
-    def get_paths(base, max_zoom):
+    def get_paths(base, zoom_range):
         return {
             "source":
-                f"{IIAB_MAP_HOST_URL}/{base}.{max_zoom}.pmtiles",
+                f"{IIAB_MAP_HOST_URL}/{base}.{zoom_range}.pmtiles",
             "extract":
                 os.path.join(HOSTING_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
             "tmp":


### PR DESCRIPTION
### Description of changes proposed in this pull request:

* Update osm vector data to April 1 2026 (satellite, terrain, and even naturalearth vector doesn't seem to change)
* Change zoom naming scheme from (for example) `zoom_0-07` to `z00-07`
* Change zoom naming scheme from `full` to (in the case of OSM) `z00-z14`. i.e. explicitly name the zoom levels.
* Add `osm-z11` option.

#### So now the way this works:

As we add a new vector file and update the `vector_data_date`, Ansible will download the new file and update the symlink that index.html looks for.

FQRs are managed via the file `extracts.json` which `index.html` reads to know which FQR files exist. This PR changes the format of `extracts.json` to include the date, which `index.html` now needs to find the file, because it can no longer assume the date based on `vector_data_date`. There's no telling how old the FQRs are. The FQR managing script now will add the dates to `extracts.json` when it updates it. It is also a bit more careful about deleting them, in case stray files with different dates are somehow sitting around.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta