### PR TITLE
Refactor repetitive parts of maps catalog downloads

### DIFF
--- a/roles/maps/tasks/download_from_catalog.yml
+++ b/roles/maps/tasks/download_from_catalog.yml
@@ -26,8 +26,10 @@
       include_tasks: download_large_file.yml
       vars:
         item: "{{ catalog_file_url }}"
+
     - name: "Select {{ catalog_item }}"
       file:
         src: "{{ dest_base_path }}/{{ dest_name }}"
         path: "{{ dest_base_path }}/{{ symlink_name }}"
         state: link
+        force: yes

--- a/roles/maps/tasks/download_from_catalog.yml
+++ b/roles/maps/tasks/download_from_catalog.yml
@@ -1,0 +1,33 @@
+- vars:
+    # NOTE: `catalog_item_config_var` is the *name* of the config variable (i.e. "maps_vector_zoom") whereas
+    # `catalog_item_variant` is its *value* (i.e. "11"). We pass in the former to generate a useful error message.
+    catalog_item_variant: "{{ lookup('vars', catalog_item_config_var) }}"
+
+    catalog_file_url: "{{ maps_catalog.data[catalog_item][catalog_item_variant | string] | default('') }}"
+    catalog_file_name: "{{ catalog_file_url | split('/') | last }}"
+
+    # How it's saved. Either a file or a directory.
+    dest_name: "{{ catalog_file_name[:-7] if expand_archive | default(false) else catalog_file_name }}"
+
+  block:
+    - name: "Make sure archives end in .tar.gz as expected"
+      assert:
+        that: (not (expand_archive | default(false))) or catalog_file_name[-7:] == ".tar.gz"
+        fail_msg: "Error: expect download file name to end in .tar.gz when expand_archive=true"
+        quiet: yes
+
+    - name: "Make sure {{ catalog_item_config_var }} has a valid value"
+      assert:
+        that: catalog_file_url != ""
+        fail_msg: "Error: {{ catalog_item_config_var }} is set to an invalid value (\"{{ catalog_item_variant }}\"). See `\"{{ catalog_item_config_var }}\"` in https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md for valid values."
+        quiet: yes
+
+    - name: "Download {{ catalog_item }} from catalog"
+      include_tasks: download_large_file.yml
+      vars:
+        item: "{{ catalog_file_url }}"
+    - name: "Select {{ catalog_item }}"
+      file:
+        src: "{{ dest_base_path }}/{{ dest_name }}"
+        path: "{{ dest_base_path }}/{{ symlink_name }}"
+        state: link

--- a/roles/maps/tasks/download_large_file.yml
+++ b/roles/maps/tasks/download_large_file.yml
@@ -37,15 +37,15 @@
 
 - name: "Make sure archives end in .tar.gz as expected"
   assert:
-    that: (not (is_archive | default(false))) or item[-7:] == ".tar.gz"
-    fail_msg: "Error: expect download file name to end in .tar.gz when is_archive=true"
+    that: (not (expand_archive | default(false))) or item[-7:] == ".tar.gz"
+    fail_msg: "Error: expect download file name to end in .tar.gz when expand_archive=true"
     quiet: yes
 
 - vars:
     file_name: "{{ item | split('/') | last }}"
 
     # Where the file eventually goes. [:-7] is for .tar.gz
-    dest_path: "{{ dest_base_path }}/{{ file_name[:-7] if is_archive | default(false) else file_name }}"
+    dest_path: "{{ dest_base_path }}/{{ file_name[:-7] if expand_archive | default(false) else file_name }}"
 
     # Use md5sum to generate the log file name:
     # * Name has short, consistent length. The "to check progress..." message
@@ -57,7 +57,7 @@
 
     # If `file_name` is an archive, it needs to be extracted to `extracted_dir_name`
     # before moving to the final destination.
-    extracted_dir_name: "{{ file_name[:-7] if is_archive | default(false) else '' }}"
+    extracted_dir_name: "{{ file_name[:-7] if expand_archive | default(false) else '' }}"
 
   block:
     - name: "Fetching file size for {{ item }} via .meta4 file"
@@ -126,7 +126,7 @@
             >> "{{ log_file }}"
 
         chmod 644 "{{ file_name }}"
