### PR TITLE
FQR bbox meta.json

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -43,10 +43,6 @@ maps_tools:
     archive_tmp_dir: "/opt/iiab/downloads/maps/pmtiles"
     archive_tmp_file: "/opt/iiab/downloads/maps/pmtiles/pmtiles.tar.gz"
     executable_path: "{{ maps_tools.base_dir }}/pmtiles"
-  pmtiles_python:
-    git_url: https://github.com/protomaps/PMTiles
-    dir_name: pmtiles-python
-    version: 8b8ddea4dbff1b0104cf2bebf2f7ff35c91b41d5
   tile_extract:
     working_dir: "{{ maps_tools.base_dir }}/tile-extract"
     info_file: "extracts.json"

--- a/roles/maps/files/bbox_test.py
+++ b/roles/maps/files/bbox_test.py
@@ -1,0 +1,44 @@
+import unittest
+tile_extract = __import__("tile-extract")
+
+class TestOverlap(unittest.TestCase):
+    def test_split_antimeridian_bbox(self):
+        self.assertEqual(tile_extract._split_antimeridian_bbox([170, 80, -170, 90]), ([170, 80, 180, 90], [-180, 80, -170, 90]))
+
+    def test_overlap_neither_antimeridian_cross(self):
+        """
+        Test overlaps and non-overlaps between two regions, neither of which cross the antimeridian
+        """
+
+        self.assertTrue(tile_extract._has_overlap([0, 0, 20, 20], [10, 10, 30, 30]), "expected: regions overlap")
+
+        self.assertFalse(tile_extract._has_overlap([0, 0, 20, 20], [30, 30, 40, 40]), "expected: no overlap - disjoint lat and lon")
+        self.assertFalse(tile_extract._has_overlap([0, 0, 20, 20], [10, 30, 30, 40]), "expected: no overlap - disjoint only lat")
+        self.assertFalse(tile_extract._has_overlap([0, 0, 20, 20], [30, 10, 40, 30]), "expected: no overlap - disjoint only lon")
+
+        self.assertFalse(tile_extract._has_overlap([0, 0, 20, 20], [20, 0, 40, 20]), "expected: no overlap - borders on lon")
+        self.assertFalse(tile_extract._has_overlap([0, 0, 20, 20], [0, 20, 20, 40]), "expected: no overlap - borders on lat")
+
+    def test_overlap_one_antimeridian_cross(self):
+        """
+        Test overlaps and non-overlaps between two regions, one of which crosses the antimeridian
+        """
+
+        self.assertTrue(tile_extract._has_overlap([160, 0, -160, 20], [-170, 0, -150, 20]), "expected: overlap - east of antimeridian (-170 to -160)")
+        self.assertTrue(tile_extract._has_overlap([160, 0, -160, 20], [150, 0, 170, 20]), "expected: overlap - west of antimeridian (160 to 170)")
+
+        self.assertFalse(tile_extract._has_overlap([160, 0, -160, 20], [-150, 0, -140, 20]), "expected: no overlap - east of antimeridian")
+        self.assertFalse(tile_extract._has_overlap([160, 0, -160, 20], [140, 0, 150, 20]), "expected: no overlap - west of antimeridian")
+
+    def test_overlap_both_antimeridian_cross(self):
+        """
+        Test overlaps and non-overlaps between two antimeridian-crossing regions
+        """
+
+        self.assertTrue(tile_extract._has_overlap([160, 0, -160, 20], [170, 0, -150, 20]), "expected: overlap - first region starts and ends more east than second region does")
+        self.assertTrue(tile_extract._has_overlap([160, 0, -160, 20], [150, 0, -170, 20]), "expected: overlap - first region starts and ends more west than second region does")
+        self.assertTrue(tile_extract._has_overlap([160, 0, -160, 20], [170, 0, -170, 20]), "expected: overlap - first region fully contains second region")
+        self.assertTrue(tile_extract._has_overlap([170, 0, -170, 20], [160, 0, -160, 20]), "expected: overlap - second region fully contains first region")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roles/maps/tasks/install_tools.yml
+++ b/roles/maps/tasks/install_tools.yml
@@ -50,15 +50,6 @@
     state: absent
     path: "{{ maps_tools.pmtiles.archive_tmp_dir }}"
 
-# Getting the Python tool, which is not usually recommended over the Go tool,
-# so that we can write code with it that we don't need to build.
-- name: Get PMTiles (Python tool)
-  git:
-    repo: "{{ maps_tools.pmtiles_python.git_url }}"
-    dest: "{{ maps_tools.tile_extract.working_dir }}/{{ maps_tools.pmtiles_python.dir_name }}"
-    version: "{{ maps_tools.pmtiles_python.version }}"
-    depth: 1
-
 - name: Install our tile extraction script
   template:
     src: "tile-extract.py.j2"

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -39,7 +39,7 @@ def get_bounds(extract_name, fqr_dir):
         # refers to the transition of adding the meta.json file to the fqr directory.
         print (f"Warning: not displaying '{extract_name}' on the map - meta.json not found. This might be because of an incomplete download, or a recent IIAB update.")
         print ("You may need to delete this region and download it again. The command to delete it is:")
-        print() # TODO - recommend an "update" instead of delete when we implement that
+        print()
         print(delete_command(extract_name))
         print() # Extra line because we may list multiple incomplete FQRs here
     except (json.decoder.JSONDecodeError, KeyError):

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -18,6 +18,14 @@ TMP_DIR = "/library/downloads/maps"
 # directory, you end up with weird errors
 os.chdir(HOSTING_DIR)
 
