### PR TITLE
Let's try MediaWiki 1.45.4 (instead of 1.44.x)

### DIFF
--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -4,8 +4,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-mediawiki_major_version: "1.44"    # "1.40" quotes nec if trailing zero
-mediawiki_minor_version: 5
+mediawiki_major_version: "1.45"    # "1.40" quotes nec if trailing zero
+mediawiki_minor_version: 4
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
 mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"


### PR DESCRIPTION
FYI 1.46 is imminent, but this security release and jump from 1.44.x to 1.45.4 will also help validate:

https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/J52N2ONQO7GP3XR7UIEA5PI7SVZYTBJ7/

Building on:

- PR #4169 
- PR #4175
- PR #4335