### PR TITLE
Maps: Query for FQR files from the front end instead of using an index file

### DIFF
--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -3,8 +3,9 @@
 
 unpkg_url: https://unpkg.com
 
-maps_serve_path: "{{ content_base }}/www/maps"        # /library/www/maps
-maps_data_root: "{{ content_base }}/maps"             # /library/maps
+maps_serve_path: "{{ content_base }}/www/maps"      # /library/www/maps
+maps_data_index_path: "{{ maps_serve_path }}/data"  # /library/www/maps/data
+maps_data_root: "{{ content_base }}/maps"           # /library/maps
 
 # For now use the same directory as maps_serve_path. Eventually we could
 # put it under a /fallback directory, but then we'd want to make sure

--- a/roles/maps/defaults/main.yml
+++ b/roles/maps/defaults/main.yml
@@ -46,7 +46,6 @@ maps_tools:
     executable_path: "{{ maps_tools.base_dir }}/pmtiles"
   tile_extract:
     working_dir: "{{ maps_tools.base_dir }}/tile-extract"
-    info_file: "extracts.json"
 
 # Basic maps.black javascript and styles
 maps_dot_black_js_and_styles_host: https://iiab.switnet.org/maps/2

--- a/roles/maps/tasks/install.yml
+++ b/roles/maps/tasks/install.yml
@@ -4,6 +4,14 @@
     state: directory
     # mode: 0755
 
+# This, combined with an nginx setting, gives the browser a full file listing via /maps/data
+- name: "Point /maps/data/ back to /maps/"
+  file:
+    src: "{{ maps_serve_path }}"
+    path: "{{ maps_data_index_path }}"
+    state: link
+    force: yes
+
 - name: Make maps directory (0755 by default)
   file:
     path: "{{ maps_data_root }}"

--- a/roles/maps/tasks/install_frontend.yml
+++ b/roles/maps/tasks/install_frontend.yml
@@ -98,13 +98,6 @@
   args:
     executable: /bin/bash
 
-- name: Initiate the extracts json
-  copy:
-    content: '{"regions": {}}'
-    dest: "{{ maps_serve_path }}/{{ maps_tools.tile_extract.info_file }}"
-    mode: "0644"
-    force: false
-
 - name: "Download preset full quality regions"
   # TODO - Is there a safer way to pass in item.name and item.bbox?
   shell: |

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -804,7 +804,7 @@
                             // east > west, and `render_bounds` should be the entire width of the world because
                             // it's actually two partial regions on opposite sides of the map
                             dates,
-                              bbox: meta.bbox,
+                            bbox: meta.bbox,
                             ui_bounds: [meta.bbox[0], meta.bbox[1], meta.bbox[2] + 360, meta.bbox[3]],
                             render_bounds: [-179.99999999, meta.bbox[1], 180, meta.bbox[3]],
                           }

--- a/roles/maps/templates/index.html.j2
+++ b/roles/maps/templates/index.html.j2
@@ -119,13 +119,13 @@
                             const pmtilesDates = downloadedFQRegions.regions[fqrName].dates
 
                             const s2Id = "s2maps-sentinel2-2023"
-                            const s2FqrId = makeFqrSourceId(fqrName, s2Id, pmtilesDates.satellite)
+                            const s2FqrId = makeFqrSourceId(fqrName, s2Id, pmtilesDates[s2Id])
                             const osmId = "openstreetmap-openmaptiles"
-                            const osmFqrId = makeFqrSourceId(fqrName, osmId, pmtilesDates.vector)
+                            const osmFqrId = makeFqrSourceId(fqrName, osmId, pmtilesDates[osmId])
                             const terrariumId = "terrarium"
-                            const terrariumFqrId = makeFqrSourceId(fqrName, terrariumId, pmtilesDates.terrain)
+                            const terrariumFqrId = makeFqrSourceId(fqrName, terrariumId, pmtilesDates[terrariumId])
                             const hillshadeId = "hillshade"
-                            const hillshadeFqrId = makeFqrSourceId(fqrName, hillshadeId, pmtilesDates.terrain)
+                            const hillshadeFqrId = makeFqrSourceId(fqrName, hillshadeId, pmtilesDates[terrariumId])
                             const naturalEarth6Id = "naturalearth6-NE2_HR_SR_W_DR-WEBP"
                             const backgroundLayerId = "background"
 
@@ -555,7 +555,7 @@
                         // awkward situation to be looking at multiple regions,
                         // so take the first one (which is the closest to the
                         // map center, see sorting above)
