### PR TITLE
2604 net Rpi [Softcode iiab_wireless_lan_iface for Ubuntu 26.04 on RPi: wld0 instead of ap0]

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -55,7 +55,7 @@ strict_networking: False
 iiab_demo_mode: False
 gui_static_wan: False
 wan_cidr: ""
-virtual_network_devices: "-e wwlan -e ppp -e ap0 -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e tailscale0"
+virtual_network_devices: "-e wwlan -e ppp -e ap0 -e wld0 -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e tailscale0"
 
 # Set defaults for discovery process as strings
 wifi1: "not found-1"

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -55,7 +55,7 @@ strict_networking: False
 iiab_demo_mode: False
 gui_static_wan: False
 wan_cidr: ""
-virtual_network_devices: "-e wwlan -e ppp -e ap0 -e wld0 -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e tailscale0"
+virtual_network_devices: "-e wwlan -e ppp -e ap0 -e wld0 -e lo -e br0 -e tun -e br- -e docker -e bridge0 -e veth -e tailscale0 -e bnep0"
 
 # Set defaults for discovery process as strings
 wifi1: "not found-1"

--- a/roles/network/tasks/NM-debian.yml
+++ b/roles/network/tasks/NM-debian.yml
@@ -42,7 +42,7 @@
 - name: Copy ap0-manage.conf for NetworkManager
   template:
     dest: /etc/NetworkManager/conf.d/ap0-manage.conf
-    src: network/ap0-manage.conf
+    src: network/ap0-manage.conf.j2
     mode: "0644"
   when: discovered_wireless_iface != "none" and wifi_up_down
 

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -110,13 +110,13 @@
   set_fact:
     wifi2: "{{ item | trim }}"
     discovered_wireless_iface: "{{ item | trim }}"
-  when: wireless_list2.stdout is defined and item | trim != "ap0"
+  when: wireless_list2.stdout is defined and item | trim != "ap0" and item | trim != "wld0"
   with_items:
     - "{{ wireless_list2.stdout_lines }}"
 #item | trim != discovered_wan_iface
 
 - name: Count WiFi ifaces
-  shell: "ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}' | grep -v -e ap0 | wc -l"
+  shell: "ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}' | grep -v -e ap0 -e wld0 | wc -l"
   register: count_wifi_interfaces
 
 - name: Remember number of WiFi devices
@@ -227,6 +227,12 @@
   set_fact:
     iiab_wireless_lan_iface: ap0
   when: discovered_wireless_iface != "none" and wifi_up_down
+
+# might need to expand the coverage to NM and non-rpi hardware
+- name: Set iiab_wireless_lan_iface to wld0 if WiFi device is present on U26.04 and is a Rpi
+  set_fact:
+    iiab_wireless_lan_iface: wld0
+  when: discovered_wireless_iface != "none" and wifi_up_down and systemd_networkd_active and rpi_model != "none" and os_ver is version('ubuntu-2604', '<=')
 
 - name: Set iiab_wired_lan_iface if present
   set_fact:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -232,7 +232,7 @@
 - name: Set iiab_wireless_lan_iface to wld0 if WiFi device is present on U26.04 and is a Rpi
   set_fact:
     iiab_wireless_lan_iface: wld0
-  when: discovered_wireless_iface != "none" and wifi_up_down and rpi_model != "none" and is_ubuntu and os_ver is version('ubuntu-2604', '<=')
+  when: discovered_wireless_iface != "none" and wifi_up_down and rpi_model != "none" and is_ubuntu and os_ver is version('ubuntu-2604', 'ge')
 
 - name: Set iiab_wired_lan_iface if present
   set_fact:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -391,6 +391,14 @@
     value: "{{ cmdline_country_code.stdout }}"
   when: cmdline_country_code.stdout is defined and cmdline_country_code.stdout != ""
 
+- name: Add 'detected_network' variable 'wireless_lan_iface' value if defined and non-empty, to {{ iiab_ini_file }}
+  ini_file:
+    dest: "{{ iiab_ini_file }}"
+    section: detected_network
+    option: wireless_lan_iface
+    value: "{{ iiab_wireless_lan_iface }}"
+  when: iiab_wireless_lan_iface is defined and iiab_wireless_lan_iface != ""
+
 # well if there ever was a point to tell the user things are FUBAR this is it.
 # limit 2 network adapters wifi wired
 - name: I'm not guessing declare gateway please

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -232,7 +232,7 @@
 - name: Set iiab_wireless_lan_iface to wld0 if WiFi device is present on U26.04 and is a Rpi
   set_fact:
     iiab_wireless_lan_iface: wld0
