### PR TITLE
Clean up pmtiles installer

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -30,7 +30,6 @@ maps_orig_global_catalog: "{{ maps_serve_path }}/maps-catalog-global-orig.json"
 maps_tools:
   base_dir: "/opt/iiab/maps"
   pmtiles:
-    version: a3e4951ea6a0477b784c27c1dcbfd9c130878c5a # run `pmtiles version` to find this. determines whether to update.
     releases:
       armhf:
         src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.31.2_Linux_armv7.tar.gz

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -30,6 +30,7 @@ maps_orig_global_catalog: "{{ maps_serve_path }}/maps-catalog-global-orig.json"
 maps_tools:
   base_dir: "/opt/iiab/maps"
   pmtiles:
+    version: a3e4951ea6a0477b784c27c1dcbfd9c130878c5a # run `pmtiles version` to find this. determines whether to update.
     releases:
       armhf:
         src_url: https://iiab.switnet.org/binaries/pmtiles-32b/go-pmtiles_1.31.2_Linux_armv7.tar.gz

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -22,6 +22,9 @@
     fail_msg: "Error: unsupported architecture for pmtiles: "
     quiet: yes
 
+# NOTE: This will download every time despite the checksum because we clean up
+# this archive after installing the executable. We could find another way to
+# prevent repeated downloads but it's not worth the complexity.
 - name: Download pmtiles archive for {{ dpkg_arch.stdout }}
   get_url:
     url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -42,6 +42,11 @@
     dest: "{{ maps_tools.pmtiles.executable_path }}"
     mode: "0744"
 
+- name: Clean up pmtiles unarchiving dir
+  file:
+    state: absent
+    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+
 # Getting the Python tool, which is not usually recommended over the Go tool,
 # so that we can write code with it that we don't need to build.
 - name: Get PMTiles (Python tool)

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -4,14 +4,10 @@
     path: "{{ maps_tools.tile_extract.working_dir }}"
 
 - name: Check what version of pmtiles is installed
-  shell: |
-    sudo {{ maps_tools.pmtiles.executable_path }} version || echo
-  args:
-    executable: /bin/bash
-
-  # The existence of console output in download_file_details
-  # implies that the download should happen.
+  command: "{{ maps_tools.pmtiles.executable_path }} version"
   register: pmtiles_version
+  changed_when: false
+  failed_when: false
 
 - name: Install pmtiles tool
   when: maps_tools.pmtiles.version not in pmtiles_version.stdout
@@ -53,7 +49,7 @@
       copy:
         src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
         dest: "{{ maps_tools.pmtiles.executable_path }}"
-        mode: "0744"
+        mode: "0755"
 
     - name: Clean up pmtiles unarchiving dir
       file:

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -3,58 +3,49 @@
     state: directory
     path: "{{ maps_tools.tile_extract.working_dir }}"
 
