### PR TITLE
detected_network.yml: Fix & Refactor condition for 'can_be_ap' fact setting

### DIFF
--- a/roles/network/tasks/detected_network.yml
+++ b/roles/network/tasks/detected_network.yml
@@ -140,7 +140,8 @@
 - name: "Set 'can_be_ap: True' if 'iw list' output contains suitable '* AP'"
   set_fact:
     can_be_ap: True
-  when: look_for_ap.skipped is defined and not look_for_ap.skipped and look_for_ap.failed is defined and not look_for_ap.failed
+  when: look_for_ap.rc is defined and look_for_ap.rc == 0    # 2026-05-20: Rework due to ansible-core 2.21.0 breaking changes: #4405, PR #4406, PR #4409
+  #when: (look_for_ap.skipped is not defined or look_for_ap.skipped is defined and not look_for_ap.skipped) and look_for_ap.failed is defined and not look_for_ap.failed
 
 - name: Detect wifi gateway active
   shell: ip r | grep default | grep {{ discovered_wireless_iface }} | wc -l


### PR DESCRIPTION
### Fixes bug:

- https://github.com/iiab/iiab/pull/4406#issuecomment-4502479116

### Description of changes proposed in this pull request:

Fix & Simplify condition for setting 'can_be_ap' to handle ansible-core 2.21.0 breaking changes.

CLARIF around why Ansible register variable's `.rc` (return code) attribute works:

> "The command iw list | grep pattern returns a return code (RC) of 1 if the pattern is not found.
>
> In a standard Linux/Unix pipeline, the exit status of the entire command is the exit status of the last command in the pipe. For grep, the following exit statuses apply:
>
> 0: One or more matches were found.[1](https://forum.keyboardmaestro.com/t/do-shell-script-grep-action-fails-when-script-returns-nothing/21130)
1: No matches were found (the pattern was not in the output of iw list).[2](https://unix.stackexchange.com/questions/48535/can-grep-return-true-false-or-are-there-alternative-methods)
2 (or >1): An error occurred, such as a syntax error or a missing file."

### Smoke-tested on which OS or OS's:

Ubuntu Server 24.04 and RPiOS Lite 13 Trixie.

Older versions of Ansible are never recommended, but FWIW this PR helps with recent versions of ansible-core like 2.19.x and 2.20.x

### Mention a team member @username e.g. to help with code review:

@jvonau