### PR TITLE
maps: delete unused satellite and terrain symlinks

### DIFF
--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -81,6 +81,12 @@
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
         state: link
 
+- name: Remove unused satellite symlink
+  when: maps_satellite_zoom == "none"
+  file:
+    path: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
+    state: absent
+
 - when: maps_terrain_zoom != "none"
   block:
     - name: "Make sure maps_terrain_zoom has a valid value"
@@ -100,6 +106,12 @@
         src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
         state: link
+
+- name: Remove unused terrain symlink
+  when: maps_terrain_zoom == "none"
+  file:
+    path: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
+    state: absent
 
 - name: Initiate the extracts json
   copy:


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

If satellite or terrain are unused, `absent` the appropriate symlink file(s).

As requested: https://github.com/iiab/iiab/pull/4368#pullrequestreview-4129306826

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@holta 