### PR TITLE
maps-update.py to recover from deleted pmtiles files

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -4,8 +4,13 @@
 unpkg_url: https://unpkg.com
 iiab_map_host_url: https://iiab.switnet.org/maps/2
 
-maps_serve_path: "{{ content_base }}/www/maps"  # /library/www/maps
-maps_data_root: "{{ content_base }}/maps"       # /library/maps
+maps_serve_path: "{{ content_base }}/www/maps"        # /library/www/maps
+maps_data_root: "{{ content_base }}/maps"             # /library/maps
+
+# For now use the same directory as maps_serve_path. Eventually we could
+# put it under a /fallback directory, but then we'd want to make sure
+# we're not downloading duplicates of these fallback files.
+maps_fallback_path: "{{ maps_serve_path }}"           # /library/www/maps
 
 nominatim_user: nominatim
 nominatim_home: /srv/nominatim
@@ -134,11 +139,12 @@ maps_dot_black_vector_tiles:
   # the time to fix just for consistency.
   nat-z8: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.z00-z08.pmtiles"
 
-  # FOR TESTING ONLY
+  # FOR TESTING AND FALLBACK ONLY
   # "medium res" osm, up to zoom level 1 (original file has 14).
   # maps_vector_quality = "osm-z1"
   osm-z1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z01.pmtiles"
 
+maps_fallback_vector_quality: osm-z1
 maps_vector_max_zoom: 14
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
@@ -169,6 +175,7 @@ maps_dot_black_satellite_tiles:
   # maps_satellite_zoom = 4
   4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z04.pmtiles"
 
+maps_fallback_satellite_zoom: 7
 maps_satellite_max_zoom: 13
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
@@ -204,6 +211,7 @@ maps_dot_black_terrain_tiles:
   # needs if we have FQRs and the user enables terrain.
   none: "terrarium-none.pmtiles"
 
+maps_fallback_terrain_zoom: none
 maps_terrain_max_zoom: 10
 
 # Similar to pmtiles, search databases should follow this convention:

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -31,6 +31,8 @@ maps_vector_data_date: "2026-07-01"
 maps_search_data_date: "2026-04-22"
 maps_slow_data_date: "2025-12-10"
 
+maps_tools_dir: "/opt/iiab/maps"
+
 tile_extract:
   pmtiles:
     armhf:
@@ -48,7 +50,7 @@ tile_extract:
     version: 8b8ddea4dbff1b0104cf2bebf2f7ff35c91b41d5
   pmtiles_archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
   pmtiles_archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
-  working_dir: "/opt/iiab/maps/tile-extract"
+  working_dir: "{{ maps_tools_dir }}/tile-extract"
   info_file: "extracts.json"
 
 # Basic maps.black javascript and styles

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -11,7 +11,7 @@
       - python3-xmltodict
       - python3-requests
 
-- include_tasks: install_tile_extract.yml
+- include_tasks: install_tools.yml
 
 - include_tasks: install_frontend.yml
 

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -12,7 +12,6 @@
       - python3-requests
 
 - include_tasks: install_tile_extract.yml
-  when: maps_region_downloader
 
 - include_tasks: install_frontend.yml
 

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -105,12 +105,6 @@
     mode: "0644"
     force: false
 
-- name: "Make sure maps_region_downloader is true if maps_preset_full_quality_regions has items"
-  assert:
-    that: maps_region_downloader or (maps_preset_full_quality_regions | length <= 0)
-    fail_msg: "Error: you have maps_preset_full_quality_regions. Either set maps_region_downloader to true or unset maps_preset_full_quality_regions (this will not delete any already downloaded regions)."
-    quiet: yes
-
 - name: "Download preset full quality regions"
   # TODO - Is there a safer way to pass in item.name and item.bbox?
   shell: |

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -53,6 +53,13 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
 
+- name: Download fallback vector tiles
+  include_tasks: download_large_file.yml
+  when: maps_vector_quality != maps_fallback_vector_quality
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
+    item: "{{ maps_dot_black_vector_tiles[maps_fallback_vector_quality] }}"
+
 - when: maps_satellite_zoom != "none"
   block:
     - name: "Make sure maps_satellite_zoom has a valid value"
@@ -72,6 +79,13 @@
         src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
         state: link
