### PR TITLE
Kolibri PPA: Ubuntu 26.10 disallows SHA1 apt pkg sigs, so do as on Debian

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -70,15 +70,16 @@ kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-preven
 
 # Custom repo data by OS (PR #4300)
 kolibri_repo_dict:
-  True:    # when is_debian
+  True:    # when newer OS
     repo: https://learningequality.github.io/kolibri-installer-debian/
     keyring: /etc/apt/keyrings/learningequality-kolibri.asc
     suite: stable
-  False:    # when not is_debian
+  False:    # when older OS
     repo: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
     keyring: /etc/apt/keyrings/learningequality-kolibri.gpg
     suite: noble
 
-kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian].repo }}"
-kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian].keyring }}"
-kolibri_suite: "{{ kolibri_repo_dict[is_debian].suite }}"
+# SEE ALSO kolibri/tasks/install.yml LINE ~82
+kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].repo }}"
+kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].keyring }}"
+kolibri_suite: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].suite }}"

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,21 +71,15 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if not is_debian"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on older OS's"
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
     gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-  when: not is_debian
+  when: not is_debian and not (is_ubuntu and os_ver is version('ubuntu-2610', '>='))
 
-# 2026-03-11: LET'S DELETE THESE 4 LINES LATER IN 2026
-- name: "Remove Kolibri PPA's legacy apt .list"
-  file:
-    path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
-    state: absent
-
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if is_debian"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on newer OS's"
   shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"
-  when: is_debian
+  when: is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')    # SEE ALSO kolibri/defaults/main.yml LINES ~83 to ~85
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892


### PR DESCRIPTION
### Fixes bug:

- https://github.com/learningequality/kolibri/issues/15277

### Description of changes proposed in this pull request:

Do as on Debian 13+, as also explained here:
https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html

### Smoke-tested on which OS or OS's:

Ubuntu 26.10 "Stonking Stingray" which is scheduled for final release on October 15, 2026.

### Mention a team member @username e.g. to help with code review:

@chapmanjacobd