-                        return makeFqrSourceId(regionsOnScreen[0], 'terrarium', downloadedFQRegions.regions[regionsOnScreen[0]].dates.terrain)
+                        return makeFqrSourceId(regionsOnScreen[0], 'terrarium', downloadedFQRegions.regions[regionsOnScreen[0]].dates.terrarium)
                     }
                     if (WORLD_MAP_TERRAIN_MAX_ZOOM > 0) {
                         // If no FQRs are on screen and we have a world map terrain, return to it
@@ -687,48 +687,131 @@
 
             const fqrLoaded = () => !!downloadedFQRegions
 
-            function setFQRegions() {
-                return fetch('{{ maps_tools.tile_extract.info_file }}', { cache: 'no-store' })
-                    .then((response) => {
-                        if (response.status < 400) {
-                            return response.json()
-                        } else {
-                            console.error("Failed to load Full Quality Regions:", response.status, response.statusText)
-                        }
-                    })
-                    .catch((error) => {
+            async function setFQRegions() {
+                let dirList
+                try {
+                    const response = await fetch('/maps/data/', { cache: 'no-store' })
+                    if (response.status >= 400) {
                         downloadedFQRegions = {error: true, regions: {}}
-                        console.error("Failed to load Full Quality Regions:", error)
-                    })
-                    .then((json) => {
-                        if (json && json.regions) {
-                            downloadedFQRegions = {
-                                // copy the regions from extracts.json, but generate ui_bounds and render_bounds from bbox
-                                regions: Object.fromEntries(
-                                  Object.entries(json.regions).map(([regionName, regionData]) =>
-                                      [regionName,
-                                        regionData.bbox[0] <= regionData.bbox[2] ? {
-                                          // if we're not crossing the antimeridian, `ui_bounds` and `render_bounds` are the same as `bbox`
-                                          ...regionData,
-                                          ui_bounds: regionData.bbox,
-                                          render_bounds: regionData.bbox,
-                                        } : {
-                                          // if we are crossing the antimeridian, `ui_bounds` should add 360 to the east so that
-                                          // east > west, and `render_bounds` should be the entire width of the world because
-                                          // it's actually two partial regions on opposite sides of the map
-                                          ...regionData,
-                                          ui_bounds: [regionData.bbox[0], regionData.bbox[1], regionData.bbox[2] + 360, regionData.bbox[3]],
-                                          render_bounds: [-179.99999999, regionData.bbox[1], 180, regionData.bbox[3]],
-                                        }
-                                      ]
-                                  )
-                                )
-                            }
-                        } else {
-                            downloadedFQRegions = {error: true, regions: {}}
-                        }
+                        console.error("Failed to load Full Quality Regions:", response.status, response.statusText)
+                        return
+                    }
+                    dirList = await response.json()
+                } catch (error) {
+                    downloadedFQRegions = {error: true, regions: {}}
+                    console.error("Failed to load Full Quality Regions:", error)
+                    return
+                }
+                regionNames = dirList
+                    .filter(entry => entry.type === "directory" && entry.name.endsWith('.fqr'))
+                    .map(entry => entry.name.slice(0, -4))
+                const regionInfo = await Promise.allSettled(
+                    regionNames.map(async regionName => {
+                        try {
+                            const metaPromise = (async () => {
+                                // Should we cache this? It will change less often, presumably, than a given FQR's bbox. Not impossible though.
+                                metaResponse = await fetch(`/maps/data/${regionName}.fqr/meta.json`) // , { cache: 'no-store' }
+                                if (metaResponse.status >= 400) {
+                                    console.error(`Failed to load meta.json for Full Quality Region: ${regionName}`, metaResponse.status, metaResponse.statusText)
+                                    return
+                                }
+                                return metaResponse.json()
+                            })()
 
-                    });
+                            const listingPromise = (async () => {
+                                // Not going to cache because updating FQR data we hope is not so uncommon.
+                                listingResponse = await fetch(`/maps/data/${regionName}.fqr`, { cache: 'no-store' })
+                                if (listingResponse.status >= 400) {
+                                    console.error(`Failed to load Full Quality Region file listing: ${regionName}`, listingResponse.status, listingResponse.statusText)
+                                    return
+                                }
+                                return await listingResponse.json()
+                            })()
+
+                            try {
+                                [meta, listing] = await Promise.all([metaPromise, listingPromise])
+                            } catch (error) {
+                                console.error(`Failed to get Full Quality Region: ${regionName}`, error)
+                            }
+
+                            if (meta && listing) {
+                                return [regionName, {meta, listing}]
+                            }
+                        } catch (error) {
+                            console.error(`Failed to load Full Quality Region: ${regionName}`, error)
+                        }
+                    })
+                )
+
+                // At this point we're done making requests. We should have all of the data we need to set up our FQRs here.
+                //
+                // regions = {regionName: {meta, listing}, ...}
+                downloadedFQRegions = {
+                  regions: Object.fromEntries(
+                      regionInfo
+                      .map(res=>res.value)  // [regionName, {meta, listing}] (see above)
+                      .filter(Boolean)      // remove errors in getting meta or listing
+                      .map(([regionName, {meta, listing}]) => {
+                          // some basic checks
+                          if (!meta.bbox) {
+                              console.log(`bbox missing for Full Quality Region: ${regionName}`)
+                              return
+                          }
+                          if (meta.bbox.length != 4) {
+                              console.log(`bbox malformed for Full Quality Region: ${regionName}`)
+                              return
+                          }
+
+                          const dates = {}
+
+                          // Each valid pmtiles file in an FQR has the format:
+                          // [regionExtractType].[date].pmtiles
+                          // We want the latest date for each regionExtractType, assuming there are
+                          // (for some reason) multiple. If we sort it in alphabetical order, the
+                          // pmtiles for each regionExtractType should also be listed in chronological
+                          // order. So long as we overwrite, the latest date for each regionExtractType
+                          // should end up in `dates`.
+                          listing.sort()
+                          listing.forEach(entry => {
+                              if (entry.type !== "file") {
+                                      return
+                              }
+
+                              const REGION_EXTRACT_TYPES = [
+                                  's2maps-sentinel2-2023',
+                                  'terrarium',
+                                  'openstreetmap-openmaptiles',
+                              ]
+                              const [regionExtractType, date, pmtiles, ...rest] = entry.name.split(".")
+                              if (
+                                REGION_EXTRACT_TYPES.includes(regionExtractType)            &&
+                                date.match(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)  &&
+                                pmtiles === "pmtiles"                                       &&
+                                !rest.length
+                              ) {
+                                  dates[regionExtractType] = date
+                              }
+                          })
+
+                          const fqrData = meta.bbox[0] <= meta.bbox[2] ? {
+                            // if we're not crossing the antimeridian, `ui_bounds` and `render_bounds` are the same as `bbox`
+                            dates,
+                            bbox: meta.bbox,
+                            ui_bounds: meta.bbox,
+                            render_bounds: meta.bbox,
+                          } : {
+                            // if we are crossing the antimeridian, `ui_bounds` should add 360 to the east so that
+                            // east > west, and `render_bounds` should be the entire width of the world because
+                            // it's actually two partial regions on opposite sides of the map
+                            dates,
+                              bbox: meta.bbox,
+                            ui_bounds: [meta.bbox[0], meta.bbox[1], meta.bbox[2] + 360, meta.bbox[3]],
+                            render_bounds: [-179.99999999, meta.bbox[1], 180, meta.bbox[3]],
+                          }
+                          return [regionName, fqrData]
+                      })
+                      .filter(Boolean)      // remove errors in finishing setting up the region
+                )}
             }
             setFQRegions()
 

--- a/roles/maps/templates/maps-nginx.conf.j2
+++ b/roles/maps/templates/maps-nginx.conf.j2
@@ -19,5 +19,19 @@ location ~ ^/maps/ {
         gzip_static on;
     }
 
+    # This, combined with making data a symlink back to /, gives the browser a directory listing in json format of /maps/ and all subdirectories
+    location ~ ^/maps/data/ {
+        autoindex on;
+        autoindex_format json;
+
+        # Need to disable /maps/data/index.html to see the directory listing, since /maps/index.html exists
+        index does-not-exist-920f18f8cfc29bcbaa0c8430288fa4a919cd2be30a37dc4369b247193aa0d5ab.html;
+
+        # In case some wise guy tries to visit /maps/data/data/data/data/data/data/data/... and causes a problem.
+        location ~ ^/maps/data/data/ {
+            return 404;
+        }
+    }
+
     root /library/www;
 }

--- a/roles/maps/templates/tile-extract.py.j2
+++ b/roles/maps/templates/tile-extract.py.j2
@@ -9,7 +9,6 @@ sys.path.insert(1, "{{ maps_tools.tile_extract.working_dir }}/pmtiles-python/pyt
 
 CATALOG_URL = "{{ maps_catalog_url }}"
 HOSTING_DIR = Path("{{ maps_serve_path }}")
-EXTRACTS_JSON = HOSTING_DIR / "{{ maps_tools.tile_extract.info_file }}"
 PMTILES = "{{ maps_tools.pmtiles.executable_path }}"
 TMP_DIR = Path("/library/downloads/maps")
 
@@ -469,17 +468,9 @@ def check_for_overlaps(new_fqr):
 
     return True
 
-def update_extracts_json():
-    # region_extracts[extract_name] = {
-    #   "bbox": coordinates,
-    #   "dates": {
-    #     "terrain": terrain_date,
-    #     "vector": vector_date,
-    #     "satellite": satellite_date,
-    #   },
-    # }
+def debug_extracts_json():
     print () # Give space in case this is run after another command
-    print ("Updating extracts.json")
+    print ("Checking FQRs...")
     region_extracts = defaultdict(
         lambda: dict(dates=defaultdict(dict)),
     )
@@ -523,15 +514,12 @@ def update_extracts_json():
             print() # TODO - recommend an "update" instead of delete when we implement that
             print(delete_command(extract_name))
 
-    extracts = {"regions": region_extracts}
-    with EXTRACTS_JSON.open("w") as f:
-        json.dump(extracts, f)
 
 def main():
     match sys.argv[1]:
-        case "update-json":
+        case "debug":
             assert len(sys.argv) == 2, "update-json takes no extra arguments"
-            update_extracts_json()
+            debug_extracts_json()
 
         case "delete":
             assert len(sys.argv) == 3, "delete takes one argument: extract_name"
@@ -539,7 +527,7 @@ def main():
             validate_extract_name(extract_name)
 
             delete_extract(extract_name)
-            update_extracts_json()
+            debug_extracts_json()
 
         case "extract":
             # Get and validate arguments
@@ -582,7 +570,7 @@ def main():
 
             # Do the extracts
             create_extract(new_fqr, extract_name, extract_paths)
-            update_extracts_json() # Add the newly added extract
+            debug_extracts_json()
 
         case unknown:
             raise Exception("Unknown option:", unknown)


### PR DESCRIPTION
### Description of changes proposed in this pull request:

Right now the FQR downloader tool generates a file called `extracts.json` that lists all of the FQRs and their bboxes. That way the front end only has to get this one file and it gets all of that info.

This change will instead allow the front end to inspect the available FQR files on its own. Nginx will give a json-formatted directory listing at `/maps/data/` of all of the files under `/maps/`. Subdirectories work as well, which means fqrs can be inspected. So now the front end looks at `/maps/data/` for any directories called `*.fqr`. For each FQR it reads its `meta.json` for its bbox. It also does another directory listing on each `*fqr` directory itself to find its specific pmtiles file names (since they have an arbitrary date). This change has (2n + 1) queries instead of 1 query for this info, but the files are tiny. And more importantly, changes to the files will be visible right away.

So what's up with the `/maps/data/` subdirectory? I can't have `/maps/` list its files because it has an index.html. I could have put all of the data under `/maps/data/`, and maybe I should eventually. But for now, I just hacked it with a symlink from `/maps/data/` to `/maps/`. Nginx treats it as a different directory which allows us to give it different properties.

*  `extracts.json` no longer exists (and we no longer have to have our discussion of how to change its format)
* `update-json` / `reload` or whatever we were going to call it, no longer exists (though for now I turned it into a "debug" command that gives some warnings)
* Grassroots FQRs - copied by the implementer from a friend, etc - should be detected and show up immediately (assuming file permissions are set correctly?)

It works. I have a curiosity about performance; I thought I saw it load slower a couple times, but not always. Of course I test with a lot of FQRs so that could be not a priority for us anyway. I might have other thoughts about details before merging. I haven't had time to ponder it overall. But I think I'm pretty close to done.

#### In the future I could similarly implement:

* Automatic front-end "self-healing" of world maps after the implementer deletes files. This would replace the CLI utility `maps-update.py` that I made a few weeks back.
* "Debug" warnings about pmtiles files in the front end (so long as they don't require inspecting the file with the `pmtiles` CLI, though even then maybe we could figure something out)

### Smoke-tested on which OS or OS's:

Ubuntu 26.04 on Multipass

- [x] I'd like to try on RPi Zero 2W to see if the performance wrt Ngnix isn't somehow a problem.

### Mention a team member @username e.g. to help with code review:
@holta @chapmanjacobd 