-  when: discovered_wireless_iface != "none" and wifi_up_down and rpi_model != "none" and os_ver is version('ubuntu-2604', '<=')
+  when: discovered_wireless_iface != "none" and wifi_up_down and rpi_model != "none" and is_ubuntu and os_ver is version('ubuntu-2604', '<=')
 
 - name: Set iiab_wired_lan_iface if present
   set_fact:

--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -228,11 +228,11 @@
     iiab_wireless_lan_iface: ap0
   when: discovered_wireless_iface != "none" and wifi_up_down
 
-# might need to expand the coverage to NM and non-rpi hardware
+# might need to expand the coverage to non-rpi hardware
 - name: Set iiab_wireless_lan_iface to wld0 if WiFi device is present on U26.04 and is a Rpi
   set_fact:
     iiab_wireless_lan_iface: wld0
-  when: discovered_wireless_iface != "none" and wifi_up_down and systemd_networkd_active and rpi_model != "none" and os_ver is version('ubuntu-2604', '<=')
+  when: discovered_wireless_iface != "none" and wifi_up_down and rpi_model != "none" and os_ver is version('ubuntu-2604', '<=')
 
 - name: Set iiab_wired_lan_iface if present
   set_fact:

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -36,7 +36,7 @@
     - { src: 'hostapd/iiab-clone-wifi.service.j2', dest: '/etc/systemd/system/iiab-clone-wifi.service', mode: '0644' }
     #- { src: 'hostapd/iiab-wifi-test.service.j2', dest: '/etc/systemd/system/iiab-wifi-test.service', mode: '0644'}
     - { src: 'hostapd/iiab-test-wifi.j2', dest: '/usr/sbin/iiab-test-wifi', mode: '0755' }
-    - { src: 'hostapd/98-iiab.conf', dest: '/etc/sysctl.d/98-iiab.conf', mode: '0644' }
+    - { src: 'hostapd/98-iiab.conf.j2', dest: '/etc/sysctl.d/98-iiab.conf', mode: '0644' }
   when: can_be_ap
 
 - name: Use custom 'hostapd' systemd service unit file for {{ discovered_wireless_iface }} when not wifi_up_down

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -15,7 +15,7 @@
   when: current_client_channel.stdout is defined and current_client_channel.stdout != "" and current_client_channel.stdout|int <= 13
 
 - name: Generate new random mac address for ap0
-  shell: tr -dc A-F0-9 < /dev/urandom | head -c 10 | sed -r 's/(..)/\1:/g;s/:$//;s/^/02:/'
+  shell: tr -dc A-F0-9 < /dev/urandom | head -c 10 | sed -r 's/(..)/\1:/g;s/:$//;s/^/02:/' | tr '[:upper:]' '[:lower:]'
   register: ap0_mac
   when: can_be_ap
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -51,6 +51,9 @@
   #### End services
 
   #### Start network layout
+    - name: hostapd
+      include_tasks: hostapd.yml
+
     - name: netplan bridge
       include_tasks: netplan-br0.yml
       when: has_netplan and iiab_lan_iface == "br0"
@@ -119,9 +122,6 @@
         - not is_raspbian and not network_manager_active and not systemd_networkd_active
         - not is_proot
     #### end network layout
-
-    - name: hostapd
-      include_tasks: hostapd.yml
 
     - name: Restart services (and clone wifi to create ap0 if necessary)
       include_tasks: restart.yml

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -29,6 +29,7 @@
     mode: "0600"
 
 - name: Copy netplan templates for br0 wired slaves
+  when: use_wired_slaves
   template:
     src: network/60-slave.yml.j2
     dest: /etc/netplan/60-slave-{{ item | trim }}.yaml

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -28,7 +28,7 @@
 
 - name: Find macaddress for br0 bluetooth slave
   when: bluetooth_enabled