-        if "{{ 'true' if is_archive | default(false) else 'false' }}"; then
+        if "{{ 'true' if expand_archive | default(false) else 'false' }}"; then
             rm -rf "{{ extracted_dir_name }}"
             mkdir "{{ extracted_dir_name }}"
             chmod 755 "{{ extracted_dir_name }}"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -17,17 +17,13 @@
     dest_base_path: "{{ maps_serve_path }}"
   with_items: "{{ maps_dot_black_js_and_styles }}"
 
-- name: Download naturalearth6 tiles
-  include_tasks: download_large_file.yml
+- name: Get naturalearth6 from catalog
+  include_tasks: download_from_catalog.yml
   vars:
+    catalog_item: naturalearth6
+    catalog_item_config_var: maps_ne6_zoom
+    symlink_name: "{{ maps_dot_black_naturalearth6_symlink_name }}"
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_catalog.data.naturalearth6[maps_ne6_zoom | string] }}"
-
-- name: Select naturalearth6 tiles
-  file:
-    src: "{{ maps_serve_path }}/{{ maps_catalog.data.naturalearth6[maps_ne6_zoom | string] | split('/') | last }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_naturalearth6_symlink_name }}"
-    state: link
 
 # This helps avoid silent errors transitioning between variable names. It can be deleted 2026/09/04.
 - name: Error on deprecated maps_vector_quality
@@ -37,23 +33,14 @@
       - "'maps_vector_quality' has been renamed to 'maps_vector_zoom' with new valid values. Please update your"
       - "/etc/iiab/local_vars.yml and see https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md for valid values."
 
-- name: "Make sure maps_vector_zoom has a valid value"
-  assert:
-    that: maps_catalog.data.vector[maps_vector_zoom | string] is defined
-    fail_msg: "Error: maps_vector_zoom is set to an invalid value. See `vector` in https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md for valid values."
-    quiet: yes
 
-- name: Download vector tiles
-  include_tasks: download_large_file.yml
+- name: Get vector from catalog
+  include_tasks: download_from_catalog.yml
   vars:
+    catalog_item: vector
+    catalog_item_config_var: maps_vector_zoom
+    symlink_name: "{{ maps_dot_black_osm_symlink_name }}"
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_catalog.data.vector[maps_vector_zoom | string] }}"
-
-- name: Select vector tiles
-  file:
-    src: "{{ maps_serve_path }}/{{ maps_catalog.data.vector[maps_vector_zoom | string] | split('/') | last }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_osm_symlink_name }}"
-    state: link
 
 - name: Download fallback vector tiles
   include_tasks: download_large_file.yml
@@ -62,32 +49,21 @@
     dest_base_path: "{{ maps_serve_path }}"
     item: "{{ maps_catalog.data.vector[maps_fallback_vector_zoom | string] }}"
 
-- when: maps_satellite_zoom != "none"
-  block:
-    - name: "Make sure maps_satellite_zoom has a valid value"
-      assert:
-        that: maps_catalog.data.satellite[maps_satellite_zoom | string] is defined
-        fail_msg: "Error: maps_satellite_zoom is set to an invalid value. See `satellite` in https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md for valid values."
-        quiet: yes
+- name: Get satellite from catalog
+  when: maps_satellite_zoom != "none"
+  include_tasks: download_from_catalog.yml
+  vars:
+    catalog_item: satellite
+    catalog_item_config_var: maps_satellite_zoom
+    symlink_name: "{{ maps_dot_black_satellite_symlink_name }}"
+    dest_base_path: "{{ maps_serve_path }}"
 
-    - name: Download satellite tiles
-      include_tasks: download_large_file.yml
-      vars:
-        dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_catalog.data.satellite[maps_satellite_zoom | string] }}"
-
-    - name: Select satellite tiles
-      file:
-        src: "{{ maps_serve_path }}/{{ maps_catalog.data.satellite[maps_satellite_zoom | string] | split('/') | last }}"
-        dest: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
-        state: link
-
-    - name: Download fallback satellite tiles
-      include_tasks: download_large_file.yml
-      when: maps_satellite_zoom != maps_fallback_satellite_zoom
-      vars:
-        dest_base_path: "{{ maps_serve_path }}"
-        item: "{{ maps_catalog.data.satellite[maps_fallback_satellite_zoom | string] }}"
+- name: Download fallback satellite tiles
+  when: (maps_satellite_zoom != "none") and (maps_satellite_zoom != maps_fallback_satellite_zoom)
+  include_tasks: download_large_file.yml
+  vars:
+    dest_base_path: "{{ maps_serve_path }}"
+    item: "{{ maps_catalog.data.satellite[maps_fallback_satellite_zoom | string] }}"
 
 - name: Remove unused satellite symlink
   when: maps_satellite_zoom == "none"