+def delete_command(extract_name):
+    """
+    Helper function that returns the text for the delete command, which we use in a few places.
+    """
+    return (
+        f"sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py delete {extract_name}"
+    )
+
 # Any pmtiles file for a region that crosses 180/-180 longitude (aka the
 # antimeridian) will say its min and max longitudes are -180 and 180.
 # Technically true, but there's of course the massive gap in the middle.
@@ -501,12 +509,16 @@ def check_for_existing_name(extract_name):
         # automatically. It's a separate non-trivial task because the deletion
         # sequence itself has yes/no logic related to unexpected files. And so
         # the deletion may not happen, which we then have to account for here.
-        print(f'Already have a full quality region called \"{extract_name}\". If you would like to overwrite it, please delete it first:')
-        print("")
-        print(f"sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py delete {extract_name}")
+        #
+        # I specifically say "looks like" because this comes up (as it should)
+        # even if you have an invalid fqr, i.e. a directory without a meta.json
+        # file. Such a directory would, all the same, block you from
+        # downloading a new region with that name.
+        print(f'It looks like you already have a Full Quality Region called \"{extract_name}\". To delete this region, run:')
+        print() # TODO - recommend an "update" in case that's what they want to do, when we implement that
+        print(delete_command(extract_name))
         return False
-    else:
-        return True
+    return True
 
 def check_for_overlaps(new_box):
     [new_min_lon, new_min_lat, new_max_lon, new_max_lat] = new_box

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -146,7 +146,7 @@ def check_bbox_error(bbox):
         if lat > 90:
             return "latitude > 90"
         if lat < -90:
-            return "longitude < -90"
+            return "latitude < -90"
 
 def clean_bbox_from_ui_tool(extract_box_str):
     """

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -412,7 +412,7 @@ def create_extract(extract_box, extract_name, extract_paths):
     # Let's write the meta.json first, making it an official fqr, before we
     # move the pmtiles files. If we move the pmtiles files first and there's
     # an error before making the meta file, it won't be an official fqr and
-    # they may have trouble deleting it. If there's an error after the meta
+    # they may get confusing error messages. If there's an error after the meta
     # file but before the pmtiles files, they can at least delete it and
     # try again. (or eventually, they can "update" it which will grab any
     # missing pmtiles files).
@@ -518,7 +518,7 @@ def check_for_existing_name(extract_name):
         # file. Such a directory would, all the same, block you from
         # downloading a new region with that name.
         print(f'It looks like you already have a Full Quality Region called \"{extract_name}\". To delete this region, run:')
-        print() # TODO - recommend an "update" in case that's what they want to do, when we implement that
+        print() # TODO - recommend an "update" (if they have a meta.json) in case that's what they want to do, when we implement that
         print(delete_command(extract_name))
         return False
     return True

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -6,8 +6,6 @@ from collections import defaultdict
 
 sys.path.insert(1, "{{ maps_tools.tile_extract.working_dir }}/pmtiles-python/python/pmtiles")
 
-from pmtiles.reader import MmapSource, all_tiles
-
 CATALOG_URL = "{{ maps_catalog_url }}"
 HOSTING_DIR = "{{ maps_serve_path }}"
 EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ maps_tools.tile_extract.info_file }}")
@@ -18,6 +16,8 @@ TMP_DIR = "/library/downloads/maps"
 # directory, you end up with weird errors
 os.chdir(HOSTING_DIR)
 
+# Helpers
+
 def delete_command(extract_name):
     """
     Helper function that returns the text for the delete command, which we use in a few places.
@@ -26,109 +26,51 @@ def delete_command(extract_name):
         f"sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py delete {extract_name}"
     )
 
-# Any pmtiles file for a region that crosses 180/-180 longitude (aka the
-# antimeridian) will say its min and max longitudes are -180 and 180.
-# Technically true, but there's of course the massive gap in the middle.
-# So here we inspect the file to find where that hole is.
-def get_bounds(full_path):
-    output = subprocess.getoutput(f"{PMTILES} show {full_path} --header-json")
+def get_bounds(extract_name, fqr_dir):
+    # If we want to inspect the actual files (perhaps to inform users if their
+    # pmtiles files don't match their fqr's bbox), see the version of
+    # `get_bounds` at commit 351399c7fdc534d6ea6ce7f64dae9757d695ceaf
     try:
-        render_bounds = [float(coord) for coord in json.loads(output)["bounds"]]
-    except:
-        print (f"Failed to get bounds from pmtiles header for {full_path}. Got this output from pmtiles:\n", output)
-        return None, None
+        bbox = json.load(
+            get_meta_file_path(fqr_dir).open("r")
+        )["bbox"]
+    except FileNotFoundError:
+        # TODO nov 2026 or so we can remove "updated your IIAB recently". This
+        # refers to the transition of adding the meta.json file to the fqr directory.
+        print (f"Warning: not displaying '{extract_name}' on the map - meta.json not found. This might be because of an incomplete download, or a recent IIAB update.")
+        print ("You may need to delete this region and download it again. The command to delete it is:")
+        print() # TODO - recommend an "update" instead of delete when we implement that
+        print(delete_command(extract_name))
+        print() # Extra line because we may list multiple incomplete FQRs here
+    except (json.decoder.JSONDecodeError, KeyError):
+        print (f"Warning: not displaying '{extract_name}' on the map - malformed meta.json")
+    else:
+        error = check_bbox_error(bbox)
+        if error:
+            print (f"Warning: not displaying '{extract_name}' on the map - bbox error - {error}")
+            return None, None
 
-    if (render_bounds[0], render_bounds[2]) != (-180, 180):
-        # render_bounds is what the pmtiles system needs to know about what area may be displayed
-        # ui_bounds is the area with actual tiles, which we can use to draw the rectangles and check for overlaps
-        # In the normal case here, i.e. not crossing the antimeridian, they're one and the same.
-        ui_bounds = render_bounds
+        if bbox[0] < bbox[2]:
+            # normal
+            ui_bounds = render_bounds = bbox
+        else:
+            # cross antimeridian
+            ui_bounds = [
+                bbox[0],
+                bbox[1],
+                bbox[2] + 360,
+                bbox[3],
+            ]
+            render_bounds = [
+                -180,
+                bbox[1],
+                180,
+                bbox[3],
+            ]
+
         return render_bounds, ui_bounds
 
-    # At this point we have a pmtiles file that reports to span -180 to 180, i.e. the entire
-    # logical width of the map. While this might actually be the case, it's more likely that
-    # it's a normal sized region that crosses the antimeridian, i.e. starts before 180 and
-    # wraps around to end after -180. But pmtiles doesn't like the concept of wrapping
-    # around the map. We're able to create such regions by asking pmtiles to make an extract
-    # across the antimeridian, and it grabs the right tiles for the requested bbox, but in
-    # the header it still says -180 to 180 (and we just got it with render_bounds).
-    #
-    # For ui_bounds, we want the coordinates of the actual tiles (something like 165 to 190)
-    # so maplibre can draw the rectangle. And to find those numbers, we need to inspect the
-    # file to see where all of the tiles are.
-
-    with full_path.open("r+b") as f:
-        source = MmapSource(f)
-        # all_tiles(source) = generator of [((z,x,y), tile_data)]
-        # tiles = [(z,x,y)]
-        tiles = [tile[0] for tile in all_tiles(source)]
-
-    # We want a high zoom level that gives us a reasonably precise rectangular region. But we
-    # also want something that's available to vector, satellite, and terrain. That way our
-    # bounding box will tend to be consistent between them.
-    zoom = 10
-
-    # For all the tiles, what are all of the "x values" of those tiles?
-    # Tiles have z: zoom, x: horizontal index, and y: vertical index.
-    # For z=0, x is always 0. For z=1, x can be 0-1. For z=2, x can be 0-3. And so on.
-    # x = 0 represents the tiles that are -180 on their western edge.
-    # x = (2 ** z - 1) represents the tiles that are 180 on their eastern edge.
-    # For all the tiles in this file at our desired zoom level, let's first put their
-    # x values in order, removing duplicates. This will tell us where we have actual
-    # tile data:
-    x_values = sorted({tile[1] for tile in tiles if tile[0] == zoom})
-    if len(x_values) == 0:
-        # Not sure how we got here but we don't have any tiles!
-        print (f"Warning: Got zero tiles, skipping {full_path}")
-        return None, None
-
-    # Now that we know what all the x values are, we can find the gaps between them.
-    # Usually, within a region, tiles are continuous, thus gaps are 1. (Sometimes
-    # they're a different small number so we can't rely on it.) For a region that
-    # crosses the antimeridian, it shows up as if it's two regions, and thus two
-    # clusters of x values: One close to x = 0 (aka -180 lng) and another close to
-    # x = 2 ** zoom - 1 (aka 180 lng), with a large gap between them. If we find that
-    # large gap, we can figure out the x values at the edges of the clusters, and
-    # translate those to the longitudes of the borders of the region.
-    gaps = [b - a for (a, b) in zip(x_values, x_values[1:])]
-
-    if gaps:
-        biggest_gap = max(gaps)               # Find the biggest gap.
-        gap_start = gaps.index(biggest_gap)   # Get the index of that gap so we can use it to find the x values before and after the gap.
-        eastern_x = x_values[gap_start] + 1   # The last tile before the gap is the eastern side of the region. We add 1 to get on the eastern side of that tile.
-        western_x = x_values[gap_start + 1]   # The first tile after the gap is the western side of the region.
-
-        # Note: if biggest_gap is very small, it means that our region does indeed wrap around the
-        # entire world. Our current logic should still be fine. It doesn't really matter which
-        # "eastern and western borders" we pick for such a region.
-    else:
-        print (f"Warning: Got zero tile gaps, doing our best for {full_path}")
-
-        # If we somehow have no gaps, it must mean the region is one tile wide. I'm not sure this is even possible for a file
-        # that reports -180 to 180 in the header, but let's just do our best. At this point we're forgetting about the gap and
-        # even the antimeridian. We just take the one tile width and draw the border around it.
-        western_x = x_values[0]      # The western side of the one tile
-        eastern_x = x_values[0] + 1  # The eastern side (+ 1) of the one tile
-
-    # Translate x values to longitudes.
-    def x_to_lng(x):
-        degrees_per_x_values = 360 / (2 ** zoom)
-        return x * degrees_per_x_values - 180
-
-    # We add 360 to the eastern end because otherwise it would be to the west of the western end, given that we wrapped
-    # around the antimeridian. This will be > 180, thus an "invalid" value from the point of view of a pmtiles file,
-    # but from a UI perspective this works and is probably more proper. It draws the correct rectangle, it becomes the
-    # correct clickable area.
-    ui_bounds = [
-        x_to_lng(western_x),
-        render_bounds[1],
-        x_to_lng(eastern_x) + 360,
-        render_bounds[3],
-    ]
-
-    return render_bounds, ui_bounds
-
-# Helpers
+    return None, None
 
 # `REGION_TYPES_FOR_DATE` maps the region types seen in the pmtiles file names
 # to the keys in the "dates" substructure in the extracts file:
@@ -168,7 +110,49 @@ def validate_extract_name(extract_name):
     if error:
         raise ValueError(f"Invalid FQR name ({extract_name}): {error}")
 
-def clean_extract_box(extract_box_str):
+def check_bbox_error(bbox):
+    """
+    What gets passed here ought to be ready to save to meta.json or pass to the
+    pmtiles tool (i.e. not directly from the ui tool). So here we make sure
+    that it is indeed so. We'll try not to make assumptions about where it came
+    from (whether a post-cleaning ui tool, or from a meta.json file, or maybe
+    someplace else), so we'll check the structure of everything as well.
+    """
+
+    if not isinstance(bbox, list):
+        return "bbox is not an array"
+    if len(bbox) != 4:
+        return "bbox has unexpected length"
+    for coord in bbox:
+        if not isinstance(coord, (int, float)):
+            return "coordinate is not a number"
+
+    min_lon, min_lat, max_lon, max_lat = bbox
+
+    if min_lon == max_lon:
+        return "longitudes are equal"
+    for lon in [min_lon, max_lon]:
+        if lon >= 180:
+            return "longitude >= 180"
+        if lon < -180:
+            return "longitude < -180"
+
+    if min_lat >= max_lat:
+        return "latitudes are equal or out of order"
+    for lat in [min_lat, max_lat]:
+        if lat > 90:
+            return "latitude > 90"
+        if lat < -90:
+            return "longitude < -90"
+
+def clean_bbox_from_ui_tool(extract_box_str):
+    """
+    This function converts the bbox string that comes from the UI tool to a
+    bbox ready to save to meta.json or pass to the pmtiles tool. It asserts a
+    few assumptions that are specific to the bbox coming out of the UI tool,
+    then "cleans" the numbers and does a final check for other errors in the
+    numbers to make sure it's fit for saving or pmtiles tool.
+    """
     try:
         # `float` is important here even if just as a parsing check.
         min_lon, min_lat, max_lon, max_lat = [float(n) for n in extract_box_str.split(",")]
@@ -194,7 +178,11 @@ def clean_extract_box(extract_box_str):
           )
         ) - 180             # Finally subtracting 180 will *in fact* set our range to -180 <= x < 180
 
-    return [lon_modulo(min_lon), min_lat, lon_modulo(max_lon), max_lat]
+    bbox = [lon_modulo(min_lon), min_lat, lon_modulo(max_lon), max_lat]
+    error = check_bbox_error(bbox)
+    if error:
+        raise ValueError(f"Extract box ({extract_box_str}) is invalid after cleaning ({bbox}) : {error}")
+    return bbox
 
 def validate_noninteractive(noninteractive):
     assert noninteractive in ("", "noninteractive"), f"`noninteractive` (optional) should only be set to \"noninteractive\". Got {noninteractive}"
@@ -226,6 +214,9 @@ def get_extract_dir(extract_name):
     Make sure this matches makeFqrSourceId in index.html
     """
     return Path(HOSTING_DIR) / f"{extract_name}.fqr"
+
+def get_meta_file_path(fqr_dir):
+    return fqr_dir / "meta.json"
 
 def get_new_extract_paths(extract_name):
     """
@@ -289,7 +280,7 @@ def get_fqrs():
             fqrs[extract_name] = fqr_dir
     return fqrs
 
