### PR TITLE
Update to Moodle 5.2

### DIFF
--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -11,7 +11,7 @@
 # April 2025: Currently testing Moodle's main branch is mandatory if your...
 # OS PHP >= 8.5, see moodle/tasks/install.yml for detail!  OR, *IF* your...
 # OS PHP < 8.5, then {{ moodle_version }} will be attempted:
-moodle_version: MOODLE_501_STABLE    # Moodle 5.1
+moodle_version: MOODLE_502_STABLE    # Moodle 5.2
 #moodle_version: main                # e.g. to try Moodle's "weekly" 5.1dev pre-release *EVEN IF* OS PHP < 8.5
 moodle_repo_url: https://github.com/moodle/moodle
 #moodle_repo_url: git://git.moodle.org/moodle.git    # 2020-10-16: VERY Slow!

--- a/roles/moodle/tasks/install.yml
+++ b/roles/moodle/tasks/install.yml
@@ -90,21 +90,21 @@
 #     moodle_version: MOODLE_401_STABLE    # i.e. Moodle 4.1 LTS
 #   when: php_version is version('8.0', '<') or not dpkg_arch.stdout is search("64")
 
-- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} < 8.5
+- name: Download (clone) {{ moodle_repo_url }} branch '{{ moodle_version }}' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} <= 8.5
   git:
     repo: "{{ moodle_repo_url }}"    # https://github.com/moodle/moodle
     dest: "{{ moodle_base }}"        # /opt/iiab/moodle
     depth: 1
     version: "{{ moodle_version }}"    # e.g. MOODLE_500_STABLE (Moodle 5.0)
-  when: php_version is version('8.5', '<')
+  when: php_version is version('8.5', '<=')
 
-- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'main' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} >= 8.5"
+- name: "MOODLE PRE-RELEASE TESTING: Download (clone) {{ moodle_repo_url }} branch 'main' to {{ moodle_base }} (~476 MB initially, ~504 MB later) if OS PHP {{ php_version }} > 8.5"
   git:
     repo: "{{ moodle_repo_url }}"
     dest: "{{ moodle_base }}"
     depth: 1
     version: main    # For "weekly" Moodle pre-releases: https://download.moodle.org/releases/development/ (e.g. 3.5beta+ in May 2018, 4.1dev in Sept 2022, 4.2dev in Dec 2022, 4.3dev in May 2023, 4.4dev in Oct 2023, 4.5dev in Apr 2024, 5.0dev in Oct 2024, 5.1dev in Apr 2025, 5.2dev in Oct 2025)
-  when: php_version is version('8.5', '>=')
+  when: php_version is version('8.5', '>')
 
 - name: chown -R {{ apache_user }}:{{ apache_user }} {{ moodle_base }} (by default dirs 755 & files 644)
   file:


### PR DESCRIPTION
New Moodle 5.2 release process is fully underway since yesterday — official announcement is tomorrow:

- https://moodledev.io/general/releases/5.2
- https://docs.moodle.org/502/en/New_features

FYI this PR also forces the install of pre-release Moodle 8.3dev (forthcoming LTS) if PHP > 8.5 is detected.  If really necessary, we can change that condition down the road, to PHP > 8.4

Building on:

- PR https://github.com/iiab/iiab/pull/4110