### PR TITLE
[proot] add switch for nginx config value on proot installations

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -51,8 +51,15 @@ http {
     access_log {{ nginx_log_dir }}/access.log awstats;
 
     # 2025-04-20 Have syslog write nginx error logs to modern systemd / journalctl logs
+{% if is_proot %}
+    # In PRoot, there is not systemd daemon, so we write to a standard file.
+    error_log {{ nginx_log_dir }}/error.log;
+    # error_log syslog:server=unix:/dev/log;
+{% else %}
+    # Standard environment with systemd.
     # error_log {{ nginx_log_dir }}/error.log;
     error_log syslog:server=unix:/dev/log;
+{% endif %}
 
     log_format scripts '$request > $document_root$fastcgi_script_name $fastcgi_path_info';
     access_log {{ nginx_log_dir }}/scripts.log scripts;


### PR DESCRIPTION
### Fixes bug:
Terminal spammed with log not being logging correctly

### Description of changes proposed in this pull request:
Adds a switch on the config template to behave according to the host installation setup

### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 