-  command: hciconfig | grep 'BD Address' | cut -d' ' -f3
+  shell: hciconfig | grep 'BD Address' | cut -d' ' -f3
   register: BT_mac
 
 - name: Setting ap0 mac address for use in hostapd service file

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -1,9 +1,3 @@
-- name: Copy netplan template for br0
-  template:
-    src: network/60-iiab.yml.j2
-    dest: /etc/netplan/60-iiab.yaml
-    mode: "0600"
-
 - name: Remove stale IIAB-Bridge.network when using netplan
   file:
     path: /etc/systemd/network/IIAB-Bridge.network
@@ -13,6 +7,26 @@
   file:
     path: /etc/systemd/network/IIAB-Bridge.netdev
     state: absent
+
+- name: Copy netplan template for br0
+  template:
+    src: network/60-iiab.yml.j2
+    dest: /etc/netplan/60-iiab.yaml
+    mode: "0600"
+
+- name: Copy netplan template for br0 WiFi slave
+  when: iiab_wireless_lan_iface is defined
+  template:
+    src: network/60-WiFi.yml.j2
+    dest: /etc/netplan/60-WiFi.yaml
+    mode: "0600"
+
+- name: Copy netplan template for br0 bluetooth slave
+  when: bluetooth_enabled
+  template:
+    src: network/60-BT.yml
+    dest: /etc/netplan/60-BT-iiab.yaml
+    mode: "0600"
 
 - name: Copy netplan templates for br0 wired slaves
   template:

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -21,6 +21,11 @@
     dest: /etc/netplan/60-WiFi.yaml
     mode: "0600"
 
+- name: Remove stale br0 WiFi slave
+  when: iiab_wireless_lan_iface is defined
+  command: nmcli c delete netplan-{{ iiab_wireless_lan_iface }}
+  ignore_errors: True
+
 - name: Copy netplan template for br0 bluetooth slave
   when: bluetooth_enabled
   template:

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -29,14 +29,13 @@
     mode: "0600"
 
 - name: Copy netplan templates for br0 wired slaves
-  when: use_wired_slaves
+  when: use_wired_slaves and iiab_wired_lan_iface is defined and num_lan_interfaces | int >= 1
   template:
     src: network/60-slave.yml.j2
     dest: /etc/netplan/60-slave-{{ item | trim }}.yaml
     mode: "0600"
   with_items:
     - "{{ lan_list_result.stdout_lines }}"
-  when: iiab_wired_lan_iface is defined and num_lan_interfaces | int >= 1
 
 - name: Generate Netplan bridge files
   shell: netplan generate

--- a/roles/network/tasks/netplan-br0.yml
+++ b/roles/network/tasks/netplan-br0.yml
@@ -26,6 +26,16 @@
   command: nmcli c delete netplan-{{ iiab_wireless_lan_iface }}
   ignore_errors: True
 
+- name: Find macaddress for br0 bluetooth slave
+  when: bluetooth_enabled
+  command: hciconfig | grep 'BD Address' | cut -d' ' -f3
+  register: BT_mac
+
+- name: Setting ap0 mac address for use in hostapd service file
+  when: bluetooth_enabled
+  set_fact:
+    BT_mac_addr: "{{ BT_mac.stdout }}"
+
 - name: Copy netplan template for br0 bluetooth slave
   when: bluetooth_enabled
   template:

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -18,11 +18,11 @@
   systemd:
     name: iiab-clone-wifi
     state: restarted
-  when: wifi_up_down and can_be_ap and ansible_facts.iiab_wireless_lan_iface is undefined and rpi_image is undefined
+  when: wifi_up_down and can_be_ap and ansible_facts.ap0 is undefined and ansible_facts.wld0 is undefined and rpi_image is undefined
 
-- name: Waiting {{ hostapd_wait }} seconds for network to stabilize for ap0
+- name: Waiting {{ hostapd_wait }} seconds for network to stabilize for ap0/wld0
   shell: sleep {{ hostapd_wait }}
-  when: ansible_facts.iiab_wireless_lan_iface is undefined
+  when: ansible_facts.ap0 is undefined and ansible_facts.wld0 is undefined
 
 - name: Restart hostapd when WiFi is present but not when using WiFi as gateway
   systemd:

--- a/roles/network/tasks/restart.yml
+++ b/roles/network/tasks/restart.yml
@@ -18,11 +18,11 @@
   systemd:
     name: iiab-clone-wifi
     state: restarted
