### PR TITLE
U2604workflow

### DIFF
--- a/.github/workflows/07min-unittest-on-U2604.yml
+++ b/.github/workflows/07min-unittest-on-U2604.yml
@@ -1,0 +1,67 @@
+name: '"07 min" UNITTEST on Ubuntu 26.04'
+# run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.svg'
+      - '**/*.jpg'
+      - '**/*.png'
+      - '**/*.php'
+      - '**/*.js'
+  pull_request:  # needed to show up in Pull Request UI
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.svg'
+      - '**/*.jpg'
+      - '**/*.png'
+      - '**/*.php'
+      - '**/*.js'
+  workflow_dispatch:
+
+jobs:
+  test-install:
+    runs-on: ubuntu-26.04
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      #- name: Dump GitHub context (typically almost 500 lines)
+      #  env:
+      #    GITHUB_CONTEXT: ${{ toJSON(github) }}
+      #  run: echo "$GITHUB_CONTEXT"
+      - name: Check out repository code    # Clones repo onto github runner
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.  FYI "fetch-depth: 0" works but is way too greedy, downloading all branches.  The ideal would've been "fetch-depth: 10000" with "fetch-tags: true" -- but this remains broken as of actions/checkout@v4 on 2025-03-26: see issues #217, #338, PR #1396, #1467, #1471, #1662 in https://github.com/actions/checkout -- Dec 2020 background: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+      - run: echo "🍏 This job's status [SO FAR!] is ${{ job.status }}."
+      - name: GitHub Actions "runner" environment
+        run: |
+          uname -a    # uname -srm
+          whoami      # Typically 'runner' instead of 'root'
+          pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}
+          # tree /home/runner/work/_actions /home/runner/work/_temp /opt/hostedtoolcache (reusable deps; 88,000+ lines!)
+          # ls -la /opt    # az, containerd, google, hostedtoolcache, microsoft, mssql-tools, pipx, pipx_bin, post-generation, runner, vsts
+          # apt update && apt dist-upgrade -y && apt autoremove -y
+      - name: Set up /opt/iiab/iiab    # Some steps to get ready for the install
+        run: |
+          mkdir /opt/iiab
+          mv $GITHUB_WORKSPACE /opt/iiab
+          mkdir $GITHUB_WORKSPACE    # OR SUBSEQUENT STEPS WILL FAIL ('working-directory: /opt/iiab/iiab' hacks NOT worth it!)
+      - name: Set up /etc/iiab/local_vars.yml
+        run: |
+          sudo mkdir /etc/iiab
+          # local_vars_unittest.yml installs a quite minimal IIAB, without IIAB Apps
+          sudo cp /opt/iiab/iiab/vars/local_vars_unittest.yml /etc/iiab/local_vars.yml
+      - run: sudo /opt/iiab/iiab/scripts/ansible    # Installs Ansible
+        working-directory: /opt/iiab/iiab
+      - run: sudo ./iiab-install                    # Installs IIAB!
+        working-directory: /opt/iiab/iiab
+      - run: iiab-summary
+      - run: diff /opt/iiab/iiab/.github/workflows/tests/expected_state_unittest.yml /etc/iiab/iiab_state.yml --color    # Final validation

--- a/.github/workflows/30min-large-on-U2604.yml
+++ b/.github/workflows/30min-large-on-U2604.yml
@@ -71,4 +71,4 @@ jobs:
         working-directory: /opt/iiab/iiab
 
       - run: iiab-summary
-      - run: diff /opt/iiab/iiab/.github/workflows/tests/expected_state_large.yml /etc/iiab/iiab_state.yml --color    # Final validation
+      - run: diff /opt/iiab/iiab/.github/workflows/tests/expected_state_large2604.yml /etc/iiab/iiab_state.yml --color    # Final validation

--- a/.github/workflows/30min-large-on-U2604.yml
+++ b/.github/workflows/30min-large-on-U2604.yml
@@ -1,0 +1,74 @@
+name: '"30 min" LARGE on Ubuntu 26.04'
+# run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.svg'
+      - '**/*.jpg'
+      - '**/*.png'
+      - '**/*.php'
+      - '**/*.js'
+  pull_request:  # needed to show up in Pull Request UI
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.svg'
+      - '**/*.jpg'
+      - '**/*.png'
+      - '**/*.php'
+      - '**/*.js'
+  workflow_dispatch:
+
+jobs:
+  test-install:
+    runs-on: ubuntu-26.04
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+
+      #- name: Dump GitHub context (typically almost 500 lines)
+      #  env:
+      #    GITHUB_CONTEXT: ${{ toJSON(github) }}
+      #  run: echo "$GITHUB_CONTEXT"
+
+      - name: Check out repository code    # Clones repo onto github runner
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0    # Default is 1, but iiab-summary (below) needs git tag history.  FYI "fetch-depth: 0" works but is way too greedy, downloading all branches.  The ideal would've been "fetch-depth: 10000" with "fetch-tags: true" -- but this remains broken as of actions/checkout@v4 on 2025-03-26: see issues #217, #338, PR #1396, #1467, #1471, #1662 in https://github.com/actions/checkout -- Dec 2020 background: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+
+      - name: Set up /opt/iiab/iiab    # Some steps to get ready for the install
+        run: |
+          mkdir /opt/iiab
+          mv $GITHUB_WORKSPACE /opt/iiab
+          mkdir $GITHUB_WORKSPACE    # OR SUBSEQUENT STEPS WILL FAIL
+
+      - run: echo "🍏 This job's status [SO FAR!] is ${{ job.status }}."
+      - name: GitHub Actions "runner" environment
+        run: |
+          uname -a    # uname -srm
+          whoami      # Typically 'runner' instead of 'root'
+          pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}
+          # tree /home/runner/work/_actions /home/runner/work/_temp /opt/hostedtoolcache (reusable deps; 88,000+ lines!)
+          # ls -la /opt    # az, containerd, google, hostedtoolcache, microsoft, mssql-tools, pipx, pipx_bin, post-generation, runner, vsts
+          # apt update && apt dist-upgrade -y && apt autoremove -y
+
+      - name: Install Ansible
+        run: sudo /opt/iiab/iiab/scripts/ansible
+
+      - name: Set up /etc/iiab/local_vars.yml
+        run: |
+          sudo mkdir /etc/iiab
+          sudo cp /opt/iiab/iiab/vars/local_vars_large.yml /etc/iiab/local_vars.yml
+
+      - run: sudo ./iiab-install
+        working-directory: /opt/iiab/iiab
+
+      - run: iiab-summary
+      - run: diff /opt/iiab/iiab/.github/workflows/tests/expected_state_large.yml /etc/iiab/iiab_state.yml --color    # Final validation

--- a/.github/workflows/tests/expected_state_large2604.yml
+++ b/.github/workflows/tests/expected_state_large2604.yml
@@ -1,0 +1,42 @@
+# DO *NOT* MANUALLY EDIT THIS, THANKS!
+# IIAB does NOT currently support uninstalling apps/services.
+
+sshd_installed: True
+tailscale_installed: True
+remoteit_installed: True
+iiab_admin_installed: True
+network_installed: True
+nginx_installed: True
+www_base_installed: True
+pylibs_installed: True
+usb_lib_installed: True
+cups_installed: True
+samba_installed: True
+www_options_installed: True
+gitea_installed: True
+nodejs_installed: True
+jupyterhub_installed: True
+mysql_installed: True
+mediawiki_installed: True
+mosquitto_installed: True
+nodered_installed: True
+nextcloud_installed: True
+wordpress_installed: True
+kolibri_installed: True
+kiwix_installed: True
+postgresql_installed: True
+moodle_installed: True
+osm_vector_maps_installed: True
+mongodb_installed: True
+sugarizer_installed: True
+transmission_installed: True
+awstats_installed: True
+matomo_installed: True
+vnstat_installed: True
+captiveportal_installed: True
+yarn_installed: True
+internetarchive_installed: True
+luanti_installed: True
+calibreweb_installed: True
+code_installed: True
+munin_installed: True

--- a/collections.yml
+++ b/collections.yml
@@ -5,7 +5,7 @@
 ---
 collections:
   - name: community.general
-  - name: community.mysql
+  - name: ansible.mariadb
   - name: community.postgresql
   - name: ansible.posix    # 2020-11-28: For ~3 modules below...
 

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -67,13 +67,13 @@
   when: is_proot
 
 - name: Create MariaDB Database for Matomo
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ matomo_db_name }}"
     #login_unix_socket: /var/run/mysqld/mysqld.sock
   when: not is_proot
 
 - name: Add Admin User to MariaDB Database
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ matomo_db_user }}"
     password: "{{ matomo_db_pass }}"
     update_password: on_create    # OR SHOULD './runrole --reinstall matomo' FORCE A COMPLETELY CLEAN INSTALL?
@@ -85,7 +85,7 @@
   when: is_proot
   block:
     - name: Create MariaDB Database for Matomo (proot)
