### PR TITLE
proot_services: seed Kolibri reserved network locations on start

### DIFF
--- a/roles/proot_services/files/pdsm/usr_local_pdsm/services-available/kolibri
+++ b/roles/proot_services/files/pdsm/usr_local_pdsm/services-available/kolibri
@@ -26,6 +26,20 @@ start() {
   # Ensure nginx is up as a requirement
   require_service "nginx"
 
+  # Seed Studio & KDP "reserved" NetworkLocations if absent.
+  # Normally created via the ZeroConf registration event, which does not
+  # run under proot (netlink is blocked). Seed directly.
+  reserved_count=$(sqlite3 "${KOLIBRI_HOME%/}/networklocation.sqlite3" \
+    "SELECT COUNT(*) FROM discovery_networklocation WHERE location_type='reserved';" \
+    2>/dev/null || echo 0)
+  if [ "${reserved_count:-0}" -eq 0 ]; then
+    echo "[pdsm:$SERVICE_NAME] seeding reserved network locations (Studio/KDP)"
+    "$KOLIBRI_BIN" manage shell -c \
+      "from kolibri.core.discovery.tasks import _refresh_reserved_locations; _refresh_reserved_locations()" \
+      >/dev/null 2>&1 || \
+      echo "[pdsm:$SERVICE_NAME] WARNING: reserved-location seeding failed (continuing)" >&2
+  fi
+
   "$KOLIBRI_BIN" start
 
   # Small wait loop so 'start' only returns when it's actually alive


### PR DESCRIPTION
### Fixes bug:
Under proot, "Kolibri Studio (online)" is disabled in the content import "Select a source" dialog even with working internet.

### Root cause:
Kolibri reaches Studio only if it exists as a "reserved" NetworkLocation in its DB. Those reserved locations (Studio and KDP) are seeded as a side effect of the ZeroConf registration event.
Under proot, ZeroConf cannot start, interface enumeration needs netlink, which Android blocks ("Cannot bind netlink socket: Permission denied"), so the event never fires, the reserved locations are never created, and the status check reports offline.

TLS/CA and outbound HTTPS are not involved: a plain request to Studio and `kolibri manage importchannel/importcontent` from the CLI both succeed. The gap is purely the missing reserved-location rows.

### Description of changes proposed in this pull request:
Seed the reserved NetworkLocations in the Kolibri pdsm `start()` if they are absent, before launching the server. Presence is checked with a direct sqlite query, so an already-seeded instance incurs no cost. Seeding runs via `_refresh_reserved_locations()`; failures are logged and do not block startup.

This is a proot-specific workaround. The upstream fix would be for Kolibri to seed reserved locations at server startup unconditionally, rather than only via the ZeroConf event; if that lands, this can be removed.

### Smoke-tested on which OS or OS's:
Debian 13 (proot on Android 15). Before: reserved-location count 0, Studio disabled. After start: count 2 (Studio + KDP), Studio import enabled; a second restart re-seeds nothing.

### Mention a team member @username e.g. to help with code review:
@holta