-  when: wifi_up_down and can_be_ap and ansible_facts.ap0 is undefined and rpi_image is undefined
+  when: wifi_up_down and can_be_ap and ansible_facts.iiab_wireless_lan_iface is undefined and rpi_image is undefined
 
 - name: Waiting {{ hostapd_wait }} seconds for network to stabilize for ap0
   shell: sleep {{ hostapd_wait }}
-  when: ansible_facts.ap0 is undefined
+  when: ansible_facts.iiab_wireless_lan_iface is undefined
 
 - name: Restart hostapd when WiFi is present but not when using WiFi as gateway
   systemd:

--- a/roles/network/templates/hostapd/98-iiab.conf
+++ b/roles/network/templates/hostapd/98-iiab.conf
@@ -1,1 +1,0 @@
-net.ipv6.conf.ap0.disable_ipv6=1

--- a/roles/network/templates/hostapd/98-iiab.conf.j2
+++ b/roles/network/templates/hostapd/98-iiab.conf.j2
@@ -1,0 +1,1 @@
+net.ipv6.conf.{{ iiab_wireless_lan_iface }}.disable_ipv6=1

--- a/roles/network/templates/hostapd/NM-disp.j2
+++ b/roles/network/templates/hostapd/NM-disp.j2
@@ -5,7 +5,7 @@ ACTION=$2
 {% if wifi_up_down and discovered_wireless_iface != "none" %}
 if [ "$IFACE" == "{{ discovered_wireless_iface }}" ] && [ "$ACTION" == "down" ] ; then
     echo "NM-DISP-WiFi $IFACE $STATE"
-    /usr/sbin/ip link set ap0 up
+    /usr/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 fi
 if [ "$IFACE" == "{{ discovered_wireless_iface }}" ] && [ "$ACTION" == "up" ]; then
     echo "NM-DISP-WiFi $IFACE $STATE"
@@ -23,7 +23,7 @@ if [ "$IFACE" == "{{ discovered_wireless_iface }}" ] && [ "$ACTION" == "up" ]; t
         echo "Upstream Channel greater than 13 or is the same - not changing hostapd.conf"
     fi
     sleep 3
-    /usr/sbin/ip link set ap0 up
+    /usr/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 fi
 
 {% endif %}

--- a/roles/network/templates/hostapd/hostapd.service.j2
+++ b/roles/network/templates/hostapd/hostapd.service.j2
@@ -18,7 +18,7 @@ Type=forking
 #RestartSec=2
 PIDFile=/run/hostapd.pid
 ExecStart=/usr/sbin/hostapd -B -P /run/hostapd.pid /etc/hostapd/hostapd.conf
-ExecStartPost=-/sbin/ip link set ap0 up
+ExecStartPost=-/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
+++ b/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
@@ -13,6 +13,7 @@ Before=wpa_supplicant@{{ discovered_wireless_iface }}.service
 Before=NetworkManager.service
 Before=netplan-wpa@{{ discovered_wireless_iface }}.service
 Before=hostapd.service
+Before=netplan-configure.service
 
 [Service]
 Type=oneshot
@@ -21,8 +22,8 @@ RemainAfterExit=yes
 ExecStartPre=-/bin/bash -c '/sbin/iw phy "$(ls /sys/class/ieee80211/ | head -1)" interface add ap0 type __ap'
 ExecStartPre=-/sbin/ip link set ap0 address {{ ap0_mac_addr }}
 ExecStartPre=-/usr/sbin/rfkill unblock wlan
-ExecStart=-/sbin/ip link set ap0 up
-ExecStop=-/sbin/iw dev ap0 del
+ExecStart=-/sbin/ip link set {{ iiab_wireless_lan_iface }} up
+ExecStop=-/sbin/iw dev {{ iiab_wireless_lan_iface }} del
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
+++ b/roles/network/templates/hostapd/iiab-clone-wifi.service.j2
@@ -20,7 +20,7 @@ Type=oneshot
 RemainAfterExit=yes
 # 2025-03-12: #3961 phy0 can no longer be assumed (phy1 also occurs very regularly) -- so read phyname dynamically from /sys/class/ieee80211/ -- explanation at: roles/firmware/tasks/warn_fw_crash.yml
 ExecStartPre=-/bin/bash -c '/sbin/iw phy "$(ls /sys/class/ieee80211/ | head -1)" interface add ap0 type __ap'
