### PR TITLE
maps: normalize vector map related setting names and values

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -28,7 +28,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
    maps_install: True
    maps_enabled: True
 
-   maps_vector_quality: nat-z8
+   maps_vector_zoom: nat-z8
    maps_satellite_zoom: 7
    ```
 
@@ -38,7 +38,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
 2. Or if you want **~9.5 GB** = 8.3 GB vector (Higher detail, up to zoom 11 [users can overzoom to zoom 15], from OpenStreetMap) + 1.2 GB satellite (up to zoom 9), include:
 
    ```
-   maps_vector_quality: osm-z11
+   maps_vector_zoom: 11
    maps_satellite_zoom: 9
    ```
 
@@ -48,7 +48,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
 3. Or if you want **~160 GB** = 80 GB vector (Higher detail, up to zoom 14 [users can overzoom to zoom 18], including 3D buildings, from OpenStreetMap) + 80 GB satellite (up to zoom 12), include:
 
    ```
-   maps_vector_quality: osm-z14
+   maps_vector_zoom: 14
    maps_satellite_zoom: 12
    ```
 
@@ -245,7 +245,7 @@ If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "u
    ```
    maps_ne6_zoom: ci
 
-   maps_vector_quality: osm-z1
+   maps_vector_zoom: 1
    maps_satellite_zoom: 4
 
    maps_search_engine: static

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -118,16 +118,16 @@ maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
 maps_dot_black_vector_tiles:
   # "high res" full osm, including 3d buildings.
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
-  # maps_vector_quality = "osm-z14"
-  osm-z14: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z14.pmtiles"
+  # maps_vector_zoom = 14
+  14: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z14.pmtiles"
 
   # "medium res" osm, up to zoom level 11 (original file has 14).
   # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
-  # maps_vector_quality = "osm-z11"
-  osm-z11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z11.pmtiles"
+  # maps_vector_zoom = 11
+  11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z11.pmtiles"
 
   # "low res" - mostly borders, rivers, country names, large roads.
-  # maps_vector_quality = "nat-z8"
+  # maps_vector_zoom = "nat-z8"
   # (nat-z8 = "Natural Earth")
   #
   # NOTE: We will pass this into maps.black as if it's the OpenStreetMap data, even though
@@ -141,10 +141,10 @@ maps_dot_black_vector_tiles:
 
   # FOR TESTING AND FALLBACK ONLY
   # "medium res" osm, up to zoom level 1 (original file has 14).
-  # maps_vector_quality = "osm-z1"
-  osm-z1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z01.pmtiles"
+  # maps_vector_zoom = 1
+  1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z01.pmtiles"
 
-maps_fallback_vector_quality: osm-z1
+maps_fallback_vector_zoom: 1
 maps_vector_max_zoom: 14
 
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -35,30 +35,30 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
     state: link
 
-- name: "Make sure maps_vector_quality has a valid value"
+- name: "Make sure maps_vector_zoom has a valid value"
   assert:
-    that: maps_dot_black_vector_tiles[maps_vector_quality] is defined
-    fail_msg: "Error: maps_vector_quality is set to an invalid value. See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    that: maps_dot_black_vector_tiles[maps_vector_zoom] is defined
+    fail_msg: "Error: maps_vector_zoom is set to an invalid value. See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
     quiet: yes
 
 - name: Download vector tiles
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
+    item: "{{ maps_dot_black_vector_tiles[maps_vector_zoom] }}"
 
 - name: Select vector tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_quality] }}"
+    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_zoom] }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
 
 - name: Download fallback vector tiles
   include_tasks: download_large_file.yml
-  when: maps_vector_quality != maps_fallback_vector_quality
+  when: maps_vector_zoom != maps_fallback_vector_zoom
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_vector_tiles[maps_fallback_vector_quality] }}"
+    item: "{{ maps_dot_black_vector_tiles[maps_fallback_vector_zoom] }}"
 
 - when: maps_satellite_zoom != "none"
   block:

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -35,6 +35,14 @@
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
     state: link
 
+# This helps avoid silent errors transitioning between variable names. It can be deleted 2026/09/04.
+- name: Error on deprecated maps_vector_quality
+  assert:
+    that: maps_vector_quality is not defined
+    msg:
+      - "'maps_vector_quality' has been renamed to 'maps_vector_zoom' with new valid values. Please update your"
+      - "/etc/iiab/local_vars.yml and see https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+
 - name: "Make sure maps_vector_zoom has a valid value"
   assert:
     that: maps_dot_black_vector_tiles[maps_vector_zoom] is defined

--- a/roles/maps/tasks/main.yml
+++ b/roles/maps/tasks/main.yml
@@ -37,8 +37,8 @@
           value: "{{ maps_enabled }}"
         - option: maps_region_downloader
           value: "{{ maps_region_downloader }}"
-        - option: maps_vector_quality
-          value: "{{ maps_vector_quality }}"
+        - option: maps_vector_zoom
+          value: "{{ maps_vector_zoom }}"
         - option: maps_satellite_zoom
           value: "{{ maps_satellite_zoom }}"
         - option: maps_terrain_zoom

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -18,7 +18,7 @@ vector_symlink = maps_serve_path / '{{ maps_dot_black_osm_symlink_name }}'
 satellite_symlink = maps_serve_path / '{{ maps_dot_black_satellite_symlink_name }}'
 terrain_symlink = maps_serve_path / '{{ maps_dot_black_terrain_symlink_name }}'
 
-vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles[maps_fallback_vector_quality] }}'
+vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles[maps_fallback_vector_zoom] }}'
 satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[maps_fallback_satellite_zoom] }}'
 terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles[maps_fallback_terrain_zoom] }}'
 
@@ -71,7 +71,7 @@ handle_fallback_file(terrain_symlink, terrain_fallback)
 # terrain is enabled.
 WORLD_MAP_VECTOR_MAX_ZOOM = get_max_zoom(
     vector_symlink,
-    get_fallback_zoom_number("{{ maps_fallback_vector_quality }}")
+    get_fallback_zoom_number("{{ maps_fallback_vector_zoom }}")
 )
 if satellite_symlink.exists():
     # Allow for satellite=none

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -511,7 +511,7 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False
 maps_enabled: False
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_android_large.yml
+++ b/vars/local_vars_android_large.yml
@@ -46,7 +46,7 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_android_medium.yml
+++ b/vars/local_vars_android_medium.yml
@@ -46,7 +46,7 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_android_small.yml
+++ b/vars/local_vars_android_small.yml
@@ -46,7 +46,7 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -299,7 +299,7 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -318,7 +318,7 @@ osm_vector_maps_enabled: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_quality: osm-z1             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: 1                     # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -299,7 +299,7 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -299,7 +299,7 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -299,7 +299,7 @@ osm_vector_maps_enabled: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -305,7 +305,7 @@ osm_vector_maps_enabled: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_quality: nat-z8             # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Make the vector zoom setting more in line with satellite and terrain. Just have them be numbers for the most part.

* `maps_vector_quality` -> `maps_vector_zoom`
* `osm-z11` -> `11`
* etc

Leaving `nat-z8` for now. Hopefully we get rid of Natural Earth eventually anyway.

This is pulled from #4433. I am still mulling over some other questions regarding keys. For instance, the value `ci-1`/`1-ci` that I considered in #4433 doesn't make sense anymore if 1 is also the fallback zoom for vector. However those questions shake out, I think the change in this PR is something we can get out of the way.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta