### PR TITLE
Map search length and placeholder

### DIFF
--- a/roles/maps/files/static_search.js
+++ b/roles/maps/files/static_search.js
@@ -18,6 +18,7 @@ var AddressTextualIndex = class {
     const data = await (await this.fetcher(`${this.baseURL}/index_metadata.json`)).json();
     this.stopWords = new Set(data.stopwords);
     this.minLength = data.token_length;
+    this.numCities = data.num_cities;
   }
   async fileSearch(queryTokens) {
     let results = [];

--- a/roles/maps/files/static_search.js
+++ b/roles/maps/files/static_search.js
@@ -18,7 +18,7 @@ var AddressTextualIndex = class {
     const data = await (await this.fetcher(`${this.baseURL}/index_metadata.json`)).json();
     this.stopWords = new Set(data.stopwords);
     this.minLength = data.token_length;
-    this.numCities = data.num_cities;
+    this.numCities = data.num_cities || 163042;
   }
   async fileSearch(queryTokens) {
     let results = [];

--- a/roles/maps/files/static_search.js
+++ b/roles/maps/files/static_search.js
@@ -18,7 +18,7 @@ var AddressTextualIndex = class {
     const data = await (await this.fetcher(`${this.baseURL}/index_metadata.json`)).json();
     this.stopWords = new Set(data.stopwords);
     this.minLength = data.token_length;
-    this.numCities = data.num_cities || 163042;
+    this.numCities = Number(data.num_cities) || 163042;
   }
   async fileSearch(queryTokens) {
     let results = [];

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -916,7 +916,7 @@
 
                         if (window.staticSearch.engine.numCities) {
                             geocoder.setPlaceholder(
-                              `Search ${window.staticSearch.engine.numCities} cities`
+                              `Search ${window.staticSearch.engine.numCities} places`
                             )
                         }
                     },

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -825,6 +825,20 @@
                 }
             };
 
+            const getMaxSearchResults = () => {
+                // Instead of trying to test for phone (but not tablet), let's
+                // just get to the point that small screens should have fewer results.
+                // In case the user changes their orientation in a way that crosses the
+                // 1000 height threshold, we can call this again to reset the limit.
+
+                // If it's a small screen only have 5 results
+                if (window.innerHeight < 650 || window.innerWidth < 650)
+                {
+                    return 5
+                }
+                return 10
+            }
+
             // have to use MAX_SEARCH_RESULT_ZOOM in a couple different places to cover a couple different scenarios, it seems
             const MAX_SEARCH_RESULT_ZOOM = 10;
             const geocoderCommonOptions = {
@@ -834,6 +848,7 @@
                     maxZoom: MAX_SEARCH_RESULT_ZOOM,
                 },
                 popup: true,
+                limit: getMaxSearchResults(),
             }
 
             const geocoderAlternatives = {
@@ -903,6 +918,9 @@
                     geocoderAlternatives[MAP_SEARCH_ENGINE].api,
                     geocoderAlternatives[MAP_SEARCH_ENGINE].options,
                 )