@@ -95,24 +71,14 @@
     path: "{{ maps_serve_path }}/{{ maps_dot_black_satellite_symlink_name }}"
     state: absent
 
-- name: "Make sure maps_terrain_zoom has a valid value"
-  assert:
-    that: maps_catalog.data.terrain[maps_terrain_zoom | string] is defined
-    fail_msg: "Error: maps_terrain_zoom is set to an invalid value. See `terrain` in https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md for valid values."
-    quiet: yes
-
-- name: Download terrain tiles
-  include_tasks: download_large_file.yml
+# Unlike with satellite, if the user selects "none" for terrain, we download a dummy file
+- name: Get terrain from catalog
+  include_tasks: download_from_catalog.yml
   vars:
+    catalog_item: terrain
+    catalog_item_config_var: maps_terrain_zoom
+    symlink_name: "{{ maps_dot_black_terrain_symlink_name }}"
     dest_base_path: "{{ maps_serve_path }}"
-    item: "{{ maps_catalog.data.terrain[maps_terrain_zoom | string] }}"
-
-# If the user selects "none", we download a dummy file
-- name: Select terrain tiles
-  file:
-    src: "{{ maps_serve_path }}/{{ maps_catalog.data.terrain[maps_terrain_zoom | string] | split('/') | last }}"
-    dest: "{{ maps_serve_path }}/{{ maps_dot_black_terrain_symlink_name }}"
-    state: link
 
 - name: Download fallback terrain tiles
   include_tasks: download_large_file.yml

--- a/roles/maps/tasks/install_nominatim.yml
+++ b/roles/maps/tasks/install_nominatim.yml
@@ -32,17 +32,13 @@
     mode: '0755'
     owner: "{{ nominatim_user }}"
 
-- name: Download nominatim database
-  include_tasks: download_large_file.yml
+- name: Get nominatim database from catalog
+  include_tasks: download_from_catalog.yml
   vars:
+    catalog_item: nominatim
+    catalog_item_config_var: maps_search_nominatim_db
+    symlink_name: "{{ nominatim_db_symlink_name }}"
     dest_base_path: "{{ maps_data_root }}"
-    item: "{{ maps_catalog.data.nominatim[maps_search_nominatim_db | string] }}"
-
-- name: Select nominatim database
-  file:
-    src: "{{ maps_data_root }}/{{ maps_catalog.data.nominatim[maps_search_nominatim_db | string] | split('/') | last }}"
-    dest: "{{ maps_data_root }}/{{ nominatim_db_symlink_name }}"
-    state: link
 
 - name: Set up nominatim virtual environment {{ nominatim_venv }}
   pip:

--- a/roles/maps/tasks/install_static_search.yml
+++ b/roles/maps/tasks/install_static_search.yml
@@ -9,16 +9,11 @@
     dest: "{{ maps_static_search_root }}/static_search.js"
     mode: "0644"
 
-- name: Download static search database
-  include_tasks: download_large_file.yml
+- name: Get static search from catalog
+  include_tasks: download_from_catalog.yml
   vars:
+    catalog_item: static_search
+    catalog_item_config_var: maps_search_static_db
+    symlink_name: "{{ static_search_symlink_name }}"
     dest_base_path: "{{ maps_static_search_root }}"
-    item: "{{ maps_catalog.data.static_search[maps_search_static_db | string] }}"
-    is_archive: true
-
-- name: Select static database
-  file:
-    src: "{{ maps_static_search_root }}/{{ (maps_catalog.data.static_search[maps_search_static_db | string] | split('/') | last)[:-7] }}"
-    dest: "{{ maps_static_search_root }}/{{ static_search_symlink_name }}"
-    state: link
-    force: yes
+    expand_archive: true


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Move a few repetitive tasks (check for valid config value, download map item, point symlink) into a new .yml file. Hopefully more readable and fewer errors. (In fact I found a case or two where I skipped the check for valid config value).

As I put this together I realized that I could clean it up further but I'll save it for a followup PR.

This is part of #4433 Hopefully the last unmerged part but I have to double check.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 