### PR TITLE
add new uwsgi-initscripts package to restore prior behavior [for Captive Portal, on Ubuntu 26.10]

### DIFF
--- a/roles/captiveportal/tasks/enable-or-disable.yml
+++ b/roles/captiveportal/tasks/enable-or-disable.yml
@@ -9,7 +9,6 @@
 - name: Stop 'uwsgi' systemd service (may include 3 child processes for Captive Portal, and 3 child processes for Admin Console)
   systemd:
     name: uwsgi
-    daemon_reload: yes
     state: stopped
 
 - name: Install /etc/uwsgi/apps-enabled/captiveportal.ini from template (if captiveportal_enabled)
@@ -52,7 +51,6 @@
 - name: Start & Enable 'uwsgi' systemd service (may include 3 child processes for Captive Portal, and 3 child processes for Admin Console)
   systemd:
     name: uwsgi
-    daemon_reload: yes
     state: started
     enabled: true
 

--- a/roles/captiveportal/tasks/enable-or-disable.yml
+++ b/roles/captiveportal/tasks/enable-or-disable.yml
@@ -9,6 +9,7 @@
 - name: Stop 'uwsgi' systemd service (may include 3 child processes for Captive Portal, and 3 child processes for Admin Console)
   systemd:
     name: uwsgi
+    daemon_reload: yes
     state: stopped
 
 - name: Install /etc/uwsgi/apps-enabled/captiveportal.ini from template (if captiveportal_enabled)

--- a/roles/captiveportal/tasks/enable-or-disable.yml
+++ b/roles/captiveportal/tasks/enable-or-disable.yml
@@ -51,6 +51,7 @@
 - name: Start & Enable 'uwsgi' systemd service (may include 3 child processes for Captive Portal, and 3 child processes for Admin Console)
   systemd:
     name: uwsgi
+    daemon_reload: yes
     state: started
     enabled: true
 

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -33,6 +33,7 @@
 - name: Reload systemd after installing uWSGI packages
   systemd:
     daemon_reload: yes
+  when: not is_proot
 
 
 # 2021-08-07: Legacy from roles/httpd/tasks/install.yml

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -24,16 +24,15 @@
 
 # Ubuntu 26.10 moved the legacy uwsgi.service and apps-enabled support into a separate package: uwsgi-initscripts
 # IIAB uses this aggregate service for Admin Console and Captive Portal
-- name: 'Install legacy uWSGI service support on Ubuntu 26.10+'
+- name: Install legacy uWSGI service support (if available; for changes in Ubuntu 26.10+)
   package:
     name: uwsgi-initscripts
     state: present
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version is version('26.10', '>=')
+  ignore_errors: true
 
-- name: Reload systemd after installing legacy uWSGI service support
+- name: Reload systemd after installing uWSGI packages
   systemd:
     daemon_reload: yes
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version is version('26.10', '>=')
 
 
 # 2021-08-07: Legacy from roles/httpd/tasks/install.yml

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -28,7 +28,7 @@
   package:
     name: uwsgi-initscripts
     state: present
-  when: is_ubuntu and ansible_facts.distribution_version is version('26.10', '>=')
+  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version is version('26.10', '>=')
 
 
 # 2021-08-07: Legacy from roles/httpd/tasks/install.yml

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -22,6 +22,14 @@
       - uwsgi-plugin-python3    # these 2 packages on demand (not every IIAB needs these).
     state: present
 
+# Ubuntu 26.10 moved the legacy uwsgi.service and apps-enabled support into a separate package: uwsgi-initscripts
+# IIAB uses this aggregate service for Admin Console and Captive Portal
+- name: 'Install legacy uWSGI service support on Ubuntu 26.10+'
+  package:
+    name: uwsgi-initscripts
+    state: present
+  when: is_ubuntu and ansible_facts.distribution_version is version('26.10', '>=')
+
 
 # 2021-08-07: Legacy from roles/httpd/tasks/install.yml
 

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -30,6 +30,11 @@
     state: present
   when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version is version('26.10', '>=')
 
+- name: Reload systemd after installing legacy uWSGI service support
+  systemd:
+    daemon_reload: yes
+  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version is version('26.10', '>=')
+
 
 # 2021-08-07: Legacy from roles/httpd/tasks/install.yml
 


### PR DESCRIPTION
### Fixes bug:

systemd service uwsgi somehow being missing on Ubuntu 26.10?

### Description of changes proposed in this pull request:

add uwsgi-initscripts

https://packages.ubuntu.com/stonking/all/uwsgi-initscripts/filelist

### Smoke-tested on which OS or OS's:

We should test this on 26.10... should we add a CI test for _stonking_?

### Mention a team member @username e.g. to help with code review:

@holta