+                addEventListener("resize", () => {
+                    geocoder.setLimit(getMaxSearchResults())
+                })
             }
             const scaleControl = new maplibregl.ScaleControl()
             drawControl = new MaplibreTerradrawControl.MaplibreTerradrawControl({

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -842,10 +842,7 @@
             const getMaxSearchResults = () => {
                 // Instead of trying to test for phone (but not tablet), let's
                 // just get to the point that small screens should have fewer results.
-                // In case the user changes their orientation in a way that crosses the
-                // 1000 height threshold, we can call this again to reset the limit.
 
-                // If it's a small screen only have 5 results
                 if (window.innerHeight < 650 || window.innerWidth < 650)
                 {
                     return 5

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -66,8 +66,6 @@
             const WORLD_MAP_TERRAIN_MAX_ZOOM = (num => {
                 if (Number.isNaN(num)) {
                     if ("{{ maps_terrain_zoom }}" === "none") {
-                        // I don't think this will ever happen so long as we don't
-                        // let the user look at satellite or hybrid.
                         return null
                     }
 
@@ -243,6 +241,22 @@
 
                 // contour lines is another thing that uses terrain maps, which we can consider
                 mb.terrain = mb.hillshade = (terrain === 't') && terrainAvailable()
+            }
+
+            // await until(function () { return someCondition })
+            // or
+            // await until(() => someCondition)
+            function until(condition, period=300) {
+                return new Promise(resolve => {
+                    function check() {
+                        if (condition()) {
+                            resolve()
+                        } else {
+                            setTimeout(check, period)
+                        }
+                    }
+                    check()
+                })
             }
 
             // We need a timeout to wait for mb.map.style.loaded() to be true and
@@ -860,6 +874,7 @@
                         "wikipedia": "Wikipedia is used to determine importance of search results.\n\nhttps://en.wikipedia.org/wiki/Wikipedia:Copyrights",
                         "wikidata": "Wikidata is used to determine importance of search results.\n\nhttps://www.wikidata.org/wiki/Wikidata:Licensing",
                     },
+                    setPlaceholder: () => {},
                 },
                 static: {
                     licenses: {
@@ -893,6 +908,21 @@
 
                         ...geocoderCommonOptions
                     },
+                    setPlaceholder: async () => {
+                        // some stuff that needs to exist before we can set the placeholder
+                        await until(() => (
+                          window.staticSearch &&
+                          window.staticSearch.engine &&
+                          window.staticSearch.engine.numCities &&
+                          geocoder._inputEl
+                        ))
+
+                        if (window.staticSearch.engine.numCities) {
+                            geocoder.setPlaceholder(
+                              `Search ${window.staticSearch.engine.numCities} cities`
+                            )
+                        }
+                    },
                 },
             }
 
@@ -921,6 +951,7 @@
                 addEventListener("resize", () => {
                     geocoder.setLimit(getMaxSearchResults())
                 })
+                geocoderAlternatives[MAP_SEARCH_ENGINE].setPlaceholder()
             }
             const scaleControl = new maplibregl.ScaleControl()
             drawControl = new MaplibreTerradrawControl.MaplibreTerradrawControl({

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -916,7 +916,7 @@
 
                         if (window.staticSearch.engine.numCities) {
                             geocoder.setPlaceholder(
-                              `Search ${window.staticSearch.engine.numCities} places`
+                              `Search ${window.staticSearch.engine.numCities.toLocaleString()} places`
                             )
                         }
                     },


### PR DESCRIPTION
### Description of changes proposed in this pull request:

#### More search results shown.

At least for now, instead of looking at user agent and trying to figure out "what counts as a phone but not a tablet?" I figure we could cut to the chase and look at the window size. (Not even screen size; if a desktop user shrinks their window we may as well accommodate that as well). For now for "small windows" I stay at 5 search results, for larger I do 10.

We may want to tweak all of this. For instance on my phone in landscape mode I only see 4 but on portrait mode I can fit all 5. But I haven't made anything worse.

#### List city count in placeholder text

In my data repository, [I made a change](https://github.com/iiab/maps2/commit/981e492ed6f10caba6584e87062659e4e4e2afd6) to add the city count to the static search database, primarily so that we can easily see it to add it to the README. It's not in the currently released database, but soon. In the mean time, so long as it's there, I thought I'd experiment with showing it in the search bar as the placeholder text, as seen here:

<img width="249" height="51" alt="search" src="https://github.com/user-attachments/assets/d02a775c-8a6e-4a0f-b955-d8ec3106453a" />


Again this number is not in the currently released database so until it's released it'll still say "Search".

I can also remove or revise this. It was an idea. I may have seen it in the previous IIAB osm-vector-maps actually, maybe I got the idea from there.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta 