### PR TITLE
iiab-vpn: Convert whitespace to '_' in eccentric hostnames (for clean output columns)

### DIFF
--- a/roles/tailscale/templates/iiab-vpn
+++ b/roles/tailscale/templates/iiab-vpn
@@ -63,7 +63,7 @@ echo -e "    tailscale logout\n"
 #echo -e '\033[44;37mVPN peers: ("true" in 6th column means online)\033[0m\n'
 echo -e '\033[44;37mVPN peers: (6th column = online/offline)\033[0m\n'
 # (try .Tags[] catch "-") is safer than (.Tags[]? // "-") according to: https://stackoverflow.com/questions/54794749/jq-error-at-stdin0-cannot-iterate-over-null-null
-tailscale status --json | jq -r '.Self,.Peer[] | (try .Tags[] catch "-") + " " + .TailscaleIPs[] + " " + .HostName + " " + .DNSName + " " + (if .Relay == "" then "-" else .Relay end) + " XXX" + (.Online|tostring) + "XXX " + .OS' | sort -V | column -t | \
+tailscale status --json | jq -r '.Self,.Peer[] | (try .Tags[] catch "-") + " " + .TailscaleIPs[] + " " + (.HostName | gsub("\\s+"; "_")) + " " + .DNSName + " " + (if .Relay == "" then "-" else .Relay end) + " XXX" + (.Online|tostring) + "XXX " + .OS' | sort -V | column -t | \
     while read l; do
         line=$(echo "$l" | sed 's/ XXXtrueXXX /\\033[0;32m ✅\\033[0m/ ; s/ XXXfalseXXX /\\033[0;31m ❌ \\033[0m/')
         echo -e "$line" $(tailscale whois --json $(echo $line | cut -d' ' -f2) | jq -r '.Node.Hostinfo | .Distro + " " + .DistroVersion + " " + .DeviceModel');


### PR DESCRIPTION
### Fixes bug:

"Pixel 6a" was being broken apart into 2 coluimns.

### Description of changes proposed in this pull request:

Whitespace in tailscale hostnames is converted to underscores (e.g. "Pixel_6a") — allowing for `iiab-vpn` text output columns to remain clean.

### Smoke-tested on which OS or OS's:

Ubuntu 24.04

### Mention a team member @username e.g. to help with code review:

@ZachLiebl