### PR TITLE
Estimate FQR disk usage, with {URBAN, MOUNTAINS, ISLANDS, RURAL} examples

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -160,7 +160,7 @@ DETAILS: IIAB's downloadable regions (FQRs) include OpenStreetMap vector data up
 | | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km URBAN [example](https://opencagedata.com/tools/bounds-finder#76.6942553,28.1845497,77.7196694,29.0845497) | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km MOUNTAINS [example](https://opencagedata.com/tools/bounds-finder#84.4154371,28.0376883,85.4394215,28.9376883) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km ISLANDS [example](https://opencagedata.com/tools/bounds-finder#-76.8383789,16.2146745,-67.2163479,25.2146745) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km RURAL [example](https://opencagedata.com/tools/bounds-finder#101.5270099,62.4567592,124.5198784,71.4567592) |
 | ---: | :---: | :---: | :---: | :---: |
 | OSM Vector Data (MB)                                       | 39  | 13  | 119 | 91   |
-| Satellite&nbsp;Photos, Depth&nbsp;Sounding&nbsp;(MB) | 19  | 16  | 207 | 2369 |
+| Satellite&nbsp;Photos, Depth&nbsp;Sounding&nbsp;(MB)       | 19  | 16  | 207 | 2369 |
 | 3D Terrain (MB)                                            | 1.5 | 2.8 | 126 | 381  |
 | **FQR TOTAL (MB)**                                         | 58  | 32  | 451 | 2840 |
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -159,10 +159,10 @@ DETAILS: IIAB's downloadable regions (FQRs) include OpenStreetMap vector data up
 
 | | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km URBAN [example](https://opencagedata.com/tools/bounds-finder#76.6942553,28.1845497,77.7196694,29.0845497) | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km MOUNTAINS [example](https://opencagedata.com/tools/bounds-finder#84.4154371,28.0376883,85.4394215,28.9376883) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km ISLANDS [example](https://opencagedata.com/tools/bounds-finder#-76.8383789,16.2146745,-67.2163479,25.2146745) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km RURAL [example](https://opencagedata.com/tools/bounds-finder#101.5270099,62.4567592,124.5198784,71.4567592) |
 | ---: | :---: | :---: | :---: | :---: |
-| OSM Vector Data (MB)                                        | 39  | 13  | 119 | 91   |
-| Satellite&nbsp;Photos&nbsp;or Depth&nbsp;Sounding&nbsp;(MB) | 19  | 16  | 207 | 2369 |
-| 3D Terrain (MB)                                             | 1.5 | 2.8 | 126 | 381  |
-| **FQR TOTAL (MB)**                                          | 58  | 32  | 451 | 2840 |
+| OSM Vector Data (MB)                                       | 39  | 13  | 119 | 91   |
+| Satellite&nbsp;Photos, Depth&nbsp;Sounding&nbsp;(MB) | 19  | 16  | 207 | 2369 |
+| 3D Terrain (MB)                                            | 1.5 | 2.8 | 126 | 381  |
+| **FQR TOTAL (MB)**                                         | 58  | 32  | 451 | 2840 |
 
 ### Prerequisites
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -157,39 +157,12 @@ DETAILS: IIAB's downloadable regions (FQRs) include OpenStreetMap vector data up
 
 ### How big will these files be?
 
-<!-- See https://github.com/iiab/maps2/blob/master/build-tiles/stats.py for obtaining these numbers -->
-
-An FQR has three files: vector, satellite, and terrain.
-
-For a typical FQR that is **1 square km**:
-
-The *total* size (all three files) will be **3.5MB**, but it can get as big as **6MB**.
-
-Breaking it down by type:
-
-* Vector: typically **2.4MB**, sometimes **4.2MB**.
-* Satellite: typically **0.2MB**, sometimes **0.7MB**.
-* Terrain: typically **0.9MB**, sometimes **1.6MB**.
-
-For a typical FQR in an **urban area** that is **1 square km**:
-
-The *total* size (all three files) will be **5MB**, but it can get as big as **9MB**.
-
-Breaking it down by type:
-
-* Vector: typically **3.8MB**, sometimes **7MB**.
-* Satellite: typically **0.2MB**, sometimes **0.7MB**.
-* Terrain: typically **0.9MB**, sometimes **1.6MB**.
-
-For a typical FQR that is **1000 square km**:
-
-The *total* size (all three files) will be **1.9GB**, but it can get as big as **4.4GB**.
-
-Breaking it down by type:
-
-* Vector: typically **380MB**, sometimes **2GB**.
-* Satellite: typically **1.4GB**, sometimes **3GB**.
-* Terrain: typically **140MB**, sometimes **500MB**.
+| | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km URBAN [example](https://opencagedata.com/tools/bounds-finder#76.6942553,28.1845497,77.7196694,29.0845497) | 100&nbsp;km&nbsp;×&nbsp;100&nbsp;km MOUNTAINS [example](https://opencagedata.com/tools/bounds-finder#84.4154371,28.0376883,85.4394215,28.9376883) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km ISLANDS [example](https://opencagedata.com/tools/bounds-finder#-76.8383789,16.2146745,-67.2163479,25.2146745) | 1000&nbsp;km&nbsp;×&nbsp;1000&nbsp;km RURAL [example](https://opencagedata.com/tools/bounds-finder#101.5270099,62.4567592,124.5198784,71.4567592) |
+| ---: | :---: | :---: | :---: | :---: |
+| OSM Vector Data (MB)                                        | 39  | 13  | 119 | 91   |
+| Satellite&nbsp;Photos&nbsp;or Depth&nbsp;Sounding&nbsp;(MB) | 19  | 16  | 207 | 2369 |
+| 3D Terrain (MB)                                             | 1.5 | 2.8 | 126 | 381  |
+| **FQR TOTAL (MB)**                                          | 58  | 32  | 451 | 2840 |
 
 ### Prerequisites
 

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -155,6 +155,42 @@ DETAILS: IIAB's downloadable regions (FQRs) include OpenStreetMap vector data up
 
 *NOTE: The satellite data is licensed "NonCommercial" under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).*
 
+### How big will these files be?
+
+<!-- See https://github.com/iiab/maps2/blob/master/build-tiles/stats.py for obtaining these numbers -->
+
+An FQR has three files: vector, satellite, and terrain.
+
+For a typical FQR that is **1 square km**:
+
+The *total* size (all three files) will be **3.5MB**, but it can get as big as **6MB**.
+
+Breaking it down by type:
+
+* Vector: typically **2.4MB**, sometimes **4.2MB**.
+* Satellite: typically **0.2MB**, sometimes **0.7MB**.
+* Terrain: typically **0.9MB**, sometimes **1.6MB**.
+
+For a typical FQR in an **urban area** that is **1 square km**:
+
+The *total* size (all three files) will be **5MB**, but it can get as big as **9MB**.
+
+Breaking it down by type:
+
+* Vector: typically **3.8MB**, sometimes **7MB**.
+* Satellite: typically **0.2MB**, sometimes **0.7MB**.
+* Terrain: typically **0.9MB**, sometimes **1.6MB**.
+
+For a typical FQR that is **1000 square km**:
+
+The *total* size (all three files) will be **1.9GB**, but it can get as big as **4.4GB**.
+
+Breaking it down by type:
+
+* Vector: typically **380MB**, sometimes **2GB**.
+* Satellite: typically **1.4GB**, sometimes **3GB**.
+* Terrain: typically **140MB**, sometimes **500MB**.
+
 ### Prerequisites
 
 1. Confirm that at least a [minimum IIAB Maps](#whats-a-minimum-iiab-maps-install) is installed.

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
-import json, glob, os, re, shutil, string, subprocess, sys, tempfile
+import json, glob, math, os, random, re, shutil, string, subprocess, sys, tempfile
+from pprint import pprint
 from collections import defaultdict
 
-sys.path.insert(1, "{{ tile_extract.working_dir }}/{{ tile_extract.pmtiles_python.dir_name }}/python/pmtiles")
+sys.path.insert(1, "/opt/iiab/maps/tile-extract/pmtiles-python/python/pmtiles")
 
 from pmtiles.reader import MmapSource, all_tiles
 
@@ -339,11 +340,18 @@ def create_extract(extract_name, extract_box):
         shutil.move(paths["tmp"], paths["extract"])
 
 
-def approve_download_size(extract_name, extract_box):
-    extract_paths = get_new_extract_paths(extract_name)
-    extract_sizes = {}
+# Determine the sizes of all of the pmtiles files in bytes
+UNIT_MULT = {
+    'kB': 1_000,
+    'MB': 1_000_000,
+    'GB': 1_000_000_000,
+    'TB': 1_000_000_000_000,
+}
 
-    print("Determining download size...")
+
+def get_estimates(extract_box):
+    extract_paths = get_new_extract_paths("test")
+    extract_sizes = {}
 
     with tempfile.NamedTemporaryFile(delete_on_close=False, mode="w") as geojson_file:
         set_region_geojson(extract_box, geojson_file)
@@ -377,28 +385,31 @@ def approve_download_size(extract_name, extract_box):
                     break
 
             if re_match is None:
-                return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?")
+                return None
 
             (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
 
-            # Determine the sizes of all of the pmtiles files in bytes
-            unit_mult = {
-                'kB': 1_000,
-                'MB': 1_000_000,
-                'GB': 1_000_000_000,
-                'TB': 1_000_000_000_000,
-            }
             extract_sizes[paths['source']] = {
-                "transfer": float(transfer_num) * unit_mult[transfer_unit],
-                "archive":  float(archive_num)   * unit_mult[archive_unit],
+                "transfer": float(transfer_num) * UNIT_MULT[transfer_unit],
+                "archive":  float(archive_num)  * UNIT_MULT[archive_unit],
             }
+
+    return extract_sizes
+
+
+def approve_download_size(extract_name, extract_box):
+    print("Determining download size...")
+
+    extract_sizes = get_estimates(extract_box)
+    if extract_sizes is None:
+        return yes_no("Cannot get file size estimate due to unexpected output from pmtiles. Download anyway?")
 
     # Convert the file sizes back to the best available unit
     transfer_total = sum(size['transfer'] for size in extract_sizes.values())
     archive_total = sum(size['archive'] for size in extract_sizes.values())
 
     def display(num_bytes):
-        for unit, mult in unit_mult.items():
+        for unit, mult in UNIT_MULT.items():
             if 1 <= num_bytes / mult < 1000:
                 return f"{round(num_bytes / mult, 2)} {unit}"
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -340,7 +340,6 @@ def create_extract(extract_name, extract_box):
         shutil.move(paths["tmp"], paths["extract"])
 
 
-# Determine the sizes of all of the pmtiles files in bytes
 UNIT_MULT = {
     'kB': 1_000,
     'MB': 1_000_000,
@@ -389,6 +388,7 @@ def get_estimates(extract_box):
 
             (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
 
+            # Determine the sizes of all of the pmtiles files in bytes
             extract_sizes[paths['source']] = {
                 "transfer": float(transfer_num) * UNIT_MULT[transfer_unit],
                 "archive":  float(archive_num)  * UNIT_MULT[archive_unit],

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -313,10 +313,10 @@ maps_from_internet_archive: False
 # 36M  resourcetiles-minimal.pmtiles
 # 2M   s2maps-sentinel2-2023.2025-12-10.zoom_0-04.pmtiles
 # 1M   static-search.2025-12-10.pop-100k-cities.tar.gz
-# 15M  full quality regions
+# 20M  full quality regions
 #
 # ---------------------------------------------------------------
-# 63M  Total (with possible rounding errors)
+# 68M  Total (with possible rounding errors)
 
 maps_install: True
 maps_enabled: True


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Gives typical file sizes for FQRs per my best interpretation of @holta 's request, [in the README](https://github.com/orblivion/iiab/blob/estimate-fqr-sizes/roles/maps/README.md#how-big-will-these-files-be).

I gave a bit more info (both the average and max of my random sampling) than he asked for because a) file size variance is kind of high b) urban is more data than general. But I do think it's "too much information". So I'm making this a draft. I'm putting it out there to see what is deemed useful. (If it's just the averages, so be it.)

Also: refactor the FQR code a bit to facilitate [the code I used](https://github.com/iiab/maps2/blob/master/build-tiles/stats.py) to get these file size stats.

Also, unrelated: Update the comments about file sizes in the maps test yml to reflect the third FQR I added.

### Smoke-tested on which OS or OS's:

RasPiOS Trixie

### Mention a team member @username e.g. to help with code review:
@holta (for the README)
@chapmanjacobd (for the python)