### PR TITLE
Move maps web root to /library/www/maps

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -4,10 +4,8 @@
 unpkg_url: https://unpkg.com
 iiab_map_host_url: https://iiab.switnet.org/maps/2
 
-# TODO I wonder if it should go under /library/maps/vector_tiles and symlink from the www directory.
-# That way it would be near the search data. It would be easier to find everything.
-maps_serve_path: "{{ content_base }}/www/osm/maps"    # /library/www/osm/maps
-maps_data_root: "{{ content_base }}/maps"             # /library/maps
+maps_serve_path: "{{ content_base }}/www/maps"  # /library/www/maps
+maps_data_root: "{{ content_base }}/maps"       # /library/maps
 
 nominatim_user: nominatim
 nominatim_home: /srv/nominatim

--- a/roles/maps/templates/maps-nginx.conf.j2
+++ b/roles/maps/templates/maps-nginx.conf.j2
@@ -19,5 +19,5 @@ location ~ ^/maps/ {
         gzip_static on;
     }
 
-    root /library/www/osm;
+    root /library/www;
 }


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Move web root of maps from /library/www/osm/maps to /library/www/maps

### Smoke-tested on which OS or OS's:

RasPi OS Trixie. I tried running maps role then osm-vector-maps role and then maps role again after to make sure that "last installed wins" still works.

### Mention a team member @username e.g. to help with code review:
@holta 

### NOTE
For anybody running this on existing installations: you may consider manually moving the directory to avoid downloading everything all over again!