### PR TITLE
Move map options from main.yml to catalog.json and change some keys

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -55,7 +55,7 @@ Here are 3 examples below, to help you decide what you'll put in [/etc/iiab/loca
 ![Vector OSM Full Zoom](README-assets/vector/vector-osm-z14.png)
 ![Satellite Full Zoom](README-assets/satellite/satellite-z12.png)
 
-See `maps_dot_black_vector_tiles` and `maps_dot_black_satellite_tiles` [here](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) for all valid values.
+See `vector` and `satellite` [here](https://github.com/iiab/iiab/blob/master/roles/maps/generate-catalog.py) for all valid values.
 
 *NOTE: The satellite data is licensed "NonCommercial" under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).  To skip worldwide satellite imagery, set:*
 
@@ -99,7 +99,7 @@ PREREQ: Confirm that at least a [minimum IIAB Maps](#whats-a-minimum-iiab-maps-i
 
 ![Terrain Full Zoom](README-assets/terrain/terrain-z10.png)
 
-See `maps_dot_black_terrain_tiles` [here](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) for all valid values.
+See `terrain` [here](https://github.com/iiab/iiab/blob/master/roles/maps/generate-catalog.py) for all valid values.
 
 ### How do I view 3D Terrain?
 
@@ -243,10 +243,10 @@ If you are installing IIAB Maps for testing purposes (QA, CI, etc), there are "u
 [*] Grand total disk usage is [~66 MB instead of the ~312 MB delivered by default_vars.yml](https://github.com/iiab/iiab/pull/4324), as of March 2026.
 
    ```
-   maps_ne6_zoom: ci
+   maps_ne6_zoom: 4-ci
 
-   maps_vector_zoom: 1
-   maps_satellite_zoom: 4
+   maps_vector_zoom: 1-ci
+   maps_satellite_zoom: 4-ci
 
    maps_search_engine: static
    maps_search_static_db: pop-100k-cities
@@ -280,7 +280,8 @@ sudo ./runrole maps --reinstall
 
 ## Further options & detail:
 
-* [Key map variables](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) originally based on [PR #4120](https://github.com/iiab/iiab/pull/4120) from Oct/Nov 2025
+* [Values for `*_zoom` variables](https://github.com/iiab/iiab/blob/master/roles/maps/generate-catalog.py)
+* [Other map variables](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) originally based on [PR #4120](https://github.com/iiab/iiab/pull/4120) from Oct/Nov 2025
 * Map data files are updated quasi-monthly here, since 2026-04-14: https://iiab.switnet.org/maps/2/
 * IIAB integration thanks to [Dan Krol](https://github.com/orblivion)
 * [Details on data file naming conventions](https://github.com/iiab/iiab/blob/master/roles/maps/NAMING_CONVENTION.md)

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -2,7 +2,6 @@
 # something more in line with IIAB expectations.
 
 unpkg_url: https://unpkg.com
-iiab_map_host_url: https://iiab.switnet.org/maps/2
 
 maps_serve_path: "{{ content_base }}/www/maps"        # /library/www/maps
 maps_data_root: "{{ content_base }}/maps"             # /library/maps
@@ -19,22 +18,6 @@ nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 
 maps_static_search_dir: "static-search"
 maps_static_search_root: "{{ maps_serve_path }}/{{ maps_static_search_dir }}"
-
-# `maps_vector_data_date` is for vector tiles
-# `maps_slow_data_date` is for big data that changes rarely if ever (satellite,
-#     natural earth, terrain, search [for now!])
-#
-# It sucks to have up-to-date files with different dates, but the alternative
-# is to force the user to download the same satellite file over and over every
-# time the vector data changes. This is why we have the "slow" designation.
-# Some of it may never change. Some of it, like search, will probably start
-# changing much faster once we're ready for it. We can even decide on multiple
-# date designations down the line. I just want one "slow" date to set all of
-# these items *for now*.
-#
-maps_vector_data_date: "2026-07-01"
-maps_search_data_date: "2026-04-22"
-maps_slow_data_date: "2025-12-10"
 
 maps_tools:
   base_dir: "/opt/iiab/maps"
@@ -61,6 +44,7 @@ maps_tools:
     info_file: "extracts.json"
 
 # Basic maps.black javascript and styles
+maps_dot_black_js_and_styles_host: https://iiab.switnet.org/maps/2
 maps_dot_black_js_and_styles:
 
 #    NOTE: We are now building `maps.black.js` ourselves because we want to
@@ -74,8 +58,8 @@ maps_dot_black_js_and_styles:
 #  -    filename: maps.black.js
 #  -    sha256sum: 7b3843b5ded151d585ccf3a6db02093e3a95851be36dcffc5fa92030657b9c93
 
-  - maps.black-component.js
-  - resourcetiles-minimal.pmtiles
+  - "{{ maps_dot_black_js_and_styles_host }}/maps.black-component.js"
+  - "{{ maps_dot_black_js_and_styles_host }}/resourcetiles-minimal.pmtiles"
 
 # MapLibre and plugins, javascript and css
 # TODO get the minified versions of all these?
@@ -107,78 +91,8 @@ maplibre_js_and_styles:
 
 maps_dot_black_naturalearth6_symlink_name: "naturalearth6-NE2_HR_SR_W_DR-WEBP.pmtiles"
 
-# Mostly colors, topography, etc.
-maps_dot_black_naturalearth6_tiles:
-  # For actual users
-  full: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-z06.pmtiles"
-
-  # FOR TESTING ONLY
-  ci: "naturalearth6-NE2_HR_SR_W_DR-WEBP.{{ maps_slow_data_date }}.z00-z04.pmtiles"
-
 maps_dot_black_osm_symlink_name: openstreetmap-openmaptiles.pmtiles
-
-maps_dot_black_vector_tiles:
-  # "high res" full osm, including 3d buildings.
-  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
-  # maps_vector_zoom = 14
-  14: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z14.pmtiles"
-
-  # "medium res" osm, up to zoom level 11 (original file has 14).
-  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
-  # maps_vector_zoom = 11
-  11: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z11.pmtiles"
-
-  # "low res" - mostly borders, rivers, country names, large roads.
-  # maps_vector_zoom = "nat-z8"
-  # (nat-z8 = "Natural Earth")
-  #
-  # NOTE: We will pass this into maps.black as if it's the OpenStreetMap data, even though
-  # it's Natural Earth. They're both in the OpenMapTiles schema. The OSM and NE variants of
-  # the "Natural" style we use are compatible, with just some zoom range differences (which
-  # makes no difference that I notice). This will fail to show "naturalearth" in attributions
-  # ("naturalearth6" is separate), even in "generous" attribution mode. However maps.black
-  # and the naturalearth website say that crediting authors is unnecessary. It's not worth
-  # the time to fix just for consistency.
-  nat-z8: "naturalearth-openmaptiles.{{ maps_slow_data_date }}.z00-z08.pmtiles"
-
-  # FOR TESTING AND FALLBACK ONLY
-  # "medium res" osm, up to zoom level 1 (original file has 14).
-  # maps_vector_zoom = 1
-  1: "openstreetmap-openmaptiles.{{ maps_vector_data_date }}.z00-z01.pmtiles"
-
-maps_fallback_vector_zoom: 1
-maps_vector_max_zoom: 14
-
 maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
-
-maps_dot_black_satellite_tiles:
-  # Low quality satellite, up to zoom level 7 (original file has 13)
-  # maps_satellite_zoom = 7
-  7: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z07.pmtiles"
-
-  # Moderately high quality satellite, up to zoom level 9 (original file has 13)
-  # maps_satellite_zoom = 9
-  9: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z09.pmtiles"
-
-  # Pretty high quality satellite, up to zoom level 11 (original file has 13)
-  # maps_satellite_zoom = 11
-  11: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z11.pmtiles"
-
-  # Pretty high quality satellite, up to zoom level 12 (original file has 13)
-  # maps_satellite_zoom = 12
-  12: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z12.pmtiles"
-
-  # Highest available quality satellite, up to zoom level 13
-  # maps_satellite_zoom = 13
-  13: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z13.pmtiles"
-
-  # FOR TESTING ONLY
-  # Super-low quality satellite, up to zoom level 4 (original file has 13)
-  # maps_satellite_zoom = 4
-  4: "s2maps-sentinel2-2023.{{ maps_slow_data_date }}.z00-z04.pmtiles"
-
-maps_fallback_satellite_zoom: 7
-maps_satellite_max_zoom: 13
 
 # NOTE: This symlink's name matches what maps.black is explicitly querying for.
 # However the fact that it includes "z0-z10" is not ideal, as it may point to an
@@ -187,34 +101,15 @@ maps_satellite_max_zoom: 13
 # should change this.
 maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 
-maps_dot_black_terrain_tiles:
-  # Low quality terrain, up to zoom level 7 (original file has 10)
-  # maps_terrain_zoom = 7
-  7: "terrarium.{{ maps_slow_data_date }}.z00-z07.pmtiles"
+maps_fallback_vector_zoom: 1-fallback
+maps_fallback_satellite_zoom: 7
+maps_fallback_terrain_zoom: 0-none
 
-  # maps_terrain_zoom = 8
-  8: "terrarium.{{ maps_slow_data_date }}.z00-z08.pmtiles"
-
-  # maps_terrain_zoom = 9
-  9: "terrarium.{{ maps_slow_data_date }}.z00-z09.pmtiles"
-
-  # maps_terrain_zoom = 10
-  # (This is the highest quality that maps.black offers in pmtiles format. They
-  # offer 11, 12, and 13 in squashfs format, but they are massive files.)
-  10: "terrarium.{{ maps_slow_data_date }}.z00-z10.pmtiles"
-
-  # NOT RECOMMENDED. VERY LOW QUALITY terrain, up to zoom level 5 or 6.
-  # We will probably end up getting rid of these, but we would like to test
-  # them out to be sure.
-  5: "terrarium.{{ maps_slow_data_date }}.z00-z05.pmtiles"
-  6: "terrarium.{{ maps_slow_data_date }}.z00-z06.pmtiles"
-
-  # A "dummy" maxzoom=0 world map terrain file to fill a role that maps.black/maplibre
-  # needs if we have FQRs and the user enables terrain.
-  none: "terrarium-none.pmtiles"
-
-maps_fallback_terrain_zoom: none
-maps_terrain_max_zoom: 10
+# Store max zoom with the code rather than the catalog because we may want to warn users
+# before FQRs suddenly become larger, give them options, etc.
+maps_vector_fqr_max_zoom: 14
+maps_satellite_fqr_max_zoom: 13
+maps_terrain_fqr_max_zoom: 10
 
 # Similar to pmtiles, search databases should follow this convention:
 #
@@ -230,26 +125,4 @@ maps_terrain_max_zoom: 10
 
 nominatim_db_symlink_name: nominatim.sqlite
 
-# Keeping nominatim on maps_slow_data_date until we actually update it again
-nominatim_data:
-  # Basic nominatim database
-  # maps_search_nominatim_db = "basic"
-  basic: "nominatim.{{ maps_slow_data_date }}.basic.sqlite"
-    # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
-    # TODO - Make a basic small whole-world map, at least as good as previous maps
-
-  # Full nominatim database
-  # maps_search_nominatim_db = "full"
-  full: "nominatim.{{ maps_slow_data_date }}.full.sqlite"
-
 static_search_symlink_name: world-map
-
-static_search_data:
-  # Cities-only static database
-  # maps_search_static_db = "pop-1k-cities"
-  pop-1k-cities: "static-search.{{ maps_search_data_date }}.pop-1k-cities"
-
-  # Large cities-only static database
-  # maps_search_static_db = "pop-100k-cities"
-  # FOR TESTING ONLY
-  pop-100k-cities: "static-search.{{ maps_search_data_date }}.pop-100k-cities"

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -218,9 +218,9 @@ maps_terrain_max_zoom: 10
 
 # Similar to pmtiles, search databases should follow this convention:
 #
-#   {search-engine}.{maps_slow_data_date}.full
-#   {search-engine}.{maps_slow_data_date}.{subset}
-#   {search-engine}.{maps_slow_data_date}.full-region.region-name
+#   {search-engine}.{date}.full
+#   {search-engine}.{date}.{subset}
+#   {search-engine}.{date}.full-region.region-name
 #
 # Though:
 #

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -101,7 +101,7 @@ maps_dot_black_satellite_symlink_name: s2maps-sentinel2-2023.pmtiles
 # should change this.
 maps_dot_black_terrain_symlink_name: terrarium-z0-z10.pmtiles
 
-maps_fallback_vector_zoom: 1-fallback
+maps_fallback_vector_zoom: nat-z8
 maps_fallback_satellite_zoom: 7
 maps_fallback_terrain_zoom: 0-none
 

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -157,10 +157,6 @@ nominatim_data = dict_with_order({
   "full": f"{iiab_map_host_url}/nominatim.{maps_slow_data_date}.full.sqlite",
 }, ["basic", "full"])
 
-def render(source, data):
-    rtemplate = jinja2.Environment(loader=jinja2.BaseLoader).from_string(source)
-    return rtemplate.render(**data)
-
 catalog = {
     "README": [
         "If you are installing or configuring",

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python3
+import requests, jinja2, json, yaml
+
+import os
+os.chdir(os.path.dirname(__file__))
+
+iiab_map_host_url = "https://iiab.switnet.org/maps/2"
+
+# "data dates" refer to how recent a certain type of data is
+
+maps_vector_data_date = "2026-07-01"
+maps_satellite_data_date = "2025-12-10"
+maps_static_search_data_date = "2026-04-22"
+
+# `maps_slow_data_date` is for data that changes rarely if ever
+# naturalearth, naturalearth6, terrain, nominatim search [for now!]
+maps_slow_data_date = "2025-12-10"
+
+# The order that makes sense for explanation in this file may not make as much
+# sense in the generated file. So here, we can reorder it before it gets generated.
+def dict_with_order(d, ordered_keys):
+    assert set(d.keys()) == set(ordered_keys), (d.keys(), ordered_keys)
+    return {key: d[key] for key in ordered_keys}
+
+maps_dot_black_vector_tiles = dict_with_order({
+  # "high res" full osm, including 3d buildings.
+  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
+  # maps_vector_zoom = 14
+  14: f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z14.pmtiles",
+
+  # "medium res" osm, up to zoom level 11 (original file has 14).
+  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
+  # maps_vector_zoom = 11
+  11: f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z11.pmtiles",
+
+  # "low res" - mostly borders, rivers, country names, large roads.
+  # maps_vector_zoom = "nat-z8"
+  # (nat-z8 = "Natural Earth")
+  #
+  # NOTE: We will pass this into maps.black as if it's the OpenStreetMap data, even though
+  # it's Natural Earth. They're both in the OpenMapTiles schema. The OSM and NE variants of
+  # the "Natural" style we use are compatible, with just some zoom range differences (which
+  # makes no difference that I notice). This will fail to show "naturalearth" in attributions
+  # ("naturalearth6" is separate), even in "generous" attribution mode. However maps.black
+  # and the naturalearth website say that crediting authors is unnecessary. It's not worth
+  # the time to fix just for consistency.
+  "nat-z8": f"{iiab_map_host_url}/naturalearth-openmaptiles.{maps_slow_data_date}.z00-z08.pmtiles",
+
+  # FOR TESTING OR FALLBACK ONLY
+  # "medium res" osm, up to zoom level 1 (original file has 14).
+  # maps_vector_zoom = 1
+  "1-ci": f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z01.pmtiles",
+}, ["nat-z8", 11, 14, "1-ci"])
+
+maps_dot_black_satellite_tiles = dict_with_order({
+  # Low quality satellite, up to zoom level 7 (original file has 13)
+  # maps_satellite_zoom = 7
+  7: f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z07.pmtiles",
+
+  # Moderately high quality satellite, up to zoom level 9 (original file has 13)
+  # maps_satellite_zoom = 9
+  9: f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z09.pmtiles",
+
+  # Pretty high quality satellite, up to zoom level 11 (original file has 13)
+  # maps_satellite_zoom = 11
+  11: f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z11.pmtiles",
+
+  # Pretty high quality satellite, up to zoom level 12 (original file has 13)
+  # maps_satellite_zoom = 12
+  12: f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z12.pmtiles",
+
+  # Highest available quality satellite, up to zoom level 13
+  # maps_satellite_zoom = 13
+  13: f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z13.pmtiles",
+
+  # To disable satellite, use the value "none". (There is no URL associated with this option
+  # because it doesn't download anything, but it is valid!)
+  # maps_satellite_zoom = none
+
+  # FOR TESTING ONLY
+  # Super-low quality satellite, up to zoom level 4 (original file has 13)
+  # maps_satellite_zoom = 4
+  "4-ci": f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z04.pmtiles",
+}, [7, 9, 11, 12, 13, "4-ci"])
+
+maps_dot_black_terrain_tiles = dict_with_order({
+  # Low quality terrain, up to zoom level 7 (original file has 10)
+  # maps_terrain_zoom = 7
+  7: f"{iiab_map_host_url}/terrarium.{maps_slow_data_date}.z00-z07.pmtiles",
+
+  # maps_terrain_zoom = 8
+  8: f"{iiab_map_host_url}/terrarium.{maps_slow_data_date}.z00-z08.pmtiles",
+
+  # maps_terrain_zoom = 9
+  9: f"{iiab_map_host_url}/terrarium.{maps_slow_data_date}.z00-z09.pmtiles",
+
+  # maps_terrain_zoom = 10
+  # (This is the highest quality that maps.black offers in pmtiles format. They
+  # offer 11, 12, and 13 in squashfs format, but they are massive files.)
+  10: f"{iiab_map_host_url}/terrarium.{maps_slow_data_date}.z00-z10.pmtiles",
+
+  # maps_terrain_zoom = 0-none
+  # A "dummy" maxzoom=0 world map terrain file to fill a role that maps.black/maplibre
+  # needs if we have FQRs and the user enables terrain.
+  "0-none": f"{iiab_map_host_url}/terrarium-none.pmtiles",
+}, [7, 8, 9, 10, "0-none"])
+# TODO - let's sort this out:
+#
+# The question is the relationship between user settings and catalog keys
+#
+# Option 1: literal - keys are just digits and the instructions here (or in a separate doc?) just instruct them on what to put
+#   upside: everything is consistent
+#   upside: no goofy keys anywhere
+#   downside: implementers don't get useful keys in their configs - just numbers (for none type "0")  (maybe that's fine?!? how long will implementers be manually editing configs anyway?)
+# Option 2: convert - i.e. "none" in config becomes "0" from the catalog
+#   upside: implementers don't have to think about "0 actually means none"
+#   upside: no goofy keys in the catalog
+#   downside: implementers who just look at the keys of the json file may put the wrong values
+# Option 3: Annotated keys in both config and catalog ("1-ci", "0-none", etc) and go with that for configs and catalog
+#   upside: consistent, and the keys give clues to the implementer
+#   downside: for vector, 1 is now also the "fallback" not just the CI, so the naming is not totally accurate
+#   downside: meanings could keep evolving! do we want this sort of thing for everything?
+#   downside: there's "0-none" for terrain and "none" for satellite (because in that case there really is no satellite) which is weird (though that should be short lived)
+# Option 4: redundant keys for everything? i.e have all of "1" "1-ci" "1-fallback" in the catalog and configs?
+#   upside: if uses evolve we can just keep adding keys
+#   downside: just weird
+#
+
+# Mostly colors, topography, etc.
+maps_dot_black_naturalearth6_tiles = dict_with_order({
+  # For actual users
+  6: f"{iiab_map_host_url}/naturalearth6-NE2_HR_SR_W_DR-WEBP.{maps_slow_data_date}.z00-z06.pmtiles",
+
+  # FOR TESTING ONLY
+  "4-ci": f"{iiab_map_host_url}/naturalearth6-NE2_HR_SR_W_DR-WEBP.{maps_slow_data_date}.z00-z04.pmtiles",
+}, [6, "4-ci"])
+
+static_search_data = dict_with_order({
+  # Cities-only static database
+  # maps_search_static_db = "pop-1k-cities"
+  "pop-1k-cities": f"{iiab_map_host_url}/static-search.{maps_static_search_data_date}.pop-1k-cities.tar.gz",
+
+  # Large cities-only static database
+  # maps_search_static_db = "pop-100k-cities"
+  # FOR TESTING ONLY
+  "pop-100k-cities": f"{iiab_map_host_url}/static-search.{maps_static_search_data_date}.pop-100k-cities.tar.gz",
+}, ["pop-1k-cities", "pop-100k-cities"])
+
+# Keeping nominatim on maps_slow_data_date until we actually update it again
+nominatim_data = dict_with_order({
+  # Basic nominatim database
+  # maps_search_nominatim_db = "basic"
+  "basic": f"{iiab_map_host_url}/nominatim.{maps_slow_data_date}.basic.sqlite",
+    # California admin+natural for now. TODO make a small worldwide one. (unless we go to the frontend-only one)
+    # TODO - Make a basic small whole-world map, at least as good as previous maps
+
+  # Full nominatim database
+  # maps_search_nominatim_db = "full"
+  "full": f"{iiab_map_host_url}/nominatim.{maps_slow_data_date}.full.sqlite",
+}, ["basic", "full"])
+
+def render(source, data):
+    rtemplate = jinja2.Environment(loader=jinja2.BaseLoader).from_string(source)
+    return rtemplate.render(**data)
+
+catalog = {
+    "README": [
+        "If you are installing or configuring",
+        "IIAB Maps, you should ignore this file.",
+        "See /opt/iiab/iiab/maps/generate-catalog.py",
+        "for more info.",
+    ],
+    "satellite": maps_dot_black_satellite_tiles,
+    "terrain": maps_dot_black_terrain_tiles,
+    "vector": maps_dot_black_vector_tiles,
+    "naturalearth6": maps_dot_black_naturalearth6_tiles,
+    "static_search": static_search_data,
+    "nominatim": nominatim_data,
+}
+
+for maptype, zooms in catalog.items():
+    if maptype != "README":
+        for zoom, url in zooms.items():
+            assert requests.head(url).status_code == 200, "Error with URL: " + url
+
+open("maps-catalog.json", "w").write(json.dumps(catalog, indent=4))

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -24,12 +24,10 @@ def dict_with_order(d, ordered_keys):
 
 maps_dot_black_vector_tiles = dict_with_order({
   # "high res" full osm, including 3d buildings.
-  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_zoom = 14
   14: f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z14.pmtiles",
 
   # "medium res" osm, up to zoom level 11 (original file has 14).
-  # (TODO does this include colors and topography? Or is it used along with naturalearth6 above in most styles?)
   # maps_vector_zoom = 11
   11: f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z11.pmtiles",
 

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -172,6 +172,7 @@ catalog = {
     "nominatim": nominatim_data,
 }
 
+# Make sure all of the URLs are valid
 for maptype, zooms in catalog.items():
     if maptype != "README":
         for zoom, url in zooms.items():

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -124,7 +124,7 @@ maps_dot_black_terrain_tiles = dict_with_order({
 #   downside: just weird
 #
 
-# Mostly colors, topography, etc.
+# Mostly colors, topography (as an image, not an elevation map), etc.
 maps_dot_black_naturalearth6_tiles = dict_with_order({
   # For actual users
   6: f"{iiab_map_host_url}/naturalearth6-NE2_HR_SR_W_DR-WEBP.{maps_slow_data_date}.z00-z06.pmtiles",

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -24,7 +24,7 @@ def dict_with_order(d, ordered_keys):
 
 maps_dot_black_vector_tiles = dict_with_order({
   # "high res" full osm, including 3d buildings.
-  # maps_vector_zoom = 14
+  # maps_vector_zoom = 14 (full quality)
   14: f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z14.pmtiles",
 
   # "medium res" osm, up to zoom level 11 (original file has 14).
@@ -45,7 +45,7 @@ maps_dot_black_vector_tiles = dict_with_order({
   "nat-z8": f"{iiab_map_host_url}/naturalearth-openmaptiles.{maps_slow_data_date}.z00-z08.pmtiles",
 
   # FOR TESTING OR FALLBACK ONLY
-  # "medium res" osm, up to zoom level 1 (original file has 14).
+  # "skeleton" osm, up to zoom level 1 (original file has 14).
   # maps_vector_zoom = 1
   "1-ci": f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z01.pmtiles",
 }, ["nat-z8", 11, 14, "1-ci"])

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -48,7 +48,7 @@ maps_dot_black_vector_tiles = dict_with_order({
   # "skeleton" osm, up to zoom level 1 (original file has 14).
   # maps_vector_zoom = 1
   "1-ci": f"{iiab_map_host_url}/openstreetmap-openmaptiles.{maps_vector_data_date}.z00-z01.pmtiles",
-}, ["nat-z8", 11, 14, "1-ci"])
+}, ["1-ci", "nat-z8", 11, 14])
 
 maps_dot_black_satellite_tiles = dict_with_order({
   # Low quality satellite, up to zoom level 7 (original file has 13)
@@ -79,7 +79,7 @@ maps_dot_black_satellite_tiles = dict_with_order({
   # Super-low quality satellite, up to zoom level 4 (original file has 13)
   # maps_satellite_zoom = 4
   "4-ci": f"{iiab_map_host_url}/s2maps-sentinel2-2023.{maps_satellite_data_date}.z00-z04.pmtiles",
-}, [7, 9, 11, 12, 13, "4-ci"])
+}, ["4-ci", 7, 9, 11, 12, 13])
 
 maps_dot_black_terrain_tiles = dict_with_order({
   # Low quality terrain, up to zoom level 7 (original file has 10)
@@ -101,28 +101,7 @@ maps_dot_black_terrain_tiles = dict_with_order({
   # A "dummy" maxzoom=0 world map terrain file to fill a role that maps.black/maplibre
   # needs if we have FQRs and the user enables terrain.
   "0-none": f"{iiab_map_host_url}/terrarium-none.pmtiles",
-}, [7, 8, 9, 10, "0-none"])
-# TODO - let's sort this out:
-#
-# The question is the relationship between user settings and catalog keys
-#
-# Option 1: literal - keys are just digits and the instructions here (or in a separate doc?) just instruct them on what to put
-#   upside: everything is consistent
-#   upside: no goofy keys anywhere
-#   downside: implementers don't get useful keys in their configs - just numbers (for none type "0")  (maybe that's fine?!? how long will implementers be manually editing configs anyway?)
-# Option 2: convert - i.e. "none" in config becomes "0" from the catalog
-#   upside: implementers don't have to think about "0 actually means none"
-#   upside: no goofy keys in the catalog
-#   downside: implementers who just look at the keys of the json file may put the wrong values
-# Option 3: Annotated keys in both config and catalog ("1-ci", "0-none", etc) and go with that for configs and catalog
-#   upside: consistent, and the keys give clues to the implementer
-#   downside: for vector, 1 is now also the "fallback" not just the CI, so the naming is not totally accurate
-#   downside: meanings could keep evolving! do we want this sort of thing for everything?
-#   downside: there's "0-none" for terrain and "none" for satellite (because in that case there really is no satellite) which is weird (though that should be short lived)
-# Option 4: redundant keys for everything? i.e have all of "1" "1-ci" "1-fallback" in the catalog and configs?
-#   upside: if uses evolve we can just keep adding keys
-#   downside: just weird
-#
+}, ["0-none", 7, 8, 9, 10])
 
 # Mostly colors, topography (as an image, not an elevation map), etc.
 maps_dot_black_naturalearth6_tiles = dict_with_order({

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -110,7 +110,7 @@ maps_dot_black_naturalearth6_tiles = dict_with_order({
 
   # FOR TESTING ONLY
   "4-ci": f"{iiab_map_host_url}/naturalearth6-NE2_HR_SR_W_DR-WEBP.{maps_slow_data_date}.z00-z04.pmtiles",
-}, [6, "4-ci"])
+}, ["4-ci", 6])
 
 static_search_data = dict_with_order({
   # Cities-only static database

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -137,12 +137,6 @@ nominatim_data = dict_with_order({
 }, ["basic", "full"])
 
 catalog = {
-    "README": [
-        "If you are installing or configuring",
-        "IIAB Maps, you should ignore this file.",
-        "See /opt/iiab/iiab/maps/generate-catalog.py",
-        "for more info.",
-    ],
     "satellite": maps_dot_black_satellite_tiles,
     "terrain": maps_dot_black_terrain_tiles,
     "vector": maps_dot_black_vector_tiles,

--- a/roles/maps/maps-catalog.json
+++ b/roles/maps/maps-catalog.json
@@ -6,25 +6,25 @@
         "for more info."
     ],
     "satellite": {
+        "4-ci": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z04.pmtiles",
         "7": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z07.pmtiles",
         "9": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z09.pmtiles",
         "11": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z11.pmtiles",
         "12": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z12.pmtiles",
-        "13": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z13.pmtiles",
-        "4-ci": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z04.pmtiles"
+        "13": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z13.pmtiles"
     },
     "terrain": {
+        "0-none": "https://iiab.switnet.org/maps/2/terrarium-none.pmtiles",
         "7": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z07.pmtiles",
         "8": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z08.pmtiles",
         "9": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z09.pmtiles",
-        "10": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z10.pmtiles",
-        "0-none": "https://iiab.switnet.org/maps/2/terrarium-none.pmtiles"
+        "10": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z10.pmtiles"
     },
     "vector": {
+        "1-ci": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z01.pmtiles",
         "nat-z8": "https://iiab.switnet.org/maps/2/naturalearth-openmaptiles.2025-12-10.z00-z08.pmtiles",
         "11": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z11.pmtiles",
-        "14": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z14.pmtiles",
-        "1-ci": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z01.pmtiles"
+        "14": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z14.pmtiles"
     },
     "naturalearth6": {
         "6": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z06.pmtiles",

--- a/roles/maps/maps-catalog.json
+++ b/roles/maps/maps-catalog.json
@@ -1,0 +1,41 @@
+{
+    "README": [
+        "If you are installing or configuring",
+        "IIAB Maps, you should ignore this file.",
+        "See /opt/iiab/iiab/maps/generate-catalog.py",
+        "for more info."
+    ],
+    "satellite": {
+        "7": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z07.pmtiles",
+        "9": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z09.pmtiles",
+        "11": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z11.pmtiles",
+        "12": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z12.pmtiles",
+        "13": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z13.pmtiles",
+        "4-ci": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z04.pmtiles"
+    },
+    "terrain": {
+        "7": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z07.pmtiles",
+        "8": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z08.pmtiles",
+        "9": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z09.pmtiles",
+        "10": "https://iiab.switnet.org/maps/2/terrarium.2025-12-10.z00-z10.pmtiles",
+        "0-none": "https://iiab.switnet.org/maps/2/terrarium-none.pmtiles"
+    },
+    "vector": {
+        "nat-z8": "https://iiab.switnet.org/maps/2/naturalearth-openmaptiles.2025-12-10.z00-z08.pmtiles",
+        "11": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z11.pmtiles",
+        "14": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z14.pmtiles",
+        "1-ci": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z01.pmtiles"
+    },
+    "naturalearth6": {
+        "6": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z06.pmtiles",
+        "4-ci": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z04.pmtiles"
+    },
+    "static_search": {
+        "pop-1k-cities": "https://iiab.switnet.org/maps/2/static-search.2026-04-22.pop-1k-cities.tar.gz",
+        "pop-100k-cities": "https://iiab.switnet.org/maps/2/static-search.2026-04-22.pop-100k-cities.tar.gz"
+    },
+    "nominatim": {
+        "basic": "https://iiab.switnet.org/maps/2/nominatim.2025-12-10.basic.sqlite",
+        "full": "https://iiab.switnet.org/maps/2/nominatim.2025-12-10.full.sqlite"
+    }
+}

--- a/roles/maps/maps-catalog.json
+++ b/roles/maps/maps-catalog.json
@@ -1,10 +1,4 @@
 {
-    "README": [
-        "If you are installing or configuring",
-        "IIAB Maps, you should ignore this file.",
-        "See /opt/iiab/iiab/maps/generate-catalog.py",
-        "for more info."
-    ],
     "satellite": {
         "4-ci": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z04.pmtiles",
         "7": "https://iiab.switnet.org/maps/2/s2maps-sentinel2-2023.2025-12-10.z00-z07.pmtiles",

--- a/roles/maps/maps-catalog.json
+++ b/roles/maps/maps-catalog.json
@@ -21,8 +21,8 @@
         "14": "https://iiab.switnet.org/maps/2/openstreetmap-openmaptiles.2026-07-01.z00-z14.pmtiles"
     },
     "naturalearth6": {
-        "6": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z06.pmtiles",
-        "4-ci": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z04.pmtiles"
+        "4-ci": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z04.pmtiles",
+        "6": "https://iiab.switnet.org/maps/2/naturalearth6-NE2_HR_SR_W_DR-WEBP.2025-12-10.z00-z06.pmtiles"
     },
     "static_search": {
         "pop-1k-cities": "https://iiab.switnet.org/maps/2/static-search.2026-04-22.pop-1k-cities.tar.gz",

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -35,10 +35,17 @@
 #
 # TODO - files should be owned by www-data
 
+- name: "Make sure archives end in .tar.gz as expected"
+  assert:
+    that: (not (is_archive | default(false))) or item[-7:] == ".tar.gz"
+    fail_msg: "Error: expect download file name to end in .tar.gz when is_archive=true"
+    quiet: yes
 
 - vars:
-    # Where the file eventually goes
-    dest_path: "{{ dest_base_path }}/{{ item }}"
+    file_name: "{{ item | split('/') | last }}"
+
+    # Where the file eventually goes. [:-7] is for .tar.gz
+    dest_path: "{{ dest_base_path }}/{{ file_name[:-7] if is_archive | default(false) else file_name }}"
 
     # Use md5sum to generate the log file name:
     # * Name has short, consistent length. The "to check progress..." message
@@ -48,13 +55,12 @@
     log_file: "{{ item | hash('md5') }}.log"
     working_dir: "/library/downloads/maps"
 
-    # `file_name` is the file being downloaded. if it's an archive, it needs to
-    # be extracted to `extracted_dir_name` before moving to the final destination.
-    file_name: "{{ item }}{{ '.tar.gz' if is_archive | default(false) else '' }}"
-    extracted_dir_name: "{{ item if is_archive | default(false) else '' }}"
+    # If `file_name` is an archive, it needs to be extracted to `extracted_dir_name`
+    # before moving to the final destination.
+    extracted_dir_name: "{{ file_name[:-7] if is_archive | default(false) else '' }}"
 
   block:
-    - name: "Fetching file size for {{ iiab_map_host_url }}/{{ file_name }} via .meta4 file"
+    - name: "Fetching file size for {{ item }} via .meta4 file"
       shell: |
         import sys, xmltodict, requests, os
 
@@ -62,7 +68,7 @@
           sys.exit(0)
 
         size = int(xmltodict.parse(
-          requests.get("{{ iiab_map_host_url }}/{{ file_name }}.meta4").content
+          requests.get("{{ item }}.meta4").content
         )['metalink']['file']['size'])
         KiB = 1024
         MiB = KiB * 1024
@@ -116,7 +122,7 @@
             --enable-http-pipelining=true \
             --seed-time=0 \
             --allow-overwrite=true \
-            "{{ iiab_map_host_url }}/{{ file_name }}.meta4" \
+            "{{ item }}.meta4" \
             >> "{{ log_file }}"
 
         chmod 644 "{{ file_name }}"

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -11,6 +11,14 @@
       - python3-xmltodict
       - python3-requests
 
+# NOTE - Our intention is to (very) soon read the latest version of this file
+# from github.com rather than within the repository. This is an intermediary
+# step.
+- name: Load maps catalog
+  include_vars:
+    file: /opt/iiab/iiab/roles/maps/maps-catalog.json
+    name: maps_catalog
+
 - include_tasks: install_tools.yml
 
 - include_tasks: install_frontend.yml

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -27,11 +27,11 @@
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_naturalearth6_tiles[maps_ne6_zoom] }}"
+    item: "{{ maps_catalog.naturalearth6[maps_ne6_zoom | string] }}"
 
 - name: Select naturalearth6 tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_tiles[maps_ne6_zoom] }}"
+    src: "{{ maps_serve_path }}/{{ maps_catalog.naturalearth6[maps_ne6_zoom | string] | split('/') | last }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
     state: link
 
@@ -45,19 +45,19 @@
 
 - name: "Make sure maps_vector_zoom has a valid value"
   assert:
-    that: maps_dot_black_vector_tiles[maps_vector_zoom] is defined
-    fail_msg: "Error: maps_vector_zoom is set to an invalid value. See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    that: maps_catalog.vector[maps_vector_zoom | string] is defined
+    fail_msg: "Error: maps_vector_zoom is set to an invalid value. See `vector` in https://github.com/iiab/iiab/blob/master/roles/maps/maps-catalog.json for valid values."
     quiet: yes
 
 - name: Download vector tiles
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_vector_tiles[maps_vector_zoom] }}"
+    item: "{{ maps_catalog.vector[maps_vector_zoom | string] }}"
 
 - name: Select vector tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_vector_tiles[maps_vector_zoom] }}"
+    src: "{{ maps_serve_path }}/{{ maps_catalog.vector[maps_vector_zoom | string] | split('/') | last }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
     state: link
 
@@ -66,25 +66,25 @@
   when: maps_vector_zoom != maps_fallback_vector_zoom
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_vector_tiles[maps_fallback_vector_zoom] }}"
+    item: "{{ maps_catalog.vector[maps_fallback_vector_zoom | string] }}"
 
 - when: maps_satellite_zoom != "none"
   block:
     - name: "Make sure maps_satellite_zoom has a valid value"
       assert:
-        that: maps_dot_black_satellite_tiles[maps_satellite_zoom] is defined
-        fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+        that: maps_catalog.satellite[maps_satellite_zoom | string] is defined
+        fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `satellite` in https://github.com/iiab/iiab/blob/master/roles/maps/maps-catalog.json for valid values."
         quiet: yes
 
     - name: Download satellite tiles
       include_tasks: download_large_file.yml
       vars:
         dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+        item: "{{ maps_catalog.satellite[maps_satellite_zoom | string] }}"
 
     - name: Select satellite tiles
       file:
-        src: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_tiles[maps_satellite_zoom] }}"
+        src: "{{ maps_serve_path }}/{{ maps_catalog.satellite[maps_satellite_zoom | string] | split('/') | last }}"
         dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
         state: link
 
@@ -93,7 +93,7 @@
       when: maps_satellite_zoom != maps_fallback_satellite_zoom
       vars:
         dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_dot_black_satellite_tiles[maps_fallback_satellite_zoom] }}"
+        item: "{{ maps_catalog.satellite[maps_fallback_satellite_zoom | string] }}"
 
 - name: Remove unused satellite symlink
   when: maps_satellite_zoom == "none"
@@ -103,20 +103,20 @@
 
 - name: "Make sure maps_terrain_zoom has a valid value"
   assert:
-    that: maps_dot_black_terrain_tiles[maps_terrain_zoom] is defined
-    fail_msg: "Error: maps_terrain_zoom is set to an invalid value. See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for valid values."
+    that: maps_catalog.terrain[maps_terrain_zoom | string] is defined
+    fail_msg: "Error: maps_terrain_zoom is set to an invalid value. See `terrain` in https://github.com/iiab/iiab/blob/master/roles/maps/maps-catalog.json for valid values."
     quiet: yes
 
 - name: Download terrain tiles
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
+    item: "{{ maps_catalog.terrain[maps_terrain_zoom | string] }}"
 
 # If the user selects "none", we download a dummy file
 - name: Select terrain tiles
   file:
-    src: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_tiles[maps_terrain_zoom] }}"
+    src: "{{ maps_serve_path }}/{{ maps_catalog.terrain[maps_terrain_zoom | string] | split('/') | last }}"
     dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
     state: link
 
@@ -125,7 +125,7 @@
   when: maps_terrain_zoom != maps_fallback_terrain_zoom
   vars:
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_dot_black_terrain_tiles[maps_fallback_terrain_zoom] }}"
+    item: "{{ maps_catalog.terrain[maps_fallback_terrain_zoom | string] }}"
 
 # maps-update.py is used here but it can also be run independently. As we use
 # it here, we take advantage of its handling of pmtiles zoom levels. It only

--- a/roles/maps/tasks/install_nominatim.yml
+++ b/roles/maps/tasks/install_nominatim.yml
@@ -36,11 +36,11 @@
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_data_root }}"
-  with_items: "{{ nominatim_data[maps_search_nominatim_db] }}"
+    item: "{{ maps_catalog.nominatim[maps_search_nominatim_db | string] }}"
 
 - name: Select nominatim database
   file:
-    src: "{{ maps_data_root }}/{{ nominatim_data[maps_search_nominatim_db] }}"
+    src: "{{ maps_data_root }}/{{ maps_catalog.nominatim[maps_search_nominatim_db | string] | split('/') | last }}"
     dest: "{{ maps_data_root }}/{{ nominatim_db_symlink_name }}"
     state: link
 

--- a/roles/maps/tasks/install_static_search.yml
+++ b/roles/maps/tasks/install_static_search.yml
@@ -18,7 +18,7 @@
 
 - name: Select static database
   file:
-    src: "{{ maps_serve_path }}/{{ (maps_catalog.naturalearth6[maps_ne6_zoom | string] | split('/') | last)[:-7] }}"
+    src: "{{ maps_static_search_root }}/{{ (maps_catalog.static_search[maps_search_static_db | string] | split('/') | last)[:-7] }}"
     dest: "{{ maps_static_search_root }}/{{ static_search_symlink_name }}"
     state: link
     force: yes

--- a/roles/maps/tasks/install_static_search.yml
+++ b/roles/maps/tasks/install_static_search.yml
@@ -13,12 +13,12 @@
   include_tasks: download_large_file.yml
   vars:
     dest_base_path: "{{ maps_static_search_root }}"
-    item: "{{ static_search_data[maps_search_static_db] }}"
+    item: "{{ maps_catalog.static_search[maps_search_static_db | string] }}"
     is_archive: true
 
 - name: Select static database
   file:
-    src: "{{ maps_static_search_root }}/{{ static_search_data[maps_search_static_db] }}"
+    src: "{{ maps_serve_path }}/{{ (maps_catalog.naturalearth6[maps_ne6_zoom | string] | split('/') | last)[:-7] }}"
     dest: "{{ maps_static_search_root }}/{{ static_search_symlink_name }}"
     state: link
     force: yes

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -6,6 +6,15 @@ from pathlib import Path
 maps_serve_path = Path('{{ maps_serve_path }}')
 maps_fallback_path = Path('{{ maps_fallback_path }}')
 
+# NOTE - Our intention is to (very) soon read the latest version of this file
+# from github.com rather than within the repository. This is an intermediary
+# step.
+catalog = json.load(open("/opt/iiab/iiab/roles/maps/maps-catalog.json", "r"))
+
+VECTOR_FALLBACK_ZOOM = "{{ maps_fallback_vector_zoom }}"
+SATELLITE_FALLBACK_ZOOM = "{{ maps_fallback_satellite_zoom }}"
+TERRAIN_FALLBACK_ZOOM = "{{ maps_fallback_terrain_zoom }}"
+
 # NOTE: This file uses ansible vars defined in default/main.yml for its construction
 # but it should not use anything based in vars/ because it should facilitate those
 # same changes without ansible.
@@ -18,9 +27,9 @@ vector_symlink = maps_serve_path / '{{ maps_dot_black_osm_symlink_name }}'
 satellite_symlink = maps_serve_path / '{{ maps_dot_black_satellite_symlink_name }}'
 terrain_symlink = maps_serve_path / '{{ maps_dot_black_terrain_symlink_name }}'
 
-vector_fallback = maps_fallback_path / '{{ maps_dot_black_vector_tiles[maps_fallback_vector_zoom] }}'
-satellite_fallback = maps_fallback_path / '{{ maps_dot_black_satellite_tiles[maps_fallback_satellite_zoom] }}'
-terrain_fallback = maps_fallback_path / '{{ maps_dot_black_terrain_tiles[maps_fallback_terrain_zoom] }}'
+vector_fallback = maps_fallback_path / catalog["vector"][VECTOR_FALLBACK_ZOOM].split('/')[-1]
+satellite_fallback = maps_fallback_path / catalog["satellite"][SATELLITE_FALLBACK_ZOOM].split('/')[-1]
+terrain_fallback = maps_fallback_path / catalog["terrain"][TERRAIN_FALLBACK_ZOOM].split('/')[-1]
 
 def handle_fallback_file(symlink, fallback, required=True):
     if symlink.exists():
@@ -59,7 +68,10 @@ def get_max_zoom(full_path, fallback, required=True):
 def get_fallback_zoom_number(fallback_zoom_key):
     if fallback_zoom_key == "none":
         return 0
-    return int(fallback_zoom_key.split('-z')[-1])
+    return int(fallback_zoom_key
+        .split('-z')[-1] # deal with nat-z8
+        .split('-')[0]   # deal with 1-fallback
+    )
 
 handle_fallback_file(vector_symlink, vector_fallback)
 handle_fallback_file(satellite_symlink, satellite_fallback, False)

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -70,7 +70,7 @@ def get_fallback_zoom_number(fallback_zoom_key):
         return 0
     return int(fallback_zoom_key
         .split('-z')[-1] # deal with nat-z8
-        .split('-')[0]   # deal with 1-fallback
+        .split('-')[0]   # deal with 0-none etc
     )
 
 handle_fallback_file(vector_symlink, vector_fallback)

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -173,28 +173,34 @@ def get_new_extract_paths(extract_name):
     from the server. Existing FQRs on the file system may have different dates,
     so we can't rely on this function for getting an inventory or deletion.
     """
-    MAPS_VECTOR_DATA_DATE = "{{ maps_vector_data_date }}"
-    MAPS_SLOW_DATA_DATE = "{{ maps_slow_data_date }}"
-    IIAB_MAP_HOST_URL = "{{ iiab_map_host_url }}"
 
-    VECTOR_ZOOM_RANGE = "z00-z{{ '%02d' % maps_vector_max_zoom }}"
-    SATELLITE_ZOOM_RANGE = "z00-z{{ '%02d' % maps_satellite_max_zoom }}"
-    TERRAIN_ZOOM_RANGE = "z00-z{{ '%02d' % maps_terrain_max_zoom }}"
+    # NOTE - Our intention is to (very) soon read the latest version of this file
+    # from github.com rather than within the repository. This is an intermediary
+    # step.
+    catalog = json.load(open("/opt/iiab/iiab/roles/maps/maps-catalog.json", "r"))
 
-    def get_paths(base, zoom_range):
-        return {
-            "source":
-                get_mirror(f"{IIAB_MAP_HOST_URL}/{base}.{zoom_range}.pmtiles"),
-            "extract":
-                os.path.join(HOSTING_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
-            "tmp":
-                os.path.join(TMP_DIR, f"{base}.full-region.{extract_name}.pmtiles"),
-        }
+    VECTOR_MAX_ZOOM = "{{ maps_vector_fqr_max_zoom }}"
+    SATELLITE_MAX_ZOOM = "{{ maps_satellite_fqr_max_zoom }}"
+    TERRAIN_MAX_ZOOM = "{{ maps_terrain_fqr_max_zoom }}"
+
+    def get_paths(source):
+        match (source.split('/')[-1].split('.')):
+            case [base, date, _zoom_range, "pmtiles"]:
+                return {
+                    "source":
+                        get_mirror(source),
+                    "extract":
+                        os.path.join(HOSTING_DIR, f"{base}.{date}.full-region.{extract_name}.pmtiles"),
+                    "tmp":
+                        os.path.join(TMP_DIR, f"{base}.{date}.full-region.{extract_name}.pmtiles"),
+                }
+            case _:
+                raise Exception("Oops got unexpected pmtiles file name:", source)
 
     return {
-        "vector": get_paths(f"openstreetmap-openmaptiles.{MAPS_VECTOR_DATA_DATE}", VECTOR_ZOOM_RANGE),
-        "satellite": get_paths(f"s2maps-sentinel2-2023.{MAPS_SLOW_DATA_DATE}", SATELLITE_ZOOM_RANGE),
-        "terrain": get_paths(f"terrarium.{MAPS_SLOW_DATA_DATE}", TERRAIN_ZOOM_RANGE),
+        "vector": get_paths(catalog["vector"][VECTOR_MAX_ZOOM]),
+        "satellite": get_paths(catalog["satellite"][SATELLITE_MAX_ZOOM]),
+        "terrain": get_paths(catalog["terrain"][TERRAIN_MAX_ZOOM]),
     }
 
 def iter_region_files():

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -513,7 +513,7 @@ maps_install: False
 maps_enabled: False
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
@@ -521,7 +521,7 @@ maps_region_downloader: True            # Download "Full Quality Regions" -- INS
 
 # The following are intended for CI/CD. The defaults here should be kept for implementers:
 maps_preset_full_quality_regions: []    # Full-quality regions to install during installation.
-maps_ne6_zoom: full                     # Quality for naturalearth6 files.
+maps_ne6_zoom: 6                        # Quality for naturalearth6 files.
 
 # MongoDB (/library/dbdata/mongodb) greatly enhances the Sugarizer experience.
 # This role was formerly installed by roles/sugarizer/meta/main.yml

--- a/vars/local_vars_android_large.yml
+++ b/vars/local_vars_android_large.yml
@@ -48,7 +48,7 @@ maps_install: True
 maps_enabled: True
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_android_medium.yml
+++ b/vars/local_vars_android_medium.yml
@@ -48,7 +48,7 @@ maps_install: True
 maps_enabled: True
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_android_small.yml
+++ b/vars/local_vars_android_small.yml
@@ -48,7 +48,7 @@ maps_install: True
 maps_enabled: True
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -301,7 +301,7 @@ maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE 
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -318,21 +318,21 @@ osm_vector_maps_enabled: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_zoom: 1                     # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 4                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_vector_zoom: 1-ci                  # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_satellite_zoom: 4-ci               # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-100k-cities  # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Tool to select regions for full-quality download. Needed for maps_preset_full_quality_regions.
 maps_preset_full_quality_regions:       # Small portion of london and Nepal mountains
-  - name: london # test na urban setting
+  - name: london                        # Test an urban setting
     bbox: -0.172187453,51.477245915,-0.143235226,51.493348151
-  - name: himalayas # test terrain
+  - name: himalayas                     # Test terrain
     bbox: 83.680824998,28.401673033,84.055999541,28.724927625
-  - name: rabi_island_fiji # test crossing the antimeridian
+  - name: rabi_island_fiji              # Test crossing the antimeridian
     bbox: -180.032361285,-16.54082487,-179.911191897,-16.438722265
-maps_ne6_zoom: ci                       # Limited naturalearth6 for testing
+maps_ne6_zoom: 4-ci                     # Limited naturalearth6 for testing
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -301,7 +301,7 @@ maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE 
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -301,7 +301,7 @@ maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE 
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -301,7 +301,7 @@ maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE 
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -307,7 +307,7 @@ maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE 
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
 maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: none                 # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
+maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
 maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
 maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Partial implementation pulled out from #4433

*Draft for now because I wanted to test it more and self-review more carefully. However it seems to work, and unlike #4433 I'm basically ready for this to be merged.*

#### What this does

Functionally this ought to make no change. It moves the options and comments out of `main.yml` and into `maps-catalog.json`. This doesn't download from github, it reads directly from the local repository. It makes a smaller first step. It also allows us to change the format of `maps-catalog.json` without breaking anything (which I will probably do to add `_comments` fields, see below).

It makes a bunch of the necessary changes to the install code and FQR downloading code. It gives us a chance to go over all of the nuances this already brings up before we have to think about downloading from github, caching, when to update or not update, etc.

One such nuance is what to do with the goofy settings/catalog keys I've created. I will highlight a comment where I lay out the dilemma.

#### Followup PRs to expect:

* Implement `download_from_catalog.yml` from #4433 which should clean up the `install_*` files a bit.
* Move documentation comments (the same ones I just moved out of `main.yml`) out of `generate-catalog.py` to `maps-catalog.json` using `"_comments"` fields.
* The big one: download `maps-catalog.json` from github and save to `/library/www/maps/`

### Smoke-tested on which OS or OS's:

(incomplete) Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 