### PR TITLE
Update the region extract script to only deal in our standard `bbox`

### DIFF
--- a/roles/maps/FORMAT.md
+++ b/roles/maps/FORMAT.md
@@ -1,4 +1,4 @@
-# Naming Convention
+# Naming Conventions
 
 How map data files are named
 
@@ -36,10 +36,44 @@ africa . fqr / terrarium                  . 2025-12-10 . pmtiles
 [region].fqr/[type].[date].[extension (for files)]
 ```
 
-# Key
+## Key
 
 * `type` refers to the data source for pmtiles files, or the search engine for search
 * `date` refers to the date that the data was generated
 * `depth` refers to the zoom level range for pmtiles files, or in the case of search it refers to the type or amount of search data available. Depth should not be named "full-region".
 * `region` is the user-defined name of the FQR
 * `extension` is a file extension in the case of files, or nothing in the case of directories.
+
+# File Specifications
+
+## Full Quality Regions
+
+Full Quality Regions are stored in directories. They contain data files for that region, as well as `meta.json`. For example:
+
+London:
+
+```
+{"bbox": [-0.172187453, 51.477245915, -0.143235226, 51.493348151]}
+```
+
+Rabi Island, Fiji (crosses 180 longitude, see below):
+
+```
+{"bbox": [179.967638715, -16.54082487, -179.911191897, -16.438722265]}
+```
+
+The field `bbox` refers to the bounding box of the region:
+
+```
+{"bbox": [<min_lon>, <min_lat>, <max_lon>, <max_lat>]}
+```
+
+Latitudes have the following requirements:
+* `-90 <= min_lat < max_lat <= 90`
+
+Longitudes have the following requirements:
+* `min_lon != max_lon`
+* `-180 < min_lon <= 180`
+* `-180 < max_lon <= 180`
+
+Note that `max_lon < min_lon` is possible, and implies that the region crosses the 180/-180 longitude (aka the "antimeridian").

--- a/roles/maps/README.md
+++ b/roles/maps/README.md
@@ -290,7 +290,7 @@ sudo ./runrole maps --reinstall
 * [Other map variables](https://github.com/iiab/iiab/blob/master/roles/maps/defaults/main.yml) originally based on [PR #4120](https://github.com/iiab/iiab/pull/4120) from Oct/Nov 2025
 * Map data files are updated quasi-monthly here, since 2026-04-14: https://iiab.switnet.org/maps/2/
 * IIAB integration thanks to [Dan Krol](https://github.com/orblivion)
-* [Details on data file naming conventions](https://github.com/iiab/iiab/blob/master/roles/maps/NAMING_CONVENTION.md)
+* [Details on data file specs and naming conventions](https://github.com/iiab/iiab/blob/master/roles/maps/FORMAT.md)
 
 ## Next Steps
 

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -702,10 +702,32 @@
                     })
                     .then((json) => {
                         if (json && json.regions) {
-                            downloadedFQRegions = {regions: json.regions};
+                            downloadedFQRegions = {
+                                // copy the regions from extracts.json, but generate ui_bounds and render_bounds from bbox
+                                regions: Object.fromEntries(
+                                  Object.entries(json.regions).map(([regionName, regionData]) =>
+                                      [regionName,
+                                        regionData.bbox[0] <= regionData.bbox[2] ? {
+                                          // if we're not crossing the antimeridian, `ui_bounds` and `render_bounds` are the same as `bbox`
+                                          ...regionData,
+                                          ui_bounds: regionData.bbox,
+                                          render_bounds: regionData.bbox,
+                                        } : {
+                                          // if we are crossing the antimeridian, `ui_bounds` should add 360 to the east so that
+                                          // east > west, and `render_bounds` should be the entire width of the world because
+                                          // it's actually two partial regions on opposite sides of the map
+                                          ...regionData,
+                                          ui_bounds: [regionData.bbox[0], regionData.bbox[1], regionData.bbox[2] + 360, regionData.bbox[3]],
+                                          render_bounds: [-179.99999999, regionData.bbox[1], 180, regionData.bbox[3]],
+                                        }
+                                      ]
+                                  )
+                                )
+                            }
                         } else {
                             downloadedFQRegions = {error: true, regions: {}}
                         }
+
                     });
             }
             setFQRegions()

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -79,8 +79,8 @@
 
         <script src="maps.black-component.js" type="module"></script>
         <script>
-	    // MapLibre sources have IDs and URLs. For FQRs we use the ID to generate the URL,
-	    // which is why it looks sort of like a URL path.
+            // MapLibre sources have IDs and URLs. For FQRs we use the ID to generate the URL,
+            // which is why it looks sort of like a URL path.
             // Make sure this matches get_extract_dir and get_new_extract_paths in tile-extract.py
             makeFqrSourceId = (fqrName, baseId, dataDate) => `${fqrName}.fqr/${baseId}.${dataDate}`
 
@@ -1065,18 +1065,36 @@
                         //
                         // Therefore, the min/max sorting should work as intended even if the bounding box straddles the
                         // 180/-180 line. Furthermore, a lot of the downstream headaches with displaying regions go away.
+                        //
+                        // That said, when we pass these coordinates to the downloader tool, we "wrap" the numbers at
+                        // -180/180. We avoid my initial concern (above) by preserving the order of the coordinates.
                         const lats = shape.map( ([lon, lat]) => lat)
                         const lons = shape.map( ([lon, lat]) => lon)
 
-                        const min_lon = Math.min.apply(null, lons)
-                        const min_lat = Math.min.apply(null, lats)
-                        const max_lon = Math.max.apply(null, lons)
-                        const max_lat = Math.max.apply(null, lats)
+                        // As returned by the drawing tool. Useful for finding coordinates in the UI.
+                        const drawnBounds = new maplibregl.LngLatBounds([
+                          [Math.min.apply(null, lons), Math.min.apply(null, lats)],
+                          [Math.max.apply(null, lons), Math.max.apply(null, lats)],
+                        ])
 
-                        const center = [
-                            min_lon + (max_lon - min_lon) / 2,
-                            min_lat + (max_lat - min_lat) / 2,
-                        ]
+                        // With longitude within (-180 + epsilon, 180). Useful for passing to the downloader tool.
+                        const wrappedBounds = (() => {
+                            // Convert from the UI's coordinate system to our standard -180 to 180 longitude.
+                            if (drawnBounds.getEast() - drawnBounds.getWest() >= 360) {
+                                // If we naively wrape() after the user draws a region that covers *more* than the
+                                // width of the world, we would lose information and get the wrong region. Instead, if
+                                // the user does this, we'll more deliberately select the whole width of the world.
+                                return new maplibregl.LngLatBounds([
+                                  [-179.99999999, drawnBounds.getSouth()],
+                                  [180, drawnBounds.getNorth()],
+                                ])
+                            } else {
+                                return new maplibregl.LngLatBounds([
+                                  drawnBounds.getSouthWest().wrap(),
+                                  drawnBounds.getNorthEast().wrap(),
+                                ])
+                            }
+                        })()
 
                         function popupButton(textContent, onclick) {
                             const button = document.createElement('button')
@@ -1104,6 +1122,7 @@
 
                         const downloadCommand = document.createElement('div');
                         downloadCommand.set = function(downloadName) {
+                            const [[min_lon, min_lat], [max_lon, max_lat]] = wrappedBounds.toArray()
                             const downloadCommandString = `sudo {{ maps_tools.tile_extract.working_dir }}/tile-extract.py extract ${downloadName} ${min_lon},${min_lat},${max_lon},${max_lat}`
                             this.innerHTML = `<pre
                                 style="font-size:0.8em; background-color:#DDD; padding:1em; border-style:dashed; border-color:#FFF; border-width:2px; white-space: pre-wrap; word-wrap: break-word; line-height:1em;"
