### PR TITLE
maps: add NAMING_CONVENTION.md

### DIFF
--- a/roles/maps/NAMING_CONVENTION.md
+++ b/roles/maps/NAMING_CONVENTION.md
@@ -1,0 +1,42 @@
+# Naming Convention
+
+How map data files are named
+
+## Global map data files:
+
+```
+| type                       | date       | depth         | extension (for files)
+|---------------------------------------------------------------
+| s2maps-sentinel2-2023      . 2025-12-10 . z00-z07       . pmtiles
+| naturalearth-openmaptiles  . 2025-12-10 . z00-z08       . pmtiles
+| openstreetmap-openmaptiles . 2026-07-01 . z00-z14       . pmtiles
+| static-search              . 2026-04-22 . pop-1k-cities . tar.gz (*)
+| static-search              . 2026-04-22 . pop-1k-cities
+| nominatim                  . 2025-12-10 . basic         . sqlite
+```
+
+```
+[type].[date].[depth].[extension (for files)]
+```
+
+(*) Note that in the case of `.tar.gz` files (currently only static-search), the extension will be in the catalog and on the file server, but when installed locally it will be expanded into a directory with no extension.
+
+## Full Quality Regions:
+
+```
+type                       | date       | region | ...         | extension (for files)
+---------------------------------------------------------------------------
+openstreetmap-openmaptiles . 2026-07-01 . africa . full-region . pmtiles
+```
+
+```
+[type].[date].full-region.[region].[extension (for files)]
+```
+
+# Key
+
+* `type` refers to the data source for pmtiles files, or the search engine for search
+* `date` refers to the date that the data was generated
+* `depth` refers to the zoom level range for pmtiles files, or in the case of search it refers to the type or amount of search data available. Depth should not be named "full-region".
+* `region` is the user-defined name of the FQR
+* `extension` is a file extension in the case of files, or nothing in the case of directories.

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -283,6 +283,7 @@ sudo ./runrole maps --reinstall
 * [Key map variables](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) originally based on [PR #4120](https://github.com/iiab/iiab/pull/4120) from Oct/Nov 2025
 * Map data files are updated quasi-monthly here, since 2026-04-14: https://iiab.switnet.org/maps/2/
 * IIAB integration thanks to [Dan Krol](https://github.com/orblivion)
+* [Details on data file naming conventions](https://github.com/iiab/iiab/blob/master/roles/maps/NAMING_CONVENTION.md)
 
 ## Next Steps
 


### PR DESCRIPTION
Naming conventions for global and FQR map data files. This is part of the catalog and FQR updating stuff to come. It may well change as we go. But for now it stands alone so I split it out of my draft PR (#4433 ).

@holta 