### PR TITLE
Maps: turn off globe mode if we try to turn on FQR selector.

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -174,6 +174,8 @@ Look for these buttons in the top-left of your map. Click the top one to enter "
 
 (the button will turn orange and your mouse pointer should change).
 
+*NOTE: Because of compatibility issues, selecting this will automatically turn off "globe" view. You can turn it back on once you've started your download.*
+
 Draw a rectangle that represents the region you want to download.  To draw, click one corner of the rectangle and then the opposite corner.  **(Make sure to only click, do not drag!)**
 
 Once you have a rectangle, you'll immediately see a pop-up in the middle of it:

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -67,9 +67,11 @@ See `maps_dot_black_vector_tiles` and `maps_dot_black_satellite_tiles` [here](ht
 
 ## How do I install 3D terrain?
 
-To add 3D (three-dimensional) terrain files, you can set this optional setting.  You may find that when looking at mountains, high quality satellite imagery may compensate for low quality terrain, and vice versa.
+To add 3D (three-dimensional) terrain files, you can set this optional setting.
 
 PREREQ: Confirm that at least a [minimum IIAB Maps](#whats-a-minimum-iiab-maps-install) is installed!
+
+HOW TO USE IT: After 3D terrain is installed, click the "Enable terrain" button in the top-right.  Then tilt the map by holding down the **Ctrl** key on your keyboard while dragging your mouse (or drag with two fingers, if on a mobile device!)  GURU TIP: You may find that when looking at mountains, high quality satellite imagery may compensate for low quality terrain, and vice versa.
 
 1. If you want **~980 MB** terrain maps (up to zoom 7), include:
    ```
@@ -164,7 +166,7 @@ DETAILS: IIAB's downloadable regions (FQRs) include OpenStreetMap vector data up
    sudo ./runrole --reinstall maps
    ```
 
-### Downloading Regions
+### How do I download a Full Quality Region?
 
 Open your IIAB Maps, e.g. by browsing to http://box/maps or http://10.10.10.10/maps
 
@@ -172,9 +174,7 @@ Look for these buttons in the top-left of your map. Click the top one to enter "
 
 ![Download Button](README-assets/fqr-downloader-selected.png)
 
-(the button will turn orange and your mouse pointer should change).
-
-*NOTE: Because of compatibility issues, selecting this will automatically turn off "globe" view. You can turn it back on once you've started your download.*
+(The button will turn orange and your mouse pointer should change.  GURU TIP: Because of [180th meridian issues](https://github.com/iiab/iiab/pull/4418), selecting this will automatically turn off "globe" [spherical] view. You can turn it back on [by clicking the "globe" button in top-right] once you've started your download below.)
 
 Draw a rectangle that represents the region you want to download.  To draw, click one corner of the rectangle and then the opposite corner.  **(Make sure to only click, do not drag!)**
 
@@ -184,19 +184,21 @@ Once you have a rectangle, you'll immediately see a pop-up in the middle of it:
 
 Follow the instructions on the pop-up to download your region.
 
-### Viewing Regions
+### How do I view Full Quality Regions?
 
-You can test out your downloaded Full Quality Region by clicking on the new rectangle on the map.  You should be able to see everything at full quality (terrain up to zoom level 10).
+Look for rectangles on your map, and zoom in there!
 
-### Deleting Regions
+If you downloaded a mountainous region, also take a look at its [3D terrain](#how-do-i-install-3d-terrain), after clicking the "Enable terrain" button in the top-right.
+
+### How do I delete a Full Quality Region?
 
 Look for these buttons in the top-left of your map. Click the bottom one to enter "delete" mode:
 
 ![Delete Button](README-assets/fqr-deleter-selected.png)
 
-(the button will turn orange and your mouse pointer should change).
+(The button will turn orange and your mouse pointer should change.)
 
-You can then click on a region you want to delete. It will bring up a pop-up with instructions on how to delete the region.
+You can then click on a region you want to delete.  It will bring up a pop-up with instructions on how to delete the region.
 
 ### Overlapping Regions
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -65,13 +65,11 @@ See `maps_dot_black_vector_tiles` and `maps_dot_black_satellite_tiles` [here](ht
 
 *Full Quality Regions will still download satellite data, though it will not be visible in the UI.*
 
-## How do I install 3D terrain?
+## How do I install 3D Terrain?
 
 To add 3D (three-dimensional) terrain files, you can set this optional setting.
 
 PREREQ: Confirm that at least a [minimum IIAB Maps](#whats-a-minimum-iiab-maps-install) is installed!
-
-HOW TO USE IT: After 3D terrain is installed, click the "Enable terrain" button in the top-right.  Then tilt the map by holding down the **Ctrl** key on your keyboard while dragging your mouse (or drag with two fingers, if on a mobile device!)  GURU TIP: You may find that when looking at mountains, high quality satellite imagery may compensate for low quality terrain, and vice versa.
 
 1. If you want **~980 MB** terrain maps (up to zoom 7), include:
    ```
@@ -102,6 +100,14 @@ HOW TO USE IT: After 3D terrain is installed, click the "Enable terrain" button 
 ![Terrain Full Zoom](README-assets/terrain/terrain-z10.png)
 
 See `maps_dot_black_terrain_tiles` [here](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) for all valid values.
+
+### How do I view 3D Terrain?
+
+After 3D terrain is installed, enable it by clicking the mountains button in the top-right.
+
+Then tilt the map by holding down the **Ctrl** key on your keyboard while dragging your mouse (or drag with two fingers, if on a mobile device!)
+
+GURU TIP: You may find that when looking at mountains, high-quality satellite imagery may compensate for low-quality terrain, and vice versa.
 
 ## How do I install Map Search?
 
@@ -176,7 +182,7 @@ Look for these buttons in the top-left of your map. Click the top one to enter "
 
 (The button will turn orange and your mouse pointer should change.  GURU TIP: Because of [180th meridian issues](https://github.com/iiab/iiab/pull/4418), selecting this will automatically turn off "globe" [spherical] view. You can turn it back on [by clicking the "globe" button in top-right] once you've started your download below.)
 
-Draw a rectangle that represents the region you want to download.  To draw, click one corner of the rectangle and then the opposite corner.  **(Make sure to only click, do not drag!)**
+Now draw a rectangle that represents the region you want to download.  To draw, click one corner of the rectangle and then the opposite corner.  **(Make sure to only click, do not drag!)**
 
 Once you have a rectangle, you'll immediately see a pop-up in the middle of it:
 
@@ -188,11 +194,11 @@ Follow the instructions on the pop-up to download your region.
 
 Look for rectangles on your map, and zoom in there!
 
-If you downloaded a mountainous region, also take a look at its [3D terrain](#how-do-i-install-3d-terrain), after clicking the "Enable terrain" button in the top-right.
+If you downloaded a mountainous region, also take a look at its [3D terrain](#how-do-i-view-3D-terrain).
 
 ### How do I delete a Full Quality Region?
 
-Look for these buttons in the top-left of your map. Click the bottom one to enter "delete" mode:
+Look for these buttons in the top-left of your map.  Click the bottom one to enter "delete" mode:
 
 ![Delete Button](README-assets/fqr-deleter-selected.png)
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -180,7 +180,7 @@ Look for these buttons in the top-left of your map. Click the top one to enter "
 
 ![Download Button](README-assets/fqr-downloader-selected.png)
 
-(The button will turn orange and your mouse pointer should change.  GURU TIP: Because of [180th meridian issues](https://github.com/iiab/iiab/pull/4418), selecting this will automatically turn off "globe" [spherical] view. You can turn it back on [by clicking the "globe" button in top-right] once you've started your download below.)
+(The button will turn orange and your mouse pointer should change.  GURU TIP: Because of [180th meridian issues](https://github.com/iiab/iiab/pull/4418), selecting this will automatically turn off "globe" [spherical] view.  You can turn it back on [by clicking the "globe" button in top-right] once you've started your download below.)
 
 Now draw a rectangle that represents the region you want to download.  To draw, click one corner of the rectangle and then the opposite corner.  **(Make sure to only click, do not drag!)**
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -194,7 +194,7 @@ Follow the instructions on the pop-up to download your region.
 
 Look for rectangles on your map, and zoom in there!
 
-If you downloaded a mountainous region, also take a look at its [3D terrain](#how-do-i-view-3D-terrain).
+If a downloaded rectangle region contains mountains, also take a look at its [3D terrain](#how-do-i-view-3D-terrain).
 
 ### How do I delete a Full Quality Region?
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -912,6 +912,9 @@
             }
 
             class FQRegionsControl {
+                constructor(startWithDrawMode) {
+                    this.startWithDrawMode = startWithDrawMode
+                }
                 onAdd(map) {
                     this._map = map;
                     this._container = document.createElement('div');
@@ -959,6 +962,9 @@
                     this.INACTIVE_COLOR = ''
 
                     this.setupDownloaderUI()
+                    if (this.startWithDrawMode) {
+                        this.setDrawMode()
+                    }
 
                     return this._container
                 }
@@ -1022,11 +1028,20 @@
                     this.drawButton.style['background-color'] = this.INACTIVE_COLOR
                 }
                 setDrawMode() {
-                    this._mode = this.DRAW_MODE
+                    // Rectangles sometimes wrap around the world in globe mode.
+                    // If the user turns on this control in globe mode, we should
+                    // instead turn off globe mode and turn draw mode on as soon
+                    // as we refresh the map.
+                    if (!mb.globe) {
+                        this._mode = this.DRAW_MODE
 
-                    this._terraDrawInstance.setMode('rectangle') // This sets the cursor to a crosshair
-                    this.drawButton.style['background-color'] = this.ACTIVE_COLOR
-                    this.deleteButton.style['background-color'] = this.INACTIVE_COLOR
+                        this._terraDrawInstance.setMode('rectangle') // This sets the cursor to a crosshair
+                        this.drawButton.style['background-color'] = this.ACTIVE_COLOR
+                        this.deleteButton.style['background-color'] = this.INACTIVE_COLOR
+                    } else {
+                        mb.globe = false
+                        setUpMap({startFQRegionsControlWithDrawMode: true})
+                    }
                 }
                 setOffMode() {
                     this._mode = self.OFF_MODE
@@ -1550,7 +1565,7 @@
             }
             const scaleControl = new maplibregl.ScaleControl()
 
-            async function setUpMap() {
+            async function setUpMap({startFQRegionsControlWithDrawMode} = {}) {
                 // TODO (maybe?) use a maps-dot-black "on add map" callback instead, if such a thing exists.
                 // The problem is that at on creation, mb doesn't immediately contain a map.
                 // NOTE mapStyleLoaded happens much later than mapStylePresent.
@@ -1641,7 +1656,7 @@
                     }
                 })()
 
-                fqRegionsControl = new FQRegionsControl()
+                fqRegionsControl = new FQRegionsControl(startFQRegionsControlWithDrawMode)
                 mb.map.addControl(fqRegionsControl, 'top-left');
 
                 // Add all the right-side controls at once after we determine whether terrain is among them


### PR DESCRIPTION
### Fixes bug:

When using the FQR region selector with "globe" mode turned on, the rectangle would sometimes take the "long route" and wrap around the planet.

### Description of changes proposed in this pull request:

If the user turns on the FQR selector with globe mode turned on, it first turns off globe mode, refreshes the map (as is necessary), and loads the FQR selector tool ready to go.

### Smoke-tested on which OS or OS's:

RasPi OS Trixie

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd @holta 