@@ -1177,7 +1196,7 @@
                         popupContainer.appendChild(popupFinish)
 
                         downloadPopup = new maplibregl.Popup({closeOnClick: false, closeButton: false})
-                            .setLngLat(center)
+                            .setLngLat(drawnBounds.getCenter())
                             .setDOMContent(popupContainer)
                             .addTo(mb.map);
                     })

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -1103,7 +1103,7 @@
                         const wrappedBounds = (() => {
                             // Convert from the UI's coordinate system to our standard -180 to 180 longitude.
                             if (drawnBounds.getEast() - drawnBounds.getWest() >= 360) {
-                                // If we naively wrape() after the user draws a region that covers *more* than the
+                                // If we naively wrap() after the user draws a region that covers *more* than the
                                 // width of the world, we would lose information and get the wrong region. Instead, if
                                 // the user does this, we'll more deliberately select the whole width of the world.
                                 return new maplibregl.LngLatBounds([

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -40,6 +40,8 @@ def get_fqr_bbox(extract_name, fqr_dir):
     except (json.decoder.JSONDecodeError, KeyError):
         return None, "malformed meta.json"
     else:
+        # We don't necessarily trust our own meta.json files because the
+        # implementer may have been gotten it informally from a third party.
         error = check_bbox_error(bbox)
         if error:
             error = f"bbox error - {error}"
@@ -115,11 +117,8 @@ def validate_extract_name(extract_name):
 
 def check_bbox_error(bbox):
     """
-    What gets passed here ought to be ready to save to meta.json or pass to the
-    pmtiles tool (i.e. not directly from the ui tool). So here we make sure
-    that it is indeed so. We'll try not to make assumptions about where it came
-    from (whether a post-cleaning ui tool, or from a meta.json file, or maybe
-    someplace else), so we'll check the structure of everything as well.
+    Check if `bbox` meets our standard format, including the basic structure.
+    It should be ready to save to meta.json or pass to the pmtiles tool.
     """
 
     if not isinstance(bbox, list):
@@ -148,43 +147,20 @@ def check_bbox_error(bbox):
         if lat < -90:
             return "latitude < -90"
 
-def clean_bbox_from_ui_tool(extract_box_str):
+def parse_bbox(extract_box_str):
     """
-    This function converts the bbox string that comes from the UI tool to a
-    bbox ready to save to meta.json or pass to the pmtiles tool. It asserts a
-    few assumptions that are specific to the bbox coming out of the UI tool,
-    then "cleans" the numbers and does a final check for other errors in the
-    numbers to make sure it's fit for saving or pmtiles tool.
+    This function parses and validates the bbox string that comes from the UI tool
     """
     try:
         # `float` is important here even if just as a parsing check.
         min_lon, min_lat, max_lon, max_lat = [float(n) for n in extract_box_str.split(",")]
-
-        # I am concerned about longitudes in particular because -180 and 180 refer to the same place.
-        # I expect to get all all positives or all negatives for longitudes (see the big comment in
-        # index.html, inside `terraDrawInstance.on("finish"` for details) but this is just based on
-        # observation. I would like to confirm it here.
-        assert min_lon < max_lon, "longitudes seem to be out of order"
-        assert min_lat < max_lat, "latitudes seem to be out of order"
-        assert max_lon - min_lon < 360, "FQR can't wrap around the world"
-
     except Exception as e:
         raise ValueError(f"Extract box ({extract_box_str}) is malformed: {e}")
 
-    def lon_modulo(lon):
-        # We want the longitudes to be from -180 to just under 180. We want to perform a
-        # modulo 360 to give it an equivalent longitude, but starting at -180 instead of 0.
-        return (
-          (                 # Start off assuming that lon "ought to be" in the range of -180 <= x < 180
-            (lon + 180)     # Thus, lon + 180 "ought to be" in the range of 0 <= x < 360
-            % 360           # Modulo 360 will *in fact* change our range to 0 <= x < 360
-          )
-        ) - 180             # Finally subtracting 180 will *in fact* set our range to -180 <= x < 180
-
-    bbox = [lon_modulo(min_lon), min_lat, lon_modulo(max_lon), max_lat]
+    bbox = [min_lon, min_lat, max_lon, max_lat]
     error = check_bbox_error(bbox)
     if error:
-        raise ValueError(f"Extract box ({extract_box_str}) is invalid after cleaning ({bbox}) : {error}")
+        raise ValueError(f"Extract box ({extract_box_str}) is invalid: {error}")
     return bbox
 
 def validate_noninteractive(noninteractive):
@@ -631,7 +607,7 @@ def main():
             noninteractive = sys.argv[4] if len(sys.argv) > 4 else ""
 
             validate_extract_name(extract_name)
-            extract_box = clean_bbox_from_ui_tool(extract_box_str)
+            extract_box = parse_bbox(extract_box_str)
             validate_noninteractive(noninteractive)
             noninteractive = bool(noninteractive)
 

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -135,10 +135,10 @@ def check_bbox_error(bbox):
     if min_lon == max_lon:
         return "longitudes are equal"
     for lon in [min_lon, max_lon]:
-        if lon >= 180:
-            return "longitude >= 180"
-        if lon < -180:
-            return "longitude < -180"
+        if lon > 180:
+            return "longitude > 180"
+        if lon <= -180:
+            return "longitude <= -180"
 
     if min_lat >= max_lat:
         return "latitudes are equal or out of order"

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -47,43 +47,12 @@ def get_fqr_bbox(extract_name, fqr_dir):
             error = f"bbox error - {error}"
         return bbox, error
 
-def get_frontend_bounds(extract_name, fqr_dir):
-    bbox, error = get_fqr_bbox(extract_name, fqr_dir)
-    if error:
-        print (f"Warning: not displaying '{extract_name}' on the map - {error}")
-        print ("You may need to delete this region and download it again. The command to delete it is:")
-        print()
-        print(delete_command(extract_name))
-        print() # Extra line because we may list multiple incomplete FQRs here
-        return None, None
-
-    if bbox[0] < bbox[2]:
-        # normal
-        ui_bounds = render_bounds = bbox
-    else:
-        # cross antimeridian
-        ui_bounds = [
-            bbox[0],
-            bbox[1],
-            bbox[2] + 360,
-            bbox[3],
-        ]
-        render_bounds = [
-            -180,
-            bbox[1],
-            180,
-            bbox[3],
-        ]
-
-    return render_bounds, ui_bounds
-
 # `REGION_TYPES_FOR_DATE` maps the region types seen in the pmtiles file names
 # to the keys in the "dates" substructure in the extracts file:
 #
 # {
 #   extract_name: {
-#     "render_bounds": coordinates,
-#     "ui_bounds": coordinates,
+#     "bbox": coordinates,
 #     "dates": {
 #       "terrain": terrain_date,
 #       "vector": vector_date,
@@ -540,14 +509,8 @@ def check_for_overlaps(new_bbox):
     return True
 
 def update_extracts_json():
-    # render_bounds and ui_bounds are the same unless the region crosses the 180/-180 boundary.
-    # If it does cross, ui_bounds is what you'd expect, with one end of the bounds inside of
-    # the -180 to 180 range, and one outside. render_bounds on the other hand would have lng
-    # bounds of -180 to 180: two partial regions on opposite sides of the map.
-    #
     # region_extracts[extract_name] = {
-    #   "render_bounds": coordinates,
-    #   "ui_bounds": coordinates,
+    #   "bbox": coordinates,
     #   "dates": {
     #     "terrain": terrain_date,
     #     "vector": vector_date,
@@ -559,11 +522,15 @@ def update_extracts_json():
     )
 
     for extract_name, fqr_dir in get_fqrs().items():
-        render_bounds, ui_bounds = get_frontend_bounds(extract_name, fqr_dir)
-        if render_bounds is None:
+        bbox, error = get_fqr_bbox(extract_name, fqr_dir)
+        if error:
+            print (f"Warning: not displaying '{extract_name}' on the map - {error}")
+            print ("You may need to delete this region and download it again. The command to delete it is:")
+            print()
+            print(delete_command(extract_name))
+            print() # Extra line because we may list multiple incomplete FQRs here
             continue # Something went really haywire. Skip this pmtiles file.
-        region_extracts[extract_name]["ui_bounds"] = ui_bounds
-        region_extracts[extract_name]["render_bounds"] = render_bounds
+        region_extracts[extract_name]["bbox"] = bbox
 
         for _, region_extract_type, date in get_region_files_for_fqr(fqr_dir):
             region_extracts[extract_name]["dates"][REGION_TYPES_FOR_DATE[region_extract_type]] = date

--- a/vars/local_vars_maps_test.yml
+++ b/vars/local_vars_maps_test.yml
@@ -325,7 +325,7 @@ maps_preset_full_quality_regions:       # Small portion of london and Nepal moun
   - name: himalayas                     # Test terrain
     bbox: 83.680824998,28.401673033,84.055999541,28.724927625
   - name: rabi_island_fiji              # Test crossing the antimeridian
-    bbox: -180.032361285,-16.54082487,-179.911191897,-16.438722265
+    bbox: 179.967638715,-16.54082487,-179.911191897,-16.438722265
 
 # For details and valid values for these variables, see: https://github.com/iiab/iiab/blob/master/roles/maps/MAPS_CATALOG_DETAILS.md
 maps_vector_zoom: 1-ci


### PR DESCRIPTION
Sorry it's a lot of words here, but I think it's a relatively simple change.

### Description of changes proposed in this pull request:

Update the region extract script to only deal in our standard "-180 to 180" `bbox` (i.e. the one we save to `meta.json` for FQRs). Previously, the extract script would handle transformations that were useful for the UI (`ui_bounds`, `render_bounds`, etc). Now those transformations have been moved to the UI. I realized that it makes sense to push it closer to where it's actually needed.

#### Firstly, *inputs* to the extract script

When generating the CLI command for the extract script in the UI, we now transform the longitudes so that they are always between -180 and 180. Previously, the UI could pass in longitudes of 170 to 190 and the extract script would convert it to 170 to -170. Now the UI does this when generating the extract script command, and the script requires it.

While I was at it: if the user makes a region that takes up more than the width of the world, it now turns the longitudes into -179.99999999 to 180 so they get the whole width. Previously the extract script threw an error if the longitude difference was more than 360.

#### Secondly, *outputs* from the extract script

No longer saving `ui_bounds` and `render_bounds` to `extracts.json` (the file that the front end reads to learn about available FQRs). Instead, we directly save `bbox`, just like `meta.json`. (We actually had this before, but it was before we came up with our new longitude standard). `ui_bounds` and `render_bounds` are now calculated by the front end upon reading `extracts.json`.

*(If you're curious: `ui_bounds` is used to draw the rectangle for the FQR, and it seems to want the same coordinate system that the rectangle drawing tool wants, i.e. east longitude > west longitude instead of -180 to 180. `render_bounds` is how big of an area is covered by pmtiles. It actually wants longitude values within -180 to 180, but for regions that cross the antimeridian [i.e. 170 to -170], it needs the values to cover the whole width of the planet, i.e. -180 to 180)*

#### Discovered along the way: change of our `bbox` standard

Update our bbox standard to match MapLibre's `wrap()`, which does the desired longitude transformation (similar to the `lon_modulo` function I previously had in the extract script). Our standard was previously -180 to 179.9999.... MapLibre seems to go by -179.9999... to 180, and I think it would make our lives easier to match them.

I also document this (along with `meta.json` in general) by renaming `NAMING_CONVENTIONS.md` to `FORMAT.md` and adding a section. Not sure where else to put it.

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

### Mention a team member @username e.g. to help with code review:
@chapmanjacobd @holta 