### PR TITLE
Fix & modernize {netwarn pop-up, chromium} graphical autostarts + CLI pwdwarn -- for RPiOS -- whereas graphical pwdwarn is going away

### DIFF
--- a/roles/iiab-admin/tasks/pwd-warnings.yml
+++ b/roles/iiab-admin/tasks/pwd-warnings.yml
@@ -2,7 +2,7 @@
 #                    AND roles/network/tasks/netwarn.yml  FOR iiab-network
 
 
-- name: Get username for UID 1000 via shell -- typical graphical desktop login on Raspberry Pi OS
+- name: Get username for UID 1000 via shell -- typical primary login on Raspberry Pi OS
   command: id -nu 1000
   register: uid_1000_username
   ignore_errors: true

--- a/roles/iiab-admin/tasks/pwd-warnings.yml
+++ b/roles/iiab-admin/tasks/pwd-warnings.yml
@@ -14,9 +14,9 @@
     mode: '0644'
 
 
-# 2026-05-09: Sadly end-of-the-line for iiab-pwdwarn-labwc.j2, as its checking
-# for published passwords in /etc/shadow no longer works, so no more pop-up
-# warnings -- due to RPiOS chance April 2026 mandating sudo passwords:
+# 2026-05-10: Sadly end-of-the-line for published password pop-up warnings on
+# RPiOS graphical desktop, as iiab-pwdwarn-labwc checking /etc/shadow no longer
+# works, due to RPiOS sudo mandating passwords starting mid-April 2026:
 # https://www.raspberrypi.com/news/a-security-update-for-raspberry-pi-os/
 
 # # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321

--- a/roles/iiab-admin/tasks/pwd-warnings.yml
+++ b/roles/iiab-admin/tasks/pwd-warnings.yml
@@ -2,35 +2,53 @@
 #                    AND roles/network/tasks/netwarn.yml  FOR iiab-network
 
 
+- name: Get username for UID 1000 via shell -- typical graphical desktop login on Raspberry Pi OS
+  command: id -nu 1000
+  register: uid_1000_username
+  ignore_errors: true
+
 - name: Install /etc/profile.d/iiab-pwdwarn-profile.sh from template, to issue warnings (during shell/ssh logins) if iiab-admin password is the default
   template:
     src: iiab-pwdwarn-profile.sh.j2
     dest: "{{ etc_path }}/profile.d/iiab-pwdwarn-profile.sh"
     mode: '0644'
 
-- name: Does directory /home/{{ iiab_admin_user }}/.config/labwc/ exist?
-  stat:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/
-  register: labwc_dir
 
-- name: "If so, install from template: /usr/local/sbin/iiab-pwdwarn-labwc"
-  template:
-    src: iiab-pwdwarn-labwc.j2
-    dest: /usr/local/sbin/iiab-pwdwarn-labwc
-    mode: '0755'
-  when: labwc_dir.stat.exists and labwc_dir.stat.isdir
+# 2026-05-09: Sadly end-of-the-line for iiab-pwdwarn-labwc.j2, as its checking
+# for published passwords in /etc/shadow no longer works, so no more pop-up
+# warnings -- due to RPiOS chance April 2026 mandating sudo passwords:
+# https://www.raspberrypi.com/news/a-security-update-for-raspberry-pi-os/
 
-# 2019-03-07: This pop-up (/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh) did
-# not actually appear when triggered by /etc/xdg/autostart/pprompt-iiab.desktop
-# (or pprompt.desktop as Raspbian has working since 2018-11-13!)  Too bad as it
-# would be really nice to standardize pop-ups across Ubermix & all distros...
-# Is this a permissions/security issue presumably?  Official autostart spec is:
-# https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html
-# Raspbian's 2016-2018 evolution here: https://github.com/iiab/iiab/issues/1537
+# # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
+# - name: Does directory /home/{{ uid_1000_username.stdout }}/.config/labwc/ exist?
+#   stat:
+#     path: /home/{{ uid_1000_username.stdout }}/.config/labwc/
+#   register: labwc_dir
+#   when: uid_1000_username.stdout is defined and uid_1000_username.stdout != ""
 
-- name: ...and put a line in /home/{{ iiab_admin_user }}/.config/labwc/autostart to trigger iiab-pwdwarn-labwc (& pop-up as nec)
-  lineinfile:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/autostart    # iiab-admin
-    create: yes
-    line: '/usr/local/sbin/iiab-pwdwarn-labwc &'
-  when: labwc_dir.stat.exists and labwc_dir.stat.isdir
+# - name: If so, install at-spi2-core
+#   package:
+#     name: at-spi2-core
+#   when: labwc_dir.stat.exists and labwc_dir.stat.isdir
+
+# - name: "...and install from template: /usr/local/sbin/iiab-pwdwarn-labwc"
+#   template:
+#     src: iiab-pwdwarn-labwc.j2
+#     dest: /usr/local/sbin/iiab-pwdwarn-labwc
+#     mode: '0755'
+#   when: labwc_dir.stat.exists and labwc_dir.stat.isdir
+
+# # 2019-03-07: This pop-up (/etc/xdg/lxsession/LXDE-pi/sshpwd-lxde-iiab.sh) did
+# # not actually appear when triggered by /etc/xdg/autostart/pprompt-iiab.desktop
+# # (or pprompt.desktop as Raspbian has working since 2018-11-13!)  Too bad as it
+# # would be really nice to standardize pop-ups across Ubermix & all distros...
+# # Is this a permissions/security issue presumably?  Official autostart spec is:
+# # https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html
+# # Raspbian's 2016-2018 evolution here: https://github.com/iiab/iiab/issues/1537
+
+# - name: ...and put a line in /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart to trigger iiab-pwdwarn-labwc (& pop-up as nec)
+#   lineinfile:
+#     path: /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart    # iiab-admin
+#     create: yes
+#     line: '/usr/local/sbin/iiab-pwdwarn-labwc &'
+#   when: labwc_dir.stat.exists and labwc_dir.stat.isdir

--- a/roles/iiab-admin/tasks/pwd-warnings.yml
+++ b/roles/iiab-admin/tasks/pwd-warnings.yml
@@ -26,7 +26,7 @@
 #   register: labwc_dir
 #   when: uid_1000_username.stdout is defined and uid_1000_username.stdout != ""
 
-# - name: If so, install at-spi2-core
+# - name: If so, install at-spi2-core (GNOME Accessibility, avoids zenity CLI warnings)
 #   package:
 #     name: at-spi2-core
 #   when: labwc_dir.stat.exists and labwc_dir.stat.isdir

--- a/roles/iiab-admin/templates/iiab-pwdwarn-labwc.j2.unused
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-labwc.j2.unused
@@ -48,3 +48,7 @@ if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; the
     zenity --warning --width=600 --text="Published password in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
     #zenity --warning --width=600 --text="SSH is enabled and the published password is in use by user '{{ iiab_admin_user }}'.\n\nTHIS IS A SECURITY RISK - please change its password using IIAB's Admin Console (http://box.lan/admin) -> Utilities -> Change Password.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
 fi
+
+if [[ "{{ iiab_admin_user }}" != "{{ uid_1000_username.stdout }}" ]] && check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [presumed graphical login] g0adm1n
+    zenity --warning --width=600 --text="Published password in use by user '{{ uid_1000_username.stdout }}'.\n\nTHIS IS A SECURITY RISK - please change it using the 'passwd' command.\n\nSee 'What are the default passwords?' at http://FAQ.IIAB.IO"
+fi

--- a/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
@@ -56,14 +56,14 @@ check_user_pwd() {
 
 echo
 
-if check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [presumed primary login] g0adm1n
+if check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [OS's presumed primary login] / g0adm1n
     echo -e "\e[41;1mPublished password in use by user '{{ uid_1000_username.stdout }}'.\e[0m"
     echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ uid_1000_username.stdout }}' to change it.\e[0m"
     echo
 fi
 {% if uid_1000_username.stdout != iiab_admin_user %}
 
-if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin g0adm1n
+if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # If username different from above, also check: iiab-admin / g0adm1n
     echo -e "\e[41;1mPublished password in use by user '{{ iiab_admin_user }}'.\e[0m"
     echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.\e[0m"
     echo

--- a/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
@@ -58,5 +58,12 @@ if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; the
     echo
     echo -e "\e[41;1mPublished password in use by user '{{ iiab_admin_user }}'.\e[0m"
     echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.\e[0m"
-    echo
 fi
+
+if [[ "{{ iiab_admin_user }}" != "{{ uid_1000_username.stdout }}" ]] && check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [presumed primary login] g0adm1n
+    echo
+    echo -e "\e[41;1mPublished password in use by user '{{ uid_1000_username.stdout }}'.\e[0m"
+    echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ uid_1000_username.stdout }}' to change it.\e[0m"
+fi
+
+echo

--- a/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
+++ b/roles/iiab-admin/templates/iiab-pwdwarn-profile.sh.j2
@@ -54,16 +54,18 @@ check_user_pwd() {
 # "iiab-admin ALL=(ALL) NOPASSWD: ALL" in /etc/sudoers as seen in the older:
 # https://github.com/iiab/iiab/blob/master/roles/iiab-admin/tasks/admin-user.yml
 
-if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin g0adm1n
-    echo
-    echo -e "\e[41;1mPublished password in use by user '{{ iiab_admin_user }}'.\e[0m"
-    echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.\e[0m"
-fi
+echo
 
-if [[ "{{ iiab_admin_user }}" != "{{ uid_1000_username.stdout }}" ]] && check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [presumed primary login] g0adm1n
-    echo
+if check_user_pwd "{{ uid_1000_username.stdout }}" "{{ iiab_admin_published_pwd }}" ; then    # [presumed primary login] g0adm1n
     echo -e "\e[41;1mPublished password in use by user '{{ uid_1000_username.stdout }}'.\e[0m"
     echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ uid_1000_username.stdout }}' to change it.\e[0m"
+    echo
 fi
+{% if uid_1000_username.stdout != iiab_admin_user %}
 
-echo
+if check_user_pwd "{{ iiab_admin_user }}" "{{ iiab_admin_published_pwd }}" ; then    # iiab-admin g0adm1n
+    echo -e "\e[41;1mPublished password in use by user '{{ iiab_admin_user }}'.\e[0m"
+    echo -e "\e[100;1mTHIS IS A SECURITY RISK - please run 'sudo passwd {{ iiab_admin_user }}' to change it.\e[0m"
+    echo
+fi
+{% endif %}

--- a/roles/network/tasks/netwarn.yml
+++ b/roles/network/tasks/netwarn.yml
@@ -17,7 +17,7 @@
   register: labwc_dir
   when: uid_1000_username.stdout is defined and uid_1000_username.stdout != ""
 
-- name: If so, install at-spi2-core
+- name: If so, install at-spi2-core (GNOME Accessibility, avoids zenity CLI warnings)
   package:
     name: at-spi2-core
   when: labwc_dir.stat.exists and labwc_dir.stat.isdir

--- a/roles/network/tasks/netwarn.yml
+++ b/roles/network/tasks/netwarn.yml
@@ -5,14 +5,26 @@
 # shell / ssh logins (across all OS's/distros/window managers) might also make sense?
 
 
-- name: Does directory /home/{{ iiab_admin_user }}/.config/labwc/ exist?
-  stat:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/
-  register: labwc_dir
+- name: Get username for UID 1000 via shell -- typical graphical desktop login on Raspberry Pi OS
+  command: id -nu 1000
+  register: uid_1000_username
+  ignore_errors: true
 
-- name: If so, add '/usr/local/sbin/iiab-netwarn &' to /home/{{ iiab_admin_user }}/.config/labwc/autostart
+# 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
+- name: Does directory /home/{{ uid_1000_username.stdout }}/.config/labwc/ exist?
+  stat:
+    path: /home/{{ uid_1000_username.stdout }}/.config/labwc/
+  register: labwc_dir
+  when: uid_1000_username.stdout is defined and uid_1000_username.stdout != ""
+
+- name: If so, install at-spi2-core
+  package:
+    name: at-spi2-core
+  when: labwc_dir.stat.exists and labwc_dir.stat.isdir
+
+- name: ...and add '/usr/local/sbin/iiab-netwarn &' to /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart
   lineinfile:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/autostart    # iiab-admin
+    path: /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart    # iiab-admin
     create: yes
     line: '/usr/local/sbin/iiab-netwarn &'
   when: labwc_dir.stat.exists and labwc_dir.stat.isdir

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -50,7 +50,7 @@
   register: chromium_browser
 
 # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
-- name: ...and add '/usr/bin/chromium --disable-restore-session-state http://box/home &' to /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart
+- name: ...and add '/usr/bin/chromium --hide-crash-restore-bubble http://box/home &' to /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart
   lineinfile:
     path: /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart    # iiab-admin
     create: yes

--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -31,11 +31,17 @@
 # 2022-07-22: SIMILAR TO roles/iiab-admin/tasks/pwd-warnings.yml FOR passwords
 #                    AND roles/network/tasks/netwarn.yml      FOR iiab-network
 
+- name: Get username for UID 1000 via shell -- typical graphical desktop login on Raspberry Pi OS
+  command: id -nu 1000
+  register: uid_1000_username
+  ignore_errors: true
+
 # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
-- name: Does directory /home/{{ iiab_admin_user }}/.config/labwc/ exist?
+- name: Does directory /home/{{ uid_1000_username.stdout }}/.config/labwc/ exist?
   stat:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/
+    path: /home/{{ uid_1000_username.stdout }}/.config/labwc/
   register: labwc_dir
+  when: uid_1000_username.stdout is defined and uid_1000_username.stdout != ""
 
 # 2025-12-14: RasPiOS 13 "Trixie" recently renamed chromium-browser to chromium
 - name: Does /usr/bin/chromium exist?
@@ -43,26 +49,14 @@
     path: /usr/bin/chromium
   register: chromium_browser
 
-# - name: Does /usr/bin/chromium exist? (check for browser filename change)
-#   stat:
-#     path: /usr/bin/chromium
-#   register: chromium_present
-
 # 2024-12-12: RasPiOS changed compositor from wayfire to labwc: https://forums.raspberrypi.com/viewtopic.php?t=379321
-- name: If both above exist, add '/usr/bin/chromium --disable-restore-session-state http://box/home &' to /home/{{ iiab_admin_user }}/.config/labwc/autostart
+- name: ...and add '/usr/bin/chromium --disable-restore-session-state http://box/home &' to /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart
   lineinfile:
-    path: /home/{{ iiab_admin_user }}/.config/labwc/autostart    # iiab-admin
+    path: /home/{{ uid_1000_username.stdout }}/.config/labwc/autostart    # iiab-admin
     create: yes
     regexp: '^/usr/bin/chromium'
-    line: '/usr/bin/chromium --disable-restore-session-state http://box/home &'
+    line: '/usr/bin/chromium --hide-crash-restore-bubble http://box/home &'
   when: labwc_dir.stat.exists and labwc_dir.stat.isdir and chromium_browser.stat.exists
-
-# - name: Add chromium to /etc/xdg/lxsession/LXDE-pi/autostart
-#   lineinfile:
-#     path: /etc/xdg/lxsession/LXDE-pi/autostart
-#     regexp: '^/usr/bin/chromium'
-#     line: '/usr/bin/chromium --disable-restore-session-state http://box/home'
-#   when: lxde_pi_autostart_present.stat.exists and chromium_present.stat.exists
 
 
 # 2022-12-29: php-settings.yml is ALSO attempted (on demand) by every

--- a/runrole
+++ b/runrole
@@ -96,6 +96,8 @@ if [ $ROLE_NAME == "calibre-web" ]; then
     ROLE_VAR=calibreweb
 #elif [ $ROLE_NAME == "httpd" ]; then
 #    ROLE_VAR=apache
+elif [ $ROLE_NAME == "iiab-admin" ]; then
+    ROLE_VAR=iiab_admin
 elif [ $ROLE_NAME == "osm-vector-maps" ]; then    # TO BE REMOVED in 2026/2027
     ROLE_VAR=osm_vector_maps
 else


### PR DESCRIPTION
### Fixes bug:

3 of these 4 warrnings / autostarts are now fixed and enhanced.

On the not-so-happy side of things, 1 of the original 4 triggers is going away: as auto-detection of published passwords is no longer practical in that graphical desktop case — certainly it's no longer easy with [labwc](https://labwc.github.io/)'s autostart since April 2026, when Raspberry Pi OS new hardened sudo's security began asking for a sudo password by default: https://www.raspberrypi.com/news/a-security-update-for-raspberry-pi-os/

### Description of changes proposed in this pull request:

- 2 of these (autostarting visually on graphical desktop) are not only fixed, but also now work much better: `/usr/local/sbin/iiab-netwarn &` and `/usr/bin/chromium --hide-crash-restore-bubble http://box/home &` — will each be triggered by the OS's presumed primary graphical desktop user's `/home/USER/.config/labwc/autostart` file going forward.  To keep things very simple, the primary graphical desktop user is presumed to have OS UID 1000 — which is usually the case, and certainly a way better approach than our past assumption (to date) that `iiab_admin_user: iiab-admin` would really correspond to the OS's primary graphical desktop user.  REASON: IIAB implementers often install their OS / distro with a very different username than that, as can be customized in [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?) (but often that var's left untouched!)

- The 3rd trigger is also refined (CLI warnings about published passwords, using `/etc/profile.d/iiab-pwdwarn-profile.sh`) to remind/alert the IIAB implementer about weak passwords for both `iiab-admin` _and_ also for the username associated with OS UID 1000 — when/if one or both are confirmed to have a password hash corresponding to Ansible var `iiab_admin_published_pwd`.

### Smoke-tested on which OS or OS's:

Raspberry Pi OS with desktop 2026-04-21

### Mention a team member @username e.g. to help with code review:

@ZachLiebl