### PR TITLE
Update Sugarizer version to 2.0.0

### DIFF
--- a/roles/sugarizer/defaults/main.yml
+++ b/roles/sugarizer/defaults/main.yml
@@ -9,8 +9,8 @@
 # All above are set in: github.com/iiab/iiab/blob/master/vars/default_vars.yml
 # If nec, change them by editing /etc/iiab/local_vars.yml prior to installing!
 
-sugarizer_dir_version: sugarizer-1.9.0    # WAS: sugarizer-1.0, sugarizer-master, sugarizer-1.1.0, sugarizer-1.2.0, sugarizer-1.3.0, sugarizer-1.4.0, sugarizer-1.5.0, sugarizer-1.6.0, sugarizer-1.7.0, sugarizer-1.8.0
-sugarizer_git_version: v1.9.0             # WAS: v1.0.1, master, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v1.7.0, v1.8.0
+sugarizer_dir_version: sugarizer-2.0.0    # WAS: sugarizer-1.0, sugarizer-master, sugarizer-1.1.0, sugarizer-1.2.0, sugarizer-1.3.0, sugarizer-1.4.0, sugarizer-1.5.0, sugarizer-1.6.0, sugarizer-1.7.0, sugarizer-1.8.0, sugarizer-1.9.0
+sugarizer_git_version: v2.0.0             # WAS: v1.0.1, master, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v1.7.0, v1.8.0, v1.9.0
 # PLEASE HELP MONITOR https://github.com/llaske/sugarizer/releases
 
 sugarizer_server_dir_version: sugarizer-server-1.5.0    # WAS: sugarizer-server-1.0, sugarizer-server-master, sugarizer-server-dev, sugarizer-server-1.1.0, sugarizer-server-1.1.1, sugarizer-server-1.2.0, sugarizer-server-1.3.0, sugarizer-server-1.4.0


### PR DESCRIPTION
Announcements:
- https://groups.google.com/g/unleashkids/c/PMnVXtJ5GkM
- https://github.com/llaske/sugarizer/releases/tag/v2.0.0

Changelog:

https://github.com/llaske/sugarizer/blob/master/CHANGELOG.md#200---2026-07-17

### Smoke-tested on which OS or OS's:

Testing on Ubuntu 26.04 is probably enough, but let's also give this a try on the latest RPiOS !