+
+    - name: Download fallback satellite tiles
+      include_tasks: download_large_file.yml
+      when: maps_satellite_zoom != maps_fallback_satellite_zoom
+      vars:
+        dest_base_path: "{{ maps_serve_path }}"
+        item: "{{ maps_dot_black_satellite_tiles[maps_fallback_satellite_zoom] }}"
 
 - name: Remove unused satellite symlink
   when: maps_satellite_zoom == "none"
@@ -97,6 +111,24 @@
     src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
     state: link
+
+- name: Download fallback terrain tiles
+  include_tasks: download_large_file.yml
+  when: maps_terrain_zoom != maps_fallback_terrain_zoom
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
+    item: "{{ maps_dot_black_terrain_tiles[maps_fallback_terrain_zoom] }}"
+
+# maps-update.py is used here but it can also be run independently. As we use
+# it here, we take advantage of its handling of pmtiles zoom levels. It only
+# partially handles symlink repairs for now so we still need to set symlinks
+# by other means.
+- name: "Final map configuration"
+  shell: |
+    set -euo pipefail
+    {{ maps_tools_dir }}/maps-update.py
+  args:
+    executable: /bin/bash
 
 - name: Initiate the extracts json
   copy:

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -56,3 +56,9 @@
     src: "tile-extract.py.j2"
     dest: "{{ tile_extract.working_dir }}/tile-extract.py"
     mode: "0755"
+
+- name: Install maps-update.py
+  template:
+    src: "maps-update.py.j2"
+    dest: "{{ maps_tools_dir }}/maps-update.py"
+    mode: "0755"

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -41,7 +41,6 @@
              *    configs   *
              ****************/
 
-            const WORLD_MAP_IS_NATURAL_EARTH = "{{ maps_vector_quality }}".startsWith("nat-")
             const MAP_SEARCH_ENGINE = "{{ maps_search_engine }}"
             const REGION_DOWNLOADER_ENABLED = "{{ maps_region_downloader }}" === "True"
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -37,62 +37,17 @@
             const STYLE_SATELLITE = "satellite"
             const STYLE_HYBRID = "hybrid"
 
-            const VECTOR_TYPE_OSM = "osm"
-            const VECTOR_TYPE_NATURAL_EARTH = "nat"
-
             /****************
              *    configs   *
              ****************/
 
-            const WORLD_MAP_VECTOR_MAX_ZOOM = (num => {
-                if (Number.isNaN(num)) {
-                    // Use a default that is hopefully always available.
-                    // We hope they notice and report the bug if it ever comes here!
-                    console.warn("Unexpected value for maps_vector_quality")
-                    return 1
-                }
-                return num
-            })(Number(
-                // "osm-z11" -> "11", "nat-z8" -> "8", "somethingelse" -> undefined, etc
-                "{{ maps_vector_quality }}".split("-z")[1]
-            ))
-            // VECTOR_TYPE_OSM or VECTOR_TYPE_NATURAL_EARTH
-            const WORLD_MAP_VECTOR_TYPE = "{{ maps_vector_quality }}".split("-z")[0]
-
-            const WORLD_MAP_SATELLITE_MAX_ZOOM = (num => {
-                if (Number.isNaN(num)) {
-                    if ("{{ maps_satellite_zoom }}" === "none") {
-                        return null
-                    }
-
-                    // Use a default that is hopefully always available.
-                    // We hope they notice and report the bug if it ever comes here!
-                    console.warn("Unexpected value for maps_satellite_zoom")
-                    return 7
-                }
-                return num
-            })(Number("{{ maps_satellite_zoom }}"))
-
-            const WORLD_MAP_TERRAIN_MAX_ZOOM = (num => {
-                if (Number.isNaN(num)) {
-                    if ("{{ maps_terrain_zoom }}" === "none") {
-                        // Note that terrarium-none.pmtiles which is maxzoom=0 will still be used in
-                        // this case as a dummy to make maps.black / maplibre happy if we have FQRs
-                        // and the user enables terrain.
-                        return 0
-                    }
-
-                    // Use a default that we hope will not break everything. We hope they notice
-                    // the warning and report the bug if it ever comes here!
-                    console.warn("Unexpected value for maps_terrain_zoom")
-                    return 0
-                }
-                return num
-            })(Number("{{ maps_terrain_zoom }}"))
-
+            const WORLD_MAP_IS_NATURAL_EARTH = "{{ maps_vector_quality }}".startsWith("nat-")
             const MAP_SEARCH_ENGINE = "{{ maps_search_engine }}"
             const REGION_DOWNLOADER_ENABLED = "{{ maps_region_downloader }}" === "True"
 
