### PR TITLE
detected_network.yml: Fix `can_be_ap` for ansible-core 2.21.0

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -140,7 +140,7 @@
 - name: "Set 'can_be_ap: True' if 'iw list' output contains suitable '* AP'"
   set_fact:
     can_be_ap: True
-  when: look_for_ap.failed is defined and not look_for_ap.failed
+  when: look_for_ap.skipped is defined and not look_for_ap.skipped and look_for_ap.failed is defined and not look_for_ap.failed
 
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/pull/4405#issuecomment-4482515010

### Description of changes proposed in this pull request:

ansible-core 2.21.0 (released earlier today) has suddenly begun to include the `.failed` attribute in register variables, in new situation(s) such as when the Ansible stanza is skipped due a `when:` condition being negative.  (FYI in these situation(s), the register's `.failed` attribute is correctly set to `False` !)

So... Line 143 in `detected_network.yml` here... needs to become more rigorous:

https://github.com/iiab/iiab/blob/e7c1dc072479cb735241768b2fff58012548da31/roles/network/tasks/detected_network.yml#L143

This PR changes it to:

```
  when: look_for_ap.skipped is defined and not look_for_ap.skipped and look_for_ap.failed is defined and not look_for_ap.failed
```

### Smoke-tested on which OS or OS's:

Ubuntu Server 24.04

### Mention a team member @username e.g. to help with code review:

@jvonau