-      community.mysql.mysql_db:
+      ansible.mysql.mysql_db:
         name: "{{ matomo_db_name }}"
         state: present
         encoding: utf8mb4
@@ -94,7 +94,7 @@
         check_implicit_admin: true
 
     - name: Ensure Matomo DB user exists for localhost and 127.0.0.1 (proot)
-      community.mysql.mysql_user:
+      ansible.mysql.mysql_user:
         name: "{{ matomo_db_user }}"
         host: "{{ item }}"
         password: "{{ matomo_db_pass }}"

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -73,7 +73,7 @@
   when: not is_proot
 
 - name: Add Admin User to MariaDB Database
-  ansible.mysql.mysql_user:
+  ansible.mariadb.mariadb_user:
     name: "{{ matomo_db_user }}"
     password: "{{ matomo_db_pass }}"
     update_password: on_create    # OR SHOULD './runrole --reinstall matomo' FORCE A COMPLETELY CLEAN INSTALL?
@@ -94,7 +94,7 @@
         check_implicit_admin: true
 
     - name: Ensure Matomo DB user exists for localhost and 127.0.0.1 (proot)
-      ansible.mysql.mysql_user:
+      ansible.mariadb.mariadb_user:
         name: "{{ matomo_db_user }}"
         host: "{{ item }}"
         password: "{{ matomo_db_pass }}"

--- a/roles/matomo/tasks/install.yml
+++ b/roles/matomo/tasks/install.yml
@@ -67,7 +67,7 @@
   when: is_proot
 
 - name: Create MariaDB Database for Matomo
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ matomo_db_name }}"
     #login_unix_socket: /var/run/mysqld/mysqld.sock
   when: not is_proot
@@ -85,7 +85,7 @@
   when: is_proot
   block:
     - name: Create MariaDB Database for Matomo (proot)
-      ansible.mysql.mysql_db:
+      ansible.mariadb.mariadb_db:
         name: "{{ matomo_db_name }}"
         state: present
         encoding: utf8mb4

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -66,12 +66,12 @@
     state: started
 
 - name: Create MySQL database {{ mediawiki_db_name }}
-  mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ mediawiki_db_name }}"    # iiab_mediawiki
     #state: present
 
 - name: Create MySQL database user {{ mediawiki_db_user }} with password, and permissions to above db
-  mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ mediawiki_db_user }}"    # iiab_mediawiki_user
     password: "{{ mediawiki_db_user_password }}"
     priv: "{{ mediawiki_db_name }}.*:ALL,GRANT"

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -71,7 +71,7 @@
     #state: present
 
 - name: Create MySQL database user {{ mediawiki_db_user }} with password, and permissions to above db
-  ansible.mysql.mysql_user:
+  ansible.mariadb.mariadb_user:
     name: "{{ mediawiki_db_user }}"    # iiab_mediawiki_user
     password: "{{ mediawiki_db_user_password }}"
     priv: "{{ mediawiki_db_name }}.*:ALL,GRANT"

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -66,7 +66,7 @@
     state: started
 
 - name: Create MySQL database {{ mediawiki_db_name }}
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ mediawiki_db_name }}"    # iiab_mediawiki
     #state: present
 

--- a/roles/nextcloud/tasks/setup.yml
+++ b/roles/nextcloud/tasks/setup.yml
@@ -1,9 +1,9 @@
 - name: 'Create MySQL database with name: {{ nextcloud_dbname }}'
-  mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ nextcloud_dbname }}"
 
 - name: Add username/password to the MySQL database (associated with trusted IP's like localhost)
-  mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ nextcloud_dbuser }}"
     host: "{{ item }}"
     password: "{{ nextcloud_dbpassword }}"

--- a/roles/nextcloud/tasks/setup.yml
+++ b/roles/nextcloud/tasks/setup.yml
@@ -3,7 +3,7 @@
     name: "{{ nextcloud_dbname }}"
 
 - name: Add username/password to the MySQL database (associated with trusted IP's like localhost)
-  ansible.mysql.mysql_user:
+  ansible.mariadb.mariadb_user:
     name: "{{ nextcloud_dbuser }}"
     host: "{{ item }}"
     password: "{{ nextcloud_dbpassword }}"

--- a/roles/nextcloud/tasks/setup.yml
+++ b/roles/nextcloud/tasks/setup.yml
@@ -1,5 +1,5 @@
 - name: 'Create MySQL database with name: {{ nextcloud_dbname }}'
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ nextcloud_dbname }}"
 
 - name: Add username/password to the MySQL database (associated with trusted IP's like localhost)

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -150,7 +150,7 @@
 
 
 - name: FreePBX - Add MySQL user ({{ asterisk_db_user }})
-  mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ asterisk_db_user }}"            # asterisk
     password: "{{ asterisk_db_password }}"    # asterisk
     priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"
