### PR TITLE
Update to Node.js 26.x (annual release, as we do every spring)

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -443,7 +443,7 @@ mosquitto_port: 1883
 # JupyterHub, nodered (Node-RED), pbx (Asterix, FreePBX) &/or Sugarizer:
 nodejs_install: False
 nodejs_enabled: False
-nodejs_version: 24.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20, 18.x til 2023-05-20, 20.x til 2024-05-03, 22.x til 2025-05-29
+nodejs_version: 26.x    # was 8.x til 2019-02-02, 10.x til 2019-12-21, 12.x til 2020-10-29, 14.x til 2021-06-17, 16.x til 2022-04-20, 18.x til 2023-05-20, 20.x til 2024-05-03, 22.x til 2025-05-29, 24.x til 2026-05-27
 
 # Flow-based visual programming for wiring together IoT hardware devices etc
 nodered_install: False


### PR DESCRIPTION
As we've done every springtime (Northern hemisphere) for a decade, Node.js is being updated from 24.x to 26.x:

- Note that _next year_ (in 2027), Node.js will be moving away from the even/odd version numbering tradition, adopting a new numbering scheme to match the year, i.e. `27.x` at that time.

- Arguably of course, this transition already began about a month ago, when 26.x was released (coincidentally matching the year 2026, during an even year thankfully, with _even numbers_ having meant LTS up until now ;)

- In short, what were odd-numbered dev releases of Node.js during every year in the past, will instead be renamed as "Alpha" releases going forward (corresponding to the upcoming/imminent number of the actual year!)

### Description of changes proposed in this pull request:

Update to `nodejs_version: 26.x` in vars/defaults_vars.yml

### Smoke-tested on which OS or OS's:

Ubuntu Server 26.04