### PR TITLE
www_options: guard labwc autostart against skipped stat (fixes instal…

### DIFF
--- a/roles/www_options/tasks/main.yml
+++ b/roles/www_options/tasks/main.yml
@@ -56,8 +56,7 @@
     create: yes
     regexp: '^/usr/bin/chromium'
     line: '/usr/bin/chromium --hide-crash-restore-bubble http://box/home &'
-  when: labwc_dir.stat.exists and labwc_dir.stat.isdir and chromium_browser.stat.exists
-
+  when: labwc_dir.stat is defined and labwc_dir.stat.exists and labwc_dir.stat.isdir and chromium_browser.stat.exists
 
 # 2022-12-29: php-settings.yml is ALSO attempted (on demand) by every
 # <ROLE>/tasks/install.yml that needs it (Matomo, Moodle, Nextcloud, PBX,


### PR DESCRIPTION
…l crash in root-only/no-UID-1000 environments)

### Fixes bug:
The install aborts in root-only environments; no UID 1000 user (proot/Termux, containers, VPS); during www_options:

```
TASK [www_options : ...add '/usr/bin/chromium ... to /home//.config/labwc/autostart]
[ERROR]: A 'when' expression failed: object of type 'dict' has no attribute 'stat'
when: labwc_dir.stat.exists and labwc_dir.stat.isdir and chromium_browser.stat.exists
```

### Description of changes proposed in this pull request:
Gate the `lineinfile` condition on `labwc_dir.stat is defined` first. Ansible `when` lists are AND with short-circuit, so when the stat was skipped the remaining terms are never evaluated. RasPiOS-desktop behavior is unchanged (the chromium kiosk autostart still gets written when the labwc dir exists); the task is simply skipped where the stat did not run.

Note: `roles/iiab-admin/tasks/pwd-warnings.yml` already neutralized the identical labwc block (commented out 2026-05-10); this applies the equivalent robustness to the copy in `www_options` that is still live.

### Smoke-tested on which OS or OS's:
Debian 13 (proot), or any other root-only environment

### Mention a team member @username e.g. to help with code review:
@holta
