### PR TITLE
Cleaner UX, reducing CLI confusion when changing Raspberry Pi WiFi firmware

### DIFF
--- a/roles/firmware/tasks/install.yml
+++ b/roles/firmware/tasks/install.yml
@@ -3,7 +3,7 @@
   when: firmware_downloaded is undefined    # SEE ALSO firmware_installed below
 
 
-# Set 2 symlinks for RPi 3 B+ and 4 (43455)
+# Set 2 symlinks for RPi 3 B+, 4, 5, 500, 500+ (43455) -- whereas 400 uses (43456)
 # COMPARE: update-alternatives --display cyfmac43455-sdio.bin
 # https://github.com/moodlebox/moodlebox/blob/main/roles/accesspoint/tasks/main.yml#L3-L6
 
@@ -41,7 +41,7 @@
     force: yes
 
 
-# Set 2 symlinks for RPi Zero W and 3 (43430)
+# Set 2 symlinks for RPi Zero W and 3 (43430) -- whereas Zero 2W uses (43436 or 43436S)
 
 - name: Populate rpizerow_rpi3_wifi_firmwares dictionary (lookup table for operator-chosen .bin and .clm_blob files in /lib/firmware/cypress)
   set_fact:
@@ -69,6 +69,10 @@
     path: /lib/firmware/cypress/cyfmac43430-sdio.clm_blob.iiab
     state: link
     force: yes
+
+
+- name: Touch /tmp/.fw_modified so that /usr/bin/iiab-check-firmware always asks for a reboot after './runrole --reinstall firmware' (in case any of the above 2 + 2 "lower level" symlinks were changed)
+  command: touch /tmp/.fw_modified
 
 
 - name: 'Install from template: /usr/bin/iiab-check-firmware, /etc/systemd/system/iiab-check-firmware.service & /etc/profile.d/iiab-firmware-warn.sh'

--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -3,7 +3,8 @@
 # client devices that can access your Raspberry Pi's internal WiFi hotspot.
 
 # If IIAB's already installed, you should then run 'cd /opt/iiab/iiab' and
-# then 'sudo ./runrole firmware' (DO RUN iiab-check-firmware FOR MORE TIPS!)
+# then 'sudo ./runrole firmware' -- or if you changed any firmware vars, run
+# 'sudo ./runrole --reinstall firmware' (DO RUN iiab-check-firmware FOR TIPS!)
 
 # 2018-2023 Background & Progress:
 #

--- a/roles/firmware/templates/iiab-check-firmware
+++ b/roles/firmware/templates/iiab-check-firmware
@@ -58,10 +58,10 @@ else
     echo -e "settings in /etc/iiab/local_vars.yml, please then run:"
     echo
     echo -e "  cd /opt/iiab/iiab"
-    echo -e "  sudo iiab-hotspot-off    # NO LONGER NEC? eg to restore 'wifi_up_down: True'"
+    echo -e "  sudo iiab-hotspot-off    # NOT NEEDED ?"
     echo -e "  sudo ./runrole --reinstall firmware"
-    echo -e "  sudo iiab-network        # SOMETIMES NECESSARY"
-    echo -e "  sudo iiab-hotspot-on     # NO LONGER NEC? eg to restore 'wifi_up_down: True'"
+    echo -e "  sudo iiab-network        # NEEDED IF YOU CHANGED 'wifi_up_down'"
+    echo -e "  sudo iiab-hotspot-on     # OFTEN NEEDED !"
     echo -e "  sudo reboot\n"
     #echo
     #echo -e "Disconnect your power cord before rebooting, for better WiFi firmware results.\n"


### PR DESCRIPTION
### Fixes bug:

Explanations were lacking.  This PR is just a small cleanup of roles/firmware, updating it to avoid a few common UX snafus.

### Description of changes proposed in this pull request:

Just a small cleanup of CLI tools, to help implementers maintain their RPi WiFi firmware.

### Smoke-tested on which OS or OS's:

RPiOS with desktop on RPi 500.

### Mention a team member @username e.g. to help with code review:

@ZachLiebl