+        </script>
+        <script src='maps-config.js'>
+            // Various MAX_ZOOM and other configs are found in this file
         </script>
         <script type="module">
             import { AddressTextualIndex } from "./{{ maps_static_search_dir }}/static_search.js"
@@ -1640,7 +1595,7 @@
                 // in case of nat-z8 and no FQRs, get rid of OSM attribution.
                 (async () => {
                     await until(fqrLoaded)
-                    if (WORLD_MAP_VECTOR_TYPE === VECTOR_TYPE_NATURAL_EARTH && !fqRegionsExist()) {
+                    if (WORLD_MAP_IS_NATURAL_EARTH && !fqRegionsExist()) {
                         await until(() =>
                           mb.licenses &&
                           mb.licenses.data &&

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -141,12 +141,6 @@
                 patchResource: async handlerResult => {
                     const style = handlerResult && handlerResult.data
                     if (style && style.sources && !style.iiabPatched) {
-                        // Cut down on noise. Sometimes a protomaps style is set before our chosen
-                        // style. If we find a way to actually stop that, we should remove this.
-                        if ('openstreetmap-protomaps' in style.sources) {
-                            return handlerResult
-                        }
-
                         await until(fqrLoaded, 100)
 
                         // Grab the sources and layers as they are so we can replicate them in FQRs

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -63,10 +63,14 @@ else:
     WORLD_MAP_SATELLITE_MAX_ZOOM = "null"
 WORLD_MAP_TERRAIN_MAX_ZOOM = get_max_zoom(terrain_symlink, 0)
 
+jsbool = lambda b: "true" if b else "false"
+WORLD_MAP_IS_NATURAL_EARTH = jsbool("naturalearth" in str(vector_symlink.readlink()))
+
 (maps_serve_path / "maps-config.js").write_text(
 f"""
 const WORLD_MAP_VECTOR_MAX_ZOOM = {WORLD_MAP_VECTOR_MAX_ZOOM}
 const WORLD_MAP_SATELLITE_MAX_ZOOM = {WORLD_MAP_SATELLITE_MAX_ZOOM}
 const WORLD_MAP_TERRAIN_MAX_ZOOM = {WORLD_MAP_TERRAIN_MAX_ZOOM}
+const WORLD_MAP_IS_NATURAL_EARTH = {WORLD_MAP_IS_NATURAL_EARTH}
 """
 )

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+import json, subprocess, sys
+from pathlib import Path
+
+maps_serve_path = Path('{{ maps_serve_path }}')
+maps_fallback_path = Path('{{ maps_fallback_path }}')
+
+# NOTE: This file uses ansible vars defined in default/main.yml for its construction
+# but it should not use anything based in vars/ because it should facilitate those
+# same changes without ansible.
+
+# Ansible's job is to put certain files in place. This script's job is to find those
+# files and set up maps-config.js accordingly. If the user changes the files, this
+# script should just as well set up maps-config.js accordingly.
+
+vector_symlink = maps_serve_path / '{{ maps_dot_black_osm_symlink_name }}'
+satellite_symlink = maps_serve_path / '{{ maps_dot_black_satellite_symlink_name }}'
+terrain_symlink = maps_serve_path / '{{ maps_dot_black_terrain_symlink_name }}'
+
+vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles["osm-z1"] }}'
+satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[7] }}'
+terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles["none"] }}'
+
+def handle_fallback_file(symlink, fallback, required=True):
+    if not symlink.exists():
+        if not fallback.exists():
+            if required:
+                sys.stderr.write(f"You deleted both the symlink:\n\n{symlink}\n\nand the fallback file:\n\n{fallback}\n\n. Can't continue, sorry.\n")
+                sys.stderr.flush()
+                sys.exit(1)
+            return
+        # The symlink is either deleted or broken. For simplicity let's make sure it's just deleted.
+        if symlink.is_symlink():
+            symlink.unlink()
+        print (f"Falling back: pointing {symlink} to {fallback}")
+        symlink.symlink_to(fallback)
+
+def get_max_zoom(full_path, fallback, required=True):
+    PMTILES = Path('{{ tile_extract.working_dir }}') / "pmtiles"
+    output = subprocess.getoutput(f"{PMTILES} show {full_path} --header-json")
+    try:
+        return json.loads(output)["maxzoom"]
+    except:
+        # We hope they notice and report the bug if it ever comes here!
+        print (f"Failed to get max zoom from pmtiles header for {full_path}. Falling back to {fallback}")
+        print (f"Got this output from pmtiles:\n{output}")
+        return fallback
+
+handle_fallback_file(vector_symlink, vector_fallback)
+handle_fallback_file(satellite_symlink, satellite_fallback, False)
+handle_fallback_file(terrain_symlink, terrain_fallback)
+
+# Use defaults that are hopefully always available.
+# terrarium-none.pmtiles which is maxzoom=0 will always be used as a
+# dummy to make maps.black / maplibre happy if we have FQRs and the
+# terrain is enabled.
+WORLD_MAP_VECTOR_MAX_ZOOM = get_max_zoom(vector_symlink, 1)
+if satellite_symlink.exists():
+    # Allow for satellite=none
+    WORLD_MAP_SATELLITE_MAX_ZOOM = get_max_zoom(satellite_symlink, 7, False)
+else:
+    WORLD_MAP_SATELLITE_MAX_ZOOM = "null"
+WORLD_MAP_TERRAIN_MAX_ZOOM = get_max_zoom(terrain_symlink, 0)
+
+(maps_serve_path / "maps-config.js").write_text(
+f"""
+const WORLD_MAP_VECTOR_MAX_ZOOM = {WORLD_MAP_VECTOR_MAX_ZOOM}
+const WORLD_MAP_SATELLITE_MAX_ZOOM = {WORLD_MAP_SATELLITE_MAX_ZOOM}
+const WORLD_MAP_TERRAIN_MAX_ZOOM = {WORLD_MAP_TERRAIN_MAX_ZOOM}
+"""
+)

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -18,9 +18,9 @@ vector_symlink = maps_serve_path / '{{ maps_dot_black_osm_symlink_name }}'
 satellite_symlink = maps_serve_path / '{{ maps_dot_black_satellite_symlink_name }}'
 terrain_symlink = maps_serve_path / '{{ maps_dot_black_terrain_symlink_name }}'
 
-vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles["osm-z1"] }}'
-satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[7] }}'
-terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles["none"] }}'
+vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles[maps_fallback_vector_quality] }}'
+satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[maps_fallback_satellite_zoom] }}'
+terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles[maps_fallback_terrain_zoom] }}'
 
 def handle_fallback_file(symlink, fallback, required=True):
     if symlink.exists():