@@ -160,7 +160,7 @@
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_facts.default_ipv4.address) }}"
 
 - name: FreePBX - Add MySQL db ({{ asterisk_db_dbname }})
-  mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ asterisk_db_dbname }}"    # asterisk
     encoding: utf8
     collation: utf8_general_ci
@@ -169,7 +169,7 @@
     login_password: "{{ asterisk_db_password }}"
 
 - name: FreePBX - Add CDR MySQL db ({{ asterisk_db_cdrdbname }})
-  mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ asterisk_db_cdrdbname }}"    # asteriskcdrdb
     encoding: utf8
     collation: utf8_general_ci

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -160,7 +160,7 @@
     host: "{{ (asterisk_db_host == 'localhost') | ternary('localhost', ansible_facts.default_ipv4.address) }}"
 
 - name: FreePBX - Add MySQL db ({{ asterisk_db_dbname }})
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ asterisk_db_dbname }}"    # asterisk
     encoding: utf8
     collation: utf8_general_ci
@@ -169,7 +169,7 @@
     login_password: "{{ asterisk_db_password }}"
 
 - name: FreePBX - Add CDR MySQL db ({{ asterisk_db_cdrdbname }})
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ asterisk_db_cdrdbname }}"    # asteriskcdrdb
     encoding: utf8
     collation: utf8_general_ci

--- a/roles/pbx/tasks/freepbx.yml
+++ b/roles/pbx/tasks/freepbx.yml
@@ -150,7 +150,7 @@
 
 
 - name: FreePBX - Add MySQL user ({{ asterisk_db_user }})
-  ansible.mysql.mysql_user:
+  ansible.mariadb.mariadb_user:
     name: "{{ asterisk_db_user }}"            # asterisk
     password: "{{ asterisk_db_password }}"    # asterisk
     priv: "{{ asterisk_db_dbname }}.*:ALL/{{ asterisk_db_cdrdbname }}.*:ALL"

--- a/roles/wordpress/tasks/setup.yml
+++ b/roles/wordpress/tasks/setup.yml
@@ -4,11 +4,11 @@
     name: "{{ mysql_service }}"
 
 - name: 'Create MySQL database for WordPress: {{ wp_db_name }}'
-  mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ wp_db_name }}"
 
 - name: Create MySQL username ({{ wp_db_user }}) with password, for above database
-  mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ wp_db_user }}"
     password: "{{ wp_db_user_password }}"
     priv: "{{ wp_db_name }}.*:ALL,GRANT"

--- a/roles/wordpress/tasks/setup.yml
+++ b/roles/wordpress/tasks/setup.yml
@@ -4,7 +4,7 @@
     name: "{{ mysql_service }}"
 
 - name: 'Create MySQL database for WordPress: {{ wp_db_name }}'
-  ansible.mysql.mysql_db:
+  ansible.mariadb.mariadb_db:
     name: "{{ wp_db_name }}"
 
 - name: Create MySQL username ({{ wp_db_user }}) with password, for above database

--- a/roles/wordpress/tasks/setup.yml
+++ b/roles/wordpress/tasks/setup.yml
@@ -8,7 +8,7 @@
     name: "{{ wp_db_name }}"
 
 - name: Create MySQL username ({{ wp_db_user }}) with password, for above database
-  ansible.mysql.mysql_user:
+  ansible.mariadb.mariadb_user:
     name: "{{ wp_db_user }}"
     password: "{{ wp_db_user_password }}"
     priv: "{{ wp_db_name }}.*:ALL,GRANT"


### PR DESCRIPTION
### Fixes bug:
Warning: : Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: community.mysql.mysql_db has been deprecated. Use ansible.mysql.mysql_db instead. This feature will be removed from collection 'community.mysql' version 6.0.0.
Origin: <unknown>
community.mysql.mysql_db
[DEPRECATION WARNING]: community.mysql.mysql_user has been deprecated. Use ansible.mysql.mysql_user instead. This feature will be removed from collection 'community.mysql' version 6.0.0.
Origin: <unknown>
community.mysql.mysql_user

### Description of changes proposed in this pull request:
Get rid of above warnings and introduce U26.04 test runners 
https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/
### Smoke-tested on which OS or OS's:
CI
### Mention a team member @username e.g. to help with code review:
@chapmanjacobd 