### PR TITLE
MediaWiki: download from git tag instead of release tarball

### DIFF
--- a/modules/get_curl.py
+++ b/modules/get_curl.py
@@ -18,6 +18,7 @@ def run_module():
         timeout=dict(type='int', default=60),
         retries=dict(type='int', default=10),
         force=dict(type='bool', default=False),
+        http_version=dict(type='str', choices=['0.9', '1.0', '1.1', '2', '2-prior-knowledge', '3', '3-only']),
     )
 
     module = AnsibleModule(argument_spec=argument_spec, add_file_common_args=True, supports_check_mode=True)
@@ -29,6 +30,7 @@ def run_module():
     timeout = module.params['timeout']
     retries = module.params['retries']
     force = module.params['force']
+    http_version = module.params['http_version']
 
     if dest.endswith('/'):
         try:
@@ -80,6 +82,8 @@ def run_module():
             "--retry-max-time",
             "1200",
         ]
+        if http_version:
+            cmd.append(f"--http{http_version}")
         if headers:
             for key, value in headers.items():
                 cmd.extend(["-H", f"{key}: {value}"])

--- a/modules/get_curl.py
+++ b/modules/get_curl.py
@@ -18,7 +18,6 @@ def run_module():
         timeout=dict(type='int', default=60),
         retries=dict(type='int', default=10),
         force=dict(type='bool', default=False),
-        http_version=dict(type='str', choices=['0.9', '1.0', '1.1', '2', '2-prior-knowledge', '3', '3-only']),
     )
 
     module = AnsibleModule(argument_spec=argument_spec, add_file_common_args=True, supports_check_mode=True)
@@ -30,7 +29,6 @@ def run_module():
     timeout = module.params['timeout']
     retries = module.params['retries']
     force = module.params['force']
-    http_version = module.params['http_version']
 
     if dest.endswith('/'):
         try:
@@ -82,8 +80,6 @@ def run_module():
             "--retry-max-time",
             "1200",
         ]
-        if http_version:
-            cmd.append(f"--http{http_version}")
         if headers:
             for key, value in headers.items():
                 cmd.extend(["-H", f"{key}: {value}"])

--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -8,8 +8,7 @@ mediawiki_major_version: "1.46"    # "1.40" quotes nec if trailing zero
 mediawiki_minor_version: 0
 mediawiki_version: "{{ mediawiki_major_version }}.{{ mediawiki_minor_version }}"
 
-mediawiki_download_base_url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_major_version }}"
-mediawiki_src: "mediawiki-{{ mediawiki_version }}.tar.gz"
+mediawiki_repo_url: "https://gerrit.wikimedia.org/r/mediawiki/core.git"
 
 mediawiki_db_name: iiab_mediawiki
 mediawiki_db_user: iiab_mediawiki_user

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -44,6 +44,7 @@
     url: "{{ mediawiki_download_base_url }}/{{ mediawiki_src }}"
     dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
     timeout: "{{ download_timeout }}"
+    http_version: "1.1"
 
 - name: Unarchive (unpack) it to permanent location {{ mediawiki_abs_path }} ({{ apache_user }}:{{ apache_user }}, u+rw,g+r,o+r)
   unarchive:

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -54,6 +54,7 @@
     depth: 1
     recursive: yes
     update: yes
+  become: yes
   become_user: "{{ apache_user }}"
 
 - name: Symlink {{ doc_root }}/{{ mediawiki_symlink }} -> {{ mediawiki_abs_path }}

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -39,21 +39,22 @@
 #    state: present
 #  when: php_version is version('8.0', '<')
 
-- name: Download {{ mediawiki_download_base_url }}/{{ mediawiki_src }} to {{ downloads_dir }}
-  get_curl:
-    url: "{{ mediawiki_download_base_url }}/{{ mediawiki_src }}"
-    dest: "{{ downloads_dir }}"    # /opt/iiab/downloads
-    timeout: "{{ download_timeout }}"
-    http_version: "1.1"
-
-- name: Unarchive (unpack) it to permanent location {{ mediawiki_abs_path }} ({{ apache_user }}:{{ apache_user }}, u+rw,g+r,o+r)
-  unarchive:
-    src: "{{ downloads_dir }}/{{ mediawiki_src }}"
-    dest: "{{ mediawiki_install_path }}"    # /library
+- name: Create {{ mediawiki_abs_path }} for the MediaWiki checkout
+  file:
+    path: "{{ mediawiki_abs_path }}"
+    state: directory
     owner: "{{ apache_user }}"    # www-data on debuntu
     group: "{{ apache_user }}"
-    mode: u+rw,g+r,o+r    # '0755' forced executable bits on files
-    keep_newer: yes
+
+- name: Checkout MediaWiki {{ mediawiki_version }} from Gerrit to {{ mediawiki_abs_path }}
+  git:
+    repo: "{{ mediawiki_repo_url }}"
+    dest: "{{ mediawiki_abs_path }}"
+    version: "{{ mediawiki_version }}"
+    depth: 1
+    recursive: yes
+    update: yes
+  become_user: "{{ apache_user }}"
 
 - name: Symlink {{ doc_root }}/{{ mediawiki_symlink }} -> {{ mediawiki_abs_path }}
   file:

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -43,8 +43,8 @@
           value: "{{ mediawiki_install }}"
         - option: mediawiki_enabled
           value: "{{ mediawiki_enabled }}"
-        - option: mediawiki_src
-          value: "{{ mediawiki_src }}"
+        - option: mediawiki_repo_url
+          value: "{{ mediawiki_repo_url }}"
         - option: mediawiki_abs_path
           value: "{{ mediawiki_abs_path }}"
         - option: mediawiki_db_name


### PR DESCRIPTION
### Fixes bug:

https://github.com/iiab/iiab/actions/runs/32272209759/job/96157191370?pr=4471

hopefully improves the mediawiki flaky downloads

### Smoke-tested on which OS or OS's:

CI

### Mention a team member @username e.g. to help with code review:

@holta