### PR TITLE
add missing zim lang codes

### DIFF
--- a/roles/www_base/files/html/assets/lang_codes.json
+++ b/roles/www_base/files/html/assets/lang_codes.json
@@ -1,311 +1,1872 @@
-{"aar":{"iso2":"aa","engname":"Afar","locname":"Afar"},
-"abk":{"iso2":"ab","engname":"Abkhazian","locname":"Аҧсуа"},
-"ace":{"iso2":"ace","engname":"Acehnese","locname":"Bahsa Acèh"},
-"afr":{"iso2":"af","engname":"Afrikaans","locname":"Afrikaans"},
-"aka":{"iso2":"ak","engname":"Akan","locname":"Akana"},
-"als":{"iso2":"als","engname":"Alemannic","locname":"Alemannisch"},
-"amh":{"iso2":"am","engname":"Amharic","locname":"አማርኛ"},
-"ang":{"iso2":"ang","engname":"Anglo-Saxon","locname":"Englisc"},
-"ara":{"iso2":"ar","engname":"Arabic","locname":"العربية"},
-"arc":{"iso2":"arc","engname":"Aramaic","locname":"ܐܪܡܝܐ"},
-"arg":{"iso2":"an","engname":"Aragonese","locname":"Aragonés"},
-"arz":{"iso2":"arz","engname":"Egyptian Arabic","locname":"مصرى (Maṣri)"},
-"asm":{"iso2":"as","engname":"Assamese","locname":"অসমীয়া"},
-"ast":{"iso2":"ast","engname":"Asturian","locname":"Asturianu"},
-"ava":{"iso2":"av","engname":"Avar","locname":"Авар"},
-"aym":{"iso2":"ay","engname":"Aymara","locname":"Aymar"},
-"aze":{"iso2":"az","engname":"Azerbaijani","locname":"Azərbaycanca"},
-"bak":{"iso2":"ba","engname":"Bashkir","locname":"Башҡорт"},
-"bam":{"iso2":"bm","engname":"Bambara","locname":"Bamanankan"},
-"bar":{"iso2":"bar","engname":"Bavarian","locname":"Boarisch"},
-"bat-smg":{"iso2":"bat-smg","engname":"Samogitian","locname":"Žemaitėška"},
-"bcl":{"iso2":"bcl","engname":"Central Bicolano","locname":"Bikol"},
-"bel":{"iso2":"be","engname":"Belarusian","locname":"Беларуская"},
-"ben":{"iso2":"bn","engname":"Bengali","locname":"বাংলা"},
-"be-x-old":{"iso2":"be-x-old","engname":"Belarusian (Taraškievica)","locname":"Беларуская (тарашкевіца)"},
-"bgd":{"iso2":"bgd","engname":"Pawri","locname":"Pawri"},
-"bho":{"iso2":"bh","engname":"Bhojpuri","locname":"भोजपुरी"},
-"bis":{"iso2":"bi","engname":"Bislama","locname":"Bislama"},
-"bjn":{"iso2":"bjn","engname":"Banjar","locname":"Bahasa Banjar"},
-"bod":{"iso2":"bo","engname":"Tibetan","locname":"བོད་སྐད"},
-"bos":{"iso2":"bs","engname":"Bosnian","locname":"Bosanski"},
-"bpy":{"iso2":"bpy","engname":"Bishnupriya Manipuri","locname":"ইমার ঠার/বিষ্ণুপ্রিয়া মণিপুরী"},
-"bre":{"iso2":"br","engname":"Breton","locname":"Brezhoneg"},
-"bug":{"iso2":"bug","engname":"Buginese","locname":"Basa Ugi"},
-"bul":{"iso2":"bg","engname":"Bulgarian","locname":"Български"},
-"bxr":{"iso2":"bxr","engname":"Buryat (Russia)","locname":"Буряад"},
-"cat":{"iso2":"ca","engname":"Catalan","locname":"Català"},
-"cbk-zam":{"iso2":"cbk-zam","engname":"Zamboanga Chavacano","locname":"Chavacano de Zamboanga"},
-"cdo":{"iso2":"cdo","engname":"Min Dong","locname":"Mìng-dĕ̤ng-ngṳ̄"},
-"ceb":{"iso2":"ceb","engname":"Cebuano","locname":"Sinugboanong Binisaya"},
-"ces":{"iso2":"cs","engname":"Czech","locname":"Čeština"},
-"cha":{"iso2":"ch","engname":"Chamorro","locname":"Chamoru"},
-"che":{"iso2":"ce","engname":"Chechen","locname":"Нохчийн"},
-"cho":{"iso2":"cho","engname":"Choctaw","locname":"Choctaw"},
-"chr":{"iso2":"chr","engname":"Cherokee","locname":"ᏣᎳᎩ"},
-"chu":{"iso2":"cu","engname":"Old Church Slavonic","locname":"Словѣньскъ"},
-"chv":{"iso2":"cv","engname":"Chuvash","locname":"Чăваш"},
-"chy":{"iso2":"chy","engname":"Cheyenne","locname":"Tsetsêhestâhese"},
-"ckb":{"iso2":"ckb","engname":"Sorani","locname":"Soranî / کوردی"},
-"cnm":{"iso2":"zh","engname":"Chinese","locname":"中文"},
-"cor":{"iso2":"kw","engname":"Cornish","locname":"Kernewek/Karnuack"},
-"cos":{"iso2":"co","engname":"Corsican","locname":"Corsu"},
-"cre":{"iso2":"cr","engname":"Cree","locname":"Nehiyaw"},
-"crh":{"iso2":"crh","engname":"Crimean Tatar","locname":"Qırımtatarca"},
-"csb":{"iso2":"csb","engname":"Kashubian","locname":"Kaszëbsczi"},
-"cym":{"iso2":"cy","engname":"Welsh","locname":"Cymraeg"},
-"dan":{"iso2":"da","engname":"Danish","locname":"Dansk"},
-"de":{"iso2":"de","engname":"German","locname":"Deutsch"},
-"deu":{"iso2":"de","engname":"German","locname":"Deutsch"},
-"diq":{"iso2":"diq","engname":"Zazaki","locname":"Zazaki"},
-"div":{"iso2":"dv","engname":"Divehi","locname":"ދިވެހިބަސް"},
-"dsb":{"iso2":"dsb","engname":"Lower Sorbian","locname":"Dolnoserbski"},
-"dty":{"iso2":"dty","engname":"Doteli","locname":"डोटेली"},
-"dzo":{"iso2":"dz","engname":"Dzongkha","locname":"ཇོང་ཁ"},
-"ell":{"iso2":"el","engname":"Greek","locname":"Ελληνικά"},
-"eml":{"iso2":"eml","engname":"Emilian-Romagnol","locname":"Emiliàn e rumagnòl"},
-"en":{"iso2":"en","engname":"English","locname":"English"},
-"eng":{"iso2":"en","engname":"English","locname":"English"},
-"epo":{"iso2":"eo","engname":"Esperanto","locname":"Esperanto"},
-"est":{"iso2":"et","engname":"Estonian","locname":"Eesti"},
-"eus":{"iso2":"eu","engname":"Basque","locname":"Euskara"},
-"ewe":{"iso2":"ee","engname":"Ewe","locname":"Eʋegbe"},
-"ext":{"iso2":"ext","engname":"Extremaduran","locname":"Estremeñu"},
-"fao":{"iso2":"fo","engname":"Faroese","locname":"Føroyskt"},
-"fas":{"iso2":"fa","engname":"Persian","locname":"فارسی"},
-"fij":{"iso2":"fj","engname":"Fijian","locname":"Na Vosa Vakaviti"},
-"fin":{"iso2":"fi","engname":"Finnish","locname":"Suomi"},
-"fiu-vro":{"iso2":"fiu-vro","engname":"Võro","locname":"Võro"},
-"fra":{"iso2":"fr","engname":"French","locname":"Français"},
-"fr":{"iso2":"fr","engname":"French","locname":"Français"},
-"frp":{"iso2":"frp","engname":"Franco-Provençal/Arpitan","locname":"Arpitan"},
-"frr":{"iso2":"frr","engname":"North Frisian","locname":"Nordfriisk"},
-"fry":{"iso2":"fy","engname":"West Frisian","locname":"Frysk"},
-"ful":{"iso2":"ff","engname":"Fula","locname":"Fulfulde"},
-"fur":{"iso2":"fur","engname":"Friulian","locname":"Furlan"},
-"gag":{"iso2":"gag","engname":"Gagauz","locname":"Gagauz"},
-"gan":{"iso2":"gan","engname":"Gan","locname":"贛語"},
-"gla":{"iso2":"gd","engname":"Scottish Gaelic","locname":"Gàidhlig"},
-"gle":{"iso2":"ga","engname":"Irish","locname":"Gaeilge"},
-"glg":{"iso2":"gl","engname":"Galician","locname":"Galego"},
-"glk":{"iso2":"glk","engname":"Gilaki","locname":"گیلکی"},
-"glv":{"iso2":"gv","engname":"Manx","locname":"Gaelg"},
-"gom":{"iso2":"gom","engname":"Goan Konkani","locname":"गोंयची कोंकणी "},
-"gon":{"iso2":"gon","engname":"Gondi","locname":"Gondi"},
-"got":{"iso2":"got","engname":"Gothic","locname":"𐌲𐌿𐍄𐌹𐍃𐌺"},
-"grn":{"iso2":"gn","engname":"Guarani","locname":"Avañe'ẽ"},
-"grt":{"iso2":"grt","engname":"Garo","locname":"আ·চিক"},
-"gsw":{"iso2":"de","engname":"German","locname":"Deutsch"},
-"guj":{"iso2":"gu","engname":"Gujarati","locname":"ગુજરાતી"},
-"hak":{"iso2":"hak","engname":"Hakka","locname":"Hak-kâ-fa / 客家話"},
-"hat":{"iso2":"ht","engname":"Haitian","locname":"Krèyol ayisyen"},
-"hau":{"iso2":"ha","engname":"Hausa","locname":"هَوُسَ"},
-"haw":{"iso2":"haw","engname":"Hawaiian","locname":"Hawai`i"},
-"heb":{"iso2":"he","engname":"Hebrew","locname":"עברית"},
-"her":{"iso2":"hz","engname":"Herero","locname":"Otsiherero"},
-"hif":{"iso2":"hif","engname":"Fiji Hindi","locname":"Fiji Hindi"},
-"hin":{"iso2":"hi","engname":"Hindi","locname":"हिन्दी"},
-"hmo":{"iso2":"ho","engname":"Hiri Motu","locname":"Hiri Motu"},
-"hrv":{"iso2":"hr","engname":"Croatian","locname":"Hrvatski"},
-"hsb":{"iso2":"hsb","engname":"Upper Sorbian","locname":"Hornjoserbsce"},
-"hun":{"iso2":"hu","engname":"Hungarian","locname":"Magyar"},
-"hye":{"iso2":"hy","engname":"Armenian","locname":"Հայերեն"},
-"ibo":{"iso2":"ig","engname":"Igbo","locname":"Igbo"},
-"ido":{"iso2":"io","engname":"Ido","locname":"Ido"},
-"iii":{"iso2":"ii","engname":"Sichuan Yi","locname":"ꆇꉙ"},
-"iku":{"iso2":"iu","engname":"Inuktitut","locname":"ᐃᓄᒃᑎᑐᑦ"},
-"ile":{"iso2":"ie","engname":"Interlingue","locname":"Interlingue"},
-"ilo":{"iso2":"ilo","engname":"Ilokano","locname":"Ilokano"},
-"ina":{"iso2":"ia","engname":"Interlingua","locname":"Interlingua"},
-"ind":{"iso2":"id","engname":"Indonesian","locname":"Bahasa Indonesia"},
-"ipk":{"iso2":"ik","engname":"Inupiak","locname":"Iñupiak"},
-"isl":{"iso2":"is","engname":"Icelandic","locname":"Íslenska"},
-"ita":{"iso2":"it","engname":"Italian","locname":"Italiano"},
-"jav":{"iso2":"jv","engname":"Javanese","locname":"Basa Jawa"},
-"jbo":{"iso2":"jbo","engname":"Lojban","locname":"Lojban"},
-"jpn":{"iso2":"ja","engname":"Japanese","locname":"日本語"},
-"kaa":{"iso2":"kaa","engname":"Karakalpak","locname":"Qaraqalpaqsha"},
-"kab":{"iso2":"kab","engname":"Kabyle","locname":"Taqbaylit"},
-"kal":{"iso2":"kl","engname":"Greenlandic","locname":"Kalaallisut"},
-"kan":{"iso2":"kn","engname":"Kannada","locname":"ಕನ್ನಡ"},
-"kas":{"iso2":"ks","engname":"Kashmiri","locname":"कश्मीरी / كشميري"},
-"kat":{"iso2":"ka","engname":"Georgian","locname":"ქართული"},
-"kau":{"iso2":"kr","engname":"Kanuri","locname":"Kanuri"},
-"kaz":{"iso2":"kk","engname":"Kazakh","locname":"Қазақша"},
-"kbd":{"iso2":"kbd","engname":"Kabardian Circassian","locname":"Адыгэбзэ (Adighabze)"},
-"kfq":{"iso2":"kfq","engname":"Korku","locname":"Korku"},
-"kha":{"iso2":"kha","engname":"Khasi","locname":"খাশি"},
-"khm":{"iso2":"km","engname":"Khmer","locname":"ភាសាខ្មែរ"},
-"kik":{"iso2":"ki","engname":"Kikuyu","locname":"Gĩkũyũ"},
-"kin":{"iso2":"rw","engname":"Kinyarwanda","locname":"Ikinyarwanda"},
-"kir":{"iso2":"ky","engname":"Kirghiz","locname":"Кыргызча"},
-"koi":{"iso2":"koi","engname":"Komi-Permyak","locname":"Перем Коми (Perem Komi)"},
-"kok":{"iso2":"kok","engname":"Konkani","locname":"ಕೊಂಕಣಿ"},
-"kokana":{"iso2":"kokana","engname":"Kokana","locname":"Kokana"},
-"kom":{"iso2":"kv","engname":"Komi","locname":"Коми"},
-"kon":{"iso2":"kg","engname":"Kongo","locname":"KiKongo"},
-"kor":{"iso2":"ko","engname":"Korean","locname":"한국어"},
-"krc":{"iso2":"krc","engname":"Karachay-Balkar","locname":"Къарачай-Малкъар (Qarachay-Malqar)"},
-"ksh":{"iso2":"ksh","engname":"Ripuarian","locname":"Ripoarisch"},
-"kua":{"iso2":"kj","engname":"Kuanyama","locname":"Kuanyama"},
-"kur":{"iso2":"ku","engname":"Kurdish","locname":"Kurdî / كوردی"},
-"lad":{"iso2":"lad","engname":"Ladino","locname":"Dzhudezmo"},
-"lao":{"iso2":"lo","engname":"Lao","locname":"ລາວ"},
-"lat":{"iso2":"la","engname":"Latin","locname":"Latina"},
-"lav":{"iso2":"lv","engname":"Latvian","locname":"Latviešu"},
-"lbe":{"iso2":"lbe","engname":"Lak","locname":"Лакку"},
-"lbj":{"iso2":"lbj","engname":"Ladakhi","locname":"ལ་དྭགས་སྐད"},
-"lez":{"iso2":"lez","engname":"Lezgian","locname":"Лезги чІал (Lezgi č’al)"},
-"lij":{"iso2":"lij","engname":"Ligurian","locname":"Líguru"},
-"lim":{"iso2":"li","engname":"Limburgish","locname":"Limburgs"},
-"lin":{"iso2":"ln","engname":"Lingala","locname":"Lingala"},
-"lit":{"iso2":"lt","engname":"Lithuanian","locname":"Lietuvių"},
-"lmo":{"iso2":"lmo","engname":"Lombard","locname":"Lumbaart"},
-"ltg":{"iso2":"ltg","engname":"Latgalian","locname":"Latgaļu"},
-"ltz":{"iso2":"lb","engname":"Luxembourgish","locname":"Lëtzebuergesch"},
-"lug":{"iso2":"lg","engname":"Luganda","locname":"Luganda"},
-"lus":{"iso2":"lus","engname":"Mizo","locname":"Mizo"},
-"mah":{"iso2":"mh","engname":"Marshallese","locname":"Ebon"},
-"mai":{"iso2":"mai","engname":"Maithili","locname":"मैथिली"},
-"mal":{"iso2":"ml","engname":"Malayalam","locname":"മലയാളം"},
-"map-bms":{"iso2":"map-bms","engname":"Banyumasan","locname":"Basa Banyumasan"},
-"mar":{"iso2":"mr","engname":"Marathi","locname":"मराठी"},
-"mdf":{"iso2":"mdf","engname":"Moksha","locname":"Мокшень (Mokshanj Kälj)"},
-"mhr":{"iso2":"mhr","engname":"Meadow Mari","locname":"Олык Марий (Olyk Marij)"},
-"min":{"iso2":"min","engname":"Minangkabau","locname":"Minangkabau"},
-"mkd":{"iso2":"mk","engname":"Macedonian","locname":"Македонски"},
-"mlg":{"iso2":"mg","engname":"Malagasy","locname":"Malagasy"},
-"mlt":{"iso2":"mt","engname":"Maltese","locname":"Malti"},
-"mni":{"iso2":"mni","engname":"Manipuri","locname":"মৈতৈলোন্"},
-"mo":{"iso2":"mo","engname":"Moldovan","locname":"Молдовеняскэ"},
-"mon":{"iso2":"mn","engname":"Mongolian","locname":"Монгол"},
-"mri":{"iso2":"mi","engname":"Maori","locname":"Māori"},
-"mrj":{"iso2":"mrj","engname":"Hill Mari","locname":"Кырык Мары (Kyryk Mary)"},
-"msa":{"iso2":"ms","engname":"Malay","locname":"Bahasa Melayu"},
-"mul":{"iso2":"mul","engname":"Multiple","locname":"Multiple"},
-"mus":{"iso2":"mus","engname":"Muscogee","locname":"Muskogee"},
-"mwl":{"iso2":"mwl","engname":"Mirandese","locname":"Mirandés"},
-"mya":{"iso2":"my","engname":"Burmese","locname":"မြန်မာဘာသာ"},
-"myv":{"iso2":"myv","engname":"Erzya","locname":"Эрзянь (Erzjanj Kelj)"},
-"mzn":{"iso2":"mzn","engname":"Mazandarani","locname":"مَزِروني"},
-"nah":{"iso2":"nah","engname":"Nahuatl","locname":"Nāhuatl"},
-"nap":{"iso2":"nap","engname":"Neapolitan","locname":"Nnapulitano"},
-"nau":{"iso2":"na","engname":"Nauruan","locname":"dorerin Naoero"},
-"nav":{"iso2":"nv","engname":"Navajo","locname":"Diné bizaad"},
-"ndo":{"iso2":"ng","engname":"Ndonga","locname":"Oshiwambo"},
-"nds":{"iso2":"nds","engname":"Low Saxon","locname":"Plattdüütsch"},
-"nds-nl":{"iso2":"nds-nl","engname":"Dutch Low Saxon","locname":"Nedersaksisch"},
-"nep":{"iso2":"ne","engname":"Nepali","locname":"नेपाली"},
-"new":{"iso2":"new","engname":"Newar / Nepal Bhasa","locname":"नेपाल भाषा"},
-"nid":{"iso2":"nid","engname":"Ngandi","locname":"Ngandi"},
-"nld":{"iso2":"nl","engname":"Dutch","locname":"Nederlands"},
-"nno":{"iso2":"nn","engname":"Norwegian (Nynorsk)","locname":"Nynorsk"},
-"nob":{"iso2":"no","engname":"Norwegian (Bokmål)","locname":"Norsk (Bokmål)"},
-"nor":{"iso2":"no","engname":"Norwegian (Bokmål)","locname":"Norsk (Bokmål)"},
-"nov":{"iso2":"nov","engname":"Novial","locname":"Novial"},
-"nrm":{"iso2":"nrm","engname":"Norman","locname":"Nouormand/Normaund"},
-"nso":{"iso2":"nso","engname":"Northern Sotho","locname":"Sepedi"},
-"nya":{"iso2":"ny","engname":"Chichewa","locname":"Chichewa"},
-"oci":{"iso2":"oc","engname":"Occitan","locname":"Occitan"},
-"ori":{"iso2":"or","engname":"Oriya","locname":"ଓଡ଼ିଆ"},
-"orm":{"iso2":"om","engname":"Oromo","locname":"Oromoo"},
-"oss":{"iso2":"os","engname":"Ossetian","locname":"Иронау"},
-"pag":{"iso2":"pag","engname":"Pangasinan","locname":"Pangasinan"},
-"pam":{"iso2":"pam","engname":"Kapampangan","locname":"Kapampangan"},
-"pan":{"iso2":"pa","engname":"Punjabi","locname":"ਪੰਜਾਬੀ"},
-"pap":{"iso2":"pap","engname":"Papiamentu","locname":"Papiamentu"},
-"pcd":{"iso2":"pcd","engname":"Picard","locname":"Picard"},
-"pdc":{"iso2":"pdc","engname":"Pennsylvania German","locname":"Deitsch"},
-"pfl":{"iso2":"pfl","engname":"Palatinate German","locname":"Pälzisch"},
-"pih":{"iso2":"pih","engname":"Norfolk","locname":"Norfuk"},
-"pli":{"iso2":"pi","engname":"Pali","locname":"पाऴि"},
-"pms":{"iso2":"pms","engname":"Piedmontese","locname":"Piemontèis"},
-"pnb":{"iso2":"pnb","engname":"Western Panjabi","locname":"شاہ مکھی پنجابی (Shāhmukhī Pañjābī)"},
-"pnt":{"iso2":"pnt","engname":"Pontic","locname":"Ποντιακά"},
-"pol":{"iso2":"pl","engname":"Polish","locname":"Polski"},
-"por":{"iso2":"pt","engname":"Portuguese","locname":"Português"},
-"pus":{"iso2":"ps","engname":"Pashto","locname":"پښتو"},
-"que":{"iso2":"qu","engname":"Quechua","locname":"Runa Simi"},
-"rmy":{"iso2":"rmy","engname":"Romani","locname":"romani - रोमानी"},
-"roa-rup":{"iso2":"roa-rup","engname":"Aromanian","locname":"Armãneashce"},
-"roa-tara":{"iso2":"roa-tara","engname":"Tarantino","locname":"Tarandíne"},
-"roh":{"iso2":"rm","engname":"Romansh","locname":"Rumantsch"},
-"ron":{"iso2":"ro","engname":"Romanian","locname":"Română"},
-"ru":{"iso2":"ru","engname":"Russian","locname":"Русский"},
-"rue":{"iso2":"rue","engname":"Rusyn","locname":"Русиньскый"},
-"run":{"iso2":"rn","engname":"Kirundi","locname":"Kirundi"},
-"rus":{"iso2":"ru","engname":"Russian","locname":"Русский"},
-"sag":{"iso2":"sg","engname":"Sango","locname":"Sängö"},
-"sah":{"iso2":"sah","engname":"Sakha","locname":"Саха тыла (Saxa Tyla)"},
-"san":{"iso2":"sa","engname":"Sanskrit","locname":"संस्कृतम्"},
-"scn":{"iso2":"scn","engname":"Sicilian","locname":"Sicilianu"},
-"sco":{"iso2":"sco","engname":"Scots","locname":"Scots"},
-"sh":{"iso2":"sh","engname":"Serbo-Croatian","locname":"Srpskohrvatski / Српскохрватски"},
-"simple":{"iso2":"simple","engname":"Simple English","locname":"Simple English"},
-"sin":{"iso2":"si","engname":"Sinhalese","locname":"සිංහල"},
-"slk":{"iso2":"sk","engname":"Slovak","locname":"Slovenčina"},
-"slv":{"iso2":"sl","engname":"Slovenian","locname":"Slovenščina"},
-"sme":{"iso2":"se","engname":"Northern Sami","locname":"Sámegiella"},
-"smo":{"iso2":"sm","engname":"Samoan","locname":"Gagana Samoa"},
-"sna":{"iso2":"sn","engname":"Shona","locname":"chiShona"},
-"snd":{"iso2":"sd","engname":"Sindhi","locname":"سنڌي، سندھی ، सिन्ध"},
-"som":{"iso2":"so","engname":"Somali","locname":"Soomaali"},
-"sot":{"iso2":"st","engname":"Sesotho","locname":"Sesotho"},
-"spa":{"iso2":"es","engname":"Spanish","locname":"Español"},
-"sqi":{"iso2":"sq","engname":"Albanian","locname":"Shqip"},
-"srd":{"iso2":"sc","engname":"Sardinian","locname":"Sardu"},
-"srn":{"iso2":"srn","engname":"Sranan","locname":"Sranantongo"},
-"srp":{"iso2":"sr","engname":"Serbian","locname":"Српски / Srpski"},
-"ssw":{"iso2":"ss","engname":"Swati","locname":"SiSwati"},
-"stq":{"iso2":"stq","engname":"Saterland Frisian","locname":"Seeltersk"},
-"sun":{"iso2":"su","engname":"Sundanese","locname":"Basa Sunda"},
-"swa":{"iso2":"sw","engname":"Swahili","locname":"Kiswahili"},
-"swe":{"iso2":"sv","engname":"Swedish","locname":"Svenska"},
-"szl":{"iso2":"szl","engname":"Silesian","locname":"Ślůnski"},
-"tah":{"iso2":"ty","engname":"Tahitian","locname":"Reo Mā`ohi"},
-"tam":{"iso2":"ta","engname":"Tamil","locname":"தமிழ்"},
-"tat":{"iso2":"tt","engname":"Tatar","locname":"Tatarça / Татарча"},
-"tcy":{"iso2":"tcy","engname":"Tulu","locname":"ತುಳು"},
-"tel":{"iso2":"te","engname":"Telugu","locname":"తెలుగు"},
-"tet":{"iso2":"tet","engname":"Tetum","locname":"Tetun"},
-"tgk":{"iso2":"tg","engname":"Tajik","locname":"Тоҷикӣ"},
-"tgl":{"iso2":"tl","engname":"Tagalog","locname":"Tagalog"},
-"tha":{"iso2":"th","engname":"Thai","locname":"ไทย"},
-"tir":{"iso2":"ti","engname":"Tigrinya","locname":"ትግርኛ"},
-"ton":{"iso2":"to","engname":"Tongan","locname":"faka Tonga"},
-"tpi":{"iso2":"tpi","engname":"Tok Pisin","locname":"Tok Pisin"},
-"tsn":{"iso2":"tn","engname":"Tswana","locname":"Setswana"},
-"tso":{"iso2":"ts","engname":"Tsonga","locname":"Xitsonga"},
-"tuk":{"iso2":"tk","engname":"Turkmen","locname":"تركمن / Туркмен"},
-"tum":{"iso2":"tum","engname":"Tumbuka","locname":"chiTumbuka"},
-"tur":{"iso2":"tr","engname":"Turkish","locname":"Türkçe"},
-"twi":{"iso2":"tw","engname":"Twi","locname":"Twi"},
-"tyv":{"iso2":"tyv","engname":"Tuvan","locname":"Тыва"},
-"udm":{"iso2":"udm","engname":"Udmurt","locname":"Удмурт кыл"},
-"uig":{"iso2":"ug","engname":"Uyghur","locname":"ئۇيغۇر تىلى"},
-"ukr":{"iso2":"uk","engname":"Ukrainian","locname":"Українська"},
-"urd":{"iso2":"ur","engname":"Urdu","locname":"اردو"},
-"uzb":{"iso2":"uz","engname":"Uzbek","locname":"O‘zbek"},
-"vec":{"iso2":"vec","engname":"Venetian","locname":"Vèneto"},
-"ven":{"iso2":"ve","engname":"Venda","locname":"Tshivenda"},
-"vep":{"iso2":"vep","engname":"Vepsian","locname":"Vepsän"},
-"vie":{"iso2":"vi","engname":"Vietnamese","locname":"Tiếng Việt"},
-"vls":{"iso2":"vls","engname":"West Flemish","locname":"West-Vlams"},
-"vol":{"iso2":"vo","engname":"Volapük","locname":"Volapük"},
-"war":{"iso2":"war","engname":"Waray-Waray","locname":"Winaray"},
-"wln":{"iso2":"wa","engname":"Walloon","locname":"Walon"},
-"wol":{"iso2":"wo","engname":"Wolof","locname":"Wolof"},
-"wuu":{"iso2":"wuu","engname":"Wu","locname":"吴语"},
-"xal":{"iso2":"xal","engname":"Kalmyk","locname":"Хальмг"},
-"xho":{"iso2":"xh","engname":"Xhosa","locname":"isiXhosa"},
-"xmf":{"iso2":"xmf","engname":"Mingrelian","locname":"მარგალური (Margaluri)"},
-"yid":{"iso2":"yi","engname":"Yiddish","locname":"ייִדיש"},
-"yor":{"iso2":"yo","engname":"Yoruba","locname":"Yorùbá"},
-"zea":{"iso2":"zea","engname":"Zeelandic","locname":"Zeêuws"},
-"zha":{"iso2":"za","engname":"Zhuang","locname":"Cuengh"},
-"zh-classical":{"iso2":"zh-classical","engname":"Classical Chinese","locname":"古文 / 文言文"},
-"zh-min-nan":{"iso2":"zh-min-nan","engname":"Min Nan","locname":"Bân-lâm-gú"},
-"zho":{"iso2":"zh","engname":"Chinese","locname":"中文"},
-"zh-yue":{"iso2":"zh-yue","engname":"Cantonese","locname":"粵語"},
-"zul":{"iso2":"zu","engname":"Zulu","locname":"isiZulu"}}
-
+{
+  "aar": {
+    "iso2": "aa",
+    "engname": "Afar",
+    "locname": "Afar"
+  },
+  "abk": {
+    "iso2": "ab",
+    "engname": "Abkhazian",
+    "locname": "Аҧсуа"
+  },
+  "ace": {
+    "iso2": "ace",
+    "engname": "Acehnese",
+    "locname": "Bahsa Acèh"
+  },
+  "ady": {
+    "iso2": "ady",
+    "engname": "Adyghe",
+    "locname": "Adyghe"
+  },
+  "afr": {
+    "iso2": "af",
+    "engname": "Afrikaans",
+    "locname": "Afrikaans"
+  },
+  "aka": {
+    "iso2": "ak",
+    "engname": "Akan",
+    "locname": "Akana"
+  },
+  "ale": {
+    "iso2": "ale",
+    "engname": "Aleut",
+    "locname": "Aleut"
+  },
+  "als": {
+    "iso2": "als",
+    "engname": "Alemannic",
+    "locname": "Alemannisch"
+  },
+  "alt": {
+    "iso2": "alt",
+    "engname": "Southern Altai",
+    "locname": "Southern Altai"
+  },
+  "amh": {
+    "iso2": "am",
+    "engname": "Amharic",
+    "locname": "አማርኛ"
+  },
+  "ami": {
+    "iso2": "ami",
+    "engname": "Amis",
+    "locname": "Amis"
+  },
+  "ang": {
+    "iso2": "ang",
+    "engname": "Anglo-Saxon",
+    "locname": "Englisc"
+  },
+  "anp": {
+    "iso2": "anp",
+    "engname": "Angika",
+    "locname": "Angika"
+  },
+  "ara": {
+    "iso2": "ar",
+    "engname": "Arabic",
+    "locname": "العربية"
+  },
+  "arc": {
+    "iso2": "arc",
+    "engname": "Aramaic",
+    "locname": "ܐܪܡܝܐ"
+  },
+  "arg": {
+    "iso2": "an",
+    "engname": "Aragonese",
+    "locname": "Aragonés"
+  },
+  "arp": {
+    "iso2": "arp",
+    "engname": "Arapaho",
+    "locname": "Arapaho"
+  },
+  "ary": {
+    "iso2": "ary",
+    "engname": "Moroccan Arabic",
+    "locname": "Moroccan Arabic"
+  },
+  "arz": {
+    "iso2": "arz",
+    "engname": "Egyptian Arabic",
+    "locname": "مصرى (Maṣri)"
+  },
+  "asm": {
+    "iso2": "as",
+    "engname": "Assamese",
+    "locname": "অসমীয়া"
+  },
+  "ast": {
+    "iso2": "ast",
+    "engname": "Asturian",
+    "locname": "Asturianu"
+  },
+  "atj": {
+    "iso2": "atj",
+    "engname": "Atikamekw",
+    "locname": "Atikamekw"
+  },
+  "ava": {
+    "iso2": "av",
+    "engname": "Avar",
+    "locname": "Авар"
+  },
+  "avk": {
+    "iso2": "avk",
+    "engname": "Kotava",
+    "locname": "Kotava"
+  },
+  "awa": {
+    "iso2": "awa",
+    "engname": "Awadhi",
+    "locname": "Awadhi"
+  },
+  "aym": {
+    "iso2": "ay",
+    "engname": "Aymara",
+    "locname": "Aymar"
+  },
+  "azb": {
+    "iso2": "azb",
+    "engname": "South Azerbaijani",
+    "locname": "South Azerbaijani"
+  },
+  "aze": {
+    "iso2": "az",
+    "engname": "Azerbaijani",
+    "locname": "Azərbaycanca"
+  },
+  "bak": {
+    "iso2": "ba",
+    "engname": "Bashkir",
+    "locname": "Башҡорт"
+  },
+  "bam": {
+    "iso2": "bm",
+    "engname": "Bambara",
+    "locname": "Bamanankan"
+  },
+  "ban": {
+    "iso2": "ban",
+    "engname": "Balinese",
+    "locname": "Balinese"
+  },
+  "bar": {
+    "iso2": "bar",
+    "engname": "Bavarian",
+    "locname": "Boarisch"
+  },
+  "bat-smg": {
+    "iso2": "bat-smg",
+    "engname": "Samogitian",
+    "locname": "Žemaitėška"
+  },
+  "bcl": {
+    "iso2": "bcl",
+    "engname": "Central Bicolano",
+    "locname": "Bikol"
+  },
+  "be-x-old": {
+    "iso2": "be-x-old",
+    "engname": "Belarusian (Taraškievica)",
+    "locname": "Беларуская (тарашкевіца)"
+  },
+  "bel": {
+    "iso2": "be",
+    "engname": "Belarusian",
+    "locname": "Беларуская"
+  },
+  "ben": {
+    "iso2": "bn",
+    "engname": "Bengali",
+    "locname": "বাংলা"
+  },
+  "bgd": {
+    "iso2": "bgd",
+    "engname": "Pawri",
+    "locname": "Pawri"
+  },
+  "bgs": {
+    "iso2": "bgs",
+    "engname": "Tagabawa",
+    "locname": "Tagabawa"
+  },
+  "bho": {
+    "iso2": "bh",
+    "engname": "Bhojpuri",
+    "locname": "भोजपुरी"
+  },
+  "bis": {
+    "iso2": "bi",
+    "engname": "Bislama",
+    "locname": "Bislama"
+  },
+  "bjn": {
+    "iso2": "bjn",
+    "engname": "Banjar",
+    "locname": "Bahasa Banjar"
+  },
+  "blk": {
+    "iso2": "blk",
+    "engname": "Pa'o Karen",
+    "locname": "Pa'o Karen"
+  },
+  "bod": {
+    "iso2": "bo",
+    "engname": "Tibetan",
+    "locname": "བོད་སྐད"
+  },
+  "bos": {
+    "iso2": "bs",
+    "engname": "Bosnian",
+    "locname": "Bosanski"
+  },
+  "bpy": {
+    "iso2": "bpy",
+    "engname": "Bishnupriya Manipuri",
+    "locname": "ইমার ঠার/বিষ্ণুপ্রিয়া মণিপুরী"
+  },
+  "bre": {
+    "iso2": "br",
+    "engname": "Breton",
+    "locname": "Brezhoneg"
+  },
+  "brx": {
+    "iso2": "brx",
+    "engname": "Bodo",
+    "locname": "Bodo"
+  },
+  "bug": {
+    "iso2": "bug",
+    "engname": "Buginese",
+    "locname": "Basa Ugi"
+  },
+  "bul": {
+    "iso2": "bg",
+    "engname": "Bulgarian",
+    "locname": "Български"
+  },
+  "bxr": {
+    "iso2": "bxr",
+    "engname": "Buryat (Russia)",
+    "locname": "Буряад"
+  },
+  "cat": {
+    "iso2": "ca",
+    "engname": "Catalan",
+    "locname": "Català"
+  },
+  "cbk": {
+    "iso2": "cbk",
+    "engname": "Chavacano",
+    "locname": "Chavacano"
+  },
+  "cbk-zam": {
+    "iso2": "cbk-zam",
+    "engname": "Zamboanga Chavacano",
+    "locname": "Chavacano de Zamboanga"
+  },
+  "cdo": {
+    "iso2": "cdo",
+    "engname": "Min Dong",
+    "locname": "Mìng-dĕ̤ng-ngṳ̄"
+  },
+  "ceb": {
+    "iso2": "ceb",
+    "engname": "Cebuano",
+    "locname": "Sinugboanong Binisaya"
+  },
+  "ces": {
+    "iso2": "cs",
+    "engname": "Czech",
+    "locname": "Čeština"
+  },
+  "cha": {
+    "iso2": "ch",
+    "engname": "Chamorro",
+    "locname": "Chamoru"
+  },
+  "che": {
+    "iso2": "ce",
+    "engname": "Chechen",
+    "locname": "Нохчийн"
+  },
+  "cho": {
+    "iso2": "cho",
+    "engname": "Choctaw",
+    "locname": "Choctaw"
+  },
+  "chr": {
+    "iso2": "chr",
+    "engname": "Cherokee",
+    "locname": "ᏣᎳᎩ"
+  },
+  "chu": {
+    "iso2": "cu",
+    "engname": "Old Church Slavonic",
+    "locname": "Словѣньскъ"
+  },
+  "chv": {
+    "iso2": "cv",
+    "engname": "Chuvash",
+    "locname": "Чăваш"
+  },
+  "chy": {
+    "iso2": "chy",
+    "engname": "Cheyenne",
+    "locname": "Tsetsêhestâhese"
+  },
+  "ckb": {
+    "iso2": "ckb",
+    "engname": "Sorani",
+    "locname": "Soranî / کوردی"
+  },
+  "cnm": {
+    "iso2": "zh",
+    "engname": "Chinese",
+    "locname": "中文"
+  },
+  "cor": {
+    "iso2": "kw",
+    "engname": "Cornish",
+    "locname": "Kernewek/Karnuack"
+  },
+  "cos": {
+    "iso2": "co",
+    "engname": "Corsican",
+    "locname": "Corsu"
+  },
+  "cre": {
+    "iso2": "cr",
+    "engname": "Cree",
+    "locname": "Nehiyaw"
+  },
+  "crh": {
+    "iso2": "crh",
+    "engname": "Crimean Tatar",
+    "locname": "Qırımtatarca"
+  },
+  "csb": {
+    "iso2": "csb",
+    "engname": "Kashubian",
+    "locname": "Kaszëbsczi"
+  },
+  "cym": {
+    "iso2": "cy",
+    "engname": "Welsh",
+    "locname": "Cymraeg"
+  },
+  "dag": {
+    "iso2": "dag",
+    "engname": "Dagbani",
+    "locname": "Dagbani"
+  },
+  "dan": {
+    "iso2": "da",
+    "engname": "Danish",
+    "locname": "Dansk"
+  },
+  "de": {
+    "iso2": "de",
+    "engname": "German",
+    "locname": "Deutsch"
+  },
+  "deu": {
+    "iso2": "de",
+    "engname": "German",
+    "locname": "Deutsch"
+  },
+  "din": {
+    "iso2": "din",
+    "engname": "Dinka",
+    "locname": "Dinka"
+  },
+  "diq": {
+    "iso2": "diq",
+    "engname": "Zazaki",
+    "locname": "Zazaki"
+  },
+  "div": {
+    "iso2": "dv",
+    "engname": "Divehi",
+    "locname": "ދިވެހިބަސް"
+  },
+  "dsb": {
+    "iso2": "dsb",
+    "engname": "Lower Sorbian",
+    "locname": "Dolnoserbski"
+  },
+  "dty": {
+    "iso2": "dty",
+    "engname": "Doteli",
+    "locname": "डोटेली"
+  },
+  "dzo": {
+    "iso2": "dz",
+    "engname": "Dzongkha",
+    "locname": "ཇོང་ཁ"
+  },
+  "efi": {
+    "iso2": "efi",
+    "engname": "Efik",
+    "locname": "Efik"
+  },
+  "ell": {
+    "iso2": "el",
+    "engname": "Greek",
+    "locname": "Ελληνικά"
+  },
+  "eml": {
+    "iso2": "eml",
+    "engname": "Emilian-Romagnol",
+    "locname": "Emiliàn e rumagnòl"
+  },
+  "en": {
+    "iso2": "en",
+    "engname": "English",
+    "locname": "English"
+  },
+  "eng": {
+    "iso2": "en",
+    "engname": "English",
+    "locname": "English"
+  },
+  "enm": {
+    "iso2": "enm",
+    "engname": "Middle English",
+    "locname": "Middle English"
+  },
+  "epo": {
+    "iso2": "eo",
+    "engname": "Esperanto",
+    "locname": "Esperanto"
+  },
+  "est": {
+    "iso2": "et",
+    "engname": "Estonian",
+    "locname": "Eesti"
+  },
+  "eus": {
+    "iso2": "eu",
+    "engname": "Basque",
+    "locname": "Euskara"
+  },
+  "ewe": {
+    "iso2": "ee",
+    "engname": "Ewe",
+    "locname": "Eʋegbe"
+  },
+  "ext": {
+    "iso2": "ext",
+    "engname": "Extremaduran",
+    "locname": "Estremeñu"
+  },
+  "fao": {
+    "iso2": "fo",
+    "engname": "Faroese",
+    "locname": "Føroyskt"
+  },
+  "fas": {
+    "iso2": "fa",
+    "engname": "Persian",
+    "locname": "فارسی"
+  },
+  "fat": {
+    "iso2": "fat",
+    "engname": "Fanti",
+    "locname": "Fanti"
+  },
+  "fij": {
+    "iso2": "fj",
+    "engname": "Fijian",
+    "locname": "Na Vosa Vakaviti"
+  },
+  "fin": {
+    "iso2": "fi",
+    "engname": "Finnish",
+    "locname": "Suomi"
+  },
+  "fiu-vro": {
+    "iso2": "fiu-vro",
+    "engname": "Võro",
+    "locname": "Võro"
+  },
+  "fon": {
+    "iso2": "fon",
+    "engname": "Fon",
+    "locname": "Fon"
+  },
+  "fr": {
+    "iso2": "fr",
+    "engname": "French",
+    "locname": "Français"
+  },
+  "fra": {
+    "iso2": "fr",
+    "engname": "French",
+    "locname": "Français"
+  },
+  "frp": {
+    "iso2": "frp",
+    "engname": "Franco-Provençal/Arpitan",
+    "locname": "Arpitan"
+  },
+  "frr": {
+    "iso2": "frr",
+    "engname": "North Frisian",
+    "locname": "Nordfriisk"
+  },
+  "fry": {
+    "iso2": "fy",
+    "engname": "West Frisian",
+    "locname": "Frysk"
+  },
+  "ful": {
+    "iso2": "ff",
+    "engname": "Fula",
+    "locname": "Fulfulde"
+  },
+  "fur": {
+    "iso2": "fur",
+    "engname": "Friulian",
+    "locname": "Furlan"
+  },
+  "fvr": {
+    "iso2": "fvr",
+    "engname": "Fur",
+    "locname": "Fur"
+  },
+  "gag": {
+    "iso2": "gag",
+    "engname": "Gagauz",
+    "locname": "Gagauz"
+  },
+  "gan": {
+    "iso2": "gan",
+    "engname": "Gan",
+    "locname": "贛語"
+  },
+  "gcr": {
+    "iso2": "gcr",
+    "engname": "French Guianese Creole",
+    "locname": "French Guianese Creole"
+  },
+  "gla": {
+    "iso2": "gd",
+    "engname": "Scottish Gaelic",
+    "locname": "Gàidhlig"
+  },
+  "gle": {
+    "iso2": "ga",
+    "engname": "Irish",
+    "locname": "Gaeilge"
+  },
+  "glg": {
+    "iso2": "gl",
+    "engname": "Galician",
+    "locname": "Galego"
+  },
+  "glk": {
+    "iso2": "glk",
+    "engname": "Gilaki",
+    "locname": "گیلکی"
+  },
+  "glv": {
+    "iso2": "gv",
+    "engname": "Manx",
+    "locname": "Gaelg"
+  },
+  "gom": {
+    "iso2": "gom",
+    "engname": "Goan Konkani",
+    "locname": "गोंयची कोंकणी "
+  },
+  "gon": {
+    "iso2": "gon",
+    "engname": "Gondi",
+    "locname": "Gondi"
+  },
+  "gor": {
+    "iso2": "gor",
+    "engname": "Gorontalo",
+    "locname": "Gorontalo"
+  },
+  "got": {
+    "iso2": "got",
+    "engname": "Gothic",
+    "locname": "𐌲𐌿𐍄𐌹𐍃𐌺"
+  },
+  "grc": {
+    "iso2": "grc",
+    "engname": "Ancient Greek",
+    "locname": "Ancient Greek"
+  },
+  "grn": {
+    "iso2": "gn",
+    "engname": "Guarani",
+    "locname": "Avañe'ẽ"
+  },
+  "grt": {
+    "iso2": "grt",
+    "engname": "Garo",
+    "locname": "আ·চিক"
+  },
+  "gsw": {
+    "iso2": "de",
+    "engname": "German",
+    "locname": "Deutsch"
+  },
+  "guc": {
+    "iso2": "guc",
+    "engname": "Wayuu",
+    "locname": "Wayuu"
+  },
+  "guj": {
+    "iso2": "gu",
+    "engname": "Gujarati",
+    "locname": "ગુજરાતી"
+  },
+  "gur": {
+    "iso2": "gur",
+    "engname": "Frafra",
+    "locname": "Frafra"
+  },
+  "guw": {
+    "iso2": "guw",
+    "engname": "Gun",
+    "locname": "Gun"
+  },
+  "hak": {
+    "iso2": "hak",
+    "engname": "Hakka",
+    "locname": "Hak-kâ-fa / 客家話"
+  },
+  "hat": {
+    "iso2": "ht",
+    "engname": "Haitian",
+    "locname": "Krèyol ayisyen"
+  },
+  "hau": {
+    "iso2": "ha",
+    "engname": "Hausa",
+    "locname": "هَوُسَ"
+  },
+  "haw": {
+    "iso2": "haw",
+    "engname": "Hawaiian",
+    "locname": "Hawai`i"
+  },
+  "hbs": {
+    "iso2": "hbs",
+    "engname": "Serbo-Croatian",
+    "locname": "Serbo-Croatian"
+  },
+  "heb": {
+    "iso2": "he",
+    "engname": "Hebrew",
+    "locname": "עברית"
+  },
+  "her": {
+    "iso2": "hz",
+    "engname": "Herero",
+    "locname": "Otsiherero"
+  },
+  "hif": {
+    "iso2": "hif",
+    "engname": "Fiji Hindi",
+    "locname": "Fiji Hindi"
+  },
+  "hin": {
+    "iso2": "hi",
+    "engname": "Hindi",
+    "locname": "हिन्दी"
+  },
+  "hmo": {
+    "iso2": "ho",
+    "engname": "Hiri Motu",
+    "locname": "Hiri Motu"
+  },
+  "hrv": {
+    "iso2": "hr",
+    "engname": "Croatian",
+    "locname": "Hrvatski"
+  },
+  "hsb": {
+    "iso2": "hsb",
+    "engname": "Upper Sorbian",
+    "locname": "Hornjoserbsce"
+  },
+  "hun": {
+    "iso2": "hu",
+    "engname": "Hungarian",
+    "locname": "Magyar"
+  },
+  "hye": {
+    "iso2": "hy",
+    "engname": "Armenian",
+    "locname": "Հայերեն"
+  },
+  "hyw": {
+    "iso2": "hyw",
+    "engname": "Western Armenian",
+    "locname": "Western Armenian"
+  },
+  "ibo": {
+    "iso2": "ig",
+    "engname": "Igbo",
+    "locname": "Igbo"
+  },
+  "ido": {
+    "iso2": "io",
+    "engname": "Ido",
+    "locname": "Ido"
+  },
+  "iii": {
+    "iso2": "ii",
+    "engname": "Sichuan Yi",
+    "locname": "ꆇꉙ"
+  },
+  "iku": {
+    "iso2": "iu",
+    "engname": "Inuktitut",
+    "locname": "ᐃᓄᒃᑎᑐᑦ"
+  },
+  "ile": {
+    "iso2": "ie",
+    "engname": "Interlingue",
+    "locname": "Interlingue"
+  },
+  "ilo": {
+    "iso2": "ilo",
+    "engname": "Ilokano",
+    "locname": "Ilokano"
+  },
+  "ina": {
+    "iso2": "ia",
+    "engname": "Interlingua",
+    "locname": "Interlingua"
+  },
+  "ind": {
+    "iso2": "id",
+    "engname": "Indonesian",
+    "locname": "Bahasa Indonesia"
+  },
+  "inh": {
+    "iso2": "inh",
+    "engname": "Ingush",
+    "locname": "Ingush"
+  },
+  "ipk": {
+    "iso2": "ik",
+    "engname": "Inupiak",
+    "locname": "Iñupiak"
+  },
+  "isl": {
+    "iso2": "is",
+    "engname": "Icelandic",
+    "locname": "Íslenska"
+  },
+  "ita": {
+    "iso2": "it",
+    "engname": "Italian",
+    "locname": "Italiano"
+  },
+  "jam": {
+    "iso2": "jam",
+    "engname": "Jamaican Creole English",
+    "locname": "Jamaican Creole English"
+  },
+  "jav": {
+    "iso2": "jv",
+    "engname": "Javanese",
+    "locname": "Basa Jawa"
+  },
+  "jbo": {
+    "iso2": "jbo",
+    "engname": "Lojban",
+    "locname": "Lojban"
+  },
+  "jpn": {
+    "iso2": "ja",
+    "engname": "Japanese",
+    "locname": "日本語"
+  },
+  "kaa": {
+    "iso2": "kaa",
+    "engname": "Karakalpak",
+    "locname": "Qaraqalpaqsha"
+  },
+  "kab": {
+    "iso2": "kab",
+    "engname": "Kabyle",
+    "locname": "Taqbaylit"
+  },
+  "kal": {
+    "iso2": "kl",
+    "engname": "Greenlandic",
+    "locname": "Kalaallisut"
+  },
+  "kan": {
+    "iso2": "kn",
+    "engname": "Kannada",
+    "locname": "ಕನ್ನಡ"
+  },
+  "kas": {
+    "iso2": "ks",
+    "engname": "Kashmiri",
+    "locname": "कश्मीरी / كشميري"
+  },
+  "kat": {
+    "iso2": "ka",
+    "engname": "Georgian",
+    "locname": "ქართული"
+  },
+  "kau": {
+    "iso2": "kr",
+    "engname": "Kanuri",
+    "locname": "Kanuri"
+  },
+  "kaz": {
+    "iso2": "kk",
+    "engname": "Kazakh",
+    "locname": "Қазақша"
+  },
+  "kbd": {
+    "iso2": "kbd",
+    "engname": "Kabardian Circassian",
+    "locname": "Адыгэбзэ (Adighabze)"
+  },
+  "kbp": {
+    "iso2": "kbp",
+    "engname": "Kabiyè",
+    "locname": "Kabiyè"
+  },
+  "kcg": {
+    "iso2": "kcg",
+    "engname": "Tyap",
+    "locname": "Tyap"
+  },
+  "kfq": {
+    "iso2": "kfq",
+    "engname": "Korku",
+    "locname": "Korku"
+  },
+  "kha": {
+    "iso2": "kha",
+    "engname": "Khasi",
+    "locname": "খাশি"
+  },
+  "khm": {
+    "iso2": "km",
+    "engname": "Khmer",
+    "locname": "ភាសាខ្មែរ"
+  },
+  "kik": {
+    "iso2": "ki",
+    "engname": "Kikuyu",
+    "locname": "Gĩkũyũ"
+  },
+  "kin": {
+    "iso2": "rw",
+    "engname": "Kinyarwanda",
+    "locname": "Ikinyarwanda"
+  },
+  "kir": {
+    "iso2": "ky",
+    "engname": "Kirghiz",
+    "locname": "Кыргызча"
+  },
+  "kld": {
+    "iso2": "kld",
+    "engname": "Kaili",
+    "locname": "Kaili"
+  },
+  "koi": {
+    "iso2": "koi",
+    "engname": "Komi-Permyak",
+    "locname": "Перем Коми (Perem Komi)"
+  },
+  "kok": {
+    "iso2": "kok",
+    "engname": "Konkani",
+    "locname": "ಕೊಂಕಣಿ"
+  },
+  "kokana": {
+    "iso2": "kokana",
+    "engname": "Kokana",
+    "locname": "Kokana"
+  },
+  "kom": {
+    "iso2": "kv",
+    "engname": "Komi",
+    "locname": "Коми"
+  },
+  "kon": {
+    "iso2": "kg",
+    "engname": "Kongo",
+    "locname": "KiKongo"
+  },
+  "kor": {
+    "iso2": "ko",
+    "engname": "Korean",
+    "locname": "한국어"
+  },
+  "krc": {
+    "iso2": "krc",
+    "engname": "Karachay-Balkar",
+    "locname": "Къарачай-Малкъар (Qarachay-Malqar)"
+  },
+  "ksh": {
+    "iso2": "ksh",
+    "engname": "Ripuarian",
+    "locname": "Ripoarisch"
+  },
+  "kua": {
+    "iso2": "kj",
+    "engname": "Kuanyama",
+    "locname": "Kuanyama"
+  },
+  "kur": {
+    "iso2": "ku",
+    "engname": "Kurdish",
+    "locname": "Kurdî / كوردی"
+  },
+  "lad": {
+    "iso2": "lad",
+    "engname": "Ladino",
+    "locname": "Dzhudezmo"
+  },
+  "lao": {
+    "iso2": "lo",
+    "engname": "Lao",
+    "locname": "ລາວ"
+  },
+  "lat": {
+    "iso2": "la",
+    "engname": "Latin",
+    "locname": "Latina"
+  },
+  "lav": {
+    "iso2": "lv",
+    "engname": "Latvian",
+    "locname": "Latviešu"
+  },
+  "lbe": {
+    "iso2": "lbe",
+    "engname": "Lak",
+    "locname": "Лакку"
+  },
+  "lbj": {
+    "iso2": "lbj",
+    "engname": "Ladakhi",
+    "locname": "ལ་དྭགས་སྐད"
+  },
+  "lez": {
+    "iso2": "lez",
+    "engname": "Lezgian",
+    "locname": "Лезги чІал (Lezgi č’al)"
+  },
+  "lfn": {
+    "iso2": "lfn",
+    "engname": "Lingua Franca Nova",
+    "locname": "Lingua Franca Nova"
+  },
+  "lij": {
+    "iso2": "lij",
+    "engname": "Ligurian",
+    "locname": "Líguru"
+  },
+  "lim": {
+    "iso2": "li",
+    "engname": "Limburgish",
+    "locname": "Limburgs"
+  },
+  "lin": {
+    "iso2": "ln",
+    "engname": "Lingala",
+    "locname": "Lingala"
+  },
+  "lit": {
+    "iso2": "lt",
+    "engname": "Lithuanian",
+    "locname": "Lietuvių"
+  },
+  "lld": {
+    "iso2": "lld",
+    "engname": "Ladin",
+    "locname": "Ladin"
+  },
+  "lmo": {
+    "iso2": "lmo",
+    "engname": "Lombard",
+    "locname": "Lumbaart"
+  },
+  "ltg": {
+    "iso2": "ltg",
+    "engname": "Latgalian",
+    "locname": "Latgaļu"
+  },
+  "ltz": {
+    "iso2": "lb",
+    "engname": "Luxembourgish",
+    "locname": "Lëtzebuergesch"
+  },
+  "lug": {
+    "iso2": "lg",
+    "engname": "Luganda",
+    "locname": "Luganda"
+  },
+  "lus": {
+    "iso2": "lus",
+    "engname": "Mizo",
+    "locname": "Mizo"
+  },
+  "lzh": {
+    "iso2": "lzh",
+    "engname": "Literary Chinese",
+    "locname": "Literary Chinese"
+  },
+  "mad": {
+    "iso2": "mad",
+    "engname": "Madurese",
+    "locname": "Madurese"
+  },
+  "mah": {
+    "iso2": "mh",
+    "engname": "Marshallese",
+    "locname": "Ebon"
+  },
+  "mai": {
+    "iso2": "mai",
+    "engname": "Maithili",
+    "locname": "मैथिली"
+  },
+  "mal": {
+    "iso2": "ml",
+    "engname": "Malayalam",
+    "locname": "മലയാളം"
+  },
+  "map-bms": {
+    "iso2": "map-bms",
+    "engname": "Banyumasan",
+    "locname": "Basa Banyumasan"
+  },
+  "mar": {
+    "iso2": "mr",
+    "engname": "Marathi",
+    "locname": "मराठी"
+  },
+  "mdf": {
+    "iso2": "mdf",
+    "engname": "Moksha",
+    "locname": "Мокшень (Mokshanj Kälj)"
+  },
+  "mhr": {
+    "iso2": "mhr",
+    "engname": "Meadow Mari",
+    "locname": "Олык Марий (Olyk Marij)"
+  },
+  "min": {
+    "iso2": "min",
+    "engname": "Minangkabau",
+    "locname": "Minangkabau"
+  },
+  "mkd": {
+    "iso2": "mk",
+    "engname": "Macedonian",
+    "locname": "Македонски"
+  },
+  "mlg": {
+    "iso2": "mg",
+    "engname": "Malagasy",
+    "locname": "Malagasy"
+  },
+  "mlt": {
+    "iso2": "mt",
+    "engname": "Maltese",
+    "locname": "Malti"
+  },
+  "mni": {
+    "iso2": "mni",
+    "engname": "Manipuri",
+    "locname": "মৈতৈলোন্"
+  },
+  "mnw": {
+    "iso2": "mnw",
+    "engname": "Mon",
+    "locname": "Mon"
+  },
+  "mo": {
+    "iso2": "mo",
+    "engname": "Moldovan",
+    "locname": "Молдовеняскэ"
+  },
+  "mon": {
+    "iso2": "mn",
+    "engname": "Mongolian",
+    "locname": "Монгол"
+  },
+  "mri": {
+    "iso2": "mi",
+    "engname": "Maori",
+    "locname": "Māori"
+  },
+  "mrj": {
+    "iso2": "mrj",
+    "engname": "Hill Mari",
+    "locname": "Кырык Мары (Kyryk Mary)"
+  },
+  "msa": {
+    "iso2": "ms",
+    "engname": "Malay",
+    "locname": "Bahasa Melayu"
+  },
+  "mul": {
+    "iso2": "mul",
+    "engname": "Multiple",
+    "locname": "Multiple"
+  },
+  "mus": {
+    "iso2": "mus",
+    "engname": "Muscogee",
+    "locname": "Muskogee"
+  },
+  "mwl": {
+    "iso2": "mwl",
+    "engname": "Mirandese",
+    "locname": "Mirandés"
+  },
+  "mya": {
+    "iso2": "my",
+    "engname": "Burmese",
+    "locname": "မြန်မာဘာသာ"
+  },
+  "myv": {
+    "iso2": "myv",
+    "engname": "Erzya",
+    "locname": "Эрзянь (Erzjanj Kelj)"
+  },
+  "mzn": {
+    "iso2": "mzn",
+    "engname": "Mazandarani",
+    "locname": "مَزِروني"
+  },
+  "nah": {
+    "iso2": "nah",
+    "engname": "Nahuatl",
+    "locname": "Nāhuatl"
+  },
+  "nan": {
+    "iso2": "nan",
+    "engname": "Min Nan Chinese",
+    "locname": "Min Nan Chinese"
+  },
+  "nap": {
+    "iso2": "nap",
+    "engname": "Neapolitan",
+    "locname": "Nnapulitano"
+  },
+  "nau": {
+    "iso2": "na",
+    "engname": "Nauruan",
+    "locname": "dorerin Naoero"
+  },
+  "nav": {
+    "iso2": "nv",
+    "engname": "Navajo",
+    "locname": "Diné bizaad"
+  },
+  "ndo": {
+    "iso2": "ng",
+    "engname": "Ndonga",
+    "locname": "Oshiwambo"
+  },
+  "nds": {
+    "iso2": "nds",
+    "engname": "Low Saxon",
+    "locname": "Plattdüütsch"
+  },
+  "nds-nl": {
+    "iso2": "nds-nl",
+    "engname": "Dutch Low Saxon",
+    "locname": "Nedersaksisch"
+  },
+  "nep": {
+    "iso2": "ne",
+    "engname": "Nepali",
+    "locname": "नेपाली"
+  },
+  "new": {
+    "iso2": "new",
+    "engname": "Newar / Nepal Bhasa",
+    "locname": "नेपाल भाषा"
+  },
+  "nhe": {
+    "iso2": "nhe",
+    "engname": "Eastern Huasteca Nahuatl",
+    "locname": "Eastern Huasteca Nahuatl"
+  },
+  "nia": {
+    "iso2": "nia",
+    "engname": "Nias",
+    "locname": "Nias"
+  },
+  "nid": {
+    "iso2": "nid",
+    "engname": "Ngandi",
+    "locname": "Ngandi"
+  },
+  "nld": {
+    "iso2": "nl",
+    "engname": "Dutch",
+    "locname": "Nederlands"
+  },
+  "nno": {
+    "iso2": "nn",
+    "engname": "Norwegian (Nynorsk)",
+    "locname": "Nynorsk"
+  },
+  "nob": {
+    "iso2": "no",
+    "engname": "Norwegian (Bokmål)",
+    "locname": "Norsk (Bokmål)"
+  },
+  "nor": {
+    "iso2": "no",
+    "engname": "Norwegian (Bokmål)",
+    "locname": "Norsk (Bokmål)"
+  },
+  "nov": {
+    "iso2": "nov",
+    "engname": "Novial",
+    "locname": "Novial"
+  },
+  "nqo": {
+    "iso2": "nqo",
+    "engname": "N'Ko",
+    "locname": "N'Ko"
+  },
+  "nrf": {
+    "iso2": "nrf",
+    "engname": "Jèrriais",
+    "locname": "Jèrriais"
+  },
+  "nrm": {
+    "iso2": "nrm",
+    "engname": "Norman",
+    "locname": "Nouormand/Normaund"
+  },
+  "nso": {
+    "iso2": "nso",
+    "engname": "Northern Sotho",
+    "locname": "Sepedi"
+  },
+  "nya": {
+    "iso2": "ny",
+    "engname": "Chichewa",
+    "locname": "Chichewa"
+  },
+  "oci": {
+    "iso2": "oc",
+    "engname": "Occitan",
+    "locname": "Occitan"
+  },
+  "oji": {
+    "iso2": "oji",
+    "engname": "Ojibwe",
+    "locname": "Ojibwe"
+  },
+  "olo": {
+    "iso2": "olo",
+    "engname": "Livvi",
+    "locname": "Livvi"
+  },
+  "ori": {
+    "iso2": "or",
+    "engname": "Oriya",
+    "locname": "ଓଡ଼ିଆ"
+  },
+  "orm": {
+    "iso2": "om",
+    "engname": "Oromo",
+    "locname": "Oromoo"
+  },
+  "oss": {
+    "iso2": "os",
+    "engname": "Ossetian",
+    "locname": "Иронау"
+  },
+  "pag": {
+    "iso2": "pag",
+    "engname": "Pangasinan",
+    "locname": "Pangasinan"
+  },
+  "pam": {
+    "iso2": "pam",
+    "engname": "Kapampangan",
+    "locname": "Kapampangan"
+  },
+  "pan": {
+    "iso2": "pa",
+    "engname": "Punjabi",
+    "locname": "ਪੰਜਾਬੀ"
+  },
+  "pap": {
+    "iso2": "pap",
+    "engname": "Papiamentu",
+    "locname": "Papiamentu"
+  },
+  "pcd": {
+    "iso2": "pcd",
+    "engname": "Picard",
+    "locname": "Picard"
+  },
+  "pcm": {
+    "iso2": "pcm",
+    "engname": "Nigerian Pidgin",
+    "locname": "Nigerian Pidgin"
+  },
+  "pdc": {
+    "iso2": "pdc",
+    "engname": "Pennsylvania German",
+    "locname": "Deitsch"
+  },
+  "pfl": {
+    "iso2": "pfl",
+    "engname": "Palatinate German",
+    "locname": "Pälzisch"
+  },
+  "pih": {
+    "iso2": "pih",
+    "engname": "Norfolk",
+    "locname": "Norfuk"
+  },
+  "pli": {
+    "iso2": "pi",
+    "engname": "Pali",
+    "locname": "पाऴि"
+  },
+  "pms": {
+    "iso2": "pms",
+    "engname": "Piedmontese",
+    "locname": "Piemontèis"
+  },
+  "pnb": {
+    "iso2": "pnb",
+    "engname": "Western Panjabi",
+    "locname": "شاہ مکھی پنجابی (Shāhmukhī Pañjābī)"
+  },
+  "pnt": {
+    "iso2": "pnt",
+    "engname": "Pontic",
+    "locname": "Ποντιακά"
+  },
+  "pol": {
+    "iso2": "pl",
+    "engname": "Polish",
+    "locname": "Polski"
+  },
+  "por": {
+    "iso2": "pt",
+    "engname": "Portuguese",
+    "locname": "Português"
+  },
+  "pus": {
+    "iso2": "ps",
+    "engname": "Pashto",
+    "locname": "پښتو"
+  },
+  "pwn": {
+    "iso2": "pwn",
+    "engname": "Paiwan",
+    "locname": "Paiwan"
+  },
+  "que": {
+    "iso2": "qu",
+    "engname": "Quechua",
+    "locname": "Runa Simi"
+  },
+  "rmq": {
+    "iso2": "rmq",
+    "engname": "Caló",
+    "locname": "Caló"
+  },
+  "rmy": {
+    "iso2": "rmy",
+    "engname": "Romani",
+    "locname": "romani - रोमानी"
+  },
+  "roa-rup": {
+    "iso2": "roa-rup",
+    "engname": "Aromanian",
+    "locname": "Armãneashce"
+  },
+  "roa-tara": {
+    "iso2": "roa-tara",
+    "engname": "Tarantino",
+    "locname": "Tarandíne"
+  },
+  "roh": {
+    "iso2": "rm",
+    "engname": "Romansh",
+    "locname": "Rumantsch"
+  },
+  "ron": {
+    "iso2": "ro",
+    "engname": "Romanian",
+    "locname": "Română"
+  },
+  "ru": {
+    "iso2": "ru",
+    "engname": "Russian",
+    "locname": "Русский"
+  },
+  "rue": {
+    "iso2": "rue",
+    "engname": "Rusyn",
+    "locname": "Русиньскый"
+  },
+  "run": {
+    "iso2": "rn",
+    "engname": "Kirundi",
+    "locname": "Kirundi"
+  },
+  "rup": {
+    "iso2": "rup",
+    "engname": "Aromanian",
+    "locname": "Aromanian"
+  },
+  "rus": {
+    "iso2": "ru",
+    "engname": "Russian",
+    "locname": "Русский"
+  },
+  "sag": {
+    "iso2": "sg",
+    "engname": "Sango",
+    "locname": "Sängö"
+  },
+  "sah": {
+    "iso2": "sah",
+    "engname": "Sakha",
+    "locname": "Саха тыла (Saxa Tyla)"
+  },
+  "san": {
+    "iso2": "sa",
+    "engname": "Sanskrit",
+    "locname": "संस्कृतम्"
+  },
+  "sat": {
+    "iso2": "sat",
+    "engname": "Santali",
+    "locname": "Santali"
+  },
+  "scn": {
+    "iso2": "scn",
+    "engname": "Sicilian",
+    "locname": "Sicilianu"
+  },
+  "sco": {
+    "iso2": "sco",
+    "engname": "Scots",
+    "locname": "Scots"
+  },
+  "sgs": {
+    "iso2": "sgs",
+    "engname": "Samogitian",
+    "locname": "Samogitian"
+  },
+  "sh": {
+    "iso2": "sh",
+    "engname": "Serbo-Croatian",
+    "locname": "Srpskohrvatski / Српскохрватски"
+  },
+  "shi": {
+    "iso2": "shi",
+    "engname": "Tachelhit",
+    "locname": "Tachelhit"
+  },
+  "shn": {
+    "iso2": "shn",
+    "engname": "Shan",
+    "locname": "Shan"
+  },
+  "simple": {
+    "iso2": "simple",
+    "engname": "Simple English",
+    "locname": "Simple English"
+  },
+  "sin": {
+    "iso2": "si",
+    "engname": "Sinhalese",
+    "locname": "සිංහල"
+  },
+  "skr": {
+    "iso2": "skr",
+    "engname": "Saraiki",
+    "locname": "Saraiki"
+  },
+  "slk": {
+    "iso2": "sk",
+    "engname": "Slovak",
+    "locname": "Slovenčina"
+  },
+  "slv": {
+    "iso2": "sl",
+    "engname": "Slovenian",
+    "locname": "Slovenščina"
+  },
+  "sme": {
+    "iso2": "se",
+    "engname": "Northern Sami",
+    "locname": "Sámegiella"
+  },
+  "smo": {
+    "iso2": "sm",
+    "engname": "Samoan",
+    "locname": "Gagana Samoa"
+  },
+  "sna": {
+    "iso2": "sn",
+    "engname": "Shona",
+    "locname": "chiShona"
+  },
+  "snd": {
+    "iso2": "sd",
+    "engname": "Sindhi",
+    "locname": "سنڌي، سندھی ، सिन्ध"
+  },
+  "som": {
+    "iso2": "so",
+    "engname": "Somali",
+    "locname": "Soomaali"
+  },
+  "sot": {
+    "iso2": "st",
+    "engname": "Sesotho",
+    "locname": "Sesotho"
+  },
+  "spa": {
+    "iso2": "es",
+    "engname": "Spanish",
+    "locname": "Español"
+  },
+  "sqi": {
+    "iso2": "sq",
+    "engname": "Albanian",
+    "locname": "Shqip"
+  },
+  "srd": {
+    "iso2": "sc",
+    "engname": "Sardinian",
+    "locname": "Sardu"
+  },
+  "srn": {
+    "iso2": "srn",
+    "engname": "Sranan",
+    "locname": "Sranantongo"
+  },
+  "srp": {
+    "iso2": "sr",
+    "engname": "Serbian",
+    "locname": "Српски / Srpski"
+  },
+  "ssw": {
+    "iso2": "ss",
+    "engname": "Swati",
+    "locname": "SiSwati"
+  },
+  "stq": {
+    "iso2": "stq",
+    "engname": "Saterland Frisian",
+    "locname": "Seeltersk"
+  },
+  "sun": {
+    "iso2": "su",
+    "engname": "Sundanese",
+    "locname": "Basa Sunda"
+  },
+  "swa": {
+    "iso2": "sw",
+    "engname": "Swahili",
+    "locname": "Kiswahili"
+  },
+  "swe": {
+    "iso2": "sv",
+    "engname": "Swedish",
+    "locname": "Svenska"
+  },
+  "szl": {
+    "iso2": "szl",
+    "engname": "Silesian",
+    "locname": "Ślůnski"
+  },
+  "szy": {
+    "iso2": "szy",
+    "engname": "Sakizaya",
+    "locname": "Sakizaya"
+  },
+  "tah": {
+    "iso2": "ty",
+    "engname": "Tahitian",
+    "locname": "Reo Mā`ohi"
+  },
+  "tam": {
+    "iso2": "ta",
+    "engname": "Tamil",
+    "locname": "தமிழ்"
+  },
+  "tat": {
+    "iso2": "tt",
+    "engname": "Tatar",
+    "locname": "Tatarça / Татарча"
+  },
+  "tay": {
+    "iso2": "tay",
+    "engname": "Atayal",
+    "locname": "Atayal"
+  },
+  "tcy": {
+    "iso2": "tcy",
+    "engname": "Tulu",
+    "locname": "ತುಳು"
+  },
+  "tel": {
+    "iso2": "te",
+    "engname": "Telugu",
+    "locname": "తెలుగు"
+  },
+  "tet": {
+    "iso2": "tet",
+    "engname": "Tetum",
+    "locname": "Tetun"
+  },
+  "tgk": {
+    "iso2": "tg",
+    "engname": "Tajik",
+    "locname": "Тоҷикӣ"
+  },
+  "tgl": {
+    "iso2": "tl",
+    "engname": "Tagalog",
+    "locname": "Tagalog"
+  },
+  "tha": {
+    "iso2": "th",
+    "engname": "Thai",
+    "locname": "ไทย"
+  },
+  "tir": {
+    "iso2": "ti",
+    "engname": "Tigrinya",
+    "locname": "ትግርኛ"
+  },
+  "ton": {
+    "iso2": "to",
+    "engname": "Tongan",
+    "locname": "faka Tonga"
+  },
+  "tpi": {
+    "iso2": "tpi",
+    "engname": "Tok Pisin",
+    "locname": "Tok Pisin"
+  },
+  "trv": {
+    "iso2": "trv",
+    "engname": "Taroko",
+    "locname": "Taroko"
+  },
+  "tsn": {
+    "iso2": "tn",
+    "engname": "Tswana",
+    "locname": "Setswana"
+  },
+  "tso": {
+    "iso2": "ts",
+    "engname": "Tsonga",
+    "locname": "Xitsonga"
+  },
+  "tsz": {
+    "iso2": "tsz",
+    "engname": "Purépecha",
+    "locname": "Purépecha"
+  },
+  "tuk": {
+    "iso2": "tk",
+    "engname": "Turkmen",
+    "locname": "تركمن / Туркмен"
+  },
+  "tum": {
+    "iso2": "tum",
+    "engname": "Tumbuka",
+    "locname": "chiTumbuka"
+  },
+  "tur": {
+    "iso2": "tr",
+    "engname": "Turkish",
+    "locname": "Türkçe"
+  },
+  "twi": {
+    "iso2": "tw",
+    "engname": "Twi",
+    "locname": "Twi"
+  },
+  "tyv": {
+    "iso2": "tyv",
+    "engname": "Tuvan",
+    "locname": "Тыва"
+  },
+  "udm": {
+    "iso2": "udm",
+    "engname": "Udmurt",
+    "locname": "Удмурт кыл"
+  },
+  "uig": {
+    "iso2": "ug",
+    "engname": "Uyghur",
+    "locname": "ئۇيغۇر تىلى"
+  },
+  "ukr": {
+    "iso2": "uk",
+    "engname": "Ukrainian",
+    "locname": "Українська"
+  },
+  "urd": {
+    "iso2": "ur",
+    "engname": "Urdu",
+    "locname": "اردو"
+  },
+  "uzb": {
+    "iso2": "uz",
+    "engname": "Uzbek",
+    "locname": "O‘zbek"
+  },
+  "vec": {
+    "iso2": "vec",
+    "engname": "Venetian",
+    "locname": "Vèneto"
+  },
+  "ven": {
+    "iso2": "ve",
+    "engname": "Venda",
+    "locname": "Tshivenda"
+  },
+  "vep": {
+    "iso2": "vep",
+    "engname": "Vepsian",
+    "locname": "Vepsän"
+  },
+  "vie": {
+    "iso2": "vi",
+    "engname": "Vietnamese",
+    "locname": "Tiếng Việt"
+  },
+  "vls": {
+    "iso2": "vls",
+    "engname": "West Flemish",
+    "locname": "West-Vlams"
+  },
+  "vol": {
+    "iso2": "vo",
+    "engname": "Volapük",
+    "locname": "Volapük"
+  },
+  "vro": {
+    "iso2": "vro",
+    "engname": "Võro",
+    "locname": "Võro"
+  },
+  "war": {
+    "iso2": "war",
+    "engname": "Waray-Waray",
+    "locname": "Winaray"
+  },
+  "wln": {
+    "iso2": "wa",
+    "engname": "Walloon",
+    "locname": "Walon"
+  },
+  "wol": {
+    "iso2": "wo",
+    "engname": "Wolof",
+    "locname": "Wolof"
+  },
+  "wuu": {
+    "iso2": "wuu",
+    "engname": "Wu",
+    "locname": "吴语"
+  },
+  "xal": {
+    "iso2": "xal",
+    "engname": "Kalmyk",
+    "locname": "Хальмг"
+  },
+  "xho": {
+    "iso2": "xh",
+    "engname": "Xhosa",
+    "locname": "isiXhosa"
+  },
+  "xmf": {
+    "iso2": "xmf",
+    "engname": "Mingrelian",
+    "locname": "მარგალური (Margaluri)"
+  },
+  "yid": {
+    "iso2": "yi",
+    "engname": "Yiddish",
+    "locname": "ייִדיש"
+  },
+  "yor": {
+    "iso2": "yo",
+    "engname": "Yoruba",
+    "locname": "Yorùbá"
+  },
+  "yue": {
+    "iso2": "yue",
+    "engname": "Cantonese",
+    "locname": "Cantonese"
+  },
+  "zea": {
+    "iso2": "zea",
+    "engname": "Zeelandic",
+    "locname": "Zeêuws"
+  },
+  "zgh": {
+    "iso2": "zgh",
+    "engname": "Standard Moroccan Tamazight",
+    "locname": "Standard Moroccan Tamazight"
+  },
+  "zh-classical": {
+    "iso2": "zh-classical",
+    "engname": "Classical Chinese",
+    "locname": "古文 / 文言文"
+  },
+  "zh-min-nan": {
+    "iso2": "zh-min-nan",
+    "engname": "Min Nan",
+    "locname": "Bân-lâm-gú"
+  },
+  "zh-yue": {
+    "iso2": "zh-yue",
+    "engname": "Cantonese",
+    "locname": "粵語"
+  },
+  "zha": {
+    "iso2": "za",
+    "engname": "Zhuang",
+    "locname": "Cuengh"
+  },
+  "zho": {
+    "iso2": "zh",
+    "engname": "Chinese",
+    "locname": "中文"
+  },
+  "zul": {
+    "iso2": "zu",
+    "engname": "Zulu",
+    "locname": "isiZulu"
+  }
+}


### PR DESCRIPTION
dagbani and other language codes are missing. These have to been added manually, but copilot did it quickly.
