### PR TITLE
Pmtiles native antimeridian

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -32,15 +32,14 @@ maps_tools:
   pmtiles:
     releases:
       armhf:
-        # TODO - upgrade to 1.31
-        src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.30.1_Linux_armv7.tar.gz
-        sha256sum: 9948f518efa87163d0587ce7b95dd1a98d1ddecdf11131e4286cd331fd63b04a
+        src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.31.2_Linux_armv7.tar.gz
+        sha256sum: 68bd6f5487cc57e1fd5156db8c09ed0df04157dd16cae48b660a489f85af2e0f
       arm64:
-        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.1/go-pmtiles_1.31.1_Linux_arm64.tar.gz
-        sha256sum: 2c343014c87dae67e956f47d7cf583b5be8357ab8836722dcc42121f533818d3
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.2/go-pmtiles_1.31.2_Linux_arm64.tar.gz
+        sha256sum: f8bd47e7ea866863489cad588fbaf2f31f42e5821f7a03f009b3769f05801cb1
       amd64:
-        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.1/go-pmtiles_1.31.1_Linux_x86_64.tar.gz
-        sha256sum: 71b2212d6796e172b8ba27c21e662c25ec93cacdb88adc35e508617e720f6292
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.2/go-pmtiles_1.31.2_Linux_x86_64.tar.gz
+        sha256sum: 3ed7dbf4ec2e6dfe5e25b6f70d1ffc932729f93c86db353bf514dd71010a312f
     archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
     archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
     executable_path: "{{ maps_tools.base_dir }}/pmtiles"

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -32,14 +32,15 @@ maps_tools:
   pmtiles:
     releases:
       armhf:
+        # TODO - upgrade to 1.31
         src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.30.1_Linux_armv7.tar.gz
         sha256sum: 9948f518efa87163d0587ce7b95dd1a98d1ddecdf11131e4286cd331fd63b04a
       arm64:
-        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_arm64.tar.gz
-        sha256sum: e44823cff328c2ea354096ccbfd7e7ef6c8f05b11553ad28fcaa33989123a57f
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.1/go-pmtiles_1.31.1_Linux_arm64.tar.gz
+        sha256sum: 2c343014c87dae67e956f47d7cf583b5be8357ab8836722dcc42121f533818d3
       amd64:
-        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.29.1/go-pmtiles_1.29.1_Linux_x86_64.tar.gz
-        sha256sum: 870c3aa968a75430ca1772351c3a6a6d30103b466d6df5837351bfb340640f54
+        src_url: https://github.com/protomaps/go-pmtiles/releases/download/v1.31.1/go-pmtiles_1.31.1_Linux_x86_64.tar.gz
+        sha256sum: 71b2212d6796e172b8ba27c21e662c25ec93cacdb88adc35e508617e720f6292
     archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
     archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
     executable_path: "{{ maps_tools.base_dir }}/pmtiles"

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -30,14 +30,14 @@ def get_bounds(full_path):
     # At this point we have a pmtiles file that reports to span -180 to 180, i.e. the entire
     # logical width of the map. While this might actually be the case, it's more likely that
     # it's a normal sized region that crosses the antimeridian, i.e. starts before 180 and
-    # wraps around to end after -180. But pmtiles doesn't have a concept of wrapping around
-    # the map. We were only able to create this region in the first place using a multipolygon
-    # with one part of the region after -180 and another part of the region before 180.
-    # For instance, if we created a region with longitudes from 165 to 190, we would turn it
-    # into a multipolygon from 165 to 180 and from -180 to -170. This spans from -180 to 180,
-    # and that's what gets recorded in the header (and we just got it with render_bounds).
-    # For ui_bounds, we want 165 and 190 so maplibre can draw the rectangle. And to find those
-    # numbers, we need to inspect the file to see where all of the tiles are.
+    # wraps around to end after -180. But pmtiles doesn't like the concept of wrapping
+    # around the map. We're able to create such regions by asking pmtiles to make an extract
+    # across the antimeridian, and it grabs the right tiles for the requested bbox, but in
+    # the header it still says -180 to 180 (and we just got it with render_bounds).
+    #
+    # For ui_bounds, we want the coordinates of the actual tiles (something like 165 to 190)
+    # so maplibre can draw the rectangle. And to find those numbers, we need to inspect the
+    # file to see where all of the tiles are.
 
     with open(full_path, "r+b") as f:
         source = MmapSource(f)

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-import json, glob, os, random, re, requests, shutil, string, subprocess, sys, tempfile, xmltodict, xml
+import json, glob, os, random, re, requests, shutil, string, subprocess, sys, xmltodict, xml
 from pprint import pprint
 from collections import defaultdict
 
@@ -143,24 +143,17 @@ def clean_extract_box(extract_box_str):
     except Exception:
         raise ValueError("extract_box_str is malformed: ", extract_box_str)
 
-    # We want min_lon to be from -180 to 180. We want to performa modulo 360
-    # to give it an equivalent longitude, but starting at -180 instead of 180
-    new_min_lon = (
-      (                 # start off assuming that min_lon "ought to be" in the range of -180 < x < 180
-        (min_lon + 180) # thus this "ought to be" in the range of 0 < x < 360
-        % 360           # Modulo 360 will in fact change our range to 0 < x < 360
-      )
-    ) - 180             # Finally subtracting 180 will set our range to -180 < x < 180
+    def lon_modulo(lon):
+        # We want the longitudes to be from -180 to 180. We want to perform a modulo 360
+        # to give it an equivalent longitude, but starting at -180 instead of 180
+        return (
+          (                 # Start off assuming that lon "ought to be" in the range of -180 < x < 180
+            (lon + 180)     # Thus, lon + 180 "ought to be" in the range of 0 < x < 360
+            % 360           # Modulo 360 will *in fact* change our range to 0 < x < 360
+          )
+        ) - 180             # Finally subtracting 180 will *in fact* set our range to -180 < x < 180
 
-    # Set min_lon and max_lon, adjusting by the same amount as necessary
-    # Because of our previous assurances, we know that max_lon > min_lon,
-    # and that the width of the FQR is less than the width of the whole earth (360).
-    # Thus, max_lon has a potential range of -180 < x < 540, which the system can
-    # hopefully deal with. This normalizes things nicely for us as well, which we
-    # see below.
-    min_lon, max_lon = new_min_lon, max_lon + (new_min_lon - min_lon)
-
-    return [min_lon, min_lat, max_lon, max_lat]
+    return [lon_modulo(min_lon), min_lat, lon_modulo(max_lon), max_lat]
 
 def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
@@ -297,74 +290,14 @@ def delete_extract(extract_name):
             raise Exception("Unknown error. Stopping before we delete the wrong file!", path)
         os.remove(path)
 
-def set_region_geojson(extract_box, geojson_file):
-    [min_lon, min_lat, max_lon, max_lat] = extract_box
-
-    # Since we know that now -180 < min_lon < 180, and max_lon > min_lon, crossing the antimeridian
-    # will always come in the form of max_lon > 180 and not min_lon < -180.
-    if max_lon <= 180:
-        # Normal case, one rectangle
-        coordinates = [
-          [
-            [
-              # 5 points because we have to trace out a closed square. The first and last points are the same.
-              [min_lon, min_lat],
-              [min_lon, max_lat],
-              [max_lon, max_lat],
-              [max_lon, min_lat],
-              [min_lon, min_lat],
-            ]
-          ]
-        ]
-    else:
-        # Crossing the antimeridian, split into two rectangles.
-        coordinates = [
-          [
-            [
-              # The western rectangle is on the eastern part of the -180 to 180 map.
-              # We want the part that starts at min_lon and ends at 180, since max_lon > 180
-              [min_lon, min_lat],
-              [min_lon, max_lat],
-              [180, max_lat],
-              [180, min_lat],
-              [min_lon, min_lat],
-            ],
-          ],
-          [
-            [
-              # The eastern rectangle is on the western part of the -180 to 180 map.
-              # We want the part that starts at -180 and ends at max_lon. Since
-              # max_lon > 180, we subtract 360 to get the equivalent that's within
-              # -180 and 180.
-              [-180, min_lat],
-              [-180, max_lat],
-              [max_lon - 360, max_lat],
-              [max_lon - 360, min_lat],
-              [-180, min_lat],
-            ]
-          ]
-        ]
-
-    region = {
-      "type": "MultiPolygon",
-      "coordinates": coordinates
-    }
-
-    geojson_file.write(json.dumps(region))
-
-
 def create_extract(extract_box, extract_paths):
