### PR TITLE
Modernize Kolibri PPA apt pkg sig across all OS's [required on Debian 13+ & Ubuntu 26.10+]

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -68,18 +68,6 @@ kolibri_nginx_template: "{{ 'kolibri-nginx-proot.conf.j2' if is_proot else 'koli
 # Set variables to patch kolibri on proot-distro environment
 kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-prevent_ip_error_out_due_A15_restrictions.patch"
 
-# Custom repo data by OS (PR #4300)
-kolibri_repo_dict:
-  True:    # when newer OS
-    repo: https://learningequality.github.io/kolibri-installer-debian/
-    keyring: /etc/apt/keyrings/learningequality-kolibri.asc
-    suite: stable
-  False:    # when older OS
-    repo: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
-    keyring: /etc/apt/keyrings/learningequality-kolibri.gpg
-    suite: noble
-
-# SEE ALSO kolibri/tasks/install.yml LINE ~82
-kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].repo }}"
-kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].keyring }}"
-kolibri_suite: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].suite }}"
+kolibri_repo_uris: https://learningequality.github.io/kolibri-installer-debian/
+kolibri_keyring_file: /etc/apt/keyrings/learningequality-kolibri.asc
+kolibri_suite: stable

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -70,15 +70,16 @@ kolibri_patch_path: "/opt/iiab/iiab/roles/proot_services/files/kolibri-00-preven
 
 # Custom repo data by OS (PR #4300)
 kolibri_repo_dict:
-  True:    # when is_debian
+  True:    # when newer OS
     repo: https://learningequality.github.io/kolibri-installer-debian/
     keyring: /etc/apt/keyrings/learningequality-kolibri.asc
     suite: stable
-  False:    # when not is_debian
+  False:    # when older OS
     repo: http://ppa.launchpad.net/learningequality/kolibri/ubuntu/
     keyring: /etc/apt/keyrings/learningequality-kolibri.gpg
     suite: noble
 
-kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian].repo }}"
-kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian].keyring }}"
-kolibri_suite: "{{ kolibri_repo_dict[is_debian].suite }}"
+# SEE ALSO kolibri/tasks/install.yml LINE ~82
+kolibri_repo_uris: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].repo }}"
+kolibri_keyring_file: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].keyring }}"
+kolibri_suite: "{{ kolibri_repo_dict[is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')].suite }}"

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,21 +71,15 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 # 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if not is_debian"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on older OS's"
   shell: |
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
     gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-  when: not is_debian
+  when: not is_debian and not (is_ubuntu and os_ver is version('ubuntu-2610', '>='))
 
-# 2026-03-11: LET'S DELETE THESE 4 LINES LATER IN 2026
-- name: "Remove Kolibri PPA's legacy apt .list"
-  file:
-    path: /etc/apt/sources.list.d/ppa_launchpad_net_learningequality_kolibri_ubuntu.list
-    state: absent
-
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- if is_debian"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on newer OS's"
   shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"
-  when: is_debian
+  when: is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')    # SEE ALSO kolibri/defaults/main.yml LINES ~83 to ~85
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -66,8 +66,8 @@
 # "When you use the PPA installation method, upgrades to newer versions
 # will be automatic, provided there is internet access available."
 #
-# IN REALITY: apt upgrading Kolibri is messy, as up-to-5 debconf screens prompt
-# PPL WHO DON'T KNOW with the wrong default username, instead of 'kolibri' :/
+# REALITY: apt upgrading Kolibri was (in the past?) messy, as up-to-5 debconf
+# screens prompt you with the wrong default username, instead of 'kolibri' :/
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 - name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
@@ -83,49 +83,6 @@
   template:
     src: kolibri.sources.j2
     dest: /etc/apt/sources.list.d/kolibri.sources
-#  apt_repository:
-#    repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main"
-#   when: is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12
-#   #when: is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12    # MINT 21 COVERED BY is_ubuntu_2204
-
-# - name: Add signed Kolibri PPA 'focal' (if other/older OS's)
-#   apt_repository:
-#     repo: "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu focal main"
-#   when: not (is_ubuntu and os_ver is version('ubuntu-2204', '>=') or is_linuxmint_21 or is_debian_12)
-#   #when: not (is_ubuntu_2204 or is_ubuntu_2210 or is_debian_12)
-
-# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' (if is_ubuntu and not is_linuxmint)
-#   apt_repository:
-#     repo: ppa:learningequality/kolibri
-#   when: is_ubuntu and not is_linuxmint
-
-# 2022-08-19: 'add-apt-repository ppa:learningequality/kolibri' works at CLI on
-# Mint 21 (creating /etc/apt/sources.list.d/learningequality-kolibri-jammy.list)
-# BUT equivalent Ansible command (STANZA ABOVE) failed with error...
-# "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/learningequality/kolibri/ubuntu vanessa Release' does not have a Release file."
-# ...so for now we special case Mint, similar to Debian (BOTH STANZAS BELOW!)
-
-# 2022-08-19: https://github.com/learningequality/kolibri/issues/9647 also asks
-# about the warning below, arising no matter if codename is 'focal' or 'jammy'
-# with Kolibri 0.15.6 on Mint 21 -- if you run '/usr/bin/kolibri --version':
-#
-# /usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
-# warnings.warn(
-
-# 2022-08-19: 'apt-key list' & 'apt-key del 3194 DD81' are useful if you also
-# want to clear out Kolibri's key from the DEPRECATED /etc/apt/trusted.gpg
-
-# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'jammy' (if is_linuxmint_21)
-#   apt_repository:
-#     repo: ppa:learningequality/kolibri
-#     codename: jammy    # CONSOLIDATE THIS SPECIAL CASE STANZA WITH UBUNTU ABOVE IN FUTURE?
-#   when: is_linuxmint_21
-
-# - name: Add Kolibri PPA repo 'ppa:learningequality/kolibri' with codename 'focal' (if is_debian or is_linuxmint_20)
-#   apt_repository:
-#     repo: ppa:learningequality/kolibri
-#     codename: focal    # UPDATE THIS TO 'jammy' AFTER "RasPiOS Bookworm" (based on Debian 12) IS RELEASED! (ETA Q3 2023)
-#   when: is_debian or is_linuxmint_20
 
 
 # 2024-08-07: Hack no longer needed!  As Kolibri 0.17.0 now installs via "kolibri" PPA (https://launchpad.net/~learningequality/+archive/ubuntu/kolibri).
@@ -304,13 +261,6 @@
 #     group: "{{ apache_user }}"     # www-data (on Debian/Ubuntu/Raspbian)
 #     recurse: yes
 #   when: kolibri_provision
-
-# 2019-10-07: Moved to roles/httpd/tasks/main.yml
-# 2019-09-29: roles/kiwix/tasks/kiwix_install.yml installs 4 Apache modules
-# for similar purposes (not all nec?)  Only 1 (proxy_http) is needed here.
-# - name: Enable Apache module proxy_http for http://box{{ kolibri_url }}    # i.e. http://box/kolibri
-#   apache2_module:
-#     name: proxy_http
 
 
 # RECORD Kolibri AS INSTALLED

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -70,16 +70,8 @@
 # PPL WHO DON'T KNOW with the wrong default username, instead of 'kolibri' :/
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
-# 2022-08-31: keyring /etc/apt/trusted.gpg DEPRECATED as detailed on #3343
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on older OS's"
-  shell: |
-    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-    gpg --yes --output "{{ kolibri_keyring_file }}" --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-  when: not is_debian and not (is_ubuntu and os_ver is version('ubuntu-2610', '>='))
-
-- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }} -- on newer OS's"
+- name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
   shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"
-  when: is_debian or is_ubuntu and os_ver is version('ubuntu-2610', '>=')    # SEE ALSO kolibri/defaults/main.yml LINES ~83 to ~85
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892

--- a/roles/kolibri/tasks/install.yml
+++ b/roles/kolibri/tasks/install.yml
@@ -71,7 +71,10 @@
 # https://github.com/learningequality/kolibri-installer-debian/pull/117
 
 - name: "Download Kolibri's apt key to {{ kolibri_keyring_file }}"
-  shell: "curl -fsSL https://learningequality.github.io/kolibri-installer-debian/pubkey.asc > {{ kolibri_keyring_file }}"
+  get_curl:
+    url: https://learningequality.github.io/kolibri-installer-debian/pubkey.asc
+    dest: "{{ kolibri_keyring_file }}"
+    timeout: "{{ download_timeout }}"
 
 # 2024-06-25: Strongly consider PPA "kolibri-proposed" in future...
 # https://github.com/learningequality/kolibri/issues/11892


### PR DESCRIPTION
Possible alternative/replacement for:

- PR #4495

(If this works across sufficient recent OS's, then let's make the jump!  Tested on Ubuntu 26.10 with GitHub Actions CI workflows about to provide more details on other OS's...)

@chapmanjacobd is get_url or get_curl preferred?