### PR TITLE
[maps] improve display by preventing cache on FQR.

### DIFF
--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -733,7 +733,7 @@
             const fqrLoaded = () => !!downloadedFQRegions
 
             function setFQRegions() {
-                return fetch('{{ tile_extract.info_file }}')
+                return fetch('{{ tile_extract.info_file }}', { cache: 'no-store' })
                     .then((response) => {
                         if (response.status < 400) {
                             return response.json()


### PR DESCRIPTION
### Fixes bug:
On some native browsers on Android devices FQR are not correctly displayed due browser cache.

### Description of changes proposed in this pull request:
Add a cache: no-store js argument
It might be required to also touch nginx configuration if some devices browsers report no FQR present. 

### Smoke-tested on which OS or OS's:
Debian 13 (android)

### Mention a team member @username e.g. to help with code review:
@holta @orblivion 

With this change, it shows out of the box:
<img width="356" height="791" alt="maps_shows_out_of_the_box" src="https://github.com/user-attachments/assets/bcb8c480-9839-49fe-a287-70d3d47eaf32" />