-def get_region_files_for_fqr(extract_name, fqr_dir):
+def get_region_files_for_fqr(fqr_dir):
     """
     List pmtiles files for an FQR. `fqr_dir` is a `Path` object.
 
@@ -309,15 +300,7 @@ def get_region_files_for_fqr(extract_name, fqr_dir):
             case _:
                 print(f"Warning: can't parse possible pmtiles name in existing file: {full_path}")
                 continue
-        yield full_path, region_extract_type, date, extract_name
-
-def iter_region_files():
-    """
-    Get an inventory of existing pmtiles FQR files.
-    """
-    for extract_name, fqr_dir in get_fqrs().items():
-        for line in get_region_files_for_fqr(extract_name, fqr_dir):
-            yield line
+        yield full_path, region_extract_type, date
 
 def yes_no(prompt, noninteractive=False, noninteractive_response=None):
     if noninteractive:
@@ -369,11 +352,12 @@ def delete_extract(extract_name):
         return
 
     fqr_dir = fqrs[extract_name]
-    fqr_files = list(get_region_files_for_fqr(extract_name, fqr_dir))
+    fqr_files = list(get_region_files_for_fqr(fqr_dir))
 
-    fqr_region_extract_types = [region_extract_type for (_, region_extract_type, _, _) in fqr_files]
-    fqr_file_paths = [full_path for (full_path, _, _, _) in fqr_files]
+    fqr_region_extract_types = [region_extract_type for (_, region_extract_type, _) in fqr_files]
 
+    fqr_file_paths = [full_path for (full_path, _, _) in fqr_files]
+    meta_json_path = get_meta_file_path(fqr_dir)
     all_file_paths = list(fqr_dir.glob("*"))
 
     # At most one of each type, or nothing at all
@@ -382,14 +366,18 @@ def delete_extract(extract_name):
         for region_extract_type
         in fqr_region_extract_types
     } != {1})
-    has_extra_files = bool(set(all_file_paths) - set(fqr_file_paths))
+    has_extra_files = bool(set(all_file_paths) - set(fqr_file_paths + [meta_json_path]))
+    has_missing_files = bool(set([meta_json_path]) - set(all_file_paths))
 
     # The user might have messed around with the files. Either there's more
     # than one of satellite, terrain, or vector, or there are other unknown
     # files.
-    if has_region_extract_type_dupes or has_extra_files:
-        print (f"Warning: there are unexpected files for the region '{extract_name}'")
-        print ("(expected at most one 'openstreetmap-openmaptiles', one 's2maps-sentinel2-2023', and one 'terrarium', and nothing else)")
+    if has_region_extract_type_dupes or has_extra_files or has_missing_files:
+        print (f"Warning: there are unexpected or missing files for the region '{extract_name}'. Expected:")
+        print ("  * meta.json")
+        print ("  * at most one 'openstreetmap-openmaptiles' file")
+        print ("  * at most one 's2maps-sentinel2-2023' file")
+        print ("  * at most one 'terrarium' file")
         print ()
     print ("Files and directories to be deleted:")
     list_files(fqr_dir)
@@ -416,7 +404,22 @@ def create_extract(extract_box, extract_name, extract_paths):
         if result.returncode != 0:
             raise Exception(f"Region download failed. Double-check your Internet connection. (error code {result.returncode})")
 
-    get_extract_dir(extract_name).mkdir()
+    # I considered putting the fqr into a directory and moving it over
+    # atomically. However, later we will deal in "updates" which will be harder
+    # to do atomically. I'd rather not have two different ways of doing this.
+    fqr_dir = get_extract_dir(extract_name)
+    fqr_dir.mkdir()
+    # Let's write the meta.json first, making it an official fqr, before we
+    # move the pmtiles files. If we move the pmtiles files first and there's
+    # an error before making the meta file, it won't be an official fqr and
+    # they may have trouble deleting it. If there's an error after the meta
+    # file but before the pmtiles files, they can at least delete it and
+    # try again. (or eventually, they can "update" it which will grab any
+    # missing pmtiles files).
+    json.dump(
+        {"bbox": extract_box},
+        get_meta_file_path(fqr_dir).open("w")
+    )
     for paths in extract_paths.values():
         shutil.move(paths["tmp"], paths["extract"])
 
@@ -520,23 +523,43 @@ def check_for_existing_name(extract_name):
         return False
     return True
 
-def check_for_overlaps(new_box):
-    [new_min_lon, new_min_lat, new_max_lon, new_max_lat] = new_box
+def _split_antimeridian_bbox(bbox):
+    return (
+        [bbox[0], bbox[1], 180, bbox[3]],
+        [-180, bbox[1], bbox[2], bbox[3]],
+    )
+
+def _has_overlap(bbox_1, bbox_2):
+    if bbox_1[0] > bbox_1[2]:
+        bbox_1_east, bbox_1_west = _split_antimeridian_bbox(bbox_1)
+        return (
+            _has_overlap(bbox_1_east, bbox_2) or
+            _has_overlap(bbox_1_west, bbox_2)
+        )
+    if bbox_2[0] > bbox_2[2]:
+        bbox_2_east, bbox_2_west = _split_antimeridian_bbox(bbox_2)
+        return (
+            _has_overlap(bbox_1, bbox_2_east) or
+            _has_overlap(bbox_1, bbox_2_west)
+        )
+
+    # Two normal squares
+    return (
+        bbox_1[0] < bbox_2[2] and
+        bbox_2[0] < bbox_1[2] and
+        bbox_1[1] < bbox_2[3] and
+        bbox_2[1] < bbox_1[3]
+    )
+
+def check_for_overlaps(new_bbox):
+    """
+    Assumes new_box and existing boxes are validated
+    """
 
     existing_region_extracts = json.loads(open(EXTRACTS_JSON).read())["regions"]
-    for existing in existing_region_extracts.values():
-        [long_1, lat_1, long_2, lat_2] = existing['ui_bounds']
-        existing_min_lon = min([long_1, long_2])
-        existing_max_lon = max([long_1, long_2])
-        existing_min_lat = min([lat_1, lat_2])
-        existing_max_lat = max([lat_1, lat_2])
 
-        if (
-            new_min_lon < existing_max_lon and
-            new_max_lon > existing_min_lon and
-            new_min_lat  < existing_max_lat and
-            new_max_lat  > existing_min_lat
-        ):
+    for existing_region in existing_region_extracts.values():
+        if _has_overlap(new_bbox, existing_region["ui_bounds"]):
             return False
 
     return True
@@ -559,32 +582,27 @@ def update_extracts_json():
     region_extracts = defaultdict(
         lambda: dict(dates=defaultdict(dict)),
     )
-    # region_extract_types[extract_name] = {extract_type_1, extract_type_2, etc}
-    region_extract_types = defaultdict(set)
 
-    for full_path, region_extract_type, date, extract_name in iter_region_files():
-        render_bounds, ui_bounds = get_bounds(full_path)
+    for extract_name, fqr_dir in get_fqrs().items():
+        render_bounds, ui_bounds = get_bounds(extract_name, fqr_dir)
         if render_bounds is None:
             continue # Something went really haywire. Skip this pmtiles file.
-
-        # Add coordinates unless it's for some reason inconsistent between satellite, vector, terrain.
-        if extract_name in region_extracts:
-            # Let's be lenient and let these happen with a warning. Better to have
-            # something that works. Hopefully it's close to what they need and expect.
-            old, new = region_extracts[extract_name]['render_bounds'], render_bounds
-            if old != new:
-                print (f"Warning: inconsistent render_bounds between different region extracts for '{extract_name}'", '\n* ', old, '\n* ', new)
-            old, new = region_extracts[extract_name]['ui_bounds'], ui_bounds
-            if old != new:
-                print (f"Warning: inconsistent ui_bounds between different region extracts for '{extract_name}'",     '\n* ', old, '\n* ', new)
         region_extracts[extract_name]["ui_bounds"] = ui_bounds
         region_extracts[extract_name]["render_bounds"] = render_bounds
-        region_extracts[extract_name]["dates"][REGION_TYPES_FOR_DATE[region_extract_type]] = date
-        region_extract_types[extract_name].add(region_extract_type)
 
-    for extract_name in region_extract_types:
-        if region_extract_types[extract_name] != VALID_REGION_EXTRACT_TYPES:
-            print ("Warning: don't have all three types of ptiles files for:", extract_name, "Have:", region_extract_types[extract_name])
+        for _, region_extract_type, date in get_region_files_for_fqr(fqr_dir):
+            region_extracts[extract_name]["dates"][REGION_TYPES_FOR_DATE[region_extract_type]] = date
+
+        missing_region_types = set(REGION_TYPES_FOR_DATE.values()) - set(region_extracts[extract_name]["dates"].keys())
+
+        if missing_region_types:
+            print (f"Warning: don't have all three types of pmtiles files for '{extract_name}'.")
+            print ("Have:", set(region_extracts[extract_name]["dates"].keys()), "Missing:", missing_region_types)
+            print ("To get the missing files, delete this region and download it again. The command to delete it is:")
+            print() # TODO - recommend an "update" instead of delete when we implement that
+            print(delete_command(extract_name))
+            print() # Extra line because we may list multiple incomplete FQRs here
+
     extracts = {"regions": region_extracts}
     open(EXTRACTS_JSON, "w").write(json.dumps(extracts))
 
@@ -613,7 +631,7 @@ def main():
             noninteractive = sys.argv[4] if len(sys.argv) > 4 else ""
 
             validate_extract_name(extract_name)
-            extract_box = clean_extract_box(extract_box_str)
+            extract_box = clean_bbox_from_ui_tool(extract_box_str)
             validate_noninteractive(noninteractive)
             noninteractive = bool(noninteractive)
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -26,7 +26,7 @@ def delete_command(extract_name):
         f"sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py delete {extract_name}"
     )
 
-def get_bounds(extract_name, fqr_dir):
+def get_fqr_bbox(extract_name, fqr_dir):
     # If we want to inspect the actual files (perhaps to inform users if their
     # pmtiles files don't match their fqr's bbox), see the version of
     # `get_bounds` at commit 351399c7fdc534d6ea6ce7f64dae9757d695ceaf
@@ -37,40 +37,44 @@ def get_bounds(extract_name, fqr_dir):
     except FileNotFoundError:
         # TODO nov 2026 or so we can remove "updated your IIAB recently". This
         # refers to the transition of adding the meta.json file to the fqr directory.
-        print (f"Warning: not displaying '{extract_name}' on the map - meta.json not found. This might be because of an incomplete download, or a recent IIAB update.")
+        return None, "meta.json not found. This might be because of an incomplete download, or a recent IIAB update."
+    except (json.decoder.JSONDecodeError, KeyError):
+        return None, "malformed meta.json"
+    else:
+        error = check_bbox_error(bbox)
+        if error:
+            error = f"bbox error - {error}"
+        return bbox, error
+
+def get_frontend_bounds(extract_name, fqr_dir):
+    bbox, error = get_fqr_bbox(extract_name, fqr_dir)
+    if error:
+        print (f"Warning: not displaying '{extract_name}' on the map - {error}")
         print ("You may need to delete this region and download it again. The command to delete it is:")
         print()
         print(delete_command(extract_name))
         print() # Extra line because we may list multiple incomplete FQRs here
-    except (json.decoder.JSONDecodeError, KeyError):
-        print (f"Warning: not displaying '{extract_name}' on the map - malformed meta.json")
+        return None, None
+
+    if bbox[0] < bbox[2]:
+        # normal
+        ui_bounds = render_bounds = bbox
     else:
-        error = check_bbox_error(bbox)
-        if error:
-            print (f"Warning: not displaying '{extract_name}' on the map - bbox error - {error}")
-            return None, None
+        # cross antimeridian
+        ui_bounds = [
+            bbox[0],
+            bbox[1],
+            bbox[2] + 360,
+            bbox[3],
+        ]
+        render_bounds = [
+            -180,
+            bbox[1],
+            180,
+            bbox[3],
+        ]
 
-        if bbox[0] < bbox[2]:
-            # normal
-            ui_bounds = render_bounds = bbox
-        else:
-            # cross antimeridian
-            ui_bounds = [
-                bbox[0],
-                bbox[1],
-                bbox[2] + 360,
-                bbox[3],
-            ]
-            render_bounds = [
-                -180,
-                bbox[1],
-                180,
-                bbox[3],
-            ]
-
-        return render_bounds, ui_bounds
-
-    return None, None
+    return render_bounds, ui_bounds
 
 # `REGION_TYPES_FOR_DATE` maps the region types seen in the pmtiles file names
 # to the keys in the "dates" substructure in the extracts file:
@@ -555,11 +559,9 @@ def check_for_overlaps(new_bbox):
     """
     Assumes new_box and existing boxes are validated
     """
-
-    existing_region_extracts = json.loads(open(EXTRACTS_JSON).read())["regions"]
-
-    for existing_region in existing_region_extracts.values():
-        if _has_overlap(new_bbox, existing_region["ui_bounds"]):
+    for extract_name, fqr_dir in get_fqrs().items():
+        existing_bbox, error = get_fqr_bbox(extract_name, fqr_dir)
+        if not error and _has_overlap(new_bbox, existing_bbox):
             return False
 
     return True
@@ -584,7 +586,7 @@ def update_extracts_json():
     )
 
     for extract_name, fqr_dir in get_fqrs().items():
-        render_bounds, ui_bounds = get_bounds(extract_name, fqr_dir)
+        render_bounds, ui_bounds = get_frontend_bounds(extract_name, fqr_dir)
         if render_bounds is None:
             continue # Something went really haywire. Skip this pmtiles file.
         region_extracts[extract_name]["ui_bounds"] = ui_bounds
@@ -636,7 +638,6 @@ def main():
             noninteractive = bool(noninteractive)
 
             # Check arguments against existing data
-            update_extracts_json() # Make sure we have updated data before we check for overlaps
             if not check_for_overlaps(extract_box):
                 if noninteractive:
                     sys.exit(0)

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -7,8 +7,8 @@ from collections import defaultdict
 sys.path.insert(1, "{{ maps_tools.tile_extract.working_dir }}/pmtiles-python/python/pmtiles")
 
 CATALOG_URL = "{{ maps_catalog_url }}"
-HOSTING_DIR = "{{ maps_serve_path }}"
-EXTRACTS_JSON = os.path.join(HOSTING_DIR, "{{ maps_tools.tile_extract.info_file }}")
+HOSTING_DIR = Path("{{ maps_serve_path }}")
+EXTRACTS_JSON = HOSTING_DIR / "{{ maps_tools.tile_extract.info_file }}"
 PMTILES = "{{ maps_tools.pmtiles.executable_path }}"
 TMP_DIR = "/library/downloads/maps"
 
@@ -31,9 +31,8 @@ def get_fqr_bbox(extract_name, fqr_dir):
     # pmtiles files don't match their fqr's bbox), see the version of
     # `get_bounds` at commit 351399c7fdc534d6ea6ce7f64dae9757d695ceaf
     try:
-        bbox = json.load(
-            get_meta_file_path(fqr_dir).open("r")
-        )["bbox"]
+        with get_meta_file_path(fqr_dir).open("r") as f:
+            bbox = json.load(f)["bbox"]
     except FileNotFoundError:
         # TODO nov 2026 or so we can remove "updated your IIAB recently". This
         # refers to the transition of adding the meta.json file to the fqr directory.
@@ -217,7 +216,7 @@ def get_extract_dir(extract_name):
     """
     Make sure this matches makeFqrSourceId in index.html
     """
-    return Path(HOSTING_DIR) / f"{extract_name}.fqr"
+    return HOSTING_DIR / f"{extract_name}.fqr"
 
 def get_meta_file_path(fqr_dir):
     return fqr_dir / "meta.json"
@@ -273,7 +272,7 @@ def get_fqrs():
     Directories with .fqr extension that are otherwise invalid are skipped with a warning.
     """
     fqrs = {}
