### PR TITLE
Recommend new ansible-core 2.21.0 [led to `can_be_ap` bug, with `'iiab_wireless_lan_iface' is undefined`]

### DIFF
--- a/iiab-install
+++ b/iiab-install
@@ -10,8 +10,8 @@ ARGS="--extra-vars {"    # Needs boolean not string so use JSON list.  bash forc
 CWD=`pwd`
 OS=`grep ^ID= /etc/os-release | cut -d= -f2`
 OS=${OS//\"/}    # Remove all '"'
-MIN_RPI_KERN=5.4.0        # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
-MIN_ANSIBLE_VER=2.19.9    # 2025-09-15: ansible-core 2.19 overhauled security, requiring major IIAB code changes (SEE #4030).  ansible-core 2.17 EOL is Nov 2025 per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
+MIN_RPI_KERN=5.4.0         # Do not use 'rpi-update' unless absolutely necessary: https://github.com/iiab/iiab/issues/1993
+MIN_ANSIBLE_VER=2.19.10    # 2025-09-15: ansible-core 2.19 overhauled security, requiring major IIAB code changes (SEE #4030).  ansible-core 2.17 EOL is Nov 2025 per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix  2022-11-09: Raspberry Pi 3 (and 3 B+ etc?) apparently install (and require?) ansible-core 2.11 for now -- @deldesir can explain more on PR #3419.  Historical: Ansible 2.8.3 and 2.8.6 had serious bugs, preventing their use with IIAB.
 
 REINSTALL=false
 DEBUG=false

--- a/scripts/ansible
+++ b/scripts/ansible
@@ -7,8 +7,8 @@
 # https://github.com/iiab/iiab/wiki/Technical-Contributors-Guide#female_detective-understanding-ansible
 
 APT_PATH=/usr/bin     # Avoids problematic /usr/local/bin/apt on Linux Mint
-CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.20.5]
-GOOD_VER=2.20.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
+CURR_VER=undefined    # Ansible version you have installed, e.g. [core 2.21.0]
+GOOD_VER=2.21.0       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 
 # 2021-06-22: The apt approach (with PPA source in /etc/apt/sources.list.d/ and
 # .gpg key etc) are commented out with ### below.  Associated guidance/comments
@@ -34,6 +34,8 @@ GOOD_VER=2.20.5       # Orig for 'yum install [rpm]' & XO laptops (pip install)
 # https://www.ansible.com/blog/ansible-3.0.0-qa
 # https://github.com/ansible/ansible/tags
 # https://github.com/ansible/ansible/releases
+# https://github.com/ansible/ansible/commits/stable-2.21
+# https://github.com/ansible/ansible/blob/stable-2.21/changelogs/CHANGELOG-v2.21.rst
 # https://github.com/ansible/ansible/commits/stable-2.20
 # https://github.com/ansible/ansible/blob/stable-2.20/changelogs/CHANGELOG-v2.20.rst
 # https://github.com/ansible/ansible/commits/stable-2.19


### PR DESCRIPTION
Release notes:

https://github.com/ansible/ansible/blob/v2.21.0/changelogs/CHANGELOG-v2.21.rst

In coming weeks we should work on the small refactoring needs to honor the most serious/urgent of ansible-core 2.21.0's warnings and guidelines.

This builds on:

- PR #4378