### PR TITLE
Fix mutable default arg in read_library_xml() using set pattern

### DIFF
--- a/roles/pylibs/templates/iiab_lib.py
+++ b/roles/pylibs/templates/iiab_lib.py
@@ -63,7 +63,8 @@ def read_library_xml(lib_xml_file, kiwix_exclude_attr=["favicon"]): # duplicated
       path_to_id_map (dict): A dictionary that translates zim ids to physical names
     '''
 
-    kiwix_exclude_attr.append("id") # don't include id because is key
+    excluded_attr = {'id'} # use a set and never include the key
+    excluded_attr.update(kiwix_exclude_attr)
     zims_installed = {}
     path_to_id_map = {}
     try:
@@ -75,7 +76,7 @@ def read_library_xml(lib_xml_file, kiwix_exclude_attr=["favicon"]): # duplicated
                 print("xml record missing Book Id")
             zim_id = child.attrib['id']
             for attr in child.attrib:
-                if attr not in kiwix_exclude_attr:
+                if attr not in excluded_attr:
                     attributes[attr] = child.attrib[attr] # copy if not id or in exclusion list
             zims_installed[zim_id] = attributes
             path_to_id_map[child.attrib['path']] = zim_id


### PR DESCRIPTION
### Fixes bug:

`read_library_xml()` mutates the default list argument in place, so it grows by a duplicate "id" every time the function is called without an explicit argument. Just fixed the same bug in https://github.com/iiab/iiab-admin-console/pull/656

### Description of changes proposed in this pull request:

Replaces the `.append("id") `on the default list with a local `excluded_attr` set built fresh on each call, matching the set pattern used in the admin console fix. The default argument is no longer mutated, so it can't grow across calls.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 LTS (Python 3.14)

### Mention a team member @username e.g. to help with code review:

@tim-moody 