### PR TITLE
Move pmtiles executable

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -51,6 +51,7 @@ maps_tools:
         sha256sum: 870c3aa968a75430ca1772351c3a6a6d30103b466d6df5837351bfb340640f54
     archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
     archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
+    executable_path: "{{ maps_tools.base_dir }}/pmtiles"
   pmtiles_python:
     git_url: https://github.com/protomaps/PMTiles
     dir_name: pmtiles-python

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -36,27 +36,28 @@ maps_vector_data_date: "2026-07-01"
 maps_search_data_date: "2026-04-22"
 maps_slow_data_date: "2025-12-10"
 
-maps_tools_dir: "/opt/iiab/maps"
-
-tile_extract:
+maps_tools:
+  base_dir: "/opt/iiab/maps"
   pmtiles:
-    armhf:
-      src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.30.1_Linux_armv7.tar.gz
-      sha256sum: 9948f518efa87163d0587ce7b95dd1a98d1ddecdf11131e4286cd331fd63b04a
-    arm64:
-      src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_arm64.tar.gz
-      sha256sum: e44823cff328c2ea354096ccbfd7e7ef6c8f05b11553ad28fcaa33989123a57f
-    amd64:
-      src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_x86_64.tar.gz
-      sha256sum: 870c3aa968a75430ca1772351c3a6a6d30103b466d6df5837351bfb340640f54
+    releases:
+      armhf:
+        src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.30.1_Linux_armv7.tar.gz
+        sha256sum: 9948f518efa87163d0587ce7b95dd1a98d1ddecdf11131e4286cd331fd63b04a
+      arm64:
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_arm64.tar.gz
+        sha256sum: e44823cff328c2ea354096ccbfd7e7ef6c8f05b11553ad28fcaa33989123a57f
+      amd64:
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_x86_64.tar.gz
+        sha256sum: 870c3aa968a75430ca1772351c3a6a6d30103b466d6df5837351bfb340640f54
+    archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
+    archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
   pmtiles_python:
     git_url: https://github.com/protomaps/PMTiles
     dir_name: pmtiles-python
     version: 8b8ddea4dbff1b0104cf2bebf2f7ff35c91b41d5
-  pmtiles_archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
-  pmtiles_archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
-  working_dir: "{{ maps_tools_dir }}/tile-extract"
-  info_file: "extracts.json"
+  tile_extract:
+    working_dir: "{{ maps_tools.base_dir }}/tile-extract"
+    info_file: "extracts.json"
 
 # Basic maps.black javascript and styles
 maps_dot_black_js_and_styles:

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -126,14 +126,14 @@
 - name: "Final map configuration"
   shell: |
     set -euo pipefail
-    {{ maps_tools_dir }}/maps-update.py
+    {{ maps_tools.base_dir }}/maps-update.py
   args:
     executable: /bin/bash
 
 - name: Initiate the extracts json
   copy:
     content: '{"regions": {}}'
-    dest: "{{ maps_serve_path }}/{{ tile_extract.info_file }}"
+    dest: "{{ maps_serve_path }}/{{ maps_tools.tile_extract.info_file }}"
     mode: "0644"
     force: false
 
@@ -141,7 +141,7 @@
   # TODO - Is there a safer way to pass in item.name and item.bbox?
   shell: |
     set -euo pipefail
-    {{ tile_extract.working_dir }}/tile-extract.py extract {{ item.name }} {{ item.bbox }} noninteractive
+    {{ maps_tools.tile_extract.working_dir }}/tile-extract.py extract {{ item.name }} {{ item.bbox }} noninteractive
   args:
     executable: /bin/bash
   with_items: "{{ maps_preset_full_quality_regions }}"

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -39,7 +39,7 @@
 - name: Copy pmtiles executable into working dir
   copy:
     src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
-    dest: "{{ maps_tools.tile_extract.working_dir }}/pmtiles"
+    dest: "{{ maps_tools.pmtiles.executable_path }}"
     mode: "0744"
 
 # Getting the Python tool, which is not usually recommended over the Go tool,

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -1,12 +1,12 @@
 - name: Set up tile extraction working dir
   file:
     state: directory
-    path: "{{ tile_extract.working_dir }}"
+    path: "{{ maps_tools.tile_extract.working_dir }}"
 
 - name: Set up pmtiles unarchiving dir
   file:
     state: directory
-    path: "{{ tile_extract.pmtiles_archive_tmp_dir }}"
+    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
 - name: Define detected arch
   set_fact:
@@ -24,41 +24,41 @@
 
 - name: Download pmtiles archive for {{ dpkg_arch.stdout }}
   get_url:
-    url: "{{ tile_extract.pmtiles[dpkg_arch.stdout].src_url }}"
-    dest: "{{ tile_extract.pmtiles_archive_tmp_file }}"
-    checksum: "sha256:{{ tile_extract.pmtiles[dpkg_arch.stdout].sha256sum }}"
+    url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"
+    dest: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+    checksum: "sha256:{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].sha256sum }}"
     mode: "0644"
     timeout: "{{ download_timeout }}"
 
 - name: Unarchive pmtiles archive
   unarchive:
-    src: "{{ tile_extract.pmtiles_archive_tmp_file }}"
-    dest: "{{ tile_extract.pmtiles_archive_tmp_dir }}"
+    src: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+    dest: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
     remote_src: yes
 
 - name: Copy pmtiles executable into working dir
   copy:
-    src: "{{ tile_extract.pmtiles_archive_tmp_dir }}/pmtiles"
-    dest: "{{ tile_extract.working_dir }}/pmtiles"
+    src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
+    dest: "{{ maps_tools.tile_extract.working_dir }}/pmtiles"
     mode: "0744"
 
 # Getting the Python tool, which is not usually recommended over the Go tool,
 # so that we can write code with it that we don't need to build.
 - name: Get PMTiles (Python tool)
   git:
-    repo: "{{ tile_extract.pmtiles_python.git_url }}"
-    dest: "{{ tile_extract.working_dir }}/{{ tile_extract.pmtiles_python.dir_name }}"
-    version: "{{ tile_extract.pmtiles_python.version }}"
+    repo: "{{ maps_tools.pmtiles_python.git_url }}"
+    dest: "{{ maps_tools.tile_extract.working_dir }}/{{ maps_tools.pmtiles_python.dir_name }}"
+    version: "{{ maps_tools.pmtiles_python.version }}"
     depth: 1
 
 - name: Install our tile extraction script
   template:
     src: "tile-extract.py.j2"
-    dest: "{{ tile_extract.working_dir }}/tile-extract.py"
+    dest: "{{ maps_tools.tile_extract.working_dir }}/tile-extract.py"
     mode: "0755"
 
 - name: Install maps-update.py
   template:
     src: "maps-update.py.j2"
-    dest: "{{ maps_tools_dir }}/maps-update.py"
+    dest: "{{ maps_tools.base_dir }}/maps-update.py"
     mode: "0755"

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -681,7 +681,7 @@
             const fqrLoaded = () => !!downloadedFQRegions
 
             function setFQRegions() {
-                return fetch('{{ tile_extract.info_file }}', { cache: 'no-store' })
+                return fetch('{{ maps_tools.tile_extract.info_file }}', { cache: 'no-store' })
                     .then((response) => {
                         if (response.status < 400) {
                             return response.json()
@@ -1097,7 +1097,7 @@
 
                         const downloadCommand = document.createElement('div');
                         downloadCommand.set = function(downloadName) {
-                            const downloadCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py extract ${downloadName} ${min_lon},${min_lat},${max_lon},${max_lat}`
+                            const downloadCommandString = `sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py extract ${downloadName} ${min_lon},${min_lat},${max_lon},${max_lat}`
                             this.innerHTML = `<pre
                                 style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
                                 onclick="window.getSelection().selectAllChildren(this)"
@@ -1191,7 +1191,7 @@
                     ]
 
                     const deleteCommand = document.createElement('div');
-                    const deleteCommandString = `sudo {{ tile_extract.working_dir }}/tile-extract.py delete ${regionName}`
+                    const deleteCommandString = `sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py delete ${regionName}`
                     const deleteCommandStyle = [
                         "font-size: 0.8em;",
                         "background-color: #DDD;",

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -42,7 +42,7 @@ def handle_fallback_file(symlink, fallback, required=True):
     symlink.symlink_to(fallback)
 
 def get_max_zoom(full_path, fallback, required=True):
-    PMTILES = Path('{{ tile_extract.working_dir }}') / "pmtiles"
+    PMTILES = Path('{{ maps_tools.tile_extract.working_dir }}') / "pmtiles"
     output = subprocess.getoutput(f"{PMTILES} show {full_path} --header-json")
     try:
         return json.loads(output)["maxzoom"]

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -42,7 +42,7 @@ def handle_fallback_file(symlink, fallback, required=True):
     symlink.symlink_to(fallback)
 
 def get_max_zoom(full_path, fallback, required=True):
-    PMTILES = Path('{{ maps_tools.tile_extract.working_dir }}') / "pmtiles"
+    PMTILES = Path('{{ maps_tools.pmtiles.executable_path }}')
     output = subprocess.getoutput(f"{PMTILES} show {full_path} --header-json")
     try:
         return json.loads(output)["maxzoom"]

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -4,7 +4,7 @@ import json, glob, os, random, re, requests, shutil, string, subprocess, sys, te
 from pprint import pprint
 from collections import defaultdict
 
-sys.path.insert(1, "{{ tile_extract.working_dir }}/pmtiles-python/python/pmtiles")
+sys.path.insert(1, "{{ maps_tools.tile_extract.working_dir }}/pmtiles-python/python/pmtiles")
 
 from pmtiles.reader import MmapSource, all_tiles
 
@@ -111,7 +111,7 @@ def get_bounds(full_path):
     return render_bounds, ui_bounds
 
 HOSTING_DIR = "{{ maps_serve_path }}"
-EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ tile_extract.info_file }}")
+EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ maps_tools.tile_extract.info_file }}")
 PMTILES = os.path.join(os.path.dirname(__file__), "pmtiles")
 TMP_DIR = "/library/downloads/maps"
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -112,7 +112,7 @@ def get_bounds(full_path):
 
 HOSTING_DIR = "{{ maps_serve_path }}"
 EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ maps_tools.tile_extract.info_file }}")
-PMTILES = os.path.join(os.path.dirname(__file__), "pmtiles")
+PMTILES = "{{ maps_tools.pmtiles.executable_path }}"
 TMP_DIR = "/library/downloads/maps"
 
 # Helpers


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Rearrange variables related to map tools (pmtiles, FQR extract script), and then move the go-pmtiles executable to a different path.

The reason is that we use the pmtiles executable in maps-update.py now so it doesn't make sense to keep it under the "extract" tools directory. And I want the variables to be named more accurately.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta 