### PR TITLE
Rename Natural Earth map config val from "ne" to "nat-z8"

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -19,7 +19,7 @@ You need to decide (A) how much global vector detail... and (B) how much global 
 
 Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) (do this before installing IIAB software!)
 
-1. If you want **~170 MB** = 85 MB vector (Lower detail, up to [zoom level](https://wiki.openstreetmap.org/wiki/Zoom_levels) 8 [users can overzoom to zoom 12], from [Natural Earth](https://www.naturalearthdata.com/) a.k.a. "ne") + 85 MB satellite (up to zoom 7):
+1. If you want **~170 MB** = 85 MB vector (Lower detail, up to [zoom level](https://wiki.openstreetmap.org/wiki/Zoom_levels) 8 [users can overzoom to zoom 12], from [Natural Earth](https://www.naturalearthdata.com/) a.k.a. "nat-z8") + 85 MB satellite (up to zoom 7):
 
    ```
    osm_vector_maps_install: False
@@ -28,7 +28,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
    maps_install: True
    maps_enabled: True
 
-   maps_vector_quality: ne
+   maps_vector_quality: nat-z8
    maps_satellite_zoom: 7
    ```
 

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -108,7 +108,7 @@ maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
 maps_dot_black_ne_symlink_name: naturalearth-openmaptiles.pmtiles
 
 # File size circa Sept 2025
-# TODO - hopefully before this is merged, we'll get rid of "ne" (naturalearth)
+# TODO - hopefully before this is merged, we'll get rid of "nat-z8" (naturalearth)
 # option and just have low zoom osm. So then it will be `maps_vector_zoom` and
 # just have numbers, like for satellite.
 maps_dot_black_vector_tiles:
@@ -123,9 +123,9 @@ maps_dot_black_vector_tiles:
   osm-z11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z11.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads.
-  # maps_vector_quality = "ne"
-  # (ne = "Natural Earth")
-  ne: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.z00-z08.pmtiles"
+  # maps_vector_quality = "nat-z8"
+  # (nat-z8 = "Natural Earth")
+  nat-z8: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.z00-z08.pmtiles"
 
   # FOR TESTING ONLY
   # "medium res" osm, up to zoom level 1 (original file has 14).

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -52,14 +52,14 @@
     src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
-  when: maps_vector_quality != "ne"
+  when: maps_vector_quality != "nat-z8"
 
 - name: Select vector tiles (if naturalearth)
   file:
     src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_ne_symlink_name }}"
     state: link
-  when: maps_vector_quality == "ne"
+  when: maps_vector_quality == "nat-z8"
 
 - name: "Make sure maps_satellite_zoom has a valid value"
   assert:

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -133,7 +133,7 @@
                         case 'osm-z14':
                             return 14
                         default:
-                            // It seems that maps.black sets this up whether or not "ne"
+                            // It seems that maps.black sets this up whether or not "nat-z8"
                             // (naturalearth) is selected (perhaps due to a timing issue).
                             // So, we'll give it some valid value.
                             return 1

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -512,7 +512,7 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False
 maps_enabled: False
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -512,7 +512,7 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False
 maps_enabled: False
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -45,7 +45,7 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_android.yml
+++ b/vars/local_vars_android.yml
@@ -45,7 +45,7 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -320,7 +320,7 @@ maps_from_internet_archive: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_quality: osm-z1            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: osm-z1             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -320,7 +320,7 @@ maps_from_internet_archive: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_quality: osm-z1             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: osm-z1            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -301,7 +301,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -307,7 +307,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: ne                 # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -307,7 +307,7 @@ maps_from_internet_archive: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8            # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.


### PR DESCRIPTION
### Description of changes proposed in this pull request:

A less confusing name for the Natural Earth setting that also includes the max zoom value, to put it in line with osm-z*

### Smoke-tested on which OS or OS's:

RasPiOS Trixie

### Mention a team member @username e.g. to help with code review:
@holta 