### PR TITLE
Ppa blocking [only install Kolibri PPA if it's needed]

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -82,3 +82,6 @@ kolibri_repo_dict:
 kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian].repo }}"
 kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian].keyring }}"
 kolibri_suite: "{{ kolibri_repo_dict[is_debian].suite }}"
+
+# remove when the ppa works again.
+kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.19.4-alpha0/kolibri_0.19.4a0-0ubuntu1_all.deb

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -94,6 +94,7 @@
   template:
     src: kolibri.sources.j2
     dest: /etc/apt/sources.list.d/kolibri.sources
+  when: kolibri_deb_url is undefined
 #  apt_repository:
 #    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
 #   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -279,6 +279,8 @@ wordpress_enabled: True
 kolibri_install: True
 kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
+kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.19.4-alpha0/kolibri_0.19.4a0-0ubuntu1_all.deb
+
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -280,7 +280,6 @@ kolibri_install: True
 kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
 
-
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console
 kiwix_install: True
 kiwix_enabled: True

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -279,7 +279,6 @@ wordpress_enabled: True
 kolibri_install: True
 kolibri_enabled: True
 kolibri_language: en    # ar,bg-bg,bn-bd,de,el,en,es-es,es-419,fa,fr-fr,ff-cm,gu-in,ha,hi-in,ht,id,it,ka,km,ko,mr,my,nyn,pt-br,pt-mz,sw-tz,te,uk,ur-pk,vi,yo,zh-hans
-kolibri_deb_url: https://github.com/learningequality/kolibri/releases/download/v0.19.4-alpha0/kolibri_0.19.4a0-0ubuntu1_all.deb
 
 
 # kiwix_install: True is REQUIRED, if you install IIAB's Admin Console


### PR DESCRIPTION
### Fixes bug:
POC dead ppa blocking ansible at mongodb https://github.com/iiab/iiab/issues/4386#issuecomment-4367342446 and CI runs https://github.com/iiab/iiab/pull/4390#issuecomment-4364160323
### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