-    for fqr_dir in Path(HOSTING_DIR).glob("*.fqr"):
+    for fqr_dir in HOSTING_DIR.glob("*.fqr"):
         extract_name = fqr_dir.name.rsplit('.')[0]
         error = check_extract_name_error(extract_name)
         if error:
@@ -390,7 +389,7 @@ def delete_extract(extract_name):
     if not yes_no("Confirm delete?"):
         return
 
-    if fqr_dir.parent != Path(HOSTING_DIR) or fqr_dir.name != f"{extract_name}.fqr":
+    if fqr_dir.parent != HOSTING_DIR or fqr_dir.name != f"{extract_name}.fqr":
         # Last-minute sanity check before deleting fqr_dir in case a new
         # bug is introduced before we get to this point.
         raise Exception("Unknown error. Stopping before we delete the wrong directory!", fqr_dir)
@@ -420,10 +419,8 @@ def create_extract(extract_box, extract_name, extract_paths):
     # file but before the pmtiles files, they can at least delete it and
     # try again. (or eventually, they can "update" it which will grab any
     # missing pmtiles files).
-    json.dump(
-        {"bbox": extract_box},
-        get_meta_file_path(fqr_dir).open("w")
-    )
+    with get_meta_file_path(fqr_dir).open("w") as f:
+        json.dump({"bbox": extract_box}, f)
     for paths in extract_paths.values():
         shutil.move(paths["tmp"], paths["extract"])
 
