### PR TITLE
add release header [text description & links for IIAB pre-releases]

### DIFF
--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -329,14 +329,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           read -r -d '' RELEASE_HEADER <<EOF
-            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+          Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
-            Frequently Asked Questions: https://FAQ.IIAB.IO
+          Frequently Asked Questions: https://FAQ.IIAB.IO
 
-            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+          Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
 
-            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
-            EOF
+          Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+          EOF
 
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -328,7 +328,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          read -r -d '' RELEASE_HEADER <<EOF
+          cat <<EOF > RELEASE_HEADER.txt
           Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
           Frequently Asked Questions: https://FAQ.IIAB.IO
@@ -341,7 +341,7 @@ jobs:
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
-            --notes "$RELEASE_HEADER" \
+            --notes-file RELEASE_HEADER.txt \
             --generate-notes \
             --prerelease \
             --fail-on-no-commits \

--- a/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/15min-tiny-IMAGE-on-rpios-lite.yml
@@ -328,10 +328,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ env.RELEASE_NAME }} --target ${{ github.sha }} --fail-on-no-commits \
+          read -r -d '' RELEASE_HEADER <<EOF
+            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+
+            Frequently Asked Questions: https://FAQ.IIAB.IO
+
+            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+
+            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+            EOF
+
+          gh release create ${{ env.RELEASE_NAME }} \
+            --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
+            --notes "$RELEASE_HEADER" \
             --generate-notes \
             --prerelease \
+            --fail-on-no-commits \
             --repo ${{ github.repository }} || true
 
       - name: Upload image and manifest to Release

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -323,14 +323,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           read -r -d '' RELEASE_HEADER <<EOF
-            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+          Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
-            Frequently Asked Questions: https://FAQ.IIAB.IO
+          Frequently Asked Questions: https://FAQ.IIAB.IO
 
-            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+          Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
 
-            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
-            EOF
+          Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+          EOF
 
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -322,7 +322,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          read -r -d '' RELEASE_HEADER <<EOF
+          cat <<EOF > RELEASE_HEADER.txt
           Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
           Frequently Asked Questions: https://FAQ.IIAB.IO
@@ -335,7 +335,7 @@ jobs:
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
-            --notes "$RELEASE_HEADER" \
+            --notes-file RELEASE_HEADER.txt \
             --generate-notes \
             --prerelease \
             --fail-on-no-commits \

--- a/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
+++ b/.github/workflows/20min-small-IMAGE-on-rpios-lite.yml
@@ -322,10 +322,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ env.RELEASE_NAME }} --target ${{ github.sha }} --fail-on-no-commits \
+          read -r -d '' RELEASE_HEADER <<EOF
+            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+
+            Frequently Asked Questions: https://FAQ.IIAB.IO
+
+            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+
+            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+            EOF
+
+          gh release create ${{ env.RELEASE_NAME }} \
+            --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
+            --notes "$RELEASE_HEADER" \
             --generate-notes \
             --prerelease \
+            --fail-on-no-commits \
             --repo ${{ github.repository }} || true
 
       - name: Upload image and manifest to Release

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -323,14 +323,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           read -r -d '' RELEASE_HEADER <<EOF
-            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+          Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
-            Frequently Asked Questions: https://FAQ.IIAB.IO
+          Frequently Asked Questions: https://FAQ.IIAB.IO
 
-            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+          Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
 
-            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
-            EOF
+          Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+          EOF
 
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -322,7 +322,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          read -r -d '' RELEASE_HEADER <<EOF
+          cat <<EOF > RELEASE_HEADER.txt
           Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
 
           Frequently Asked Questions: https://FAQ.IIAB.IO
@@ -335,7 +335,7 @@ jobs:
           gh release create ${{ env.RELEASE_NAME }} \
             --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
-            --notes "$RELEASE_HEADER" \
+            --notes-file RELEASE_HEADER.txt \
             --generate-notes \
             --prerelease \
             --fail-on-no-commits \

--- a/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
+++ b/.github/workflows/25min-medium-IMAGE-on-rpios-desktop.yml.paused
@@ -322,10 +322,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ env.RELEASE_NAME }} --target ${{ github.sha }} --fail-on-no-commits \
+          read -r -d '' RELEASE_HEADER <<EOF
+            Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes
+
+            Frequently Asked Questions: https://FAQ.IIAB.IO
+
+            Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!
+
+            Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))
+            EOF
+
+          gh release create ${{ env.RELEASE_NAME }} \
+            --target ${{ github.sha }} \
             --title "IIAB Daily Build ${{ env.RELEASE_NAME }}" \
+            --notes "$RELEASE_HEADER" \
             --generate-notes \
             --prerelease \
+            --fail-on-no-commits \
             --repo ${{ github.repository }} || true
 
       - name: Upload image and manifest to Release


### PR DESCRIPTION
### Fixes bug:

Adds some release notes to the header of the GitHub Releases:

Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes

Frequently Asked Questions: https://FAQ.IIAB.IO

Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) before clicking on the links in the "Assets" section below!

Please see IIAB's [Contributors Guide](https://github.com/iiab/iiab/wiki/Contributors-Guide-(EN))