@@ -52,6 +52,15 @@ def get_max_zoom(full_path, fallback, required=True):
         print (f"Got this output from pmtiles:\n{output}")
         return fallback
 
+# Since I have a bit of a mess as of right now as far as what the numbers might
+# mean, let's make a quick decoder that hopefully works on everything. This
+# should run every time on all of the fallback zoom keys so we should know
+# right away if it stops working.
+def get_fallback_zoom_number(fallback_zoom_key):
+    if fallback_zoom_key == "none":
+        return 0
+    return int(fallback_zoom_key.split('-z')[-1])
+
 handle_fallback_file(vector_symlink, vector_fallback)
 handle_fallback_file(satellite_symlink, satellite_fallback, False)
 handle_fallback_file(terrain_symlink, terrain_fallback)
@@ -60,13 +69,23 @@ handle_fallback_file(terrain_symlink, terrain_fallback)
 # terrarium-none.pmtiles which is maxzoom=0 will always be used as a
 # dummy to make maps.black / maplibre happy if we have FQRs and the
 # terrain is enabled.
-WORLD_MAP_VECTOR_MAX_ZOOM = get_max_zoom(vector_symlink, 1)
+WORLD_MAP_VECTOR_MAX_ZOOM = get_max_zoom(
+    vector_symlink,
+    get_fallback_zoom_number("{{ maps_fallback_vector_quality }}")
+)
 if satellite_symlink.exists():
     # Allow for satellite=none
-    WORLD_MAP_SATELLITE_MAX_ZOOM = get_max_zoom(satellite_symlink, 7, False)
+    WORLD_MAP_SATELLITE_MAX_ZOOM = get_max_zoom(
+        satellite_symlink,
+        get_fallback_zoom_number("{{ maps_fallback_satellite_zoom }}"),
+        False,
+    )
 else:
     WORLD_MAP_SATELLITE_MAX_ZOOM = "null"
-WORLD_MAP_TERRAIN_MAX_ZOOM = get_max_zoom(terrain_symlink, 0)
+WORLD_MAP_TERRAIN_MAX_ZOOM = get_max_zoom(
+    terrain_symlink,
+    get_fallback_zoom_number("{{ maps_fallback_terrain_zoom }}")
+)
 
 jsbool = lambda b: "true" if b else "false"
 WORLD_MAP_IS_NATURAL_EARTH = jsbool("naturalearth" in str(vector_symlink.readlink()))

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -23,18 +23,23 @@ satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[7] 
 terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles["none"] }}'
 
 def handle_fallback_file(symlink, fallback, required=True):
-    if not symlink.exists():
-        if not fallback.exists():
-            if required:
-                sys.stderr.write(f"You deleted both the symlink:\n\n{symlink}\n\nand the fallback file:\n\n{fallback}\n\n. Can't continue, sorry.\n")
-                sys.stderr.flush()
-                sys.exit(1)
-            return
-        # The symlink is either deleted or broken. For simplicity let's make sure it's just deleted.
-        if symlink.is_symlink():
-            symlink.unlink()
-        print (f"Falling back: pointing {symlink} to {fallback}")
-        symlink.symlink_to(fallback)
+    if symlink.exists():
+        return
+
+    if not fallback.exists():
+        if required:
+            sys.stderr.write(f"You deleted both the symlink:\n\n{symlink}\n\n")
+            sys.stderr.write(f"and the fallback file:\n\n{fallback}\n\n. ")
+            sys.stderr.write("Can't continue, sorry.\n")
+            sys.stderr.flush()
+            sys.exit(1)
+        return
+
+    # The symlink is either deleted or broken. For simplicity let's make sure it's just deleted.
+    if symlink.is_symlink():
+        symlink.unlink()
+    print (f"Falling back: pointing {symlink} to {fallback}")
+    symlink.symlink_to(fallback)
 
 def get_max_zoom(full_path, fallback, required=True):
     PMTILES = Path('{{ tile_extract.working_dir }}') / "pmtiles"

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -4,7 +4,7 @@ import json, glob, os, random, re, requests, shutil, string, subprocess, sys, te
 from pprint import pprint
 from collections import defaultdict
 
-sys.path.insert(1, "/opt/iiab/maps/tile-extract/pmtiles-python/python/pmtiles")
+sys.path.insert(1, "{{ tile_extract.working_dir }}/pmtiles-python/python/pmtiles")
 
 from pmtiles.reader import MmapSource, all_tiles
 


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

Add a utility called `maps-update.py` that factors some aspects of map data set management out of our ansible code. We'll work on factoring out a bit more over time. The reason is that implementers can now call it outside of ansible as well. It allows them to delete large files they don't want without having to re-run ansible. It will eventually allow us to add more features as well, such as handling user-supplied data files, which is a pain to deal with in Ansible.

Right now it recovers from the implementer deleting large vector, satellite, or terrain files by pointing the symlinks to a small "fallback" file, and then putting the "maxzoom"s in a js file imported by the front end so it can display the newly pointed-to files properly. It doesn't recover from every footgun (like deleting the fallbacks) but it's a start.

This change involves having ansible always download the "fallback" files (osm z1, terrain z0, satellite z7) for `maps-update.py` to point the symlinks to. Right now I just put them in the usual www directory. I probably should move them to a special `fallback/` directory but that would add a little complication and I'd rather save that for a new PR.

This change also includes making `maps_region_downloader` only affect the front end. It uses the `pmtiles` tool, so I figure we should just always install the backend FQR stuff which includes it.

Various small unrelated items while I was at it.

### Smoke-tested on which OS or OS's:

Ubuntu LTS via Multipass

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 