### PR TITLE
pin MongoDB v5 libssl1.1 dependency to debian security snapshot [for Sugarizer on Raspberry Pi]

### DIFF
--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -29,6 +29,9 @@ mongodb_arch_dict:
 
 mongodb_version: "{{ mongodb_arch_dict[ansible_facts.machine] | default('unknown') }}"    # A bit safer than ansible_architecture (see kiwix/defaults/main.yml)
 
+# Immutable Debian security snapshot used for MongoDB 5.0's libssl1.1 dependency.
+mongodb_debian_security_snapshot: "20260615T025018Z"
+
 #mongodb_arm64_version: 5.0    # 2023-02-24: MongoDB 6.0.4 fails to install on
 #                              # 64-bit RasPiOS 11, as it doesn't offer libssl3.
 #mongodb_amd64_version: 6.0    # 2022-10-23: 4.4 fails on Debian 12 x86_64:

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -204,10 +204,10 @@
         repo: deb http://ports.ubuntu.com/ubuntu-ports focal-security main
       when: is_ubuntu
 
-    - name: Install OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
+    - name: Install Debian security snapshot for libssl1.1 if Debian
       apt_repository:
-        repo: deb http://security.debian.org/debian-security bullseye-security main
-        #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
+        repo: "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/{{ mongodb_debian_security_snapshot }}/ bullseye-security main"
+        filename: iiab-bullseye-security-snapshot
       when: is_debian
 
     - name: Force install libssl1.1
@@ -215,10 +215,10 @@
         name: libssl1.1
         state: present
 
-    - name: Remove OLD source/repo "deb http://security.debian.org/debian-security bullseye-security main" at /etc/apt/sources.list.d/security_debian_org_debian_security.list if Debian
+    - name: Remove Debian security snapshot for libssl1.1 if Debian
       apt_repository:
-        repo: deb http://security.debian.org/debian-security bullseye-security main
-        #repo: deb https://deb.debian.org/debian-security bullseye-security main    # New way, likely equivalent
+        repo: "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/{{ mongodb_debian_security_snapshot }}/ bullseye-security main"
+        filename: iiab-bullseye-security-snapshot
         state: absent
       when: is_debian
 

--- a/roles/mongodb/templates/mongodb.sources.j2
+++ b/roles/mongodb/templates/mongodb.sources.j2
@@ -1,6 +1,7 @@
 Types: deb
 Trusted: yes
 URIs: https://repo.mongodb.org/apt/ubuntu/
+Architectures: {{ dpkg_arch.stdout }}
 {% if dpkg_arch.stdout != "arm64" %} 
 Suites: jammy/mongodb-org/{{ mongodb_version }} 
 {% else %} 


### PR DESCRIPTION
### Fixes bug:

- libssl1.1 no longer available

### Description of changes proposed in this pull request:

- pins MongoDB v5 libssl1.1 dependency to the debian security snapshot as the bullseye-security repo is archived now
- ~~upgrades to MongoDB v8 for rpi5+~~

### Smoke-tested on which OS or OS's:

CI

### Mention a team member @username e.g. to help with code review:

@holta