-ExecStartPre=-/sbin/ip link set ap0 address {{ ap0_mac_addr }}
+ExecStartPre=-/sbin/ip link set {{ iiab_wireless_lan_iface }} address {{ ap0_mac_addr }}
 ExecStartPre=-/usr/sbin/rfkill unblock wlan
 ExecStart=-/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 ExecStop=-/sbin/iw dev {{ iiab_wireless_lan_iface }} del

--- a/roles/network/templates/hostapd/iiab-hotspot-off.j2
+++ b/roles/network/templates/hostapd/iiab-hotspot-off.j2
@@ -12,7 +12,7 @@ systemctl disable hostapd
 systemctl stop hostapd
 {% if wifi_up_down %}
 systemctl disable iiab-clone-wifi.service
-systemctl disable iiab-wifi-test.service
+#systemctl disable iiab-wifi-test.service
 systemctl stop iiab-clone-wifi.service
 echo -e "\nIIAB hotspot (Wi-Fi access point) Disabled.\n"
 #exit 0

--- a/roles/network/templates/hostapd/iiab-hotspot-on.j2
+++ b/roles/network/templates/hostapd/iiab-hotspot-on.j2
@@ -23,7 +23,7 @@ sed -i "s/^HOSTAPD_ENABLED.*/HOSTAPD_ENABLED=True/" {{ iiab_env_file }}
 {% if wifi_up_down %}
 systemctl enable iiab-clone-wifi.service
 systemctl enable hostapd
-systemctl enable iiab-wifi-test.service
+#systemctl enable iiab-wifi-test.service
 #exit 0
 {% else %}
 {% if dhcpcd_result == "enabled" %}

--- a/roles/network/templates/hostapd/netd-disp.j2
+++ b/roles/network/templates/hostapd/netd-disp.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "$IFACE" == "{{ discovered_wireless_iface }}" ]; then
     echo "NET-DISP-WiFi $IFACE $STATE"
-    /usr/sbin/ip link set ap0 up
+    /usr/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 fi

--- a/roles/network/templates/hostapd/netd-disp2.j2
+++ b/roles/network/templates/hostapd/netd-disp2.j2
@@ -15,5 +15,5 @@ if [ "$IFACE" == "{{ discovered_wireless_iface }}" ]; then
         echo "Upstream Channel greater than 13 or is the same - not changing hostapd.conf"
     fi
     sleep 3
-    /usr/sbin/ip link set ap0 up
+    /usr/sbin/ip link set {{ iiab_wireless_lan_iface }} up
 fi

--- a/roles/network/templates/network/60-BT.yml
+++ b/roles/network/templates/network/60-BT.yml
@@ -4,6 +4,8 @@ network:
       dhcp4: false
       dhcp6: false
       optional: true
+      match:
+        macaddress: {{ BT_mac_addr }}
   bridges:
     br0:
       interfaces:

--- a/roles/network/templates/network/60-BT.yml
+++ b/roles/network/templates/network/60-BT.yml
@@ -1,8 +1,8 @@
 network:
   ethernets:
     bnep0:
-      dhcp4: no
-      dhcp6: no
+      dhcp4: false
+      dhcp6: false
       optional: true
   bridges:
     br0:

--- a/roles/network/templates/network/60-BT.yml
+++ b/roles/network/templates/network/60-BT.yml
@@ -1,10 +1,10 @@
 network:
   ethernets:
-    {{ item | trim }}:
+    bnep0:
       dhcp4: no
       dhcp6: no
       optional: true
   bridges:
     br0:
       interfaces:
-      - {{ item | trim }}
+      - bnep0

--- a/roles/network/templates/network/60-WiFi.yml.j2
+++ b/roles/network/templates/network/60-WiFi.yml.j2
@@ -4,6 +4,11 @@ network:
       dhcp4: false
       dhcp6: false
       optional: true
+{% if iiab_wireless_lan_iface == "ap0" or iiab_wireless_lan_iface == "wld0" %}
+      match:
+        macaddress: {{ ap0_mac_addr }}
+      set-name: {{ iiab_wireless_lan_iface }}
+{% endif %}
   bridges:
     br0:
       interfaces:

--- a/roles/network/templates/network/60-WiFi.yml.j2
+++ b/roles/network/templates/network/60-WiFi.yml.j2
@@ -4,11 +4,8 @@ network:
       dhcp4: false
       dhcp6: false
       optional: true
-{% if iiab_wireless_lan_iface == "ap0" or iiab_wireless_lan_iface == "wld0" %}
       match:
         macaddress: {{ ap0_mac_addr }}