-- name: Check what version of pmtiles is installed
-  command: "{{ maps_tools.pmtiles.executable_path }} version"
-  register: pmtiles_version
-  changed_when: false
-  failed_when: false
+- name: Set up pmtiles unarchiving dir
+  file:
+    state: directory
+    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
-- name: Install pmtiles tool
-  when: maps_tools.pmtiles.version not in pmtiles_version.stdout
-  block:
-    - name: Set up pmtiles unarchiving dir
-      file:
-        state: directory
-        path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+- name: Define detected arch
+  set_fact:
+    maps_normalized_arch: |
+      {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
+      {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
+      {% elif dpkg_arch.stdout is regex('^armv[7-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
+      {% else %}unsupported{% endif %}
 
-    - name: Define detected arch
-      set_fact:
-        maps_normalized_arch: |
-          {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
-          {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
-          {% elif dpkg_arch.stdout is regex('^armv[7-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
-          {% else %}unsupported{% endif %}
+- name: "Make sure we have a supported arch for pmtiles"
+  assert:
+    that: maps_normalized_arch != "unsupported"
+    fail_msg: "Error: unsupported architecture for pmtiles: "
+    quiet: yes
 
-    - name: "Make sure we have a supported arch for pmtiles"
-      assert:
-        that: maps_normalized_arch != "unsupported"
-        fail_msg: "Error: unsupported architecture for pmtiles: "
-        quiet: yes
+- name: Download pmtiles archive for {{ dpkg_arch.stdout }}
+  get_url:
+    url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"
+    dest: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+    checksum: "sha256:{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].sha256sum }}"
+    mode: "0644"
+    timeout: "{{ download_timeout }}"
 
-    - name: Download pmtiles archive for {{ dpkg_arch.stdout }}
-      get_url:
-        url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"
-        dest: "{{ maps_tools.pmtiles.archive_tmp_file }}"
-        checksum: "sha256:{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].sha256sum }}"
-        mode: "0644"
-        timeout: "{{ download_timeout }}"
+- name: Unarchive pmtiles archive
+  unarchive:
+    src: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+    dest: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+    remote_src: yes
 
-    - name: Unarchive pmtiles archive
-      unarchive:
-        src: "{{ maps_tools.pmtiles.archive_tmp_file }}"
-        dest: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
-        remote_src: yes
+- name: Copy pmtiles executable into working dir
+  copy:
+    src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
+    dest: "{{ maps_tools.pmtiles.executable_path }}"
+    mode: "0755"
 
-    - name: Copy pmtiles executable into working dir
-      copy:
-        src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
-        dest: "{{ maps_tools.pmtiles.executable_path }}"
-        mode: "0755"
-
-    - name: Clean up pmtiles unarchiving dir
-      file:
-        state: absent
-        path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+- name: Clean up pmtiles unarchiving dir
+  file:
+    state: absent
+    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
 # Getting the Python tool, which is not usually recommended over the Go tool,
 # so that we can write code with it that we don't need to build.

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -3,49 +3,62 @@
     state: directory
     path: "{{ maps_tools.tile_extract.working_dir }}"
 
-- name: Set up pmtiles unarchiving dir
-  file:
-    state: directory
-    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+- name: Check what version of pmtiles is installed
+  shell: |
+    sudo {{ maps_tools.pmtiles.executable_path }} version || echo
+  args:
+    executable: /bin/bash
 
-- name: Define detected arch
-  set_fact:
-    maps_normalized_arch: |
-      {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
-      {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
-      {% elif dpkg_arch.stdout is regex('^armv[7-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
-      {% else %}unsupported{% endif %}
+  # The existence of console output in download_file_details
+  # implies that the download should happen.
+  register: pmtiles_version
 
-- name: "Make sure we have a supported arch for pmtiles"
-  assert:
-    that: maps_normalized_arch != "unsupported"
-    fail_msg: "Error: unsupported architecture for pmtiles: "
-    quiet: yes
+- name: Install pmtiles tool
+  when: maps_tools.pmtiles.version not in pmtiles_version.stdout
+  block:
+    - name: Set up pmtiles unarchiving dir
+      file:
+        state: directory
+        path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
-- name: Download pmtiles archive for {{ dpkg_arch.stdout }}
-  get_url:
-    url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"
-    dest: "{{ maps_tools.pmtiles.archive_tmp_file }}"
-    checksum: "sha256:{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].sha256sum }}"
-    mode: "0644"
-    timeout: "{{ download_timeout }}"
+    - name: Define detected arch
+      set_fact:
+        maps_normalized_arch: |
+          {% if dpkg_arch.stdout in ['arm64', 'aarch64'] %}arm64
+          {% elif dpkg_arch.stdout in ['amd64', 'x86_64'] %}amd64
+          {% elif dpkg_arch.stdout is regex('^armv[7-8].*') or dpkg_arch.stdout in ['armhf', 'armeabi-v7a'] %}armhf
+          {% else %}unsupported{% endif %}
 
-- name: Unarchive pmtiles archive
-  unarchive:
-    src: "{{ maps_tools.pmtiles.archive_tmp_file }}"
-    dest: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
-    remote_src: yes
+    - name: "Make sure we have a supported arch for pmtiles"
+      assert:
+        that: maps_normalized_arch != "unsupported"
+        fail_msg: "Error: unsupported architecture for pmtiles: "
+        quiet: yes
 
-- name: Copy pmtiles executable into working dir
-  copy:
-    src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
-    dest: "{{ maps_tools.pmtiles.executable_path }}"
-    mode: "0744"
+    - name: Download pmtiles archive for {{ dpkg_arch.stdout }}
+      get_url:
+        url: "{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].src_url }}"
+        dest: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+        checksum: "sha256:{{ maps_tools.pmtiles.releases[dpkg_arch.stdout].sha256sum }}"
+        mode: "0644"
+        timeout: "{{ download_timeout }}"
 
-- name: Clean up pmtiles unarchiving dir
-  file:
-    state: absent
-    path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+    - name: Unarchive pmtiles archive
+      unarchive:
+        src: "{{ maps_tools.pmtiles.archive_tmp_file }}"
+        dest: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
+        remote_src: yes
+
+    - name: Copy pmtiles executable into working dir
+      copy:
+        src: "{{ maps_tools.pmtiles.archive_tmp_dir }}/pmtiles"
+        dest: "{{ maps_tools.pmtiles.executable_path }}"
+        mode: "0744"
+
+    - name: Clean up pmtiles unarchiving dir
+      file:
+        state: absent
+        path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
 # Getting the Python tool, which is not usually recommended over the Go tool,
 # so that we can write code with it that we don't need to build.


### PR DESCRIPTION
### Fixes bug:

Remnants of archive of `pmtiles` CLI tool was being left behind during installation. I left it behind using the sha256sum of the archive was a convenient way to do versioning.

But we don't want junk laying around. So instead I run `pmtiles version` and search for the git commit hash to see if we need to update. I chose to use that instead of the version number because it's less error prone. The version number might have a subset or something of another version number.

I guess I'm relying on that version number appearing consistently across the versions for all three architectures. If that fails, it will download each time. @Ark74 could you double check that running `pmtiles version` on the 32 bit version gives you `a3e4951ea6a0477b784c27c1dcbfd9c130878c5a` as part of the output?

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 