### PR TITLE
Download maps-catalog.json from Github

### DIFF
--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -263,16 +263,22 @@ For large file downloads:
 
 ## How to change or upgrade your IIAB Maps
 
-If your IIAB was installed many months ago (or many years ago), it's far better to start from scratch [installing a completely new version of IIAB](https://wiki.iiab.io/go/FAQ#Is_a_quick_installation_possible?).
+Your IIAB Maps **software**, **data**, and **settings** can be updated separately or together.
 
-If your IIAB was installed quite recently, it's usually safe to update your IIAB software: (at your own risk, if your IIAB is online, and has enough disk space!)
+If your IIAB was installed many months ago (or many years ago), it's far better to start from scratch than to update your **software**. See: [installing a completely new version of IIAB](https://wiki.iiab.io/go/FAQ#Is_a_quick_installation_possible?).
+
+If your IIAB was installed quite recently, it's usually safe to update your IIAB **software**: (at your own risk, if your IIAB is online, and has enough disk space!)
 
 ```
 cd /opt/iiab/iiab
 sudo git pull
 ```
 
-After [changing any IIAB Maps variables](#whats-a-minimum-iiab-maps-install) in `/etc/iiab/local_vars.yml`, you can now "reinstall" IIAB Maps to enact your new settings, by running:
+To update your **settings**, you can [change any IIAB Maps variables](#whats-a-minimum-iiab-maps-install) in `/etc/iiab/local_vars.yml`.
+
+To have access to newer map **data** for your __global basemaps__, simply delete `/library/www/maps/maps-catalog-global-orig.json`. (Full Quality Region updates always download the latest available data)
+
+You can now "reinstall" IIAB Maps to enact any of the above changes, by running:
 
 ```
 sudo ./runrole maps --reinstall

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -19,6 +19,14 @@ nominatim_venv: "{{ nominatim_home }}/nominatim-venv"
 maps_static_search_dir: "static-search"
 maps_static_search_root: "{{ maps_serve_path }}/{{ maps_static_search_dir }}"
 
+# URL where we can find a catalog of all map data files available to download.
+maps_catalog_url: "https://raw.githubusercontent.com/iiab/iiab/refs/heads/master/roles/maps/maps-catalog.json"
+
+# This is where the catalog is kept static to avoid unwanted updates when
+# running ansible. This does not apply to FQRs hence the "global". FQRs will
+# always download the latest catalog.
+maps_orig_global_catalog: "{{ maps_serve_path }}/maps-catalog-global-orig.json"
+
 maps_tools:
   base_dir: "/opt/iiab/maps"
   pmtiles:

--- a/roles/maps/generate-catalog.py
+++ b/roles/maps/generate-catalog.py
@@ -4,6 +4,13 @@ import humanize, requests, json
 import os
 os.chdir(os.path.dirname(__file__))
 
+# This file is for generating:
+#
+# * `maps-catalog.json`: a catalog of the latest available IIAB Maps data
+# * `MAPS_CATALOG_DETAILS.md`: an implementer guide for the above
+#
+# Unlike just about everything else in this repository, `maps-catalog.json` is not used directly by the IIAB Maps installation process. Instead, it is made to requested by IIAB Maps _from Github_ during installation and map upgrades. This way, as soon as a map data update is made available, we can update `maps-catalog.json` on Github and it can be installed without upgrading the IIAB Maps software.
+
 iiab_map_host_url = "https://iiab.switnet.org/maps/2"
 
 # "data dates" refer to how recent a certain type of data is

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -1,3 +1,9 @@
+- name: Make serving directory (0755 by default)
+  file:
+    path: "{{ maps_serve_path }}"
+    state: directory
+    # mode: 0755
+
 - name: Make maps directory (0755 by default)
   file:
     path: "{{ maps_data_root }}"
@@ -11,12 +17,17 @@
       - python3-xmltodict
       - python3-requests
 
-# NOTE - Our intention is to (very) soon read the latest version of this file
-# from github.com rather than within the repository. This is an intermediary
-# step.
+# NOTE: This file will not apply to FQRs. FQRs will always download the latest catalog.
+- name: "Download {{ maps_orig_global_catalog }}"
+  get_curl:
+    url: "{{ maps_catalog_url }}"
+    dest: "{{ maps_orig_global_catalog }}"
+    mode: "0644"
+    timeout: "{{ download_timeout }}"
+
 - name: Load maps catalog
   include_vars:
-    file: /opt/iiab/iiab/roles/maps/maps-catalog.json
+    file: "{{ maps_orig_global_catalog }}"
     name: maps_catalog
 
 - include_tasks: install_tools.yml

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -1,9 +1,3 @@
-- name: Make serving directory (0755 by default)
-  file:
-    path: "{{ maps_serve_path }}"
-    state: directory
-    # mode: 0755
-
 - name: Make index file
   template:
     src: index.html.j2

--- a/roles/maps/templates/maps-update.py.j2
+++ b/roles/maps/templates/maps-update.py.j2
@@ -1,15 +1,23 @@
 #!/usr/bin/python3
 
-import json, subprocess, sys
+import json, requests, subprocess, sys
 from pathlib import Path
 
 maps_serve_path = Path('{{ maps_serve_path }}')
 maps_fallback_path = Path('{{ maps_fallback_path }}')
 
-# NOTE - Our intention is to (very) soon read the latest version of this file
-# from github.com rather than within the repository. This is an intermediary
-# step.
-catalog = json.load(open("/opt/iiab/iiab/roles/maps/maps-catalog.json", "r"))["data"]
+CATALOG_URL = "{{ maps_catalog_url }}"
+
+# Unlike the global data, FQRs always stay up to date, so it downloads
+# the latest catalog.
+catalog_response = requests.get(CATALOG_URL)
+if catalog_response.status_code != 200:
+    raise Exception("Cannot find map data catalog")
+
+try:
+    catalog = catalog_response.json()["data"]
+except json.decoder.JSONDecodeError:
+    raise Exception("Error reading map data catalog")
 
 VECTOR_FALLBACK_ZOOM = "{{ maps_fallback_vector_zoom }}"
 SATELLITE_FALLBACK_ZOOM = "{{ maps_fallback_satellite_zoom }}"

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -110,6 +110,7 @@ def get_bounds(full_path):
 
     return render_bounds, ui_bounds
 
+CATALOG_URL = "{{ maps_catalog_url }}"
 HOSTING_DIR = "{{ maps_serve_path }}"
 EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ maps_tools.tile_extract.info_file }}")
 PMTILES = "{{ maps_tools.pmtiles.executable_path }}"
@@ -174,10 +175,16 @@ def get_new_extract_paths(extract_name):
     so we can't rely on this function for getting an inventory or deletion.
     """
 
-    # NOTE - Our intention is to (very) soon read the latest version of this file
-    # from github.com rather than within the repository. This is an intermediary
-    # step.
-    catalog = json.load(open("/opt/iiab/iiab/roles/maps/maps-catalog.json", "r"))["data"]
+    # Unlike the global data, FQRs always stay up to date, so it downloads
+    # the latest catalog.
+    catalog_response = requests.get(CATALOG_URL)
+    if catalog_response.status_code != 200:
+        raise Exception("Cannot find map data catalog")
+
+    try:
+        catalog = catalog_response.json()["data"]
+    except json.decoder.JSONDecodeError:
+        raise Exception("Error reading map data catalog")
 
     VECTOR_MAX_ZOOM = "{{ maps_vector_fqr_max_zoom }}"
     SATELLITE_MAX_ZOOM = "{{ maps_satellite_fqr_max_zoom }}"


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Download the catalog from github instead of using the local version in the repository. For global map, it's cached in `/library/www/maps/maps-catalog-global-orig.json` and won't be overwritten with a new version if they runrole again.

Based largely on part of #4433

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 