### PR TITLE
Fallback for no satellite but with FQRs

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -158,11 +158,6 @@ maps_dot_black_satellite_tiles:
   # maps_satellite_zoom = 13
   13: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z13.pmtiles"
 
-  # Reuse this as a "dummy" maxzoom=0 world map satellite file to fill a role that maps.black/maplibre
-  # needs if we have FQRs but no world map satellite and the user enables satellite.
-  # And it looks passable as a filler.
-  none: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
-
   # FOR TESTING ONLY
   # Super-low quality satellite, up to zoom level 4 (original file has 13)
   # maps_satellite_zoom = 4

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -158,6 +158,11 @@ maps_dot_black_satellite_tiles:
   # maps_satellite_zoom = 13
   13: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z13.pmtiles"
 
+  # Reuse this as a "dummy" maxzoom=0 world map satellite file to fill a role that maps.black/maplibre
+  # needs if we have FQRs but no world map satellite and the user enables satellite.
+  # And it looks passable as a filler.
+  none: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
+
   # FOR TESTING ONLY
   # Super-low quality satellite, up to zoom level 4 (original file has 13)
   # maps_satellite_zoom = 4
@@ -195,7 +200,7 @@ maps_dot_black_terrain_tiles:
   6: "terrarium.{{ maps_slow_data_date }}.z00-z06.pmtiles"
 
   # A "dummy" maxzoom=0 world map terrain file to fill a role that maps.black/maplibre
-  # needs if we have FQRs and the user enables terrain.
+  # needs if we have FQRs but no world map terrain and the user enables terrain.
   none: "terrarium-none.pmtiles"
 
 maps_terrain_max_zoom: 10

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -53,24 +53,31 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
 
-# If the user selects "none", we download a dummy file
-- name: "Make sure maps_satellite_zoom has a valid value"
-  assert:
-    that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
-    fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
-    quiet: yes
+- when: maps_satellite_zoom != "none"
+  block:
+    - name: "Make sure maps_satellite_zoom has a valid value"
+      assert:
+        that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
+        fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+        quiet: yes
 
-- name: Download satellite tiles
-  include_tasks: download_large_file.yml
-  vars:
-    dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+    - name: Download satellite tiles
+      include_tasks: download_large_file.yml
+      vars:
+        dest_base_path: "{{ maps_serve_path }}"
+        item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
 
-- name: Select satellite tiles
+    - name: Select satellite tiles
+      file:
+        src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+        dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
+        state: link
+
+- name: Remove unused satellite symlink
+  when: maps_satellite_zoom == "none"
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
-    state: link
+    path: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
+    state: absent
 
 - name: "Make sure maps_terrain_zoom has a valid value"
   assert:

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -53,31 +53,24 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
 
-- when: maps_satellite_zoom != "none"
-  block:
-    - name: "Make sure maps_satellite_zoom has a valid value"
-      assert:
-        that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
-        fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
-        quiet: yes
+# If the user selects "none", we download a dummy file
+- name: "Make sure maps_satellite_zoom has a valid value"
+  assert:
+    that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
+    fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    quiet: yes
 
-    - name: Download satellite tiles
-      include_tasks: download_large_file.yml
-      vars:
-        dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+- name: Download satellite tiles
+  include_tasks: download_large_file.yml
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
+    item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
 
-    - name: Select satellite tiles
-      file:
-        src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
-        dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
-        state: link
-
-- name: Remove unused satellite symlink
-  when: maps_satellite_zoom == "none"
+- name: Select satellite tiles
   file:
-    path: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
-    state: absent
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+    dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
+    state: link
 
 - name: "Make sure maps_terrain_zoom has a valid value"
   assert:

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -250,6 +250,17 @@
                         setMaxZoom('openstreetmap-openmaptiles', WORLD_MAP_VECTOR_MAX_ZOOM)
                         setMaxZoom('s2maps-sentinel2-2023', WORLD_MAP_SATELLITE_MAX_ZOOM)
 
+                        if (WORLD_MAP_SATELLITE_MAX_ZOOM === 0 && fqRegionsExist() && "s2maps-sentinel2-2023" in style.sources) {
+                            // Pick any FQR, use it as the satellite source. It has a zoom-0 full world image.
+                            const someFqr = Object.keys(downloadedFQRegions.regions)[0]
+                            const satelliteDate = downloadedFQRegions.regions[someFqr].dates.satellite
+
+                            style.sources['s2maps-sentinel2-2023'].url = style.sources['s2maps-sentinel2-2023'].url.replace(
+                              '/s2maps-sentinel2-2023.pmtiles',
+                              `/s2maps-sentinel2-2023.${satelliteDate}.full-region.${someFqr}.pmtiles`,
+                            )
+                        }
+
                         // Sources that use the terrarium file. We don't necessarily even use all of them
                         // but we'll change them here in case we do.
                         setMaxZoom('terrarium', WORLD_MAP_TERRAIN_MAX_ZOOM)

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -154,6 +154,10 @@
                         // Order of layers matters. We want the FQR layers to be after the world map layers
                         // so the FQR shows up on top. We also want all of the FQR layers to be in the same
                         // order as their world map counterpart so it shows up correctly.
+                        //
+                        // There's one exception though, which is that we want all satellite, world or FQR,
+                        // to be the bottom layers. This is because the world vector may in some cases be
+                        // on top of an FQR satellite in hybrid mode.
                         Object.keys(downloadedFQRegions.regions).forEach(fqrName => {
                             const pmtilesDates = downloadedFQRegions.regions[fqrName].dates
 
@@ -239,6 +243,21 @@
                             .forEach(fqrLayer => {
                                 style.layers.push(fqrLayer)
                             })
+                        })
+
+                        // We've copied all of the world layers to FQRs, in the same order. Now it's time to take all of the
+                        // satellite layers and move them to the beginning.
+                        for (const [index, layer] of style.layers.entries()) {
+                            layer.__sortOrder = index
+                        }
+                        style.layers.sort((a, b) => {
+                            const a_s2maps = a.id.startsWith('s2maps-sentinel2-2023')
+                            const b_s2maps = b.id.startsWith('s2maps-sentinel2-2023')
+                            if (a_s2maps !== b_s2maps) {
+                                return b_s2maps - a_s2maps
+                            } else {
+                                return a.__sortOrder - b.__sortOrder
+                            }
                         })
 
                         // set max zooms of world maps

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -62,7 +62,7 @@
             const WORLD_MAP_SATELLITE_MAX_ZOOM = (num => {
                 if (Number.isNaN(num)) {
                     if ("{{ maps_satellite_zoom }}" === "none") {
-                        return null
+                        return 0
                     }
 
                     // Use a default that is hopefully always available.
@@ -280,10 +280,10 @@
                 history.replaceState({}, "", `#${lat}/${lon}/${pitch}/${bearing}/${zoom}/${globe}/${terrain}/${mapStyleChoice}`)
             }
 
-            function readHash() {
+            async function readHash() {
                 const [lat, lon, pitch, bearing, zoom, globe, terrain, _mapStyleChoice] = window.location.hash.slice(1).split('/')
 
-                mapStyleChoice = tryAvailableStyle(_mapStyleChoice)
+                mapStyleChoice = await tryAvailableStyle(_mapStyleChoice)
 
                 if (window.location.hash) {
                     return {
@@ -589,10 +589,14 @@
             //
             // As such, we will simply say that satellite is not avaialble if
             // the user does not download it globally.
-            function satelliteAvailable() {
-                if (WORLD_MAP_SATELLITE_MAX_ZOOM) {
+            async function satelliteAvailable() {
+                if (WORLD_MAP_SATELLITE_MAX_ZOOM > 0) {
                     return true
                 }
+
+                // Full Quality Regions always have terrain
+                await until(fqrLoaded)
+                return fqRegionsExist()
             }
 
             async function terrainAvailable() {
@@ -606,19 +610,21 @@
                 return fqRegionsExist()
             }
 
-            function getAvailableStyles() {
+            async function getAvailableStyles() {
+                satelliteAvailable_ = await satelliteAvailable()
+
                 return [
                     STYLE_NATURAL,
                     STYLE_POLITICAL,
 
                     // Requires satellite tiles
-                    satelliteAvailable() ? STYLE_SATELLITE : null,
-                    satelliteAvailable() ? STYLE_HYBRID    : null,
+                    satelliteAvailable_ ? STYLE_SATELLITE : null,
+                    satelliteAvailable_ ? STYLE_HYBRID    : null,
                 ].filter(Boolean)
             }
 
-            function tryAvailableStyle(requestedStyle) {
-                const availableStyles = getAvailableStyles()
+            async function tryAvailableStyle(requestedStyle) {
+                const availableStyles = await getAvailableStyles()
 
                 // See if the one we want is available
                 if (availableStyles.includes(requestedStyle)) {
@@ -1458,14 +1464,13 @@
                 fqRegionsControl = new FQRegionsControl()
                 mb.map.addControl(fqRegionsControl, 'top-left');
 
-                // Add all the right-side controls at once after we determine whether terrain is among them
-                terrainAvailable().then(showTerrainControl => {
+                (async () => {
                     mb.map.addControl(new MapsDotBlackGlobeControl(), 'top-right');
-                    if (showTerrainControl) {
+                    if (await terrainAvailable()) {
                         mb.map.addControl(new MapsDotBlackTerrainControl(), 'top-right');
                     }
-                    mb.map.addControl(new MapsDotBlackStyleControl(getAvailableStyles()), 'top-right');
-                })
+                    mb.map.addControl(new MapsDotBlackStyleControl(await getAvailableStyles()), 'top-right');
+                })()
                 // NOTE Navigation control is added via `navigationcontrol` attribute on the maps-black tag
 
                 // The call to this function (`setUpMap`) may have been triggered by a globe, terrain, or style change.
@@ -1500,22 +1505,24 @@
     </head>
     <body>
         <script>
-          mb = document.createElement("maps-black")
+            readHash().then(hash => {
+                mb = document.createElement("maps-black")
 
-          const mbAttributes = {
-            ...readHash(),
-            "loader": "pmtiles",
-            "navigationcontrol": "true",
+                const mbAttributes = {
+                  ...hash,
+                  "loader": "pmtiles",
+                  "navigationcontrol": "true",
 
-            // `cooperativegestures=false` provides familiar zoom/scroll/tilt controls for fullscreen
-            "cooperativegestures": "false",
-          }
-          Object.entries(mbAttributes).forEach(([k, v]) => {
-            mb.setAttribute(k, v)
-          })
+                  // `cooperativegestures=false` provides familiar zoom/scroll/tilt controls for fullscreen
+                  "cooperativegestures": "false",
+                }
+                Object.entries(mbAttributes).forEach(([k, v]) => {
+                  mb.setAttribute(k, v)
+                })
 
-          console.log("setting to", mapStyleChoice, "i.e.", mbAttributes.mapstyle)
-          document.body.prepend(mb)
+                console.log("setting to", mapStyleChoice, "i.e.", mbAttributes.mapstyle)
+                document.body.prepend(mb)
+            })
         </script>
     </body>
 </html>


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Allow users to choose satellite if they have FQRs even if they don't have world satellite.

Just like with the analogous situation with terrain, maplibre needed a "dummy" file for the world map. But also, it would be good to fill it in with something. So I just reused the naturalearth6 raster images. Looks a bit weird but it's at least clear what part of the world you're looking at:

<img width="1756" height="486" alt="fqr-only-sat" src="https://github.com/user-attachments/assets/1aa9f604-29ff-4d72-8f14-507abbde5554" />

Second option that does look a little better is 2016 satellite (clipped at maxzoom=0). It doesn't have the non-commercial designation that 2023 has (so I'd feel comfortable downloading it by default even if the user doesn't want satellite), but it still requires attribution. Plus we'd have to upload a new file. I didn't want to take the time to bother with all that because I wasn't sure if it's important enough. If it is it's worth the time to make this particular mode (FQRs but no world satellite) look better, I can do it.

**Edit:** Third and current (as of this writing) option: use the zoom=0 tile from any one of the FQRs. That's the whole planet:

<img width="1920" height="862" alt="1" src="https://github.com/user-attachments/assets/09bf0671-5cf4-4d77-90e7-d5bcd3b30e2a" />
<img width="1920" height="862" alt="2" src="https://github.com/user-attachments/assets/fb136268-077e-4948-9c9c-7f5b6f4d1f24" />
<img width="1920" height="862" alt="3" src="https://github.com/user-attachments/assets/b1bef795-f037-41b3-be7d-3b04b3984bee" />

### Smoke-tested on which OS or OS's:

RasPi OS Trixie
### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 