### PR TITLE
Update vars/ instructions for maps variables

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -511,13 +511,15 @@ vector_map_path: "{{ content_base }}/www/osm-vector-maps"    # /library/www/osm-
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False
 maps_enabled: False
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # The following are intended for CI/CD. The defaults here should be kept for implementers:
 maps_preset_full_quality_regions: []    # Full-quality regions to install during installation.

--- a/vars/local_vars_android_large.yml
+++ b/vars/local_vars_android_large.yml
@@ -46,13 +46,15 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_region_downloader: True            # Tool to select regions for full-quality download
+maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 ##############################
 
 ##############################

--- a/vars/local_vars_android_medium.yml
+++ b/vars/local_vars_android_medium.yml
@@ -46,13 +46,15 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_region_downloader: True            # Tool to select regions for full-quality download
+maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 ##############################
 
 ##############################

--- a/vars/local_vars_android_small.yml
+++ b/vars/local_vars_android_small.yml
@@ -46,13 +46,15 @@ osm_vector_maps_enabled: False
 # "New" IIAB Maps, as of 2025 and 2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: True
 maps_enabled: True
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_region_downloader: True            # Tool to select regions for full-quality download
+maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 ##############################
 
 ##############################

--- a/vars/local_vars_large.yml
+++ b/vars/local_vars_large.yml
@@ -299,13 +299,15 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -318,13 +318,7 @@ osm_vector_maps_enabled: False
 
 maps_install: True
 maps_enabled: True
-maps_vector_zoom: 1-ci                  # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 4-ci               # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-100k-cities  # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_region_downloader: True            # Tool to select regions for full-quality download. Needed for maps_preset_full_quality_regions.
+maps_region_downloader: True            # Download "Full Quality Regions" (needed for maps_preset_full_quality_regions) -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
 maps_preset_full_quality_regions:       # Small portion of london and Nepal mountains
   - name: london                        # Test an urban setting
     bbox: -0.172187453,51.477245915,-0.143235226,51.493348151
@@ -332,7 +326,15 @@ maps_preset_full_quality_regions:       # Small portion of london and Nepal moun
     bbox: 83.680824998,28.401673033,84.055999541,28.724927625
   - name: rabi_island_fiji              # Test crossing the antimeridian
     bbox: -180.032361285,-16.54082487,-179.911191897,-16.438722265
-maps_ne6_zoom: 4-ci                     # Limited naturalearth6 for testing
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: 1-ci
+maps_satellite_zoom: 4-ci
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-100k-cities
+maps_ne6_zoom: 4-ci
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_medium.yml
+++ b/vars/local_vars_medium.yml
@@ -299,13 +299,15 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_small.yml
+++ b/vars/local_vars_small.yml
@@ -299,13 +299,15 @@ osm_vector_maps_enabled: True
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_tiny.yml
+++ b/vars/local_vars_tiny.yml
@@ -299,13 +299,15 @@ osm_vector_maps_enabled: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957

--- a/vars/local_vars_unittest.yml
+++ b/vars/local_vars_unittest.yml
@@ -305,13 +305,15 @@ osm_vector_maps_enabled: False
 # "NEW" IIAB Maps, as of 2025-2026 -- INSTRUCTIONS: https://github.com/iiab/iiab/blob/master/roles/maps/README.md
 maps_install: False    # AND SET 'osm_vector_maps_install: False' above (BEFORE installing IIAB!)
 maps_enabled: False    # AND SET 'osm_vector_maps_enabled: False' above (BEFORE installing IIAB!)
-maps_vector_zoom: nat-z8                # See `maps_dot_black_vector_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_satellite_zoom: 7                  # See `maps_dot_black_satellite_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_terrain_zoom: 0-none               # See `maps_dot_black_terrain_tiles` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
-maps_search_engine: static              # See https://github.com/iiab/iiab/blob/master/roles/maps/tasks/install.yml for valid values.
-maps_search_nominatim_db: basic         # Nominatim search database quality (work in progress, expected in Q2 2026!)
-maps_search_static_db: pop-1k-cities    # See `maps_` in https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml for details and valid values.
 maps_region_downloader: True            # Download "Full Quality Regions" -- INSTRUCTIONS: https://github.com/iiab/iiab/tree/master/roles/maps#full-quality-regions
+
+# For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
+maps_vector_zoom: nat-z8
+maps_satellite_zoom: 7
+maps_terrain_zoom: 0-none
+maps_search_engine: static
+maps_search_nominatim_db: basic
+maps_search_static_db: pop-1k-cities
 
 # Might stall MongoDB on Power Failure: github.com/xsce/xsce/issues/879
 # Sugarizer 1.0.1+ strategies to solve? github.com/iiab/iiab/pull/957


### PR DESCRIPTION
### Fixes bug:

Updates out-of-date comments about map related vars/ variables. Mostly quality-related variables, just pointing to `MAPS_CATALOG_DETAILS.md` in a blanket way. The old way said to search for specific things. My intention with new way is that they can search the md file for the specific variable name in question, and they'll get the same info.

The only other thing I removed is that Nominatim is "experimental" (though the Q2 is certainly out of date); I could add that back.

### Mention a team member @username e.g. to help with code review:
@holta 