@@ -606,7 +603,8 @@ def update_extracts_json():
             print() # Extra line because we may list multiple incomplete FQRs here
 
     extracts = {"regions": region_extracts}
-    open(EXTRACTS_JSON, "w").write(json.dumps(extracts))
+    with EXTRACTS_JSON.open("w") as f:
+        json.dump(extracts, f)
 
 def main():
     match sys.argv[1]:

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -144,7 +144,7 @@ REGION_TYPES_FOR_DATE = {
 VALID_REGION_EXTRACT_TYPES = set(REGION_TYPES_FOR_DATE.keys())
 
 def check_extract_name_error(extract_name):
-    if not (set(extract_name) < set(string.ascii_letters + string.digits + "-_")):
+    if not set(extract_name) < set(string.ascii_letters + string.digits + "-_"):
         return "name contains invalid characters"
     if len(extract_name) == 0:
         return "name is missing"
@@ -484,7 +484,7 @@ def approve_download_size(extract_box, extract_paths):
         # If something falls through the cracks
         return f"{num_bytes} Bytes"
 
-    total_b, used_b, free_b = shutil.disk_usage(TMP_DIR)
+    _, _, free_b = shutil.disk_usage(TMP_DIR)
 
     # Ask the user if they're okay with the size.
     return yes_no(

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -270,25 +270,25 @@ def get_fqrs():
     Directories with .fqr extension that are otherwise invalid are skipped with a warning.
     """
     fqrs = {}
-    for fqr in Path(HOSTING_DIR).glob("*.fqr"):
-        extract_name = fqr.name.rsplit('.')[0]
+    for fqr_dir in Path(HOSTING_DIR).glob("*.fqr"):
+        extract_name = fqr_dir.name.rsplit('.')[0]
         error = check_extract_name_error(extract_name)
         if error:
-            print(f"Warning: Can't parse possible FQR dir name ({fqr}) - {error}")
-        elif not fqr.is_dir():
-            print(f"Warning: not a directory - {fqr}")
+            print(f"Warning: Can't parse possible FQR dir name ({fqr_dir}) - {error}")
+        elif not fqr_dir.is_dir():
+            print(f"Warning: not a directory - {fqr_dir}")
         else:
-            fqrs[extract_name] = fqr
+            fqrs[extract_name] = fqr_dir
     return fqrs
 
-def get_region_files_for_fqr(extract_name, fqr):
+def get_region_files_for_fqr(extract_name, fqr_dir):
     """
-    List pmtiles files for an FQR. `fqr` is a `Path` object.
+    List pmtiles files for an FQR. `fqr_dir` is a `Path` object.
 
     Files with .pmtiles extension that are otherwise invalid are skipped with a warning.
     """
 
-    for full_path in fqr.glob("*.pmtiles"):
+    for full_path in fqr_dir.glob("*.pmtiles"):
         match (full_path.name.split('.')):
             case [region_extract_type, date, "pmtiles"]:
                 error = check_date_error(date)
@@ -307,8 +307,8 @@ def iter_region_files():
     """
     Get an inventory of existing pmtiles FQR files.
     """
-    for extract_name, fqr in get_fqrs().items():
-        for line in get_region_files_for_fqr(extract_name, fqr):
+    for extract_name, fqr_dir in get_fqrs().items():
+        for line in get_region_files_for_fqr(extract_name, fqr_dir):
             yield line
 
 def yes_no(prompt, noninteractive=False, noninteractive_response=None):
@@ -360,13 +360,13 @@ def delete_extract(extract_name):
         print (f"Found no Full Quality Regions with the name '{extract_name}'")
         return
 
-    fqr = fqrs[extract_name]
-    fqr_files = list(get_region_files_for_fqr(extract_name, fqr))
+    fqr_dir = fqrs[extract_name]
+    fqr_files = list(get_region_files_for_fqr(extract_name, fqr_dir))
 
     fqr_region_extract_types = [region_extract_type for (_, region_extract_type, _, _) in fqr_files]
     fqr_file_paths = [full_path for (full_path, _, _, _) in fqr_files]
 
-    all_file_paths = list(fqr.glob("*"))
+    all_file_paths = list(fqr_dir.glob("*"))
 
     # At most one of each type, or nothing at all
     has_region_extract_type_dupes = fqr_region_extract_types and ({
@@ -384,17 +384,17 @@ def delete_extract(extract_name):
         print ("(expected at most one 'openstreetmap-openmaptiles', one 's2maps-sentinel2-2023', and one 'terrarium', and nothing else)")
         print ()
     print ("Files and directories to be deleted:")
-    list_files(fqr)
+    list_files(fqr_dir)
     print()
 
     if not yes_no("Confirm delete?"):
         return
 
-    if fqr.parent != Path(HOSTING_DIR) or fqr.name != f"{extract_name}.fqr":
-        # Last-minute sanity check before deleting fqr directory in case a new
+    if fqr_dir.parent != Path(HOSTING_DIR) or fqr_dir.name != f"{extract_name}.fqr":
+        # Last-minute sanity check before deleting fqr_dir in case a new
         # bug is introduced before we get to this point.
-        raise Exception("Unknown error. Stopping before we delete the wrong directory!", fqr)
-    shutil.rmtree(fqr)
+        raise Exception("Unknown error. Stopping before we delete the wrong directory!", fqr_dir)
+    shutil.rmtree(fqr_dir)
 
     print(f"Full Quality Region data for {extract_name} has been deleted.")
 


### PR DESCRIPTION
### Description of changes proposed in this pull request:

When creating an FQR, store the region's `bbox` in `meta.json` in the FQR's directory. Use this `bbox` to determine what the region is for the purposes of displaying on the map, check for overlapping regions, etc. In the near future it'll be used for FQR updates. 

Also starting to add some tests. For now I have tests for detecting overlapping regions (since it's especially error prone). It might pass for now on a dev machine, but over time you may have to install it to run the tests it since `tile-extract.py` is made from a template. So when we put this in CI I think we should do it that way.

**This again invalidates all previous FQRs**. I tried my best to give useful error messages for IIAB-updating implementers to cope, namely to delete and download again. (While I was at it, I added this delete hint as a suggestion for users who are missing one or two of the 3 components [osm, satellite, terrain] in their FQR to get those items. However eventually that will be replaced with a suggestion to update.)

I didn't split this up quite as much to smaller commits. I felt like it was diminishing returns. LMK if it's hard to follow. I may add some clarifying comments here.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:

@holta @chapmanjacobd