### PR TITLE
maps_vector_data_date: "2026-07-01"; rm var maps_from_internet_archive

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -27,7 +27,7 @@ maps_static_search_root: "{{ maps_serve_path }}/{{ maps_static_search_dir }}"
 # date designations down the line. I just want one "slow" date to set all of
 # these items *for now*.
 #
-maps_vector_data_date: "2026-04-01"
+maps_vector_data_date: "2026-07-01"
 maps_search_data_date: "2026-04-22"
 maps_slow_data_date: "2025-12-10"
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -506,8 +506,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-vector-maps
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -295,8 +295,6 @@ moodle_enabled: True
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -300,8 +300,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: False
 osm_vector_maps_enabled: False
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -295,8 +295,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -295,8 +295,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: True
 osm_vector_maps_enabled: True
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -295,8 +295,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: False
 osm_vector_maps_enabled: False
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -301,8 +301,6 @@ moodle_enabled: False
 # Instructions: https://github.com/iiab/iiab/wiki/IIAB-Maps
 osm_vector_maps_install: False
 osm_vector_maps_enabled: False
-# Set to "True" to download .mbtiles files from Archive.org (might be slow!)
-maps_from_internet_archive: False
 
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Very minor updates:
- Offer latest OSM vector maps from 2026-07-01
- Remove legacy variable `maps_from_internet_archive` that was never actually used.

### Smoke-tested on which OS or OS's:

Latest RPiOS Lite

### Mention a team member @username e.g. to help with code review:

@orblivion