### PR TITLE
Set geocoder placeholder on every map refresh

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -948,7 +948,6 @@
                 addEventListener("resize", () => {
                     geocoder.setLimit(getMaxSearchResults())
                 })
-                geocoderAlternatives[MAP_SEARCH_ENGINE].setPlaceholder()
             }
             const scaleControl = new maplibregl.ScaleControl()
             drawControl = new MaplibreTerradrawControl.MaplibreTerradrawControl({
@@ -1226,6 +1225,8 @@
                         // https://github.com/maps-black/maps.black/blob/12205728ceb0672682381088c6c1e7ad05fdc4f5/client/maps.black.js#L120
                         mb.licenses = mb.licenses || { data: {}, styles: {}, fonts: {} }
                         mb.licenses.search = geocoderAlternatives[MAP_SEARCH_ENGINE].licenses
+
+                        geocoderAlternatives[MAP_SEARCH_ENGINE].setPlaceholder()
                     }
                     mb.map.addControl(scaleControl);
 


### PR DESCRIPTION
### Fixes bug:

Custom map search placeholder (that shows the number of places to search for) disappears when you turn the globe on or off, or change the map style.

### Description of changes proposed in this pull request:

Refresh the map placeholder in an existing function that sets up the map after each "refresh". The way maps.black is designed, it sort of rebuilds the map every time you change one of these settings.

### Smoke-tested on which OS or OS's:

RasPiOS Trixie

### Mention a team member @username e.g. to help with code review:
@holta 