### PR TITLE
[pdsm] restore actual stop command, add force stop too.

### DIFF
--- a/roles/proot_services/files/pdsm/usr_local_pdsm/services-available/calibre-web
+++ b/roles/proot_services/files/pdsm/usr_local_pdsm/services-available/calibre-web
@@ -47,6 +47,10 @@ stop() {
     return 0
   fi
 
+  echo "[pdsm:$SERVICE_NAME] stopping..."
+  # Send the polite termination signal
+  pkill -TERM -f "$APP_PATH" >/dev/null 2>&1 || true
+
   # Wait a little to ensure everything stopped
   for i in $(seq 1 "$PDSM_START_TIMEOUT"); do
     if ! running; then
@@ -55,6 +59,16 @@ stop() {
     fi
     sleep 1
   done
+
+
+  pkill -9 -f "$APP_PATH" >/dev/null 2>&1 || true
+  sleep 1
+
+  # Force stop if the app got frozen
+  if ! running; then
+    echo "[pdsm:$SERVICE_NAME] forcefully stopped"
+    return 0
+  fi
 
   echo "[pdsm:$SERVICE_NAME] did not fully stop" >&2
   return 1


### PR DESCRIPTION
### Fixes bug:
Calibre-web pdsm service (wrongly) got its stop line stripped at: da725b7745670fb4761015116562c25148a57c66
Not stopping service

### Description of changes proposed in this pull request:
Re-added stop capabilities for a clean shutdown.
 
### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 