### PR TITLE
release header: last few tweaks

### DIFF
--- a/.github/assets/RELEASE_HEADER.md
+++ b/.github/assets/RELEASE_HEADER.md
@@ -38,7 +38,7 @@ If the `Internet in a Box` Wi-Fi network does not appear within a few minutes:
 
 2. Unplug power, wait 5 seconds, and plug it back in.
 
-3. Connect a keyboard and HDMI monitor, or plug into your router with wired Ethernet, then [SSH](https://www.baeldung.com/cs/ssh-intro) in as the user you created: `ssh username@box.local` (or [use its IP address](https://www.raspberrypi.com/documentation/computers/remote-access.html#ip-address)) and run:
+3. Connect a keyboard and HDMI monitor, or plug into your router with wired Ethernet, then [SSH](https://www.baeldung.com/cs/ssh-intro) in as the user you created: `ssh username@box.local` (or `@box.lan`; or [use its IP address](https://www.raspberrypi.com/documentation/computers/remote-access.html#ip-address)) and run:
 
 ```sh
 sudo iiab-hotspot-on

--- a/.github/assets/RELEASE_HEADER.md
+++ b/.github/assets/RELEASE_HEADER.md
@@ -28,7 +28,7 @@
 
 6. Continue through the wizard with `NEXT`; do not click `SKIP CUSTOMISATION`. Be sure to set a username and password -- you will need them to log in to the IIAB Admin Console. Enable [SSH](https://www.baeldung.com/cs/ssh-intro) if you want shell access to IIAB later; otherwise leave it off.
 
-7. Write the image to the microSD card, insert the card into your Raspberry Pi, and boot it.
+7. Write the image to the microSD card, insert the card into your Raspberry Pi, and power it on (boot it).
 
 The first boot may take a few minutes but generally no more than that.
 
@@ -47,6 +47,8 @@ sudo reboot
 ```
 
 </details>
+
+## Documentation & Resources
 
 - FAQ: [FAQ.IIAB.IO](https://FAQ.IIAB.IO)
 - Release Notes: https://github.com/iiab/iiab/wiki/IIAB-8.3-Release-Notes


### PR DESCRIPTION
### Fixes bug:

`box.lan` and `box.local` use different technologies to resolve so it's useful to always include both as they are much easier for people to try than finding the IP address manually. 

`box.local` will work with any modern OS out of the box. 

`box.lan` is a simpler technology and depends on the configuration of the router and should be preferred in cases where the IIAB is the router. But it shouldn't be the first thing to try during troubleshooting scenarios where the IIAB is not the network router--still it's better to give people the option to try it if they have an old OS and mDNS isn't working.

### Smoke-tested on which OS or OS's:

documentation change

### Mention a team member @username e.g. to help with code review:

@holta