-      set-name: {{ iiab_wireless_lan_iface }}
-{% endif %}
   bridges:
     br0:
       interfaces:

--- a/roles/network/templates/network/60-WiFi.yml.j2
+++ b/roles/network/templates/network/60-WiFi.yml.j2
@@ -1,8 +1,8 @@
 network:
   ethernets:
     {{ iiab_wireless_lan_iface }}:
-      dhcp4: no
-      dhcp6: no
+      dhcp4: false
+      dhcp6: false
       optional: true
   bridges:
     br0:

--- a/roles/network/templates/network/60-WiFi.yml.j2
+++ b/roles/network/templates/network/60-WiFi.yml.j2
@@ -1,10 +1,10 @@
 network:
   ethernets:
-    {{ item | trim }}:
+    {{ iiab_wireless_lan_iface }}:
       dhcp4: no
       dhcp6: no
       optional: true
   bridges:
     br0:
       interfaces:
-      - {{ item | trim }}
+      - {{ iiab_wireless_lan_iface }}

--- a/roles/network/templates/network/60-iiab.yml.j2
+++ b/roles/network/templates/network/60-iiab.yml.j2
@@ -4,3 +4,4 @@ network:
       dhcp4: no
       dhcp6: no
       addresses: [{{ lan_ip }}/24]
+      optional: true

--- a/roles/network/templates/network/60-iiab.yml.j2
+++ b/roles/network/templates/network/60-iiab.yml.j2
@@ -1,7 +1,7 @@
 network:
   bridges:
     br0:
-      dhcp4: no
-      dhcp6: no
+      dhcp4: false
+      dhcp6: false
       addresses: [{{ lan_ip }}/24]
       optional: true

--- a/roles/network/templates/network/60-slave.yml.j2
+++ b/roles/network/templates/network/60-slave.yml.j2
@@ -3,7 +3,15 @@ network:
     {{ item | trim }}:
       dhcp4: no
       dhcp6: no
+{% if systemd_networkd_active and iiab_wireless_lan_iface is defined %}
+    {{ iiab_wireless_lan_iface }}:
+      dhcp4: no
+      dhcp6: no
+{% endif %}
   bridges:
     br0:
       interfaces:
       - {{ item | trim }}
+{% if systemd_networkd_active and iiab_wireless_lan_iface is defined %}
+      - {{ iiab_wireless_lan_iface }}
+{% endif %}

--- a/roles/network/templates/network/60-slave.yml.j2
+++ b/roles/network/templates/network/60-slave.yml.j2
@@ -1,8 +1,8 @@
 network:
   ethernets:
     {{ item | trim }}:
-      dhcp4: no
-      dhcp6: no
+      dhcp4: false
+      dhcp6: false
       optional: true
   bridges:
     br0:

--- a/roles/network/templates/network/ap0-manage.conf
+++ b/roles/network/templates/network/ap0-manage.conf
@@ -1,3 +1,0 @@
-# IIAB WiFi
-[keyfile]
-unmanaged-devices=interface-name:ap0

--- a/roles/network/templates/network/ap0-manage.conf.j2
+++ b/roles/network/templates/network/ap0-manage.conf.j2
@@ -1,0 +1,3 @@
+# IIAB WiFi
+[keyfile]
+unmanaged-devices=interface-name:{{ iiab_wireless_lan_iface }}

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -99,6 +99,7 @@ iiab_domain: lan
 lan_ip: 10.10.10.10
 network_172: False    # Change to True if you set the above to 172.18.96.1
 lan_netmask: 255.255.255.0    # Change to 255.255.224.0 if using 172.18.96.1
+use_wired_slaves: False
 
 # Internal Wi-Fi Access Point
 # Values are used if there is an internal Wi-Fi adapter and hostapd is enabled.


### PR DESCRIPTION
### Fixes bug:
https://github.com/iiab/iiab/issues/4373#issuecomment-4323334518 https://github.com/iiab/iiab/issues/4386#issuecomment-4359667400
### Description of changes proposed in this pull request:
Softcode for iiab_wireless_lan_iface to allow wld0 to be an alternate name to ap0
### Smoke-tested on which OS or OS's:
26.04 Rpi-images https://paste.centos.org/view/594bac1c
### Mention a team member @username e.g. to help with code review:
