### PR TITLE
BRIGHT green Ansible map file download explanations can be concise?

### DIFF
--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -82,16 +82,11 @@
       # implies that the download should happen.
       register: download_file_details
 
-    # Put in some space to make it easier to read by implementers.
+    # Bright green Ansible output, so blank lines are probably not necessary in the end?
     - debug:
         msg:
-          - ""
-          - ""
-          - "   To check download progress, run:       "
-          - ""
+          - "   TO CHECK DOWNLOAD PROGRESS, RUN:   "
           - "   tail {{ working_dir }}/{{ log_file }}  "
-          - ""
-          - ""
       # If the file already exists (and thus no download will happen) the above
       # task should exit before any console output.
       when: download_file_details.stdout_lines|length != 0


### PR DESCRIPTION
@orblivion can we try out more concise (and even brighter green!) map file download tips?

My hunch is that the blank lines are now necessary in the end, as this message is so bright (GREEN!) and Ansible's pause during the download draws the implementer's eye to this message regardless.