-    with tempfile.NamedTemporaryFile(delete_on_close=False, mode="w") as geojson_file:
-        set_region_geojson(extract_box, geojson_file)
-        geojson_file.close()
-
-        # Extract them all successfully before moving them.
-        for paths in extract_paths.values():
-            result = subprocess.run(
-                [PMTILES, "extract", paths["source"], paths["tmp"], f"--region={geojson_file.name}"],
-            )
-            if result.returncode != 0:
-                raise Exception(f"Region download failed. Double-check your Internet connection. (error code {result.returncode})")
+    # Extract them all successfully before moving them.
+    for paths in extract_paths.values():
+        result = subprocess.run(
+            [PMTILES, "extract", paths["source"], paths["tmp"], "--bbox=" + ",".join(map(repr, extract_box))],
+        )
+        if result.returncode != 0:
+            raise Exception(f"Region download failed. Double-check your Internet connection. (error code {result.returncode})")
 
     for paths in extract_paths.values():
         shutil.move(paths["tmp"], paths["extract"])
@@ -381,47 +314,43 @@ UNIT_MULT = {
 def get_estimates(extract_box, extract_paths):
     extract_sizes = {}
 
-    with tempfile.NamedTemporaryFile(delete_on_close=False, mode="w") as geojson_file:
-        set_region_geojson(extract_box, geojson_file)
-        geojson_file.close()
+    for paths in extract_paths.values():
+        result = subprocess.run(
+            [PMTILES, "extract", paths["source"], paths["tmp"], "--bbox=" + ",".join(map(repr, extract_box)), "--dry-run"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise Exception(f"Download size check failed. Double-check your Internet connection. (error code {result.returncode})")
 
-        for paths in extract_paths.values():
-            result = subprocess.run(
-                [PMTILES, "extract", paths["source"], paths["tmp"], f"--region={geojson_file.name}", "--dry-run"],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise Exception(f"Download size check failed. Double-check your Internet connection. (error code {result.returncode})")
+        # Parse transfer and archive sizes from the last line of --dry-run output.
+        # (Though we'll check every line to make it a bit more robust)
+        #
+        # NOTE: The reason this is two different sizes is due to something
+        # called "overfetching" which is making fewer requests at the cost of
+        # grabbing some extra data we don't need. This is actually a ratio we
+        # can control and will likely look into for optimizing user experience.
+        pattern = (
+            r'\d+/\d+/\d+ \d+:\d+:\d+ extract.go:\d*: '
+            r'Extract transferred (\d*\.?\d*) (kB|MB|GB|TB) '
+            r'\(overfetch \d*\.?\d*\) '
+            r'for an archive size of (\d*\.?\d*) (kB|MB|GB|TB)'
+        )
+        for line in result.stdout.split('\n'):
+            re_match = re.match(pattern, line)
+            if re_match is not None:
+                break
 
-            # Parse transfer and archive sizes from the last line of --dry-run output.
-            # (Though we'll check every line to make it a bit more robust)
-            #
-            # NOTE: The reason this is two different sizes is due to something
-            # called "overfetching" which is making fewer requests at the cost of
-            # grabbing some extra data we don't need. This is actually a ratio we
-            # can control and will likely look into for optimizing user experience.
-            pattern = (
-                r'\d+/\d+/\d+ \d+:\d+:\d+ extract.go:\d*: '
-                r'Extract transferred (\d*\.?\d*) (kB|MB|GB|TB) '
-                r'\(overfetch \d*\.?\d*\) '
-                r'for an archive size of (\d*\.?\d*) (kB|MB|GB|TB)'
-            )
-            for line in result.stdout.split('\n'):
-                re_match = re.match(pattern, line)
-                if re_match is not None:
-                    break
+        if re_match is None:
+            return None
 
-            if re_match is None:
-                return None
+        (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
 
-            (transfer_num, transfer_unit, archive_num, archive_unit) = re_match.groups()
-
-            # Determine the sizes of all of the pmtiles files in bytes
-            extract_sizes[paths['source']] = {
-                "transfer": float(transfer_num) * UNIT_MULT[transfer_unit],
-                "archive":  float(archive_num)  * UNIT_MULT[archive_unit],
-            }
+        # Determine the sizes of all of the pmtiles files in bytes
+        extract_sizes[paths['source']] = {
+            "transfer": float(transfer_num) * UNIT_MULT[transfer_unit],
+            "archive":  float(archive_num)  * UNIT_MULT[archive_unit],
+        }
 
     return extract_sizes
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -140,18 +140,18 @@ def clean_extract_box(extract_box_str):
         assert min_lat < max_lat, "latitudes seem to be out of order"
         assert max_lon - min_lon < 360, "FQR can't wrap around the world"
 
-    except Exception:
-        raise ValueError("extract_box_str is malformed: ", extract_box_str)
+    except Exception as e:
+        raise ValueError(f"extract_box_str is malformed ({e}): ", extract_box_str)
 
     def lon_modulo(lon):
-        # We want the longitudes to be from -180 to 180. We want to perform a modulo 360
-        # to give it an equivalent longitude, but starting at -180 instead of 180
+        # We want the longitudes to be from -180 to just under 180. We want to perform a
+        # modulo 360 to give it an equivalent longitude, but starting at -180 instead of 0.
         return (
-          (                 # Start off assuming that lon "ought to be" in the range of -180 < x < 180
-            (lon + 180)     # Thus, lon + 180 "ought to be" in the range of 0 < x < 360
-            % 360           # Modulo 360 will *in fact* change our range to 0 < x < 360
+          (                 # Start off assuming that lon "ought to be" in the range of -180 <= x < 180
+            (lon + 180)     # Thus, lon + 180 "ought to be" in the range of 0 <= x < 360
+            % 360           # Modulo 360 will *in fact* change our range to 0 <= x < 360
           )
-        ) - 180             # Finally subtracting 180 will *in fact* set our range to -180 < x < 180
+        ) - 180             # Finally subtracting 180 will *in fact* set our range to -180 <= x < 180
 
     return [lon_modulo(min_lon), min_lat, lon_modulo(max_lon), max_lat]
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -127,10 +127,10 @@ def validate_extract_name(extract_name):
     except AssertionError:
         raise ValueError("extract_name has invalid length or characters: ", extract_name)
 
-def validate_extract_box(extract_box):
+def clean_extract_box(extract_box_str):
     try:
         # `float` is important here even if just as a parsing check.
-        min_lon, min_lat, max_lon, max_lat = [float(n) for n in extract_box.split(",")]
+        min_lon, min_lat, max_lon, max_lat = [float(n) for n in extract_box_str.split(",")]
 
         # I am concerned about longitudes in particular because -180 and 180 refer to the same place.
         # I expect to get all all positives or all negatives for longitudes (see the big comment in
@@ -141,7 +141,26 @@ def validate_extract_box(extract_box):
         assert max_lon - min_lon < 360, "FQR can't wrap around the world"
 
     except Exception:
-        raise ValueError("extract_box is malformed: ", extract_box)
+        raise ValueError("extract_box_str is malformed: ", extract_box_str)
+
+    # We want min_lon to be from -180 to 180. We want to performa modulo 360
+    # to give it an equivalent longitude, but starting at -180 instead of 180
+    new_min_lon = (
+      (                 # start off assuming that min_lon "ought to be" in the range of -180 < x < 180
+        (min_lon + 180) # thus this "ought to be" in the range of 0 < x < 360
+        % 360           # Modulo 360 will in fact change our range to 0 < x < 360
+      )
+    ) - 180             # Finally subtracting 180 will set our range to -180 < x < 180
+
+    # Set min_lon and max_lon, adjusting by the same amount as necessary
+    # Because of our previous assurances, we know that max_lon > min_lon,
+    # and that the width of the FQR is less than the width of the whole earth (360).
+    # Thus, max_lon has a potential range of -180 < x < 540, which the system can
+    # hopefully deal with. This normalizes things nicely for us as well, which we
+    # see below.
+    min_lon, max_lon = new_min_lon, max_lon + (new_min_lon - min_lon)
+
+    return [min_lon, min_lat, max_lon, max_lat]
 
 def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
@@ -279,29 +298,7 @@ def delete_extract(extract_name):
         os.remove(path)
 
 def set_region_geojson(extract_box, geojson_file):
-    # TODO maybe move the "cleaning" of min_lon and max_lon to `validate_extract_box`
-    # (and rename the function) since all the logic is related
-
-    # These values come straight from the region drawing tool, and may not be
-    # friendly for pmtiles
-    [min_lon, min_lat, max_lon, max_lat] = map(float, extract_box.split(",") )
-
-    # We want min_lon to be from -180 to 180. We want to performa modulo 360
-    # to give it an equivalent longitude, but starting at -180 instead of 180
-    new_min_lon = (
-      (                 # start off assuming that min_lon "ought to be" in the range of -180 < x < 180
-        (min_lon + 180) # thus this "ought to be" in the range of 0 < x < 360
-        % 360           # Modulo 360 will in fact change our range to 0 < x < 360
-      )
-    ) - 180             # Finally subtracting 180 will set our range to -180 < x < 180
-
-    # Set min_lon and max_lon, adjusting by the same amount as necessary
-    # Because of our previous assurances, we know that max_lon > min_lon,
-    # and that the width of the FQR is less than the width of the whole earth (360).
-    # Thus, max_lon has a potential range of -180 < x < 540, which the system can
-    # hopefully deal with. This normalizes things nicely for us as well, which we
-    # see below.
-    min_lon, max_lon = new_min_lon, max_lon + (new_min_lon - min_lon)
+    [min_lon, min_lat, max_lon, max_lat] = extract_box
 
     # Since we know that now -180 < min_lon < 180, and max_lon > min_lon, crossing the antimeridian
     # will always come in the form of max_lon > 180 and not min_lon < -180.
@@ -466,21 +463,19 @@ def check_for_existing_name(extract_name, noninteractive):
         return True
 
 def check_for_overlaps(new_box):
-    [new_min_long, new_min_lat, new_max_long, new_max_lat] = [
-        float(n) for n in new_box.split(",")
-    ]
+    [new_min_lon, new_min_lat, new_max_lon, new_max_lat] = new_box
 
     existing_region_extracts = json.loads(open(EXTRACTS_JSON).read())["regions"]
     for existing in existing_region_extracts.values():
         [long_1, lat_1, long_2, lat_2] = existing['ui_bounds']
-        existing_min_long = min([long_1, long_2])
-        existing_max_long = max([long_1, long_2])
+        existing_min_lon = min([long_1, long_2])
+        existing_max_lon = max([long_1, long_2])
         existing_min_lat = min([lat_1, lat_2])
         existing_max_lat = max([lat_1, lat_2])
 
         if (
-            new_min_long < existing_max_long and
-            new_max_long > existing_min_long and
+            new_min_lon < existing_max_lon and
+            new_max_lon > existing_min_lon and
             new_min_lat  < existing_max_lat and
             new_max_lat  > existing_min_lat
         ):
@@ -563,11 +558,11 @@ if __name__ == "__main__":
             )
 
             extract_name = sys.argv[2]
-            extract_box = sys.argv[3]
+            extract_box_str = sys.argv[3]
             noninteractive = sys.argv[4] if len(sys.argv) > 4 else ""
 
             validate_extract_name(extract_name)
-            validate_extract_box(extract_box)
+            extract_box = clean_extract_box(extract_box_str)
             validate_noninteractive(noninteractive)
             noninteractive = bool(noninteractive)
 


### PR DESCRIPTION
### Fixes bug:

Stop using MultiPolygons to handle FQRs that cross the antimeridian. Instead I switch `pmtiles` to version `1.31.1` which includes @chapmanjacobd 's change that allows for this.

The reason I put this in the "Fixes bug" section is that I also change the way I think about coordinates. As I create extracts, I now think in terms of -180 to 180. Previously I'd have the eastmost longitude > westmost longitude, and as such eastmost is greater than 180 for FQRs that cross the antimeridian. Eventually we want to save a bbox explicitly alongside the pmtiles for the FQR, and we determined that longitudes should be -180 to 180. So while this is an implementation detail for now, it gets me toward thinking about coordinates correctly for the upcoming feature.

I'll add a caveat: There is a separate part of the code that "reads" the `pmtiles` file to pass info to the front end, both to display the FQR and to display the rectangle around it. This part of the code still inspects the file for location of tiles in case of crossing the antimeridian. I will need to do this until we finally save the bbox explicitly, as mentioned above. And in this part of the code, I still return coordinates the "old" way, i.e. eastmost longitude > westmost longitude for the benefit of the front end. In a future PR, I'll just move the coordinate translation logic to the front end, since it's only relevant to that drawing tool.

Still a draft ONLY because we should prepare the 32 bit `pmtiles` executable of version `1.31.1`.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 

I would recommend looking at each commit separately to make it easier to follow.