### PR TITLE
[pdsm] fix missing disable task

### DIFF
--- a/roles/proot_services/tasks/install.yml
+++ b/roles/proot_services/tasks/install.yml
@@ -19,11 +19,11 @@
         - /usr/local/pdsm/services-available
         - /usr/local/pdsm/services-enabled
 
-    - name: Install pdsm profile script (/etc/profile.d/pdsm.sh)
-      copy:
-        src: "pdsm/etc_profile.d/pdsm.sh"
-        dest: "/etc/profile.d/pdsm.sh"
-        mode: "0644"
+#    - name: Install pdsm profile script (/etc/profile.d/pdsm.sh)
+#      copy:
+#        src: "pdsm/etc_profile.d/pdsm.sh"
+#        dest: "/etc/profile.d/pdsm.sh"
+#        mode: "0644"
 
     - name: Install pdsm CLI (/usr/local/bin/pdsm)
       copy:


### PR DESCRIPTION
### Fixes bug:
Prevents failing task due disabled script.

### Description of changes proposed in this pull request:
Fix instructions that were pending to be commented on in an installation task, as part of the detachment process.

### Smoke-tested on which OS or OS's:
Debian 13 (proot)

### Mention a team member @username e.g. to help with code review:
@holta 